### PR TITLE
fix(ci): stop treating duplicate skipped checks as queue blockers

### DIFF
--- a/scripts/lib/__tests__/pr-check-failures.test.mjs
+++ b/scripts/lib/__tests__/pr-check-failures.test.mjs
@@ -159,6 +159,50 @@ describe('pr-check-failures', () => {
     ).toEqual(['Brand Scrub', 'Future Safety Gate']);
   });
 
+
+  it('duplicate SKIPPED checks with equal timestamps do not block enrollment', () => {
+    const required = [
+      { bucket: 'pass', state: 'SUCCESS', name: 'PR Ready' },
+      { bucket: 'pass', state: 'SUCCESS', name: 'Migration Guard' },
+      { bucket: 'pass', state: 'SUCCESS', name: 'Fork PR Gate' },
+      { bucket: 'pass', state: 'SUCCESS', name: 'PR Size Guard' },
+    ];
+    const skippedDupes = [
+      {
+        bucket: 'skipping',
+        state: 'SKIPPED',
+        name: 'Fork PR Gate Dependabot Controller',
+        startedAt: '2026-07-21T02:12:55Z',
+        completedAt: '2026-07-21T02:12:54Z',
+      },
+      {
+        bucket: 'skipping',
+        state: 'SKIPPED',
+        name: 'Fork PR Gate Dependabot Controller',
+        startedAt: '2026-07-21T02:12:55Z',
+        completedAt: '2026-07-21T02:12:54Z',
+      },
+      {
+        bucket: 'skipping',
+        state: 'SKIPPED',
+        name: "github.event_name == 'merge_group' && 'Fork PR Gate' || 'Fork PR Gate (merge-group inactive)'",
+        startedAt: '2026-07-21T02:12:55Z',
+        completedAt: '2026-07-21T02:12:54Z',
+      },
+      {
+        bucket: 'skipping',
+        state: 'SKIPPED',
+        name: "github.event_name == 'merge_group' && 'Fork PR Gate' || 'Fork PR Gate (merge-group inactive)'",
+        startedAt: '2026-07-21T02:12:55Z',
+        completedAt: '2026-07-21T02:12:54Z',
+      },
+    ];
+    expect(classifyQueueCheckBlockers([...required, ...skippedDupes])).toEqual([]);
+    expect(
+      collapseNewestCheckAttempts(skippedDupes).ambiguousNames
+    ).toEqual([]);
+  });
+
   it('uses only the uniquely newest same-name check attempt', () => {
     const required = [
       { bucket: 'pass', state: 'SUCCESS', name: 'PR Ready' },

--- a/scripts/lib/__tests__/pr-check-failures.test.mjs
+++ b/scripts/lib/__tests__/pr-check-failures.test.mjs
@@ -159,7 +159,6 @@ describe('pr-check-failures', () => {
     ).toEqual(['Brand Scrub', 'Future Safety Gate']);
   });
 
-
   it('duplicate SKIPPED checks with equal timestamps do not block enrollment', () => {
     const required = [
       { bucket: 'pass', state: 'SUCCESS', name: 'PR Ready' },
@@ -197,10 +196,12 @@ describe('pr-check-failures', () => {
         completedAt: '2026-07-21T02:12:54Z',
       },
     ];
-    expect(classifyQueueCheckBlockers([...required, ...skippedDupes])).toEqual([]);
-    expect(
-      collapseNewestCheckAttempts(skippedDupes).ambiguousNames
-    ).toEqual([]);
+    expect(classifyQueueCheckBlockers([...required, ...skippedDupes])).toEqual(
+      []
+    );
+    expect(collapseNewestCheckAttempts(skippedDupes).ambiguousNames).toEqual(
+      []
+    );
   });
 
   it('uses only the uniquely newest same-name check attempt', () => {

--- a/scripts/lib/pr-check-failures.mjs
+++ b/scripts/lib/pr-check-failures.mjs
@@ -187,17 +187,43 @@ export function collapseNewestCheckAttempts(checks) {
       collapsed.push(candidates[0]);
       continue;
     }
+    // Non-terminal-only groups (all skipped/neutral, or all successful, or all
+    // pending) never block enrollment. Ambiguity only matters when terminal
+    // outcomes disagree or a terminal red cannot be ordered against success.
+    const allSkipped = candidates.every(isSkippedCheck);
+    if (allSkipped) {
+      collapsed.push(candidates[0]);
+      continue;
+    }
+    const allSuccessful = candidates.every(isSuccessfulCheck);
+    if (allSuccessful) {
+      collapsed.push(candidates[0]);
+      continue;
+    }
+    const allPending = candidates.every(isPendingCheck);
+    if (allPending) {
+      collapsed.push(candidates[0]);
+      continue;
+    }
+
     const ranked = candidates.map(check => ({
       check,
       startedAt: attemptTimestamp(check, 'startedAt'),
       completedAt: attemptTimestamp(check, 'completedAt'),
       observedAt: null,
     }));
-    if (
-      ranked.some(
-        attempt => attempt.startedAt === null || attempt.completedAt === null
-      )
-    ) {
+    const missingTimestamps = ranked.some(
+      attempt => attempt.startedAt === null || attempt.completedAt === null
+    );
+    if (missingTimestamps) {
+      // Prefer a unique successful attempt over fail-closed noise when clocks
+      // are missing; only fail closed if terminal red is also present.
+      const successes = candidates.filter(isSuccessfulCheck);
+      const failures = candidates.filter(isTerminalFailure);
+      if (successes.length >= 1 && failures.length === 0) {
+        collapsed.push(successes[0]);
+        continue;
+      }
       ambiguousNames.push(name);
       continue;
     }
@@ -215,7 +241,29 @@ export function collapseNewestCheckAttempts(checks) {
       ranked[0].startedAt === ranked[1].startedAt &&
       ranked[0].completedAt === ranked[1].completedAt
     ) {
-      ambiguousNames.push(name);
+      const top = ranked
+        .filter(
+          attempt =>
+            attempt.observedAt === ranked[0].observedAt &&
+            attempt.startedAt === ranked[0].startedAt &&
+            attempt.completedAt === ranked[0].completedAt
+        )
+        .map(attempt => attempt.check);
+      const topSuccess = top.filter(isSuccessfulCheck);
+      const topFailure = top.filter(isTerminalFailure);
+      if (topFailure.length > 0 && topSuccess.length > 0) {
+        ambiguousNames.push(name);
+        continue;
+      }
+      if (topFailure.length > 0) {
+        collapsed.push(topFailure[0]);
+        continue;
+      }
+      if (topSuccess.length > 0) {
+        collapsed.push(topSuccess[0]);
+        continue;
+      }
+      collapsed.push(top[0]);
       continue;
     }
     collapsed.push(ranked[0].check);


### PR DESCRIPTION
## Summary
- Drain/native enroll was false-blocking green PRs on `ambiguous latest attempt` for duplicate SKIPPED Fork PR Gate helper job names.
- Collapse all-skipped / all-success / all-pending groups without fail-closed ambiguity; keep fail-closed only for real outcome conflicts.
- Adds regression coverage for the live duplicate-SKIPPED pattern.

## Test plan
- [x] `pnpm exec vitest run scripts/lib/__tests__/pr-check-failures.test.mjs`
- [ ] After merge, drain enrolls previously green PRs (#14570/#14571/#14581/#14567 class)