### PR TITLE
fix(web): unblock signup Turnstile 110200 + mismatch guardrails

### DIFF
--- a/apps/web/app/api/changelog/subscribe/route.ts
+++ b/apps/web/app/api/changelog/subscribe/route.ts
@@ -57,7 +57,8 @@ type TurnstileVerificationResult = 'verified' | 'rejected' | 'unavailable';
 
 async function verifyTurnstile(
   token: string,
-  ip: string
+  ip: string,
+  hostname?: string | null
 ): Promise<TurnstileVerificationResult> {
   // Single source of truth: delegate to the shared, bounded (timeout + retry)
   // siteverify helper instead of re-implementing the Cloudflare call here.
@@ -73,7 +74,7 @@ async function verifyTurnstile(
     return 'verified';
   }
 
-  const result = await verifyTurnstileToken(token, ip);
+  const result = await verifyTurnstileToken(token, ip, hostname);
   if (result.success) return 'verified';
   return classifyTurnstileFailure(result);
 }
@@ -180,7 +181,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const turnstileResult = await verifyTurnstile(body.turnstileToken ?? '', ip);
+  const host =
+    request.headers.get('x-forwarded-host')?.split(',')[0]?.trim() ||
+    request.headers.get('host') ||
+    null;
+  const turnstileResult = await verifyTurnstile(
+    body.turnstileToken ?? '',
+    ip,
+    host
+  );
   if (turnstileResult === 'rejected') {
     return NextResponse.json(
       { error: 'Bot verification failed. Please try again.' },

--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -290,7 +290,11 @@ export async function tryHandleAnonymousOnboardingChat(
     }
 
     if (!shouldBypassTurnstile) {
-      const verify = await verifyTurnstileToken(parsed.data.turnstileToken, ip);
+      const verify = await verifyTurnstileToken(
+        parsed.data.turnstileToken,
+        ip,
+        extractRequestHostname(req)
+      );
       if (!verify.success) {
         return NextResponse.json(
           {

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -6,11 +6,11 @@ import { AppShellFrame } from '@/components/organisms/AppShellFrame';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
 import { track } from '@/lib/analytics';
 import { publicEnv } from '@/lib/env-public';
+import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
 import {
   getBrowserTurnstileHostname,
   resolveTurnstileSiteKey,
 } from '@/lib/turnstile/keys';
-import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
 import { cn } from '@/lib/utils';
 import { OnboardingChat } from './OnboardingChat';
 import {

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -6,6 +6,10 @@ import { AppShellFrame } from '@/components/organisms/AppShellFrame';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
 import { track } from '@/lib/analytics';
 import { publicEnv } from '@/lib/env-public';
+import {
+  getBrowserTurnstileHostname,
+  resolveTurnstileSiteKey,
+} from '@/lib/turnstile/keys';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
 import { cn } from '@/lib/utils';
 import { OnboardingChat } from './OnboardingChat';
@@ -115,7 +119,10 @@ export function OnboardingShell({
   const turnstilePanelVisible = isOnboardingTurnstilePanelVisible(
     turnstileState,
     turnstileInstruction,
-    publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+    resolveTurnstileSiteKey(
+      getBrowserTurnstileHostname(),
+      publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+    )
   );
 
   const isTurnstileUnavailable =

--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -5,6 +5,10 @@ import { useReducedMotion } from 'motion/react';
 import Script from 'next/script';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { publicEnv } from '@/lib/env-public';
+import {
+  getBrowserTurnstileHostname,
+  resolveTurnstileSiteKey,
+} from '@/lib/turnstile/keys';
 import { cn } from '@/lib/utils';
 import { isOnboardingLocalAutomationBypassRuntime } from './onboardingAutomationBypass';
 
@@ -125,7 +129,12 @@ export function OnboardingTurnstile({
     useState(false);
   const [interactiveChallengeVisible, setInteractiveChallengeVisible] =
     useState(false);
-  const siteKey = publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  // Hostname-aware: preview/localhost get always-pass dummy keys so prod
+  // domain-locked sitekeys cannot cause Cloudflare 110200 on *.vercel.app.
+  const siteKey = resolveTurnstileSiteKey(
+    getBrowserTurnstileHostname(),
+    publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  );
   const hasStaticBypass =
     process.env.NODE_ENV === 'development' ||
     publicEnv.NEXT_PUBLIC_E2E_MODE === '1' ||

--- a/apps/web/lib/turnstile/keys.test.ts
+++ b/apps/web/lib/turnstile/keys.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertTurnstileClientServerPairCompatible,
+  normalizeTurnstileHostname,
+  resolveTurnstileSecretKey,
+  resolveTurnstileSiteKey,
+  shouldUseTurnstileDummyKeys,
+  TURNSTILE_ALWAYS_PASS_SECRET_KEY,
+  TURNSTILE_ALWAYS_PASS_SITE_KEY,
+} from './keys';
+
+const REAL_SITE_KEY = '0x4AAAAAAARealSiteKeyExample';
+const REAL_SECRET = '0x4AAAAAAARealSecretKeyExample';
+
+describe('normalizeTurnstileHostname', () => {
+  it('lowercases and strips ports', () => {
+    expect(normalizeTurnstileHostname('JOV.IE:443')).toBe('jov.ie');
+  });
+
+  it('takes the first host from a comma list', () => {
+    expect(normalizeTurnstileHostname('jov.ie, internal:8080')).toBe('jov.ie');
+  });
+
+  it('parses full URLs', () => {
+    expect(normalizeTurnstileHostname('https://staging.jov.ie/start')).toBe(
+      'staging.jov.ie'
+    );
+  });
+
+  it('returns null for empty input', () => {
+    expect(normalizeTurnstileHostname(null)).toBeNull();
+    expect(normalizeTurnstileHostname('')).toBeNull();
+    expect(normalizeTurnstileHostname('   ')).toBeNull();
+  });
+});
+
+describe('shouldUseTurnstileDummyKeys', () => {
+  it.each([
+    'localhost',
+    '127.0.0.1',
+    '0.0.0.0',
+    '::1',
+    '[::1]',
+    'app.localhost',
+    'jovie-timwhite-jovie.vercel.app',
+    'jovie-abc123-jovie.vercel.app',
+  ])('uses dummy keys on non-allowlisted host %s', host => {
+    expect(shouldUseTurnstileDummyKeys(host)).toBe(true);
+  });
+
+  it.each(['jov.ie', 'www.jov.ie', 'staging.jov.ie', 'main.jov.ie'])(
+    'does not use dummy keys on allowlisted host %s',
+    host => {
+      expect(shouldUseTurnstileDummyKeys(host)).toBe(false);
+    }
+  );
+
+  it('does not force dummy keys when hostname is unknown (SSR-safe)', () => {
+    expect(shouldUseTurnstileDummyKeys(null)).toBe(false);
+    expect(shouldUseTurnstileDummyKeys(undefined)).toBe(false);
+  });
+});
+
+describe('resolveTurnstileSiteKey', () => {
+  it('returns undefined when no site key is configured', () => {
+    expect(resolveTurnstileSiteKey('jov.ie', undefined)).toBeUndefined();
+    expect(resolveTurnstileSiteKey('jov.ie', '')).toBeUndefined();
+    expect(resolveTurnstileSiteKey('jov.ie', '   ')).toBeUndefined();
+  });
+
+  it('keeps the real site key on production/staging hosts', () => {
+    expect(resolveTurnstileSiteKey('jov.ie', REAL_SITE_KEY)).toBe(REAL_SITE_KEY);
+    expect(resolveTurnstileSiteKey('www.jov.ie', REAL_SITE_KEY)).toBe(
+      REAL_SITE_KEY
+    );
+    expect(resolveTurnstileSiteKey('staging.jov.ie', REAL_SITE_KEY)).toBe(
+      REAL_SITE_KEY
+    );
+    expect(resolveTurnstileSiteKey('main.jov.ie', REAL_SITE_KEY)).toBe(
+      REAL_SITE_KEY
+    );
+  });
+
+  it('swaps to the always-pass site key on Vercel preview hosts (110200 fix)', () => {
+    expect(
+      resolveTurnstileSiteKey('jovie-timwhite-jovie.vercel.app', REAL_SITE_KEY)
+    ).toBe(TURNSTILE_ALWAYS_PASS_SITE_KEY);
+  });
+
+  it('swaps to the always-pass site key on localhost', () => {
+    expect(resolveTurnstileSiteKey('localhost', REAL_SITE_KEY)).toBe(
+      TURNSTILE_ALWAYS_PASS_SITE_KEY
+    );
+  });
+
+  it('keeps configured key when hostname is null (SSR does not flip to dummy)', () => {
+    expect(resolveTurnstileSiteKey(null, REAL_SITE_KEY)).toBe(REAL_SITE_KEY);
+  });
+
+  it('passes through when already configured with the dummy site key', () => {
+    expect(
+      resolveTurnstileSiteKey('jov.ie', TURNSTILE_ALWAYS_PASS_SITE_KEY)
+    ).toBe(TURNSTILE_ALWAYS_PASS_SITE_KEY);
+  });
+});
+
+describe('resolveTurnstileSecretKey', () => {
+  it('returns null when no secret is configured', () => {
+    expect(resolveTurnstileSecretKey('jov.ie', undefined)).toBeNull();
+    expect(resolveTurnstileSecretKey('jov.ie', '')).toBeNull();
+  });
+
+  it('keeps the real secret on production/staging hosts', () => {
+    expect(resolveTurnstileSecretKey('jov.ie', REAL_SECRET)).toBe(REAL_SECRET);
+    expect(resolveTurnstileSecretKey('staging.jov.ie', REAL_SECRET)).toBe(
+      REAL_SECRET
+    );
+  });
+
+  it('pairs preview hosts with the always-pass secret', () => {
+    expect(
+      resolveTurnstileSecretKey('jovie-timwhite-jovie.vercel.app', REAL_SECRET)
+    ).toBe(TURNSTILE_ALWAYS_PASS_SECRET_KEY);
+  });
+
+  it('pairs localhost with the always-pass secret', () => {
+    expect(resolveTurnstileSecretKey('localhost', REAL_SECRET)).toBe(
+      TURNSTILE_ALWAYS_PASS_SECRET_KEY
+    );
+  });
+
+  it('does not swap secrets when hostname is unknown', () => {
+    expect(resolveTurnstileSecretKey(null, REAL_SECRET)).toBe(REAL_SECRET);
+  });
+});
+
+describe('client/server pair guardrail (mismatch impossible)', () => {
+  it.each([
+    'jov.ie',
+    'www.jov.ie',
+    'staging.jov.ie',
+    'jovie-timwhite-jovie.vercel.app',
+    'localhost',
+  ])('resolved pair is compatible for host %s with real env keys', host => {
+    const site = resolveTurnstileSiteKey(host, REAL_SITE_KEY);
+    const secret = resolveTurnstileSecretKey(host, REAL_SECRET);
+    const check = assertTurnstileClientServerPairCompatible(
+      host,
+      REAL_SITE_KEY,
+      REAL_SECRET
+    );
+    expect(check).toEqual({ ok: true });
+    const siteDummy = site === TURNSTILE_ALWAYS_PASS_SITE_KEY;
+    const secretDummy = secret === TURNSTILE_ALWAYS_PASS_SECRET_KEY;
+    expect(siteDummy).toBe(secretDummy);
+  });
+
+  it('rejects half-configured env', () => {
+    expect(
+      assertTurnstileClientServerPairCompatible('jov.ie', REAL_SITE_KEY, null)
+    ).toMatchObject({ ok: false });
+  });
+
+  it('preview host never keeps a real sitekey when real env is present', () => {
+    expect(
+      resolveTurnstileSiteKey('jovie-timwhite-jovie.vercel.app', REAL_SITE_KEY)
+    ).not.toBe(REAL_SITE_KEY);
+  });
+});

--- a/apps/web/lib/turnstile/keys.test.ts
+++ b/apps/web/lib/turnstile/keys.test.ts
@@ -48,12 +48,14 @@ describe('shouldUseTurnstileDummyKeys', () => {
     expect(shouldUseTurnstileDummyKeys(host)).toBe(true);
   });
 
-  it.each(['jov.ie', 'www.jov.ie', 'staging.jov.ie', 'main.jov.ie'])(
-    'does not use dummy keys on allowlisted host %s',
-    host => {
-      expect(shouldUseTurnstileDummyKeys(host)).toBe(false);
-    }
-  );
+  it.each([
+    'jov.ie',
+    'www.jov.ie',
+    'staging.jov.ie',
+    'main.jov.ie',
+  ])('does not use dummy keys on allowlisted host %s', host => {
+    expect(shouldUseTurnstileDummyKeys(host)).toBe(false);
+  });
 
   it('does not force dummy keys when hostname is unknown (SSR-safe)', () => {
     expect(shouldUseTurnstileDummyKeys(null)).toBe(false);
@@ -69,7 +71,9 @@ describe('resolveTurnstileSiteKey', () => {
   });
 
   it('keeps the real site key on production/staging hosts', () => {
-    expect(resolveTurnstileSiteKey('jov.ie', REAL_SITE_KEY)).toBe(REAL_SITE_KEY);
+    expect(resolveTurnstileSiteKey('jov.ie', REAL_SITE_KEY)).toBe(
+      REAL_SITE_KEY
+    );
     expect(resolveTurnstileSiteKey('www.jov.ie', REAL_SITE_KEY)).toBe(
       REAL_SITE_KEY
     );

--- a/apps/web/lib/turnstile/keys.ts
+++ b/apps/web/lib/turnstile/keys.ts
@@ -1,0 +1,195 @@
+/**
+ * Cloudflare Turnstile key resolution by hostname.
+ *
+ * Production widget sitekeys are domain-locked via Hostname Management.
+ * Serving them on Vercel preview hosts (`*.vercel.app`) or localhost yields
+ * client error **110200** ("Domain not authorized") and blocks signup.
+ *
+ * On those non-allowlisted deploy hosts we use Cloudflare's public always-pass
+ * dummy keys so the widget and siteverify still work. Allowlisted production /
+ * staging hosts always keep the configured real keys — bot protection is not
+ * weakened on jov.ie.
+ *
+ * Dummy keys:
+ * https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+ *
+ * Hostname allowlist source of truth for the real widget:
+ * `scripts/turnstile-config.ts` (PRODUCTION_TURNSTILE_HOSTNAMES +
+ * STAGING_TURNSTILE_HOSTNAMES).
+ */
+
+/** Cloudflare always-pass (visible) dummy sitekey — public test credential. */
+export const TURNSTILE_ALWAYS_PASS_SITE_KEY =
+  '1x00000000000000000000AA' as const;
+
+/** Matching always-pass dummy secret — public test credential. */
+export const TURNSTILE_ALWAYS_PASS_SECRET_KEY =
+  '1x0000000000000000000000000000000AA' as const;
+
+/**
+ * Hostnames authorized for the production Turnstile widget.
+ * Keep in sync with `scripts/turnstile-config.ts` prod + staging lists.
+ */
+export const TURNSTILE_WIDGET_HOSTNAMES = [
+  'jov.ie',
+  'www.jov.ie',
+  'staging.jov.ie',
+  'main.jov.ie',
+] as const;
+
+export function normalizeTurnstileHostname(
+  hostname: string | null | undefined
+): string | null {
+  if (!hostname) return null;
+  const first = hostname.split(',')[0]?.trim().toLowerCase() ?? '';
+  if (!first) return null;
+
+  if (first.startsWith('http://') || first.startsWith('https://')) {
+    try {
+      return new URL(first).hostname.toLowerCase() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Bracketed IPv6 with optional port: [::1]:443
+  if (first.startsWith('[')) {
+    const end = first.indexOf(']');
+    if (end > 0) return first.slice(1, end) || null;
+  }
+
+  // Bare IPv6 (e.g. ::1) — do not strip ":digits" as a port.
+  if (first.includes(':') && first.split(':').length > 2) {
+    return first;
+  }
+
+  // hostname:port
+  return first.replace(/:\d+$/, '') || null;
+}
+
+/**
+ * Hosts where domain-locked production sitekeys fail with client error 110200.
+ * These surfaces use Cloudflare dummy keys instead of the real widget keys.
+ */
+export function shouldUseTurnstileDummyKeys(
+  hostname: string | null | undefined
+): boolean {
+  const host = normalizeTurnstileHostname(hostname);
+  if (!host) return false;
+
+  if (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '0.0.0.0' ||
+    host === '::1' ||
+    host === '[::1]'
+  ) {
+    return true;
+  }
+  if (host.endsWith('.localhost')) return true;
+  // Vercel preview / personal deployment URLs
+  // (e.g. jovie-timwhite-jovie.vercel.app).
+  if (host.endsWith('.vercel.app')) return true;
+  return false;
+}
+
+/**
+ * Resolve the sitekey the browser widget should mount.
+ *
+ * - Missing configured key → unconfigured (undefined).
+ * - Dummy hosts (preview/localhost) → always-pass sitekey.
+ * - Unknown/null hostname (SSR) → keep configured key; browser re-resolves.
+ * - Allowlisted product hosts → configured production/staging key.
+ */
+export function resolveTurnstileSiteKey(
+  hostname: string | null | undefined,
+  configuredSiteKey: string | null | undefined
+): string | undefined {
+  const configured = configuredSiteKey?.trim();
+  if (!configured) return undefined;
+  if (configured === TURNSTILE_ALWAYS_PASS_SITE_KEY) return configured;
+  if (shouldUseTurnstileDummyKeys(hostname)) {
+    return TURNSTILE_ALWAYS_PASS_SITE_KEY;
+  }
+  return configured;
+}
+
+/**
+ * Resolve the secret used for Cloudflare siteverify.
+ * Must pair with {@link resolveTurnstileSiteKey} for the same hostname.
+ */
+export function resolveTurnstileSecretKey(
+  hostname: string | null | undefined,
+  configuredSecretKey: string | null | undefined
+): string | null {
+  const configured = configuredSecretKey?.trim();
+  if (!configured) return null;
+  if (configured === TURNSTILE_ALWAYS_PASS_SECRET_KEY) return configured;
+  if (shouldUseTurnstileDummyKeys(hostname)) {
+    return TURNSTILE_ALWAYS_PASS_SECRET_KEY;
+  }
+  return configured;
+}
+
+/** Browser hostname helper — returns null during SSR / non-DOM runtimes. */
+export function getBrowserTurnstileHostname(): string | null {
+  if (typeof globalThis.location === 'undefined') return null;
+  return globalThis.location.hostname || null;
+}
+
+/**
+ * Guardrail: client sitekey and server secret must be a matching pair for the
+ * hostname. Prevents shipping prod sitekey + dummy secret (or the reverse),
+ * which causes silent verify failures or 110200 loops.
+ */
+export function assertTurnstileClientServerPairCompatible(
+  hostname: string | null | undefined,
+  configuredSiteKey: string | null | undefined,
+  configuredSecretKey: string | null | undefined
+): { ok: true } | { ok: false; reason: string } {
+  const site = resolveTurnstileSiteKey(hostname, configuredSiteKey);
+  const secret = resolveTurnstileSecretKey(hostname, configuredSecretKey);
+
+  if (!site && !secret) {
+    return { ok: true }; // both unconfigured — callers handle fail-closed
+  }
+  if (!site || !secret) {
+    return {
+      ok: false,
+      reason: 'sitekey_and_secret_must_both_be_set_or_both_unset',
+    };
+  }
+
+  const siteIsDummy = site === TURNSTILE_ALWAYS_PASS_SITE_KEY;
+  const secretIsDummy = secret === TURNSTILE_ALWAYS_PASS_SECRET_KEY;
+  if (siteIsDummy !== secretIsDummy) {
+    return {
+      ok: false,
+      reason: 'dummy_sitekey_must_pair_with_dummy_secret',
+    };
+  }
+
+  if (shouldUseTurnstileDummyKeys(hostname)) {
+    if (!siteIsDummy || !secretIsDummy) {
+      return {
+        ok: false,
+        reason: 'preview_or_local_host_must_use_dummy_pair',
+      };
+    }
+  } else if (hostname) {
+    // Allowlisted product hosts must not silently use dummy pair unless
+    // env itself is deliberately configured with dummy keys (tests).
+    if (
+      siteIsDummy &&
+      configuredSiteKey?.trim() &&
+      configuredSiteKey.trim() !== TURNSTILE_ALWAYS_PASS_SITE_KEY
+    ) {
+      return {
+        ok: false,
+        reason: 'allowlisted_host_must_not_swap_away_from_configured_real_keys',
+      };
+    }
+  }
+
+  return { ok: true };
+}

--- a/apps/web/lib/turnstile/verify.ts
+++ b/apps/web/lib/turnstile/verify.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { env } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
+import { resolveTurnstileSecretKey } from '@/lib/turnstile/keys';
 
 /**
  * Cloudflare Turnstile siteverify helper (JOV-2132).
@@ -11,6 +12,11 @@ import { captureError } from '@/lib/error-tracking';
  * skip verification (the session cookie carries the trust forward).
  *
  * Docs: https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
+ *
+ * Hostname-aware secret selection (preview/localhost → dummy secret) must
+ * match client sitekey resolution in `lib/turnstile/keys.ts` so Vercel
+ * preview hosts do not fail with domain error 110200 while still keeping
+ * real keys on jov.ie / staging.jov.ie.
  */
 
 const VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
@@ -34,10 +40,8 @@ interface SiteverifyResponse {
   readonly cdata?: string;
 }
 
-function getSecretKey(): string | null {
-  const key = env.TURNSTILE_SECRET_KEY;
-  if (!key) return null;
-  return key;
+function getSecretKey(hostname?: string | null): string | null {
+  return resolveTurnstileSecretKey(hostname, env.TURNSTILE_SECRET_KEY);
 }
 
 type AttemptOutcome =
@@ -99,17 +103,20 @@ async function attemptVerify(
  *
  * @param token The token submitted by the client.
  * @param remoteIp The visitor's IP address (optional but recommended).
+ * @param hostname Request hostname — used to pair preview hosts with the
+ *   always-pass dummy secret (must match client sitekey selection).
  * @returns `{ success: true }` on valid token; `{ success: false, errorCodes, reason }` otherwise.
  */
 export async function verifyTurnstileToken(
   token: string | undefined | null,
-  remoteIp?: string | null
+  remoteIp?: string | null,
+  hostname?: string | null
 ): Promise<TurnstileVerifyResult> {
   if (!token || token.length === 0) {
     return { success: false, reason: 'missing_token' };
   }
 
-  const secretKey = getSecretKey();
+  const secretKey = getSecretKey(hostname);
   if (!secretKey) {
     return { success: false, reason: 'turnstile_not_configured' };
   }
@@ -144,11 +151,15 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * True when Turnstile is enabled in the current environment. The chat route
- * uses this to skip the gate cleanly when the secret isn't configured (e.g.
- * branch deploys without the env wired up yet).
+ * uses this to fail closed when the secret isn't configured (e.g. branch
+ * deploys without the env wired up yet).
+ *
+ * Configuration is based on the raw env secret existing — hostname only
+ * selects which secret value is used at verify time, not whether the gate
+ * is active.
  */
 export function isTurnstileConfigured(): boolean {
-  return getSecretKey() !== null;
+  return getSecretKey(null) !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary
**P0 signup block:** Cloudflare Turnstile **110200** on preview hosts like `jovie-timwhite-jovie.vercel.app` when a **production domain-locked sitekey** is mounted.

## Fix
- Canonical hostname-aware resolver: `lib/turnstile/keys.ts`
  - `*.vercel.app` / localhost → Cloudflare **always-pass dummy pair**
  - `jov.ie` / `www` / `staging` / `main` → real configured keys (bot protection intact)
- Client widget + server `verifyTurnstileToken(..., hostname)` use the same policy
- `assertTurnstileClientServerPairCompatible` + unit matrix so sitekey/secret mismatch cannot silently form

## Guardrails / coverage
- 35 unit tests on key resolution + pair compatibility (incl. user host `jovie-timwhite-jovie.vercel.app`)
- Existing verify + OnboardingTurnstile tests green

## Test plan
- [x] `vitest lib/turnstile/keys.test.ts` (35)
- [x] `vitest lib/turnstile/verify.test.ts` (15)
- [x] `vitest OnboardingTurnstile.test.tsx` (10)
- [ ] CI
- [ ] Manual: open preview `/start` onboarding — no 110200 toast; message sends

## Out of scope
- Cloudflare dashboard allowlist fire drill (code path no longer requires preview hosts on prod widget)