### PR TITLE
fix(dev-env): dev DB migration drift detection + pre-push SIGPIPE (ssh idle) fixes

### DIFF
--- a/.claude/rules/db.md
+++ b/.claude/rules/db.md
@@ -10,6 +10,8 @@ Single driver policy, immutable migrations, transaction discipline.
 
 The `file-protection-check.sh` hook blocks edits to existing migration files.
 
+`pnpm db:migrate` trusts the `drizzle.__drizzle_migrations` ledger and can report "up to date" on a drifted database; run `pnpm --filter @jovie/web run db:verify` (also wired into `scripts/setup.sh`) to compare the ledger against the journal and get repair steps.
+
 For migration creation/run details: `docs/DB_MIGRATIONS.md`.
 
 ## Database Access (Single Driver Policy)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,4 +8,9 @@ set -e  # Required: ensures pre-push-gate.sh failure actually blocks pushes
 # AUTOMATION_VERIFY_MAX_WORKERS overrides.
 export AUTOMATION_VERIFY_MAX_WORKERS="${AUTOMATION_VERIFY_MAX_WORKERS:-1}"
 
+# NOTE: git holds the ssh receive-pack connection open across this hook.
+# GitHub kills it after ~10 idle minutes, and a long gate then surfaces as
+# `git push` dying with SIGPIPE (exit 141) right after the last check —
+# scripts/setup.sh sets core.sshCommand keepalives to prevent that.
+
 bash scripts/hooks/pre-push-gate.sh affected

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -146,6 +146,7 @@
     "audit:icons": "node scripts/audit-icons.js",
     "danger": "danger ci --fail-on-errors --verbose",
     "db:migrate": "doppler run -- tsx scripts/drizzle-migrate.ts",
+    "db:verify": "doppler run -- tsx scripts/verify-db-migrations.ts",
     "db:seed": "doppler run -- tsx scripts/drizzle-seed.ts",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "doppler run -- tsx scripts/drizzle-migrate.ts",

--- a/apps/web/scripts/verify-db-migrations.test.ts
+++ b/apps/web/scripts/verify-db-migrations.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeMigrationDrift,
+  hashMigrationSql,
+} from './verify-db-migrations';
+
+const entry = (idx: number, tag: string, hash: string, when = idx * 1000) => ({
+  idx,
+  tag,
+  when,
+  hash,
+});
+
+describe('hashMigrationSql', () => {
+  it('matches the drizzle-orm migrator hash (sha256 of file contents)', () => {
+    // sha256("SELECT 1;") computed independently via `shasum -a 256`
+    expect(hashMigrationSql('SELECT 1;')).toBe(
+      '17db4fd369edb9244b9f91d9aeed145c3d04ad8ba6e95d06247f07a63527d11a'
+    );
+  });
+});
+
+describe('computeMigrationDrift', () => {
+  it('reports ok when journal and ledger match', () => {
+    const journal = [entry(1, '0001_a', 'h1'), entry(2, '0002_b', 'h2')];
+    const applied = [
+      { hash: 'h1', created_at: 1000 },
+      { hash: 'h2', created_at: 2000 },
+    ];
+
+    const report = computeMigrationDrift(journal, applied);
+
+    expect(report.ok).toBe(true);
+    expect(report.missing).toEqual([]);
+    expect(report.unexpected).toEqual([]);
+    expect(report.journalCount).toBe(2);
+    expect(report.ledgerCount).toBe(2);
+  });
+
+  it('flags journal entries missing from the ledger', () => {
+    const journal = [
+      entry(1, '0001_a', 'h1'),
+      entry(2, '0002_b', 'h2'),
+      entry(3, '0003_c', 'h3'),
+    ];
+    const applied = [{ hash: 'h1', created_at: 1000 }];
+
+    const report = computeMigrationDrift(journal, applied);
+
+    expect(report.ok).toBe(false);
+    expect(report.missing.map(m => m.tag)).toEqual(['0002_b', '0003_c']);
+    expect(report.unexpected).toEqual([]);
+  });
+
+  it('flags ledger rows that match no journal entry', () => {
+    const journal = [entry(1, '0001_a', 'h1')];
+    const applied = [
+      { hash: 'h1', created_at: 1000 },
+      { hash: 'stale', created_at: 999 },
+    ];
+
+    const report = computeMigrationDrift(journal, applied);
+
+    expect(report.ok).toBe(false);
+    expect(report.missing).toEqual([]);
+    expect(report.unexpected).toEqual([{ hash: 'stale', created_at: 999 }]);
+  });
+
+  it('handles interleaved drift like the 2026-07 dev DB incident', () => {
+    // 0033/0034 applied out of band: journal has them, ledger skips them.
+    const journal = [
+      entry(32, '0032_tricky_thing', 'h32'),
+      entry(33, '0033_wet_zzzax', 'h33'),
+      entry(34, '0034_youthful_white_queen', 'h34'),
+      entry(35, '0035_tranquil_stephen_strange', 'h35'),
+    ];
+    const applied = [
+      { hash: 'h32', created_at: 32000 },
+      { hash: 'h35', created_at: 35000 },
+    ];
+
+    const report = computeMigrationDrift(journal, applied);
+
+    expect(report.ok).toBe(false);
+    expect(report.missing.map(m => m.tag)).toEqual([
+      '0033_wet_zzzax',
+      '0034_youthful_white_queen',
+    ]);
+  });
+});

--- a/apps/web/scripts/verify-db-migrations.ts
+++ b/apps/web/scripts/verify-db-migrations.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env npx tsx
+/* eslint-disable @jovie/no-manual-db-pooling -- standalone script */
+/**
+ * Migration Drift Verification Script
+ *
+ * Compares the Drizzle migration journal
+ * (drizzle/migrations/meta/_journal.json + per-file SHA-256 hashes, the same
+ * hash drizzle-orm's migrator writes) against the database's
+ * drizzle.__drizzle_migrations ledger. Fails loudly when they disagree —
+ * `pnpm db:migrate` trusts the ledger and will report "up to date" even when
+ * migrations were never applied, so this is the only early warning.
+ *
+ * Usage:
+ *   pnpm run db:verify
+ *   npx tsx scripts/verify-db-migrations.ts
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { neonConfig, Pool } from '@neondatabase/serverless';
+import ws from 'ws';
+
+neonConfig.webSocketConstructor = ws;
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const webRootDir = path.resolve(scriptDir, '..');
+const migrationsDir = path.join(webRootDir, 'drizzle', 'migrations');
+
+export interface JournalEntry {
+  idx: number;
+  tag: string;
+  when: number;
+}
+
+export interface AppliedMigration {
+  hash: string;
+  created_at: number;
+}
+
+export interface MissingMigration {
+  idx: number;
+  tag: string;
+  hash: string;
+}
+
+export interface DriftReport {
+  ok: boolean;
+  journalCount: number;
+  ledgerCount: number;
+  /** Journal entries whose file hash has no row in the ledger. */
+  missing: MissingMigration[];
+  /** Ledger rows whose hash matches no journal entry file. */
+  unexpected: AppliedMigration[];
+}
+
+export function hashMigrationSql(sql: string): string {
+  return createHash('sha256').update(sql).digest('hex');
+}
+
+export function computeMigrationDrift(
+  journal: (JournalEntry & { hash: string })[],
+  applied: AppliedMigration[]
+): DriftReport {
+  const appliedHashes = new Set(applied.map(row => row.hash));
+  const journalHashes = new Set(journal.map(entry => entry.hash));
+
+  const missing = journal.filter(entry => !appliedHashes.has(entry.hash));
+  const unexpected = applied.filter(row => !journalHashes.has(row.hash));
+
+  return {
+    ok: missing.length === 0 && unexpected.length === 0,
+    journalCount: journal.length,
+    ledgerCount: applied.length,
+    missing,
+    unexpected,
+  };
+}
+
+export function readJournalWithHashes(): (JournalEntry & {
+  hash: string;
+})[] {
+  const journalPath = path.join(migrationsDir, 'meta', '_journal.json');
+  const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as {
+    entries: JournalEntry[];
+  };
+
+  return journal.entries.map(entry => {
+    const sql = readFileSync(
+      path.join(migrationsDir, `${entry.tag}.sql`),
+      'utf8'
+    );
+    return { ...entry, hash: hashMigrationSql(sql) };
+  });
+}
+
+async function fetchAppliedMigrations(
+  databaseUrl: string
+): Promise<AppliedMigration[]> {
+  const pool = new Pool({ connectionString: databaseUrl });
+  try {
+    const result = await pool.query<AppliedMigration>(
+      'SELECT hash, created_at FROM drizzle.__drizzle_migrations ORDER BY created_at'
+    );
+    return result.rows;
+  } finally {
+    await pool.end();
+  }
+}
+
+function printReport(report: DriftReport): void {
+  console.log(
+    `Journal entries: ${report.journalCount} | ledger rows: ${report.ledgerCount}`
+  );
+
+  if (report.ok) {
+    console.log(
+      '✓ Migration ledger matches the drizzle journal — no drift detected'
+    );
+    return;
+  }
+
+  console.error('✗ Migration drift detected:');
+  for (const entry of report.missing) {
+    console.error(
+      `  MISSING from database: ${entry.tag} (idx ${entry.idx}, hash ${entry.hash.slice(0, 12)}…)`
+    );
+  }
+  for (const row of report.unexpected) {
+    console.error(
+      `  NOT IN JOURNAL: hash ${row.hash.slice(0, 12)}… (created_at ${row.created_at})`
+    );
+  }
+  console.error('');
+  console.error(
+    'The drizzle migrator trusts the ledger and will report "up to date"'
+  );
+  console.error('even though these migrations never ran. To repair:');
+  console.error(
+    '  1. Apply each missing apps/web/drizzle/migrations/<tag>.sql manually'
+  );
+  console.error(
+    '     (they are written idempotently: IF NOT EXISTS / guarded DO blocks).'
+  );
+  console.error(
+    '  2. Insert the file SHA-256 into drizzle.__drizzle_migrations with the'
+  );
+  console.error('     journal `when` timestamp as created_at.');
+  console.error('  3. Re-run `pnpm run db:verify` until it passes.');
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('✗ DATABASE_URL environment variable is not set');
+    process.exit(1);
+  }
+
+  const journal = readJournalWithHashes();
+  const applied = await fetchAppliedMigrations(databaseUrl);
+  const report = computeMigrationDrift(journal, applied);
+  printReport(report);
+
+  if (!report.ok) {
+    process.exit(1);
+  }
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main().catch(error => {
+    console.error('✗ Migration verification failed to run:', error);
+    process.exit(1);
+  });
+}

--- a/scripts/lib/__tests__/pre-push-gate.test.mjs
+++ b/scripts/lib/__tests__/pre-push-gate.test.mjs
@@ -161,4 +161,17 @@ describe('pre-push gate Node and fanout wiring (JOV-4329)', () => {
       '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
     );
   });
+
+  it('wires ssh keepalives into setup so long gates do not SIGPIPE git push', () => {
+    // git push holds the ssh receive-pack connection open across the hook;
+    // GitHub closes idle connections (~10 min) and git then dies with exit
+    // 141 right after a long gate. setup.sh must set core.sshCommand
+    // keepalives, and the hook must document why they matter.
+    const setupSh = readFileSync(resolve(repoRoot, 'scripts/setup.sh'), 'utf8');
+    expect(setupSh).toContain(
+      'ssh -o ServerAliveInterval=60 -o ServerAliveCountMax=10'
+    );
+    expect(setupSh).toContain('config core.sshCommand');
+    expect(huskyPrePush).toContain('SIGPIPE');
+  });
 });

--- a/scripts/security/scan-secrets.sh
+++ b/scripts/security/scan-secrets.sh
@@ -140,12 +140,14 @@ run_trufflehog_pre_commit() {
   fi
 
   echo "Running trufflehog filesystem on ${#staged_files[@]} staged file(s)..."
+  # No $(trufflehog_exclude_args) here: --exclude-globs only exists in
+  # trufflehog's git mode (filesystem mode rejects it), and exclusions are
+  # already applied above via is_trufflehog_excluded when building the list.
   # shellcheck disable=SC2048,SC2086
   "$TRUFFLEHOG_BIN" filesystem \
     ${staged_files[@]} \
     --no-verification \
-    --fail \
-    $(trufflehog_exclude_args)
+    --fail
 }
 
 # trufflehog `git file://…` internally clones the local repo. On persistent

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -610,6 +610,24 @@ else
   info "Skipping Clerk ID sync (Doppler not configured)"
 fi
 
+# ─── Git ssh keepalive (pre-push gate) ───────────────────────────────────────
+# git push holds the ssh receive-pack connection open across the pre-push
+# hook. GitHub closes idle connections (~10 min); when the gate runs longer,
+# the connection dies and git exits with SIGPIPE (141) right after the gate.
+# Protocol-level keepalives keep the connection alive during long gates.
+echo ""
+echo "── Git ssh keepalive ───────────────────────────────────────────────"
+SSH_KEEPALIVE_CMD="ssh -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+CURRENT_SSH_COMMAND="$(git -C "$REPO_ROOT" config --get core.sshCommand || true)"
+if [[ -z "$CURRENT_SSH_COMMAND" ]]; then
+  git -C "$REPO_ROOT" config core.sshCommand "$SSH_KEEPALIVE_CMD"
+  success "core.sshCommand set (keeps pushes alive across the pre-push gate)"
+elif [[ "$CURRENT_SSH_COMMAND" == "$SSH_KEEPALIVE_CMD" ]]; then
+  success "core.sshCommand keepalive already configured"
+else
+  info "core.sshCommand already set ($CURRENT_SSH_COMMAND) — leaving as-is"
+fi
+
 # ─── 9. Migration drift check ────────────────────────────────────────────────
 # `pnpm db:migrate` trusts the drizzle.__drizzle_migrations ledger and reports
 # "up to date" even when migrations never ran (dev DB drift, 2026-07). Catch

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -610,6 +610,22 @@ else
   info "Skipping Clerk ID sync (Doppler not configured)"
 fi
 
+# ─── 9. Migration drift check ────────────────────────────────────────────────
+# `pnpm db:migrate` trusts the drizzle.__drizzle_migrations ledger and reports
+# "up to date" even when migrations never ran (dev DB drift, 2026-07). Catch
+# that at setup time by comparing the ledger against the drizzle journal.
+echo ""
+echo "── Migration drift check ─────────────────────────────────────────────"
+if command -v doppler &>/dev/null && "${DOPPLER_LOCAL_RUN[@]}" echo "ok" &>/dev/null 2>&1; then
+  if (cd "$REPO_ROOT/apps/web" && "${DOPPLER_LOCAL_RUN[@]}" pnpm tsx scripts/verify-db-migrations.ts); then
+    success "Database migrations match the drizzle journal"
+  else
+    warn "Migration drift detected — run \`pnpm --filter @jovie/web run db:verify\` for the repair steps"
+  fi
+else
+  info "Skipping migration drift check (Doppler not configured)"
+fi
+
 # ─── Final status ────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────────────────────────────────────"


### PR DESCRIPTION
## Description

Two repo-hygiene fixes for recurring local-dev failures, plus one pre-commit blocker fix discovered along the way.

### 1. Dev DB migration drift: repaired + `db:verify` prevention

The dev database's `drizzle.__drizzle_migrations` ledger had drifted from the drizzle journal: **8 journal entries were never recorded** (0033, 0034, 0044, 0067_ai_crawler_analytics, 0068, 0069, 0070, 0071) and **7 stale hash rows** pointed at file versions that no longer exist (e.g. 0004 was edited in-place after being applied). Some objects from *recorded* migrations (0030's `audience_actions`, `audience_referrers`, `audience_members.latest_referrer_url`) were also missing. `pnpm db:migrate` reported "up to date" because it trusts the ledger.

**Dev DB repair (already applied; exact statements in PR comments):** re-applied 0030, applied the 8 missing migration files (all idempotent), inserted the 8 missing ledger rows with their journal `when` timestamps, deleted the 7 stale rows. Ledger now matches the journal exactly (83/83).

**Prevention:** new `apps/web/scripts/verify-db-migrations.ts` exposed as `pnpm --filter @jovie/web run db:verify` — compares journal entries (per-file SHA-256, same hash drizzle's migrator writes) against the ledger and exits 1 with concrete repair steps on drift. Wired into `scripts/setup.sh` (non-blocking warn, matches existing conventions) and documented in `.claude/rules/db.md`.

### 2. `git push` dies with SIGPIPE (141) after the pre-push gate

**Root cause (reproduced):** git push over ssh opens the `git-receive-pack` connection **before** running the pre-push hook and holds it idle while the gate runs. GitHub closes idle connections (~10 min); when the gate outlasts that, git's first write after the hook hits a dead pipe and the push dies with exit 141 right after the final check — while the gate passes standalone and `JOVIE_SKIP_PRE_PUSH_GATE=1` "fixes" it only by shrinking the idle window. The stdin hypothesis was tested and **refuted** (git 2.50.1 tolerates hooks that never read/close stdin, even with 3000 refs).

Controlled A/B against origin with a 13-minute sleep hook:
- no keepalive → `Connection to github.com closed by remote host` → **exit 141**
- `ServerAliveInterval=30` → pack sent, branch created → **exit 0**

**Fix:** `scripts/setup.sh` now sets `core.sshCommand` to `ssh -o ServerAliveInterval=60 -o ServerAliveCountMax=10` (only when unset; existing user config is left alone), and `.husky/pre-push` documents the failure mode.

### 3. Pre-commit blocker: trufflehog `--exclude-globs` in filesystem mode

`#14550` added `--exclude-globs` to the pre-commit **filesystem** invocation, but trufflehog only supports that flag in `git` mode — every local commit failed with `unknown long flag '--exclude-globs'`. The flag is redundant there (staged files are already filtered via `is_trufflehog_excluded`), so it's removed from the filesystem rung. Unblocks all local commits.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (maintenance, dependencies, etc.)

## Testing

- [x] Unit tests pass (`verify-db-migrations.test.ts`: 5 tests; `pre-push-gate.test.mjs`: 11 tests; `scan-secrets.test.sh`: pass)
- [x] Manual testing completed (see below)
- [x] New tests added (if applicable)

### Bug-to-Test Rule (required for bug fixes)

- [x] Regression test added or updated (`apps/web/scripts/verify-db-migrations.test.ts`; ssh-keepalive contract test in `scripts/lib/__tests__/pre-push-gate.test.mjs`)
- [x] `bug-to-test: satisfied` noted in this PR description

bug-to-test: satisfied

**Manual verification:**
- `db:verify` on the repaired dev DB: `Journal entries: 83 | ledger rows: 83 — no drift detected`; `pnpm db:migrate` completes cleanly
- Dev server on :3107, `/tim` → 200, zero console errors, zero non-2xx network responses (gstack browse)
- This branch was pushed through the **unmodified** pre-push hook path (full gate: lint, affected typecheck, 2288 affected tests, ci:harness) with the keepalive fix → **exit 0** (the same push previously reproduced exit 141)

## Icon Usage Standards

Not applicable — no icon usage.
