### PR TITLE
fix(update-banner): "New Version Available" toast shows v0.0.0 instead of real release version

### DIFF
--- a/apps/web/app/api/health/build-info/route.ts
+++ b/apps/web/app/api/health/build-info/route.ts
@@ -9,7 +9,11 @@ export const dynamic = 'force-dynamic';
 let _cachedBuildId: string | undefined;
 
 export function GET() {
-  const version = env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
+  // Read directly from process.env (not the dynamic `env` proxy) so Next.js
+  // inlines the build-time value from version.json (next.config.js `env`
+  // block) into this bundle. Dynamic access via the proxy is not inlined and
+  // resolves to undefined at runtime, surfacing as "v0.0.0" (JOV-3459).
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || '0.0.0';
   const environment = env.VERCEL_ENV;
   const isDevelopment = env.NODE_ENV !== 'production';
   const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim().slice(0, 7);

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -63,6 +63,18 @@ export interface UnifiedSidebarProps {
 const VERSION_DISMISSAL_KEY = 'jovie-version-update-dismissed';
 const VERSION_NOTIFICATION_DELAY_MS = 10_000;
 
+/**
+ * Title for the update banner. Omits the version parenthetical when the
+ * incoming version is missing or the unresolved '0.0.0' placeholder so the
+ * banner never advertises a bogus release (JOV-3459).
+ */
+export function getVersionUpdateTitle(info: VersionMismatchInfo): string {
+  const version = info.newVersion?.trim();
+  return version && version !== '0.0.0'
+    ? `New Version Available (v${version})`
+    : 'New Version Available';
+}
+
 /** Render a group of nav items */
 function SettingsNavGroup({
   items,
@@ -352,9 +364,7 @@ function ShellSidebarInstallBanner() {
     return null;
   }
 
-  const title = versionUpdate.newVersion
-    ? `New Version Available (v${versionUpdate.newVersion})`
-    : 'New Version Available';
+  const title = getVersionUpdateTitle(versionUpdate);
 
   return (
     <InstallBanner

--- a/apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts
+++ b/apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getVersionUpdateTitle } from '@/components/organisms/UnifiedSidebar';
+
+describe('getVersionUpdateTitle', () => {
+  it('includes the incoming release version when available', () => {
+    expect(
+      getVersionUpdateTitle({
+        previousBuildId: 'a',
+        currentBuildId: 'b',
+        newVersion: '26.6.61',
+      })
+    ).toBe('New Version Available (v26.6.61)');
+  });
+
+  it('omits the version parenthetical when version is missing', () => {
+    expect(
+      getVersionUpdateTitle({ previousBuildId: 'a', currentBuildId: 'b' })
+    ).toBe('New Version Available');
+  });
+
+  it('never renders the unresolved v0.0.0 placeholder (JOV-3459)', () => {
+    expect(
+      getVersionUpdateTitle({
+        previousBuildId: 'a',
+        currentBuildId: 'b',
+        newVersion: '0.0.0',
+      })
+    ).toBe('New Version Available');
+  });
+
+  it('treats blank versions as unavailable', () => {
+    expect(
+      getVersionUpdateTitle({
+        previousBuildId: 'a',
+        currentBuildId: 'b',
+        newVersion: '   ',
+      })
+    ).toBe('New Version Available');
+  });
+});

--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -77,4 +77,27 @@ describe('@critical GET /api/health/build-info', () => {
     const body = await response.json();
     expect(body.buildId).toBe('development');
   });
+
+  it('returns the build-time app version instead of the 0.0.0 fallback (JOV-3459)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '26.6.61');
+
+    const { GET } = await import('@/app/api/health/build-info/route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(body.version).toBe('26.6.61');
+    expect(body.version).not.toBe('0.0.0');
+  });
+
+  it('falls back to 0.0.0 only when no app version is configured', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '');
+
+    const { GET } = await import('@/app/api/health/build-info/route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(body.version).toBe('0.0.0');
+  });
 });


### PR DESCRIPTION
## Summary

The in-app update banner rendered **(v0.0.0)** on every deploy. Root cause: `/api/health/build-info` read the app version through the dynamic `env` proxy (`process.env[prop]`), which Next.js cannot inline at build time — so `NEXT_PUBLIC_APP_VERSION` (set from canonical `version.json` via the `next.config.js` `env` block) resolved to `undefined` at runtime and the route returned its `"0.0.0"` fallback.

Changes:

- `apps/web/app/api/health/build-info/route.ts` — read `process.env.NEXT_PUBLIC_APP_VERSION` directly so the build-time value from `version.json` is inlined into the server bundle (same pattern `UserButton.tsx` already relies on). Empty string also falls back now (`||` instead of `??`).
- `apps/web/components/organisms/UnifiedSidebar.tsx` — extracted `getVersionUpdateTitle()`; the banner omits the version parenthetical when the incoming version is missing, blank, or the unresolved `0.0.0` placeholder, so it can never print "v0.0.0" again.

## Test plan / results

- `pnpm --filter web exec vitest run tests/unit/api/health/build-info.critical.test.ts components/organisms/UnifiedSidebar.version-banner.test.ts` — **10/10 pass** (new: route returns configured version instead of 0.0.0; banner title never renders v0.0.0 / blank / missing versions)
- `pnpm --filter web exec vitest run tests/unit/components/organisms/UnifiedSidebar.library.test.tsx` — 4/4 pass (no regression)
- `pnpm --filter @jovie/web run typecheck` — clean
- `pnpm biome check --write <touched files>` — clean
- Pre-commit hooks (secret scan, lint-staged, a11y, typecheck) — all green

Runtime impact: +2 fast unit-test files; no E2E added.

Fixes JOV-3459