### PR TITLE
fix(onboarding): require auth ownership before handle reservation

### DIFF
--- a/apps/web/app/api/onboarding/claim/route.ts
+++ b/apps/web/app/api/onboarding/claim/route.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db';
 import { chatAuditLog, chatConversations } from '@/lib/db/schema/chat';
 import { captureError } from '@/lib/error-tracking';
 import { materializeClaimedOnboardingProfile } from '@/lib/onboarding/claim-profile';
+import { isOnboardingOwnershipError } from '@/lib/onboarding/ownership-gate';
 import {
   clearOnboardingSessionCookie,
   getCurrentOnboardingSessionId,
@@ -182,6 +183,19 @@ export async function POST(req: Request) {
         ...profilePayload(profile),
       });
     } catch (error) {
+      // Ownership gate: unauthenticated / non-owner / missing conversation.
+      // Fail closed — never surface reserved / locked-in success without verify.
+      if (isOnboardingOwnershipError(error)) {
+        logger.warn('[onboarding/claim] ownership gate rejected claim', {
+          errorCode: error.errorCode,
+          sessionId: `${sessionId.slice(0, 8)}…`,
+        });
+        return NextResponse.json(
+          { error: error.message, errorCode: error.errorCode },
+          { status: error.status }
+        );
+      }
+
       // Unique-constraint violation on the partial index = this sessionId was
       // already claimed onto a different user. Surface a friendly 409.
       const message = error instanceof Error ? error.message.toLowerCase() : '';

--- a/apps/web/app/api/onboarding/discovery/route.ts
+++ b/apps/web/app/api/onboarding/discovery/route.ts
@@ -18,6 +18,10 @@ import {
   buildReadinessState,
   parseSpotifyImportStatus,
 } from '@/lib/onboarding/discovery-readiness';
+import {
+  assertOnboardingProfileOwner,
+  isOnboardingOwnershipError,
+} from '@/lib/onboarding/ownership-gate';
 import { getHometownFromSettings } from '@/types/db';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
@@ -88,7 +92,8 @@ export async function GET(request: Request) {
         spotifyUrl: creatorProfiles.spotifyUrl,
         appleMusicId: creatorProfiles.appleMusicId,
         onboardingCompletedAt: creatorProfiles.onboardingCompletedAt,
-        clerkId: users.clerkId,
+        // App users.id (getCachedAuth().userId is the same UUID post BA cutover).
+        ownerUserId: creatorProfiles.userId,
       })
       .from(creatorProfiles)
       .innerJoin(users, eq(users.id, creatorProfiles.userId))
@@ -102,11 +107,19 @@ export async function GET(request: Request) {
       );
     }
 
-    if (profile.clerkId !== userId) {
-      return NextResponse.json(
-        { error: 'Forbidden' },
-        { status: 403, headers: NO_STORE_HEADERS }
-      );
+    try {
+      assertOnboardingProfileOwner({
+        authenticatedUserId: userId,
+        profileOwnerUserId: profile.ownerUserId,
+      });
+    } catch (error) {
+      if (isOnboardingOwnershipError(error)) {
+        return NextResponse.json(
+          { error: 'Forbidden', errorCode: error.errorCode },
+          { status: error.status, headers: NO_STORE_HEADERS }
+        );
+      }
+      throw error;
     }
 
     const [

--- a/apps/web/components/features/onboarding/useOnboardingClaim.ts
+++ b/apps/web/components/features/onboarding/useOnboardingClaim.ts
@@ -114,8 +114,9 @@ export function useOnboardingClaim(claimTrigger = 0): ClaimStatus {
       }
       if (cancelled) return;
 
-      if (response.status === 401) {
-        // Clerk session expired between mount and request — bail silently.
+      if (response.status === 401 || response.status === 403) {
+        // Unauthenticated or non-owner — ownership gate fails closed; no
+        // reserved / locked-in / manage-as-owner success navigation.
         markTriggerCompleted();
         setStatus('error');
         return;

--- a/apps/web/lib/onboarding/claim-profile.ts
+++ b/apps/web/lib/onboarding/claim-profile.ts
@@ -19,6 +19,11 @@ import {
   type ClaimedOnboardingState,
   deriveClaimedOnboardingStateFromMessageRows,
 } from '@/lib/onboarding/claimed-state';
+import {
+  assertOnboardingProfileOwner,
+  describeArtistProfileForVisitor,
+  requireVerifiedOwnerForReservation,
+} from '@/lib/onboarding/ownership-gate';
 import { reserveOnboardingHandle } from '@/lib/onboarding/reserved-handle';
 import { normalizeUsername, validateUsername } from '@/lib/validation/username';
 
@@ -75,10 +80,13 @@ function pickInitialProfileHandle(
 
 async function reserveFallbackProfileHandle(
   state: ClaimedOnboardingState,
-  cleanedProposedHandle: string | null
+  cleanedProposedHandle: string | null,
+  userId: string
 ): Promise<string> {
+  // Fail closed: handle reservation success requires verified ownership.
   return reserveOnboardingHandle(
-    state.artist?.name ?? cleanedProposedHandle ?? 'artist'
+    state.artist?.name ?? cleanedProposedHandle ?? 'artist',
+    userId
   );
 }
 
@@ -285,9 +293,18 @@ async function persistClaimedProfileWithHandleRetry({
   const cleanedProposedHandle = pickInitialProfileHandle(proposedHandle);
   let handle =
     cleanedProposedHandle ??
-    (await reserveFallbackProfileHandle(state, cleanedProposedHandle));
+    (await reserveFallbackProfileHandle(state, cleanedProposedHandle, userId));
 
   for (let attempt = 0; attempt < HANDLE_CLAIM_MAX_ATTEMPTS; attempt++) {
+    // Existing profiles may only be claimed/updated by their verified owner.
+    // New profiles are created for this authenticated user (owner-to-be).
+    if (existingProfile) {
+      assertOnboardingProfileOwner({
+        authenticatedUserId: userId,
+        profileOwnerUserId: existingProfile.userId,
+      });
+    }
+
     const displayName =
       state.artist?.name ?? existingProfile?.displayName ?? handle;
 
@@ -311,7 +328,11 @@ async function persistClaimedProfileWithHandleRetry({
         throw error;
       }
 
-      handle = await reserveFallbackProfileHandle(state, cleanedProposedHandle);
+      handle = await reserveFallbackProfileHandle(
+        state,
+        cleanedProposedHandle,
+        userId
+      );
     }
   }
 
@@ -324,6 +345,28 @@ export async function materializeClaimedOnboardingProfile({
   ipAddress,
   userAgent,
 }: MaterializeClaimedOnboardingProfileInput): Promise<MaterializeClaimedOnboardingProfileResult> {
+  // Auth first (no DB): refuse anonymous materialize / reserve success.
+  const { userId: authenticatedUserId } = requireVerifiedOwnerForReservation({
+    userId,
+  });
+
+  // Conversation ownership: never materialize / "manage as owner" for a
+  // transcript the caller does not own.
+  const [conversation] = await db
+    .select({
+      id: chatConversations.id,
+      userId: chatConversations.userId,
+    })
+    .from(chatConversations)
+    .where(eq(chatConversations.id, conversationId))
+    .limit(1);
+
+  const { userId: verifiedUserId } = requireVerifiedOwnerForReservation({
+    userId: authenticatedUserId,
+    conversationExists: Boolean(conversation),
+    conversationUserId: conversation?.userId ?? null,
+  });
+
   const messageRows = await db
     .select({ toolCalls: chatMessages.toolCalls })
     .from(chatMessages)
@@ -335,7 +378,14 @@ export async function materializeClaimedOnboardingProfile({
     return { profileId: null, handle: null, status: 'skipped' };
   }
 
-  const existingProfile = await fetchExistingProfile(userId);
+  const existingProfile = await fetchExistingProfile(verifiedUserId);
+  if (existingProfile) {
+    assertOnboardingProfileOwner({
+      authenticatedUserId: verifiedUserId,
+      profileOwnerUserId: existingProfile.userId,
+    });
+  }
+
   const now = new Date();
   const settings = buildOnboardingSettings(
     existingProfile?.settings,
@@ -350,7 +400,7 @@ export async function materializeClaimedOnboardingProfile({
 
   const { profileId, handle, status } =
     await persistClaimedProfileWithHandleRetry({
-      userId,
+      userId: verifiedUserId,
       existingProfile,
       state,
       proposedHandle: state.handle,
@@ -362,12 +412,13 @@ export async function materializeClaimedOnboardingProfile({
   await db
     .update(users)
     .set({ activeProfileId: profileId, updatedAt: now })
-    .where(eq(users.id, userId));
+    .where(eq(users.id, verifiedUserId));
 
+  // "Manage as owner" claim row — only after verified ownership above.
   await db
     .insert(userProfileClaims)
     .values({
-      userId,
+      userId: verifiedUserId,
       creatorProfileId: profileId,
       role: 'owner',
     })
@@ -379,12 +430,17 @@ export async function materializeClaimedOnboardingProfile({
     .where(
       and(
         eq(chatConversations.id, conversationId),
-        eq(chatConversations.userId, userId)
+        eq(chatConversations.userId, verifiedUserId)
       )
     );
 
+  const artistLabel = describeArtistProfileForVisitor({
+    ownershipVerified: true,
+    artistName: state.artist?.name ?? null,
+  });
+
   await db.insert(chatAuditLog).values({
-    userId,
+    userId: verifiedUserId,
     creatorProfileId: profileId,
     conversationId,
     action: 'materialize_onboarding_profile',
@@ -396,6 +452,8 @@ export async function materializeClaimedOnboardingProfile({
       status,
       spotifyArtistId: state.artist?.id ?? null,
       spotifyArtistName: state.artist?.name ?? null,
+      // Neutral, ownership-verified label (never pre-verify "you" language).
+      artistProfileLabel: artistLabel,
     },
     ipAddress,
     userAgent,

--- a/apps/web/lib/onboarding/ownership-gate.test.ts
+++ b/apps/web/lib/onboarding/ownership-gate.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertAuthenticatedOnboardingUser,
+  assertConversationOwnedByUser,
+  assertOnboardingProfileOwner,
+  describeArtistProfileForVisitor,
+  isOnboardingOwnershipError,
+  OnboardingOwnershipError,
+  requireVerifiedOwnerForReservation,
+} from '@/lib/onboarding/ownership-gate';
+
+describe('onboarding ownership gate', () => {
+  describe('assertAuthenticatedOnboardingUser', () => {
+    it('throws UNAUTHORIZED for null, empty, or missing userId', () => {
+      for (const userId of [null, undefined, '', '   ']) {
+        try {
+          assertAuthenticatedOnboardingUser(userId);
+          expect.fail('expected throw');
+        } catch (error) {
+          expect(isOnboardingOwnershipError(error)).toBe(true);
+          expect((error as OnboardingOwnershipError).status).toBe(401);
+          expect((error as OnboardingOwnershipError).errorCode).toBe(
+            'UNAUTHORIZED'
+          );
+        }
+      }
+    });
+
+    it('accepts a non-empty authenticated userId', () => {
+      expect(() =>
+        assertAuthenticatedOnboardingUser('user_verified_1')
+      ).not.toThrow();
+    });
+  });
+
+  describe('assertOnboardingProfileOwner', () => {
+    it('blocks non-owners from manage-as-owner outcomes', () => {
+      try {
+        assertOnboardingProfileOwner({
+          authenticatedUserId: 'user_a',
+          profileOwnerUserId: 'user_b',
+        });
+        expect.fail('expected throw');
+      } catch (error) {
+        expect(isOnboardingOwnershipError(error)).toBe(true);
+        expect((error as OnboardingOwnershipError).status).toBe(403);
+        expect((error as OnboardingOwnershipError).errorCode).toBe('FORBIDDEN');
+      }
+    });
+
+    it('blocks unowned profiles (null owner) fail closed', () => {
+      expect(() =>
+        assertOnboardingProfileOwner({
+          authenticatedUserId: 'user_a',
+          profileOwnerUserId: null,
+        })
+      ).toThrow(OnboardingOwnershipError);
+    });
+
+    it('allows the verified owner', () => {
+      expect(() =>
+        assertOnboardingProfileOwner({
+          authenticatedUserId: 'user_a',
+          profileOwnerUserId: 'user_a',
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('assertConversationOwnedByUser', () => {
+    it('returns NOT_FOUND when conversation is missing', () => {
+      try {
+        assertConversationOwnedByUser({
+          authenticatedUserId: 'user_a',
+          conversationUserId: null,
+          conversationExists: false,
+        });
+        expect.fail('expected throw');
+      } catch (error) {
+        expect((error as OnboardingOwnershipError).status).toBe(404);
+        expect((error as OnboardingOwnershipError).errorCode).toBe('NOT_FOUND');
+      }
+    });
+
+    it('returns FORBIDDEN when conversation belongs to another user', () => {
+      try {
+        assertConversationOwnedByUser({
+          authenticatedUserId: 'user_a',
+          conversationUserId: 'user_b',
+          conversationExists: true,
+        });
+        expect.fail('expected throw');
+      } catch (error) {
+        expect((error as OnboardingOwnershipError).status).toBe(403);
+      }
+    });
+
+    it('allows when conversation is attached to the authenticated user', () => {
+      expect(() =>
+        assertConversationOwnedByUser({
+          authenticatedUserId: 'user_a',
+          conversationUserId: 'user_a',
+          conversationExists: true,
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('requireVerifiedOwnerForReservation', () => {
+    it('refuses anonymous reservation success', () => {
+      expect(() =>
+        requireVerifiedOwnerForReservation({ userId: null })
+      ).toThrow(/Sign in is required/);
+    });
+
+    it('returns verified userId for owner path', () => {
+      expect(
+        requireVerifiedOwnerForReservation({
+          userId: 'user_owner',
+          conversationExists: true,
+          conversationUserId: 'user_owner',
+        })
+      ).toEqual({ userId: 'user_owner' });
+    });
+  });
+
+  describe('describeArtistProfileForVisitor', () => {
+    it('uses neutral phrasing before ownership is verified', () => {
+      expect(
+        describeArtistProfileForVisitor({
+          ownershipVerified: false,
+          artistName: 'Luna Waves',
+        })
+      ).toBe('this artist profile (Luna Waves)');
+
+      expect(
+        describeArtistProfileForVisitor({
+          ownershipVerified: false,
+          artistName: null,
+        })
+      ).toBe('this artist profile');
+    });
+
+    it('names the artist only after ownership is verified', () => {
+      expect(
+        describeArtistProfileForVisitor({
+          ownershipVerified: true,
+          artistName: 'Luna Waves',
+        })
+      ).toBe("Luna Waves's profile");
+    });
+  });
+});

--- a/apps/web/lib/onboarding/ownership-gate.ts
+++ b/apps/web/lib/onboarding/ownership-gate.ts
@@ -1,0 +1,138 @@
+/**
+ * Server-side ownership gate for onboarding claim / handle reservation.
+ *
+ * Fail closed: unauthenticated callers and non-owners never get
+ * reserved / locked-in / "manage as owner" success outcomes.
+ *
+ * Pure helpers (no DB) so unit tests can import without server-only plumbing.
+ */
+
+export type OnboardingOwnershipErrorCode =
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND';
+
+export class OnboardingOwnershipError extends Error {
+  readonly code: OnboardingOwnershipErrorCode;
+  readonly status: 401 | 403 | 404;
+  readonly errorCode: OnboardingOwnershipErrorCode;
+
+  constructor(code: OnboardingOwnershipErrorCode, message: string) {
+    super(message);
+    this.name = 'OnboardingOwnershipError';
+    this.code = code;
+    this.errorCode = code;
+    this.status =
+      code === 'UNAUTHORIZED' ? 401 : code === 'FORBIDDEN' ? 403 : 404;
+  }
+}
+
+export function isOnboardingOwnershipError(
+  error: unknown
+): error is OnboardingOwnershipError {
+  return error instanceof OnboardingOwnershipError;
+}
+
+/**
+ * Require a non-empty authenticated app `users.id` before any claim,
+ * materialize, or handle-reservation success path.
+ */
+export function assertAuthenticatedOnboardingUser(
+  userId: string | null | undefined
+): asserts userId is string {
+  if (typeof userId !== 'string' || userId.trim().length === 0) {
+    throw new OnboardingOwnershipError(
+      'UNAUTHORIZED',
+      'Sign in is required before this artist profile can be reserved.'
+    );
+  }
+}
+
+/**
+ * Refuse "manage as owner" outcomes when the profile row is not owned by the
+ * authenticated user. Unowned / null owner fails closed (not auto-claimed).
+ */
+export function assertOnboardingProfileOwner(params: {
+  readonly authenticatedUserId: string | null | undefined;
+  readonly profileOwnerUserId: string | null | undefined;
+}): void {
+  assertAuthenticatedOnboardingUser(params.authenticatedUserId);
+  const ownerId =
+    typeof params.profileOwnerUserId === 'string'
+      ? params.profileOwnerUserId.trim()
+      : '';
+  if (!ownerId || ownerId !== params.authenticatedUserId) {
+    throw new OnboardingOwnershipError(
+      'FORBIDDEN',
+      'Only the verified owner can manage this artist profile.'
+    );
+  }
+}
+
+/**
+ * Verify the onboarding conversation is attached to the authenticated user
+ * before materializing a claimed public profile / reserved handle.
+ */
+export function assertConversationOwnedByUser(params: {
+  readonly authenticatedUserId: string | null | undefined;
+  readonly conversationUserId: string | null | undefined;
+  readonly conversationExists: boolean;
+}): void {
+  assertAuthenticatedOnboardingUser(params.authenticatedUserId);
+  if (!params.conversationExists) {
+    throw new OnboardingOwnershipError(
+      'NOT_FOUND',
+      'Onboarding conversation not found.'
+    );
+  }
+  const conversationUserId =
+    typeof params.conversationUserId === 'string'
+      ? params.conversationUserId.trim()
+      : '';
+  if (
+    !conversationUserId ||
+    conversationUserId !== params.authenticatedUserId
+  ) {
+    throw new OnboardingOwnershipError(
+      'FORBIDDEN',
+      'Only the verified owner can reserve a handle for this artist profile.'
+    );
+  }
+}
+
+/**
+ * Combined entry used by materialize / reserve success paths.
+ * Requires auth + conversation ownership (when a conversation is in scope).
+ */
+export function requireVerifiedOwnerForReservation(params: {
+  readonly userId: string | null | undefined;
+  readonly conversationUserId?: string | null;
+  readonly conversationExists?: boolean;
+}): { readonly userId: string } {
+  assertAuthenticatedOnboardingUser(params.userId);
+
+  if (params.conversationExists !== undefined) {
+    assertConversationOwnedByUser({
+      authenticatedUserId: params.userId,
+      conversationUserId: params.conversationUserId,
+      conversationExists: params.conversationExists,
+    });
+  }
+
+  return { userId: params.userId };
+}
+
+/**
+ * Pre-verify visitor copy must stay neutral ("this artist profile").
+ * Only after ownership is verified may we address the visitor as the owner.
+ */
+export function describeArtistProfileForVisitor(params: {
+  readonly ownershipVerified: boolean;
+  readonly artistName?: string | null;
+}): string {
+  const name = params.artistName?.trim() || null;
+  if (!params.ownershipVerified) {
+    return name ? `this artist profile (${name})` : 'this artist profile';
+  }
+  return name ? `${name}'s profile` : 'this artist profile';
+}

--- a/apps/web/lib/onboarding/reserved-handle.ts
+++ b/apps/web/lib/onboarding/reserved-handle.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { inArray } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { assertAuthenticatedOnboardingUser } from '@/lib/onboarding/ownership-gate';
 import { normalizeUsername, validateUsername } from '@/lib/validation/username';
 
 const MAX_SUFFIX_ATTEMPTS = 30;
@@ -51,7 +52,18 @@ async function findTakenHandles(candidates: string[]): Promise<Set<string>> {
   return new Set(rows.map(r => r.normalized));
 }
 
-export async function reserveOnboardingHandle(name: string): Promise<string> {
+/**
+ * Pick an available onboarding handle candidate.
+ *
+ * Auth is required: callers that surface "locked in / reserved" success must
+ * only reach this after ownership verification. Fail closed for anonymous.
+ */
+export async function reserveOnboardingHandle(
+  name: string,
+  userId: string
+): Promise<string> {
+  assertAuthenticatedOnboardingUser(userId);
+
   const bases = buildHandleCandidates(name);
 
   // Build all candidates up front, then check availability in a single query

--- a/apps/web/tests/components/features/onboarding/useOnboardingClaim.test.tsx
+++ b/apps/web/tests/components/features/onboarding/useOnboardingClaim.test.tsx
@@ -101,6 +101,25 @@ describe('useOnboardingClaim', () => {
     );
   });
 
+  it('fails closed on 403 ownership rejection without navigating to checkout', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(
+          { error: 'Forbidden', errorCode: 'FORBIDDEN' },
+          { status: 403 }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(renderClaimHarness(0));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('claim-status')).toHaveTextContent('error')
+    );
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
   it('fires exactly one POST per unique claimTrigger and does not fire again for the same trigger after completion', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ claimed: 0 }));
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/web/tests/unit/api/onboarding/discovery.test.ts
+++ b/apps/web/tests/unit/api/onboarding/discovery.test.ts
@@ -66,7 +66,8 @@ describe('GET /api/onboarding/discovery', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetCachedAuth.mockResolvedValue({ userId: 'clerk_user_123' });
+    // getCachedAuth().userId is the app users.id UUID (BA cutover).
+    mockGetCachedAuth.mockResolvedValue({ userId: 'user_owner_123' });
     mockIsActiveDiscoveryJob.mockReturnValue(false);
   });
 
@@ -141,7 +142,7 @@ describe('GET /api/onboarding/discovery', () => {
           spotifyUrl: 'https://open.spotify.com/artist/spotify_1',
           appleMusicId: null,
           onboardingCompletedAt: new Date('2025-01-01T00:00:00.000Z'),
-          clerkId: 'different_user',
+          ownerUserId: 'different_user',
         },
       ])
     );
@@ -154,7 +155,10 @@ describe('GET /api/onboarding/discovery', () => {
     );
 
     expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
+    await expect(response.json()).resolves.toEqual({
+      error: 'Forbidden',
+      errorCode: 'FORBIDDEN',
+    });
   });
 
   it('returns a shaped onboarding snapshot with pending discovery state', async () => {
@@ -178,7 +182,7 @@ describe('GET /api/onboarding/discovery', () => {
             spotifyUrl: 'https://open.spotify.com/artist/spotify_1',
             appleMusicId: 'apple_1',
             onboardingCompletedAt: new Date('2025-01-01T00:00:00.000Z'),
-            clerkId: 'clerk_user_123',
+            ownerUserId: 'user_owner_123',
           },
         ])
       )

--- a/apps/web/tests/unit/lib/onboarding/claim-profile.test.ts
+++ b/apps/web/tests/unit/lib/onboarding/claim-profile.test.ts
@@ -120,11 +120,25 @@ const HANDLE_UNIQUE_VIOLATION = new Error(
   'duplicate key value violates unique constraint "creator_profiles_username_normalized_unique"'
 );
 
+function setupConversationSelect(
+  conversation: { id: string; userId: string | null } | null
+) {
+  const limit = vi.fn().mockResolvedValue(conversation ? [conversation] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  mockDbSelect.mockReturnValueOnce({ from });
+}
+
 function setupMessageSelect() {
   const orderBy = vi.fn().mockResolvedValue([{ toolCalls: [] }]);
   const where = vi.fn().mockReturnValue({ orderBy });
   const from = vi.fn().mockReturnValue({ where });
   mockDbSelect.mockReturnValueOnce({ from });
+}
+
+function setupOwnedConversationAndMessages(userId = 'user_1') {
+  setupConversationSelect({ id: 'conv_1', userId });
+  setupMessageSelect();
 }
 
 function setupExistingProfileSelect(profile: Record<string, unknown> | null) {
@@ -209,6 +223,41 @@ describe('materializeClaimedOnboardingProfile', () => {
     mockFetchArtistBySpotifyUrl.mockResolvedValue(null);
   });
 
+  it('fails closed with UNAUTHORIZED when userId is empty (no profile created)', async () => {
+    await expect(
+      materializeClaimedOnboardingProfile({
+        userId: '',
+        conversationId: 'conv_1',
+        ipAddress: null,
+        userAgent: null,
+      })
+    ).rejects.toMatchObject({
+      errorCode: 'UNAUTHORIZED',
+      status: 401,
+    });
+
+    expect(mockDbInsert).not.toHaveBeenCalled();
+  });
+
+  it('blocks non-owners when the conversation belongs to another user', async () => {
+    setupConversationSelect({ id: 'conv_1', userId: 'other_user' });
+
+    await expect(
+      materializeClaimedOnboardingProfile({
+        userId: 'user_1',
+        conversationId: 'conv_1',
+        ipAddress: null,
+        userAgent: null,
+      })
+    ).rejects.toMatchObject({
+      errorCode: 'FORBIDDEN',
+      status: 403,
+    });
+
+    expect(mockDbInsert).not.toHaveBeenCalled();
+    expect(mockReserveOnboardingHandle).not.toHaveBeenCalled();
+  });
+
   it('skips when chat state has no materializable profile data', async () => {
     mockDeriveClaimedOnboardingStateFromMessageRows.mockReturnValue({
       artist: null,
@@ -216,7 +265,7 @@ describe('materializeClaimedOnboardingProfile', () => {
       socialLinks: [],
       interviewSignals: [],
     });
-    setupMessageSelect();
+    setupOwnedConversationAndMessages();
 
     await expect(
       materializeClaimedOnboardingProfile({
@@ -231,12 +280,13 @@ describe('materializeClaimedOnboardingProfile', () => {
       status: 'skipped',
     });
 
-    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    // conversation + messages
+    expect(mockDbSelect).toHaveBeenCalledTimes(2);
     expect(mockDbInsert).not.toHaveBeenCalled();
   });
 
   it('creates a profile using the proposed handle without a pre-insert availability check', async () => {
-    setupMessageSelect();
+    setupOwnedConversationAndMessages();
     setupExistingProfileSelect(null);
     queueProfileInsert({ id: 'profile_new' });
     queuePostPersistWrites();
@@ -280,7 +330,7 @@ describe('materializeClaimedOnboardingProfile', () => {
       services: {},
     });
 
-    setupMessageSelect();
+    setupOwnedConversationAndMessages();
     setupExistingProfileSelect(null);
     const [profileInsertValues] = queueProfileInsert({ id: 'profile_new' });
     queuePostPersistWrites();
@@ -318,7 +368,7 @@ describe('materializeClaimedOnboardingProfile', () => {
   });
 
   it('retries with a reserved handle when INSERT hits a username unique violation', async () => {
-    setupMessageSelect();
+    setupOwnedConversationAndMessages();
     setupExistingProfileSelect(null);
     queueProfileInsert([
       { error: HANDLE_UNIQUE_VIOLATION },
@@ -340,7 +390,10 @@ describe('materializeClaimedOnboardingProfile', () => {
     });
 
     expect(mockReserveOnboardingHandle).toHaveBeenCalledTimes(1);
-    expect(mockReserveOnboardingHandle).toHaveBeenCalledWith('coolartist');
+    expect(mockReserveOnboardingHandle).toHaveBeenCalledWith(
+      'coolartist',
+      'user_1'
+    );
   });
 
   it('reserves a fallback handle when the proposed handle is invalid', async () => {
@@ -360,7 +413,7 @@ describe('materializeClaimedOnboardingProfile', () => {
     });
     mockReserveOnboardingHandle.mockResolvedValue('theweeknd');
 
-    setupMessageSelect();
+    setupOwnedConversationAndMessages();
     setupExistingProfileSelect(null);
     queueProfileInsert({ id: 'profile_reserved' });
     queuePostPersistWrites();
@@ -378,11 +431,14 @@ describe('materializeClaimedOnboardingProfile', () => {
       status: 'created',
     });
 
-    expect(mockReserveOnboardingHandle).toHaveBeenCalledWith('The Weeknd');
+    expect(mockReserveOnboardingHandle).toHaveBeenCalledWith(
+      'The Weeknd',
+      'user_1'
+    );
   });
 
   it('updates an existing profile and retries on handle conflict', async () => {
-    setupMessageSelect();
+    setupOwnedConversationAndMessages();
     setupExistingProfileSelect({
       id: 'profile_existing',
       userId: 'user_1',


### PR DESCRIPTION
## Summary
Enforces authenticated ownership verification before onboarding handle reservation success, public-profile materialization, and “manage as owner” outcomes (audit **P0 #1, #8, #35**). Fail closed for unauthenticated and non-owner paths.

## Audit items
- **#1** — Handle reservation / locked-in success requires verified auth ownership
- **#8** — Public-profile mutation (materialize claim) requires conversation + user ownership
- **#35** — Non-owners cannot reach manage-as-owner claim rows / discovery manage surface

## Changes
- New pure gate: `apps/web/lib/onboarding/ownership-gate.ts` (`assertAuthenticatedOnboardingUser`, `assertOnboardingProfileOwner`, `assertConversationOwnedByUser`, `requireVerifiedOwnerForReservation`, neutral visitor copy helper)
- Wire into `materializeClaimedOnboardingProfile` (auth → conversation owner → profile owner → then create/update + `userProfileClaims` role=`owner`)
- `reserveOnboardingHandle(name, userId)` requires authenticated userId
- Claim API maps ownership errors to 401/403/404 with `errorCode`
- Discovery ownership compares app `users.id` (`ownerUserId`) instead of stale `clerkId` comparison
- Client claim hook treats 403 like 401 (no checkout navigation)

## Tests
- Unauthenticated / empty userId → 401, no profile created
- Non-owner conversation / profile → 403 blocked
- Authenticated owner path still materializes + discovery snapshot
- Hook: 403 fails closed without navigation

## Verification
```
pnpm exec biome check --write <touched paths>  # clean
pnpm --filter @jovie/web run typecheck -- --pretty false  # exit 0
pnpm --filter web exec vitest run \
  lib/onboarding/ownership-gate.test.ts \
  tests/unit/lib/onboarding/claim-profile.test.ts \
  tests/unit/api/onboarding/discovery.test.ts \
  tests/unit/api/onboarding/claim.test.ts \
  tests/components/features/onboarding/useOnboardingClaim.test.tsx
# 5 files, 45 tests passed
```
Evidence: `{scratch}/ownership-gates.log`

## Risk
Low–medium: auth fail-closed on claim/materialize/discovery. Owner happy path unchanged after conversation is CAS-claimed onto the user.

## Cost Impact
None (no new external API / cron / polling).