### PR TITLE
fix(onboarding): canonical metrics handle and social parse contract

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingProfileRail.tsx
+++ b/apps/web/components/features/onboarding/OnboardingProfileRail.tsx
@@ -2,6 +2,10 @@
 
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { ProfilePreviewBento } from '@/features/profile/ProfilePreviewBento';
+import {
+  type CanonicalArtistMetrics,
+  getDisplaySpotifyFollowers,
+} from '@/lib/onboarding/canonical-metrics';
 import { cn } from '@/lib/utils';
 import type { Artist, LegacySocialLink } from '@/types/db';
 import {
@@ -16,7 +20,12 @@ export interface OnboardingProfileArtist {
   readonly name: string;
   readonly url: string;
   readonly imageUrl?: string | null;
+  /**
+   * Display follower count — always `metrics.spotifyFollowers` when metrics
+   * are present. Kept as a convenience mirror; never store monthly listeners here.
+   */
   readonly followers?: number | null;
+  readonly metrics?: CanonicalArtistMetrics | null;
   readonly popularity?: number | null;
   readonly genres?: readonly string[];
   readonly dspMatches?: readonly OnboardingDspMatch[];
@@ -165,7 +174,10 @@ function buildPreviewArtist(
   const firstGenre = artist.genres?.[0]
     ? formatGenreLabel(artist.genres[0])
     : null;
-  const followerLabel = formatCompactCount(artist.followers);
+  // Single source: metrics.spotifyFollowers when present, else followers mirror.
+  const followerCount =
+    getDisplaySpotifyFollowers(artist.metrics) ?? artist.followers ?? null;
+  const followerLabel = formatCompactCount(followerCount);
 
   return {
     id: `onboarding-preview-${artist.id}`,

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import {
   AlertCircle,
   AtSign,
@@ -11,6 +12,11 @@ import {
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import {
+  ATTACH_ACCOUNT_CTA_LABEL,
+  CONFIRM_HANDLE_CTA_LABEL,
+  NONE_OF_THESE_CTA_LABEL,
+} from '@/lib/chat/onboarding-script/widget-events';
 import type { SpotifyArtistResult } from '@/lib/contracts/api';
 import {
   type CanonicalArtistMetrics,
@@ -65,17 +71,13 @@ export interface ArtistConfirmedOutput {
 }
 
 export interface HandleCheckOutput {
-  readonly action?: 'check_handle';
+  readonly action?: 'check_handle' | 'handle_confirmed';
   readonly handle?: string;
-  readonly availability?: HandleAvailabilityResult;
 }
 
 export interface SocialLinkOutput {
-  readonly action?: 'propose_social_link';
+  readonly action?: 'propose_social_link' | 'social_attached';
   readonly url?: string | null;
-  readonly parseOk?: boolean;
-  readonly reason?: string;
-  readonly platform?: string;
 }
 
 export interface OnboardingArtistSelection {
@@ -135,6 +137,25 @@ export function formatGenreLabel(genre: string): string {
         .join('-')
     )
     .join(' ');
+}
+
+
+function selectionFromSpotifyResult(
+  artist: SpotifyArtistResult
+): OnboardingArtistSelection {
+  const metrics = normalizeArtistMetrics(
+    { followers: artist.followers },
+    { source: 'spotify_search' }
+  );
+  return {
+    id: artist.id,
+    name: artist.name,
+    url: artist.url,
+    imageUrl: artist.imageUrl ?? undefined,
+    followers: getDisplaySpotifyFollowers(metrics) ?? undefined,
+    metrics,
+    popularity: artist.popularity ?? undefined,
+  };
 }
 
 function formatFollowers(count: number | null | undefined): string | null {
@@ -296,11 +317,13 @@ export function OnboardingSpotifyArtistPickerCard({
   inputQuery,
   disabled = false,
   onSelectArtist,
+  onNoneOfThese,
 }: ToolArtifactProps & {
   readonly output?: ArtistPickerOutput | null;
   readonly inputQuery?: string | null;
   readonly disabled?: boolean;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
+  readonly onNoneOfThese?: () => void;
 }) {
   const initialQuery = output?.query ?? inputQuery ?? '';
   const [query, setQuery] = useState(initialQuery);
@@ -311,6 +334,13 @@ export function OnboardingSpotifyArtistPickerCard({
     minQueryLength: 1,
   });
   const { search, searchImmediate, clear } = artistSearch;
+
+  // Keep the field prefilled when the tool re-opens with a new query from chat.
+  useEffect(() => {
+    if (initialQuery && !query) {
+      setQuery(initialQuery);
+    }
+  }, [initialQuery, query]);
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -437,6 +467,22 @@ export function OnboardingSpotifyArtistPickerCard({
             }}
           />
         ))}
+
+        {!isSearching && results.length > 0 && onNoneOfThese ? (
+          <Button
+            type='button'
+            variant='ghost'
+            onClick={() => {
+              if (disabled) return;
+              onNoneOfThese();
+            }}
+            disabled={disabled || selectedId !== null}
+            className='flex h-auto w-full items-center justify-center rounded-lg px-2.5 py-2 text-xs font-medium text-secondary-token hover:bg-white/[0.045] hover:text-primary-token'
+            data-testid='onboarding-artist-none-of-these'
+          >
+            {NONE_OF_THESE_CTA_LABEL}
+          </Button>
+        ) : null}
       </div>
     </div>
   );
@@ -453,7 +499,6 @@ function ArtistResultRow({
   readonly selected: boolean;
   readonly onSelect: () => void;
 }) {
-  // Canonical metrics so search rows cannot mix monthly listeners into followers.
   const metrics = normalizeArtistMetrics(
     { followers: artist.followers },
     { source: 'spotify_search' }
@@ -539,14 +584,19 @@ export function OnboardingArtistConfirmedCard({
 
 export function OnboardingHandleCheckCard({
   onHandleCandidateChange,
+  onConfirmHandle,
   state,
   output,
+  disabled = false,
 }: ToolArtifactProps & {
   readonly onHandleCandidateChange?: (handle: string | null) => void;
+  readonly onConfirmHandle?: (handle: string) => void;
   readonly output?: HandleCheckOutput | null;
+  readonly disabled?: boolean;
 }) {
   const handle = output?.handle?.replace(/^@/, '').toLowerCase() ?? null;
   const [draftHandle, setDraftHandle] = useState(handle ?? '');
+  const [confirmed, setConfirmed] = useState(false);
   const normalizedDraft = draftHandle.replace(/^@/, '').trim().toLowerCase();
   const availabilityQuery = useHandleAvailabilityQuery({
     handle: normalizedDraft || null,
@@ -585,52 +635,44 @@ export function OnboardingHandleCheckCard({
   }
 
   const loading = availabilityQuery.isLoading || availabilityQuery.isFetching;
-  // Single contract projection — never available+taken for the same handle.
   const availability = toHandleAvailabilityResult({
-    handle: normalizedDraft || handle,
+    handle: normalizedDraft || handle || '',
     available: loading ? null : (availabilityQuery.data?.available ?? null),
     error: availabilityQuery.data?.error,
     checking: loading,
-    suggestedAlternatives: output?.availability?.suggestedAlternatives,
   });
   const available =
-    availability.available && availability.reason === 'available';
-  const profilePath = availability.handle
-    ? `jov.ie/${availability.handle}`
-    : null;
+    availability.reason === 'checking' || availability.reason === 'unknown'
+      ? undefined
+      : availability.available;
+  const error = availability.error;
+  const profilePath = normalizedDraft ? `jov.ie/${normalizedDraft}` : null;
+  const canConfirm =
+    Boolean(normalizedDraft) &&
+    available === true &&
+    !loading &&
+    !disabled &&
+    !confirmed;
 
   return (
     <div
       className={cn(
         'w-full max-w-110 px-1 py-2 text-primary-token',
-        !available &&
-          availability.reason !== 'checking' &&
-          availability.reason !== 'unknown' &&
-          'text-error'
+        available === false && 'text-error'
       )}
       data-testid='onboarding-handle-check'
-      data-availability-reason={availability.reason}
-      role={
-        !available &&
-        availability.reason !== 'checking' &&
-        availability.reason !== 'unknown'
-          ? 'alert'
-          : 'status'
-      }
+      role={available === false ? 'alert' : 'status'}
     >
       <div className='flex items-start gap-3'>
         <span
           className={cn(
             'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-secondary-token',
             available && 'text-green-500',
-            !available &&
-              availability.reason !== 'checking' &&
-              availability.reason !== 'unknown' &&
-              'text-red-400'
+            available === false && 'text-red-400'
           )}
           aria-hidden
         >
-          {loading || availability.reason === 'checking' ? (
+          {loading ? (
             <Loader2 className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none' />
           ) : available ? (
             <Check className='h-3.5 w-3.5' />
@@ -641,11 +683,10 @@ export function OnboardingHandleCheckCard({
         <div className='min-w-0 flex-1'>
           <div className='flex flex-wrap items-baseline gap-x-1.5 gap-y-1 text-sm leading-5 tracking-[-0.01em]'>
             <strong className='font-semibold text-primary-token'>
-              @{availability.handle || handle}
+              @{normalizedDraft || handle}
             </strong>
             <span className='text-secondary-token'>
-              {availability.reason === 'checking' ||
-              availability.reason === 'unknown'
+              {loading || available === undefined
                 ? 'is being checked'
                 : available
                   ? 'is available'
@@ -656,49 +697,47 @@ export function OnboardingHandleCheckCard({
             <span className='text-app text-tertiary-token' aria-hidden>
               @
             </span>
-            <span className='sr-only'>Edit proposed handle</span>
+            <span className='sr-only'>Edit Proposed Handle</span>
             <input
-              aria-label='Edit proposed handle'
+              aria-label='Edit Proposed Handle'
               value={draftHandle}
               onChange={event => setDraftHandle(event.target.value)}
               className='min-w-0 flex-1 bg-transparent px-0.5 text-app leading-5 text-primary-token placeholder:text-quaternary-token focus:outline-none'
-              placeholder='handle'
+              placeholder='Handle'
               inputMode='text'
               autoCapitalize='none'
               spellCheck={false}
+              disabled={disabled || confirmed}
             />
           </label>
           <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
-            {availability.error ??
-              (available
-                ? (profilePath ?? 'Edit the handle before it is claimed.')
-                : availability.reason === 'checking' ||
-                    availability.reason === 'unknown'
-                  ? (profilePath ?? 'Checking availability…')
-                  : 'Try a sharper variant.')}
+            {error ??
+              (available === false
+                ? availability.suggestedAlternatives &&
+                  availability.suggestedAlternatives.length > 0
+                  ? `${SUGGESTED_AVAILABLE_HANDLE_LABEL}: @${availability.suggestedAlternatives[0]}`
+                  : 'Try a sharper variant.'
+                : (profilePath ?? 'Edit the handle before it is claimed.'))}
           </p>
-          {!available &&
-          availability.suggestedAlternatives &&
-          availability.suggestedAlternatives.length > 0 ? (
-            <ul
-              className='mt-2 space-y-1'
-              data-testid='onboarding-handle-suggestions'
+          {onConfirmHandle ? (
+            <Button
+              type='button'
+              data-testid='onboarding-confirm-handle'
+              disabled={!canConfirm}
+              onClick={() => {
+                if (!canConfirm || !normalizedDraft) return;
+                setConfirmed(true);
+                onConfirmHandle(normalizedDraft);
+              }}
+              className={cn(
+                'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',
+                canConfirm
+                  ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
+                  : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
+              )}
             >
-              {availability.suggestedAlternatives.map(suggestion => (
-                <li key={suggestion} className='text-xs leading-5'>
-                  <span className='text-secondary-token'>
-                    {SUGGESTED_AVAILABLE_HANDLE_LABEL}:{' '}
-                  </span>
-                  <button
-                    type='button'
-                    className='font-medium text-primary-token underline-offset-2 hover:underline focus-visible:outline-none'
-                    onClick={() => setDraftHandle(suggestion)}
-                  >
-                    @{suggestion}
-                  </button>
-                </li>
-              ))}
-            </ul>
+              {confirmed ? 'Handle Confirmed' : CONFIRM_HANDLE_CTA_LABEL}
+            </Button>
           ) : null}
         </div>
       </div>
@@ -709,9 +748,21 @@ export function OnboardingHandleCheckCard({
 export function OnboardingSocialLinkCard({
   state,
   output,
+  onAttachAccount,
+  disabled = false,
 }: ToolArtifactProps & {
   readonly output?: SocialLinkOutput | null;
+  readonly onAttachAccount?: (url: string) => void;
+  readonly disabled?: boolean;
 }) {
+  const initialUrl = output?.url ?? '';
+  const [draftUrl, setDraftUrl] = useState(initialUrl);
+  const [attached, setAttached] = useState(false);
+
+  useEffect(() => {
+    if (initialUrl) setDraftUrl(initialUrl);
+  }, [initialUrl]);
+
   if (isFailed(state)) {
     return (
       <StatusShell
@@ -734,31 +785,72 @@ export function OnboardingSocialLinkCard({
     );
   }
 
-  // Reject incomplete parses (bare instagram.com, missing account path).
-  const rawUrl = output?.url ?? null;
-  const parseOk = output?.parseOk !== false;
-  const parsed = rawUrl && parseOk ? parseSocialLinkInput(rawUrl) : null;
-
-  if (!rawUrl || !parseOk || !parsed || !parsed.ok) {
-    return (
-      <StatusShell
-        icon={<AlertCircle className='h-3.5 w-3.5' />}
-        title='Link needs a full profile URL'
-        body='Use a full URL with your account path — for example https://instagram.com/yourhandle.'
-        tone='error'
-      />
-    );
-  }
-
-  const host = hostnameFor(parsed.url);
+  const trimmed = draftUrl.trim();
+  const host = hostnameFor(trimmed || undefined);
+  const canAttach =
+    Boolean(trimmed) &&
+    Boolean(host) &&
+    !disabled &&
+    !attached &&
+    Boolean(onAttachAccount);
 
   return (
-    <StatusShell
-      icon={<Link2 className='h-3.5 w-3.5' />}
-      title='Link ready to attach'
-      body={host ?? parsed.url}
-      tone='success'
-    />
+    <div
+      className='w-full max-w-110 px-1 py-2 text-primary-token'
+      data-testid='onboarding-social-link'
+      role='status'
+    >
+      <div className='flex items-start gap-3'>
+        <span
+          className='mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-secondary-token'
+          aria-hidden
+        >
+          <Link2 className='h-3.5 w-3.5' />
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='text-sm font-semibold leading-5 tracking-[-0.01em] text-primary-token'>
+            {host ? 'Link ready to attach' : 'Attach a public social account'}
+          </p>
+          <label className='mt-2 flex h-9 items-center rounded-lg border border-subtle bg-surface-0 px-2.5 focus-within:border-white/[0.16] focus-within:shadow-[0_0_0_3px_rgba(255,255,255,0.035)]'>
+            <span className='sr-only'>Social Profile URL</span>
+            <input
+              aria-label='Social Profile URL'
+              value={draftUrl}
+              onChange={event => setDraftUrl(event.target.value)}
+              className='min-w-0 flex-1 bg-transparent text-app leading-5 text-primary-token placeholder:text-quaternary-token focus:outline-none'
+              placeholder='https://instagram.com/yourname'
+              inputMode='url'
+              autoCapitalize='none'
+              spellCheck={false}
+              disabled={disabled || attached}
+            />
+          </label>
+          <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
+            {host ?? 'Paste the full URL fans already use.'}
+          </p>
+          {onAttachAccount ? (
+            <Button
+              type='button'
+              data-testid='onboarding-attach-account'
+              disabled={!canAttach}
+              onClick={() => {
+                if (!canAttach || !trimmed) return;
+                setAttached(true);
+                onAttachAccount(trimmed);
+              }}
+              className={cn(
+                'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',
+                canAttach
+                  ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
+                  : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
+              )}
+            >
+              {attached ? 'Account Attached' : ATTACH_ACCOUNT_CTA_LABEL}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -768,26 +860,4 @@ export function useArtistSelectionMessage() {
       `I picked ${artist.name} on Spotify. Let's build my artist profile from that match.`,
     []
   );
-}
-
-/**
- * Normalize a search-result artist into the onboarding selection shape with
- * canonical metrics so downstream rail/chat use the same follower field.
- */
-export function selectionFromSpotifyResult(
-  artist: SpotifyArtistResult
-): OnboardingArtistSelection {
-  const metrics = normalizeArtistMetrics(
-    { followers: artist.followers },
-    { source: 'spotify_search' }
-  );
-  return {
-    id: artist.id,
-    name: artist.name,
-    url: artist.url,
-    imageUrl: artist.imageUrl,
-    followers: getDisplaySpotifyFollowers(metrics) ?? undefined,
-    metrics,
-    popularity: artist.popularity,
-  };
 }

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from '@jovie/ui';
 import {
   AlertCircle,
   AtSign,
@@ -12,12 +11,18 @@ import {
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import {
-  ATTACH_ACCOUNT_CTA_LABEL,
-  CONFIRM_HANDLE_CTA_LABEL,
-  NONE_OF_THESE_CTA_LABEL,
-} from '@/lib/chat/onboarding-script/widget-events';
 import type { SpotifyArtistResult } from '@/lib/contracts/api';
+import {
+  type CanonicalArtistMetrics,
+  getDisplaySpotifyFollowers,
+  normalizeArtistMetrics,
+} from '@/lib/onboarding/canonical-metrics';
+import {
+  type HandleAvailabilityResult,
+  SUGGESTED_AVAILABLE_HANDLE_LABEL,
+  toHandleAvailabilityResult,
+} from '@/lib/onboarding/handle-availability';
+import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useHandleAvailabilityQuery } from '@/lib/queries/useHandleAvailabilityQuery';
 import { cn } from '@/lib/utils';
@@ -45,12 +50,14 @@ export interface ArtistPickerOutput {
 export interface ArtistConfirmedOutput {
   readonly action?: 'spotify_artist_confirmed';
   readonly spotifyArtistId?: string;
+  readonly metrics?: CanonicalArtistMetrics | null;
   readonly artist?: {
     readonly id: string;
     readonly name: string;
     readonly url: string;
     readonly imageUrl?: string | null;
     readonly followers?: number | null;
+    readonly metrics?: CanonicalArtistMetrics | null;
     readonly popularity?: number | null;
     readonly genres?: readonly string[];
     readonly dspMatches?: readonly OnboardingDspMatch[];
@@ -58,13 +65,17 @@ export interface ArtistConfirmedOutput {
 }
 
 export interface HandleCheckOutput {
-  readonly action?: 'check_handle' | 'handle_confirmed';
+  readonly action?: 'check_handle';
   readonly handle?: string;
+  readonly availability?: HandleAvailabilityResult;
 }
 
 export interface SocialLinkOutput {
-  readonly action?: 'propose_social_link' | 'social_attached';
+  readonly action?: 'propose_social_link';
   readonly url?: string | null;
+  readonly parseOk?: boolean;
+  readonly reason?: string;
+  readonly platform?: string;
 }
 
 export interface OnboardingArtistSelection {
@@ -73,6 +84,7 @@ export interface OnboardingArtistSelection {
   readonly url: string;
   readonly imageUrl?: string;
   readonly followers?: number;
+  readonly metrics?: CanonicalArtistMetrics;
   readonly popularity?: number;
 }
 
@@ -284,13 +296,11 @@ export function OnboardingSpotifyArtistPickerCard({
   inputQuery,
   disabled = false,
   onSelectArtist,
-  onNoneOfThese,
 }: ToolArtifactProps & {
   readonly output?: ArtistPickerOutput | null;
   readonly inputQuery?: string | null;
   readonly disabled?: boolean;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
-  readonly onNoneOfThese?: () => void;
 }) {
   const initialQuery = output?.query ?? inputQuery ?? '';
   const [query, setQuery] = useState(initialQuery);
@@ -301,13 +311,6 @@ export function OnboardingSpotifyArtistPickerCard({
     minQueryLength: 1,
   });
   const { search, searchImmediate, clear } = artistSearch;
-
-  // Keep the field prefilled when the tool re-opens with a new query from chat.
-  useEffect(() => {
-    if (initialQuery && !query) {
-      setQuery(initialQuery);
-    }
-  }, [initialQuery, query]);
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -430,26 +433,10 @@ export function OnboardingSpotifyArtistPickerCard({
             selected={selectedId === artist.id}
             onSelect={() => {
               setSelectedId(artist.id);
-              onSelectArtist(artist);
+              onSelectArtist(selectionFromSpotifyResult(artist));
             }}
           />
         ))}
-
-        {!isSearching && results.length > 0 && onNoneOfThese ? (
-          <Button
-            type='button'
-            variant='ghost'
-            onClick={() => {
-              if (disabled) return;
-              onNoneOfThese();
-            }}
-            disabled={disabled || selectedId !== null}
-            className='flex h-auto w-full items-center justify-center rounded-lg px-2.5 py-2 text-xs font-medium text-secondary-token hover:bg-white/[0.045] hover:text-primary-token'
-            data-testid='onboarding-artist-none-of-these'
-          >
-            {NONE_OF_THESE_CTA_LABEL}
-          </Button>
-        ) : null}
       </div>
     </div>
   );
@@ -466,7 +453,12 @@ function ArtistResultRow({
   readonly selected: boolean;
   readonly onSelect: () => void;
 }) {
-  const followers = formatFollowers(artist.followers);
+  // Canonical metrics so search rows cannot mix monthly listeners into followers.
+  const metrics = normalizeArtistMetrics(
+    { followers: artist.followers },
+    { source: 'spotify_search' }
+  );
+  const followers = formatFollowers(getDisplaySpotifyFollowers(metrics));
   const meta = [
     followers,
     artist.popularity ? `Pop ${artist.popularity}` : null,
@@ -547,21 +539,16 @@ export function OnboardingArtistConfirmedCard({
 
 export function OnboardingHandleCheckCard({
   onHandleCandidateChange,
-  onConfirmHandle,
   state,
   output,
-  disabled = false,
 }: ToolArtifactProps & {
   readonly onHandleCandidateChange?: (handle: string | null) => void;
-  readonly onConfirmHandle?: (handle: string) => void;
   readonly output?: HandleCheckOutput | null;
-  readonly disabled?: boolean;
 }) {
   const handle = output?.handle?.replace(/^@/, '').toLowerCase() ?? null;
   const [draftHandle, setDraftHandle] = useState(handle ?? '');
-  const [confirmed, setConfirmed] = useState(false);
   const normalizedDraft = draftHandle.replace(/^@/, '').trim().toLowerCase();
-  const availability = useHandleAvailabilityQuery({
+  const availabilityQuery = useHandleAvailabilityQuery({
     handle: normalizedDraft || null,
     enabled: Boolean(normalizedDraft) && !isRunning(state) && !isFailed(state),
   });
@@ -597,36 +584,53 @@ export function OnboardingHandleCheckCard({
     );
   }
 
-  const loading = availability.isLoading || availability.isFetching;
-  const available = availability.data?.available;
-  const error = availability.data?.error;
-  const profilePath = normalizedDraft ? `jov.ie/${normalizedDraft}` : null;
-  const canConfirm =
-    Boolean(normalizedDraft) &&
-    available === true &&
-    !loading &&
-    !disabled &&
-    !confirmed;
+  const loading = availabilityQuery.isLoading || availabilityQuery.isFetching;
+  // Single contract projection — never available+taken for the same handle.
+  const availability = toHandleAvailabilityResult({
+    handle: normalizedDraft || handle,
+    available: loading ? null : (availabilityQuery.data?.available ?? null),
+    error: availabilityQuery.data?.error,
+    checking: loading,
+    suggestedAlternatives: output?.availability?.suggestedAlternatives,
+  });
+  const available =
+    availability.available && availability.reason === 'available';
+  const profilePath = availability.handle
+    ? `jov.ie/${availability.handle}`
+    : null;
 
   return (
     <div
       className={cn(
         'w-full max-w-110 px-1 py-2 text-primary-token',
-        available === false && 'text-error'
+        !available &&
+          availability.reason !== 'checking' &&
+          availability.reason !== 'unknown' &&
+          'text-error'
       )}
       data-testid='onboarding-handle-check'
-      role={available === false ? 'alert' : 'status'}
+      data-availability-reason={availability.reason}
+      role={
+        !available &&
+        availability.reason !== 'checking' &&
+        availability.reason !== 'unknown'
+          ? 'alert'
+          : 'status'
+      }
     >
       <div className='flex items-start gap-3'>
         <span
           className={cn(
             'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-secondary-token',
             available && 'text-green-500',
-            available === false && 'text-red-400'
+            !available &&
+              availability.reason !== 'checking' &&
+              availability.reason !== 'unknown' &&
+              'text-red-400'
           )}
           aria-hidden
         >
-          {loading ? (
+          {loading || availability.reason === 'checking' ? (
             <Loader2 className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none' />
           ) : available ? (
             <Check className='h-3.5 w-3.5' />
@@ -637,10 +641,11 @@ export function OnboardingHandleCheckCard({
         <div className='min-w-0 flex-1'>
           <div className='flex flex-wrap items-baseline gap-x-1.5 gap-y-1 text-sm leading-5 tracking-[-0.01em]'>
             <strong className='font-semibold text-primary-token'>
-              @{normalizedDraft || handle}
+              @{availability.handle || handle}
             </strong>
             <span className='text-secondary-token'>
-              {loading || available === undefined
+              {availability.reason === 'checking' ||
+              availability.reason === 'unknown'
                 ? 'is being checked'
                 : available
                   ? 'is available'
@@ -651,44 +656,49 @@ export function OnboardingHandleCheckCard({
             <span className='text-app text-tertiary-token' aria-hidden>
               @
             </span>
-            <span className='sr-only'>Edit Proposed Handle</span>
+            <span className='sr-only'>Edit proposed handle</span>
             <input
-              aria-label='Edit Proposed Handle'
+              aria-label='Edit proposed handle'
               value={draftHandle}
               onChange={event => setDraftHandle(event.target.value)}
               className='min-w-0 flex-1 bg-transparent px-0.5 text-app leading-5 text-primary-token placeholder:text-quaternary-token focus:outline-none'
-              placeholder='Handle'
+              placeholder='handle'
               inputMode='text'
               autoCapitalize='none'
               spellCheck={false}
-              disabled={disabled || confirmed}
             />
           </label>
           <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
-            {error ??
-              (available === false
-                ? 'Try a sharper variant.'
-                : (profilePath ?? 'Edit the handle before it is claimed.'))}
+            {availability.error ??
+              (available
+                ? (profilePath ?? 'Edit the handle before it is claimed.')
+                : availability.reason === 'checking' ||
+                    availability.reason === 'unknown'
+                  ? (profilePath ?? 'Checking availability…')
+                  : 'Try a sharper variant.')}
           </p>
-          {onConfirmHandle ? (
-            <Button
-              type='button'
-              data-testid='onboarding-confirm-handle'
-              disabled={!canConfirm}
-              onClick={() => {
-                if (!canConfirm || !normalizedDraft) return;
-                setConfirmed(true);
-                onConfirmHandle(normalizedDraft);
-              }}
-              className={cn(
-                'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',
-                canConfirm
-                  ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
-                  : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
-              )}
+          {!available &&
+          availability.suggestedAlternatives &&
+          availability.suggestedAlternatives.length > 0 ? (
+            <ul
+              className='mt-2 space-y-1'
+              data-testid='onboarding-handle-suggestions'
             >
-              {confirmed ? 'Handle Confirmed' : CONFIRM_HANDLE_CTA_LABEL}
-            </Button>
+              {availability.suggestedAlternatives.map(suggestion => (
+                <li key={suggestion} className='text-xs leading-5'>
+                  <span className='text-secondary-token'>
+                    {SUGGESTED_AVAILABLE_HANDLE_LABEL}:{' '}
+                  </span>
+                  <button
+                    type='button'
+                    className='font-medium text-primary-token underline-offset-2 hover:underline focus-visible:outline-none'
+                    onClick={() => setDraftHandle(suggestion)}
+                  >
+                    @{suggestion}
+                  </button>
+                </li>
+              ))}
+            </ul>
           ) : null}
         </div>
       </div>
@@ -699,21 +709,9 @@ export function OnboardingHandleCheckCard({
 export function OnboardingSocialLinkCard({
   state,
   output,
-  onAttachAccount,
-  disabled = false,
 }: ToolArtifactProps & {
   readonly output?: SocialLinkOutput | null;
-  readonly onAttachAccount?: (url: string) => void;
-  readonly disabled?: boolean;
 }) {
-  const initialUrl = output?.url ?? '';
-  const [draftUrl, setDraftUrl] = useState(initialUrl);
-  const [attached, setAttached] = useState(false);
-
-  useEffect(() => {
-    if (initialUrl) setDraftUrl(initialUrl);
-  }, [initialUrl]);
-
   if (isFailed(state)) {
     return (
       <StatusShell
@@ -736,72 +734,31 @@ export function OnboardingSocialLinkCard({
     );
   }
 
-  const trimmed = draftUrl.trim();
-  const host = hostnameFor(trimmed || undefined);
-  const canAttach =
-    Boolean(trimmed) &&
-    Boolean(host) &&
-    !disabled &&
-    !attached &&
-    Boolean(onAttachAccount);
+  // Reject incomplete parses (bare instagram.com, missing account path).
+  const rawUrl = output?.url ?? null;
+  const parseOk = output?.parseOk !== false;
+  const parsed = rawUrl && parseOk ? parseSocialLinkInput(rawUrl) : null;
+
+  if (!rawUrl || !parseOk || !parsed || !parsed.ok) {
+    return (
+      <StatusShell
+        icon={<AlertCircle className='h-3.5 w-3.5' />}
+        title='Link needs a full profile URL'
+        body='Use a full URL with your account path — for example https://instagram.com/yourhandle.'
+        tone='error'
+      />
+    );
+  }
+
+  const host = hostnameFor(parsed.url);
 
   return (
-    <div
-      className='w-full max-w-110 px-1 py-2 text-primary-token'
-      data-testid='onboarding-social-link'
-      role='status'
-    >
-      <div className='flex items-start gap-3'>
-        <span
-          className='mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-secondary-token'
-          aria-hidden
-        >
-          <Link2 className='h-3.5 w-3.5' />
-        </span>
-        <div className='min-w-0 flex-1'>
-          <p className='text-sm font-semibold leading-5 tracking-[-0.01em] text-primary-token'>
-            {host ? 'Link ready to attach' : 'Attach a public social account'}
-          </p>
-          <label className='mt-2 flex h-9 items-center rounded-lg border border-subtle bg-surface-0 px-2.5 focus-within:border-white/[0.16] focus-within:shadow-[0_0_0_3px_rgba(255,255,255,0.035)]'>
-            <span className='sr-only'>Social Profile URL</span>
-            <input
-              aria-label='Social Profile URL'
-              value={draftUrl}
-              onChange={event => setDraftUrl(event.target.value)}
-              className='min-w-0 flex-1 bg-transparent text-app leading-5 text-primary-token placeholder:text-quaternary-token focus:outline-none'
-              placeholder='https://instagram.com/yourname'
-              inputMode='url'
-              autoCapitalize='none'
-              spellCheck={false}
-              disabled={disabled || attached}
-            />
-          </label>
-          <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
-            {host ?? 'Paste the full URL fans already use.'}
-          </p>
-          {onAttachAccount ? (
-            <Button
-              type='button'
-              data-testid='onboarding-attach-account'
-              disabled={!canAttach}
-              onClick={() => {
-                if (!canAttach || !trimmed) return;
-                setAttached(true);
-                onAttachAccount(trimmed);
-              }}
-              className={cn(
-                'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',
-                canAttach
-                  ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
-                  : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
-              )}
-            >
-              {attached ? 'Account Attached' : ATTACH_ACCOUNT_CTA_LABEL}
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    </div>
+    <StatusShell
+      icon={<Link2 className='h-3.5 w-3.5' />}
+      title='Link ready to attach'
+      body={host ?? parsed.url}
+      tone='success'
+    />
   );
 }
 
@@ -811,4 +768,26 @@ export function useArtistSelectionMessage() {
       `I picked ${artist.name} on Spotify. Let's build my artist profile from that match.`,
     []
   );
+}
+
+/**
+ * Normalize a search-result artist into the onboarding selection shape with
+ * canonical metrics so downstream rail/chat use the same follower field.
+ */
+export function selectionFromSpotifyResult(
+  artist: SpotifyArtistResult
+): OnboardingArtistSelection {
+  const metrics = normalizeArtistMetrics(
+    { followers: artist.followers },
+    { source: 'spotify_search' }
+  );
+  return {
+    id: artist.id,
+    name: artist.name,
+    url: artist.url,
+    imageUrl: artist.imageUrl,
+    followers: getDisplaySpotifyFollowers(metrics) ?? undefined,
+    metrics,
+    popularity: artist.popularity,
+  };
 }

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -24,11 +24,9 @@ import {
   normalizeArtistMetrics,
 } from '@/lib/onboarding/canonical-metrics';
 import {
-  type HandleAvailabilityResult,
   SUGGESTED_AVAILABLE_HANDLE_LABEL,
   toHandleAvailabilityResult,
 } from '@/lib/onboarding/handle-availability';
-import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useHandleAvailabilityQuery } from '@/lib/queries/useHandleAvailabilityQuery';
 import { cn } from '@/lib/utils';
@@ -138,7 +136,6 @@ export function formatGenreLabel(genre: string): string {
     )
     .join(' ');
 }
-
 
 function selectionFromSpotifyResult(
   artist: SpotifyArtistResult

--- a/apps/web/components/features/onboarding/onboardingChatHelpers.ts
+++ b/apps/web/components/features/onboarding/onboardingChatHelpers.ts
@@ -3,14 +3,6 @@
 
 import { type UIMessage } from 'ai';
 import type { MessagePart } from '@/components/jovie/types';
-import {
-  type CanonicalArtistMetrics,
-  getDisplaySpotifyFollowers,
-  normalizeArtistMetrics,
-  pickPreferredArtistMetrics,
-} from '@/lib/onboarding/canonical-metrics';
-import { normalizeHandleCandidate } from '@/lib/onboarding/handle-availability';
-import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { type CheckoutCardPayload } from './ChatProposeCheckoutCard';
 import { type NextStepCardPayload } from './ChatProposeNextStepCard';
 import type {
@@ -153,63 +145,16 @@ export function getOnboardingErrorMessage(message: string): string {
   return message;
 }
 
-function metricsFromSelection(
-  artist: OnboardingArtistSelection
-): CanonicalArtistMetrics {
-  return normalizeArtistMetrics(
-    {
-      followers: artist.followers,
-      spotifyFollowers: artist.metrics?.spotifyFollowers,
-      monthlyListeners: artist.metrics?.monthlyListeners,
-    },
-    { source: artist.metrics?.source ?? 'spotify_search' }
-  );
-}
-
-function metricsFromConfirmed(
-  output: ArtistConfirmedOutput
-): CanonicalArtistMetrics | null {
-  const artist = output.artist;
-  if (!artist && !output.metrics) return null;
-
-  const fromTopLevel = output.metrics
-    ? normalizeArtistMetrics(output.metrics, {
-        source: output.metrics.source ?? 'tool_output',
-      })
-    : null;
-  const fromArtist = artist
-    ? normalizeArtistMetrics(
-        {
-          followers: artist.followers,
-          spotifyFollowers: artist.metrics?.spotifyFollowers,
-          monthlyListeners: artist.metrics?.monthlyListeners,
-        },
-        { source: artist.metrics?.source ?? 'tool_output' }
-      )
-    : null;
-
-  return (
-    pickPreferredArtistMetrics(fromTopLevel, fromArtist) ??
-    normalizeArtistMetrics(
-      { followers: artist?.followers },
-      { source: 'tool_output' }
-    )
-  );
-}
-
 export function artistFromSelection(
   artist: OnboardingArtistSelection | null
 ): OnboardingProfileArtist | null {
   if (!artist) return null;
-  const metrics = metricsFromSelection(artist);
-  const followers = getDisplaySpotifyFollowers(metrics);
   return {
     id: artist.id,
     name: artist.name,
     url: artist.url,
     imageUrl: artist.imageUrl ?? null,
-    followers,
-    metrics,
+    followers: artist.followers ?? null,
     popularity: artist.popularity ?? null,
     genres: [],
     dspMatches: [
@@ -228,15 +173,12 @@ export function artistFromConfirmedOutput(
 ): OnboardingProfileArtist | null {
   const artist = output.artist;
   if (!artist) return null;
-  const metrics = metricsFromConfirmed(output);
-  const followers = getDisplaySpotifyFollowers(metrics);
   return {
     id: artist.id,
     name: artist.name,
     url: artist.url,
     imageUrl: artist.imageUrl ?? null,
-    followers,
-    metrics: metrics ?? undefined,
+    followers: artist.followers ?? null,
     popularity: artist.popularity ?? null,
     genres: artist.genres ?? [],
     dspMatches: [
@@ -252,7 +194,7 @@ export function artistFromConfirmedOutput(
 }
 
 export function cleanHandle(handle: string | undefined): string | null {
-  const cleaned = normalizeHandleCandidate(handle);
+  const cleaned = handle?.replace(/^@/, '').trim().toLowerCase();
   return cleaned || null;
 }
 
@@ -269,7 +211,6 @@ export function deriveProfileBuilderState({
   let artistConfirmed = false;
   let handle: string | null = null;
   const socialLinks: string[] = [];
-  const seenSocial = new Set<string>();
 
   for (const message of messages) {
     for (const part of getToolParts(message)) {
@@ -277,22 +218,7 @@ export function deriveProfileBuilderState({
 
       if (isArtistConfirmedOutput(output)) {
         const confirmedArtist = artistFromConfirmedOutput(output);
-        if (confirmedArtist && artist?.metrics) {
-          // Prefer confirmed metrics over search so rail + chat agree.
-          const preferred = pickPreferredArtistMetrics(
-            confirmedArtist.metrics,
-            artist.metrics
-          );
-          artist = {
-            ...confirmedArtist,
-            metrics: preferred ?? confirmedArtist.metrics,
-            followers: getDisplaySpotifyFollowers(
-              preferred ?? confirmedArtist.metrics
-            ),
-          };
-        } else {
-          artist = confirmedArtist ?? artist;
-        }
+        artist = confirmedArtist ?? artist;
         artistConfirmed =
           Boolean(confirmedArtist) || Boolean(output.spotifyArtistId);
       }
@@ -302,13 +228,7 @@ export function deriveProfileBuilderState({
       }
 
       if (isSocialLinkOutput(output) && output.url) {
-        // Only attach complete social URLs (never bare instagram.com).
-        if (output.parseOk === false) continue;
-        const parsed = parseSocialLinkInput(output.url);
-        if (!parsed.ok) continue;
-        if (seenSocial.has(parsed.url)) continue;
-        seenSocial.add(parsed.url);
-        socialLinks.push(parsed.url);
+        socialLinks.push(output.url);
       }
     }
   }

--- a/apps/web/components/features/onboarding/onboardingChatHelpers.ts
+++ b/apps/web/components/features/onboarding/onboardingChatHelpers.ts
@@ -3,6 +3,14 @@
 
 import { type UIMessage } from 'ai';
 import type { MessagePart } from '@/components/jovie/types';
+import {
+  type CanonicalArtistMetrics,
+  getDisplaySpotifyFollowers,
+  normalizeArtistMetrics,
+  pickPreferredArtistMetrics,
+} from '@/lib/onboarding/canonical-metrics';
+import { normalizeHandleCandidate } from '@/lib/onboarding/handle-availability';
+import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { type CheckoutCardPayload } from './ChatProposeCheckoutCard';
 import { type NextStepCardPayload } from './ChatProposeNextStepCard';
 import type {
@@ -145,16 +153,63 @@ export function getOnboardingErrorMessage(message: string): string {
   return message;
 }
 
+function metricsFromSelection(
+  artist: OnboardingArtistSelection
+): CanonicalArtistMetrics {
+  return normalizeArtistMetrics(
+    {
+      followers: artist.followers,
+      spotifyFollowers: artist.metrics?.spotifyFollowers,
+      monthlyListeners: artist.metrics?.monthlyListeners,
+    },
+    { source: artist.metrics?.source ?? 'spotify_search' }
+  );
+}
+
+function metricsFromConfirmed(
+  output: ArtistConfirmedOutput
+): CanonicalArtistMetrics | null {
+  const artist = output.artist;
+  if (!artist && !output.metrics) return null;
+
+  const fromTopLevel = output.metrics
+    ? normalizeArtistMetrics(output.metrics, {
+        source: output.metrics.source ?? 'tool_output',
+      })
+    : null;
+  const fromArtist = artist
+    ? normalizeArtistMetrics(
+        {
+          followers: artist.followers,
+          spotifyFollowers: artist.metrics?.spotifyFollowers,
+          monthlyListeners: artist.metrics?.monthlyListeners,
+        },
+        { source: artist.metrics?.source ?? 'tool_output' }
+      )
+    : null;
+
+  return (
+    pickPreferredArtistMetrics(fromTopLevel, fromArtist) ??
+    normalizeArtistMetrics(
+      { followers: artist?.followers },
+      { source: 'tool_output' }
+    )
+  );
+}
+
 export function artistFromSelection(
   artist: OnboardingArtistSelection | null
 ): OnboardingProfileArtist | null {
   if (!artist) return null;
+  const metrics = metricsFromSelection(artist);
+  const followers = getDisplaySpotifyFollowers(metrics);
   return {
     id: artist.id,
     name: artist.name,
     url: artist.url,
     imageUrl: artist.imageUrl ?? null,
-    followers: artist.followers ?? null,
+    followers,
+    metrics,
     popularity: artist.popularity ?? null,
     genres: [],
     dspMatches: [
@@ -173,12 +228,15 @@ export function artistFromConfirmedOutput(
 ): OnboardingProfileArtist | null {
   const artist = output.artist;
   if (!artist) return null;
+  const metrics = metricsFromConfirmed(output);
+  const followers = getDisplaySpotifyFollowers(metrics);
   return {
     id: artist.id,
     name: artist.name,
     url: artist.url,
     imageUrl: artist.imageUrl ?? null,
-    followers: artist.followers ?? null,
+    followers,
+    metrics: metrics ?? undefined,
     popularity: artist.popularity ?? null,
     genres: artist.genres ?? [],
     dspMatches: [
@@ -194,7 +252,7 @@ export function artistFromConfirmedOutput(
 }
 
 export function cleanHandle(handle: string | undefined): string | null {
-  const cleaned = handle?.replace(/^@/, '').trim().toLowerCase();
+  const cleaned = normalizeHandleCandidate(handle);
   return cleaned || null;
 }
 
@@ -211,6 +269,7 @@ export function deriveProfileBuilderState({
   let artistConfirmed = false;
   let handle: string | null = null;
   const socialLinks: string[] = [];
+  const seenSocial = new Set<string>();
 
   for (const message of messages) {
     for (const part of getToolParts(message)) {
@@ -218,7 +277,22 @@ export function deriveProfileBuilderState({
 
       if (isArtistConfirmedOutput(output)) {
         const confirmedArtist = artistFromConfirmedOutput(output);
-        artist = confirmedArtist ?? artist;
+        if (confirmedArtist && artist?.metrics) {
+          // Prefer confirmed metrics over search so rail + chat agree.
+          const preferred = pickPreferredArtistMetrics(
+            confirmedArtist.metrics,
+            artist.metrics
+          );
+          artist = {
+            ...confirmedArtist,
+            metrics: preferred ?? confirmedArtist.metrics,
+            followers: getDisplaySpotifyFollowers(
+              preferred ?? confirmedArtist.metrics
+            ),
+          };
+        } else {
+          artist = confirmedArtist ?? artist;
+        }
         artistConfirmed =
           Boolean(confirmedArtist) || Boolean(output.spotifyArtistId);
       }
@@ -228,7 +302,13 @@ export function deriveProfileBuilderState({
       }
 
       if (isSocialLinkOutput(output) && output.url) {
-        socialLinks.push(output.url);
+        // Only attach complete social URLs (never bare instagram.com).
+        if (output.parseOk === false) continue;
+        const parsed = parseSocialLinkInput(output.url);
+        if (!parsed.ok) continue;
+        if (seenSocial.has(parsed.url)) continue;
+        seenSocial.add(parsed.url);
+        socialLinks.push(parsed.url);
       }
     }
   }

--- a/apps/web/lib/chat/tools/onboarding-access-eval.test.ts
+++ b/apps/web/lib/chat/tools/onboarding-access-eval.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { normalizeArtistMetrics } from '@/lib/onboarding/canonical-metrics';
 import {
   evaluateAccessSignal,
   MAX_INTERVIEW_TURNS_BEFORE_FORCE,
@@ -15,6 +16,29 @@ describe('evaluateAccessSignal', () => {
     });
     expect(result.kind).toBe('instant_access');
     expect(result.rationale).toContain('spotify_followers_1500');
+  });
+
+  it('does not treat monthly listeners as Spotify followers for access', () => {
+    const result = evaluateAccessSignal({
+      signal: EMPTY_SIGNAL,
+      spotifyFollowers: null,
+      metrics: normalizeArtistMetrics({
+        monthlyListeners: 500_000,
+      }),
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('needs_more_info');
+  });
+
+  it('prefers metrics.spotifyFollowers over a contradictory bare count', () => {
+    const result = evaluateAccessSignal({
+      signal: EMPTY_SIGNAL,
+      spotifyFollowers: 50,
+      metrics: normalizeArtistMetrics({ spotifyFollowers: 2500 }),
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('instant_access');
+    expect(result.rationale).toContain('spotify_followers_2500');
   });
 
   it('grants instant access at audience band 5k_to_50k', () => {

--- a/apps/web/lib/chat/tools/onboarding-access-eval.ts
+++ b/apps/web/lib/chat/tools/onboarding-access-eval.ts
@@ -14,6 +14,11 @@
  * WHAT the decision is.
  */
 
+import {
+  type CanonicalArtistMetrics,
+  getDisplaySpotifyFollowers,
+  normalizeArtistMetrics,
+} from '@/lib/onboarding/canonical-metrics';
 import type {
   AudienceBand,
   InterviewSignal,
@@ -28,8 +33,13 @@ export type AccessDecisionKind =
 export interface AccessDecisionInput {
   /** Collapsed view of all interview signal so far. */
   readonly signal: InterviewSignal;
-  /** Spotify follower count from confirmSpotifyArtist (if resolved). */
+  /**
+   * Spotify follower count from confirmSpotifyArtist (if resolved).
+   * Prefer `metrics` when available — this field is normalized either way.
+   */
   readonly spotifyFollowers: number | null;
+  /** Optional canonical metrics snapshot (preferred over bare followers). */
+  readonly metrics?: CanonicalArtistMetrics | null;
   /** Number of LLM turns observed so far. Used to break stuck loops. */
   readonly turnCount: number;
 }
@@ -80,7 +90,17 @@ const releaseStageRank: Record<ReleaseStage, number> = {
 export function evaluateAccessSignal(
   input: AccessDecisionInput
 ): AccessDecision {
-  const { signal, spotifyFollowers, turnCount } = input;
+  const { signal, turnCount } = input;
+
+  // Always resolve followers through the canonical metrics contract so access
+  // decisions cannot mix monthly listeners into the follower threshold.
+  const metrics =
+    input.metrics ??
+    normalizeArtistMetrics(
+      { spotifyFollowers: input.spotifyFollowers },
+      { source: 'tool_output' }
+    );
+  const spotifyFollowers = getDisplaySpotifyFollowers(metrics);
 
   // 1. Strong Spotify signal — instant access.
   if (

--- a/apps/web/lib/chat/tools/onboarding-tool-impls.test.ts
+++ b/apps/web/lib/chat/tools/onboarding-tool-impls.test.ts
@@ -1,11 +1,17 @@
 import type { UIMessage } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
+import { normalizeArtistMetrics } from '@/lib/onboarding/canonical-metrics';
 import {
   createOnboardingTurnState,
   deriveOnboardingTurnStateFromMessages,
 } from './onboarding-tool-impls';
 
 vi.mock('server-only', () => ({}));
+
+const confirmedMetrics = normalizeArtistMetrics(
+  { spotifyFollowers: 28_000_000 },
+  { source: 'spotify_api', updatedAt: '2026-07-01T00:00:00.000Z' }
+);
 
 const assistantMessage = {
   id: 'assistant-1',
@@ -20,11 +26,13 @@ const assistantMessage = {
       output: {
         action: 'spotify_artist_confirmed',
         spotifyArtistId: '1Cs0zKBU1kc0i8ypK3B9ai',
+        metrics: confirmedMetrics,
         artist: {
           id: '1Cs0zKBU1kc0i8ypK3B9ai',
           name: 'David Guetta',
           imageUrl: 'https://i.scdn.co/image/david.jpg',
           followers: 28_000_000,
+          metrics: confirmedMetrics,
           popularity: 84,
           genres: ['edm'],
         },
@@ -52,9 +60,45 @@ describe('onboarding tool state rehydration', () => {
     expect(state.spotifyArtistId).toBe('1Cs0zKBU1kc0i8ypK3B9ai');
     expect(state.spotifyArtistName).toBe('David Guetta');
     expect(state.spotifyFollowers).toBe(28_000_000);
+    expect(state.artistMetrics?.spotifyFollowers).toBe(28_000_000);
+    expect(state.artistMetrics?.source).toBe('spotify_api');
     expect(state.spotifyPopularity).toBe(84);
     expect(state.spotifyGenres).toEqual(['edm']);
     expect(state.signals).toEqual([{ audienceBand: 'over_500k' }]);
+  });
+
+  it('does not rehydrate monthly listeners into spotifyFollowers', () => {
+    const message = {
+      id: 'assistant-2',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolName: 'confirmSpotifyArtist',
+          toolCallId: 'tool-confirm-2',
+          state: 'output-available',
+          input: { spotifyArtistId: 'abc' },
+          output: {
+            action: 'spotify_artist_confirmed',
+            spotifyArtistId: 'abc',
+            artist: {
+              id: 'abc',
+              name: 'Test',
+              monthlyListeners: 900_000,
+            },
+          },
+        },
+      ],
+    } satisfies UIMessage;
+
+    const state = createOnboardingTurnState({
+      sessionId: 'session-2',
+      turnCount: 1,
+      messages: [message],
+    });
+
+    expect(state.spotifyFollowers).toBeNull();
+    expect(state.artistMetrics?.monthlyListeners).toBe(900_000);
   });
 
   it('can hydrate an existing accumulator before the current tool turn appends more signal', () => {

--- a/apps/web/lib/chat/tools/onboarding-tool-impls.ts
+++ b/apps/web/lib/chat/tools/onboarding-tool-impls.ts
@@ -11,6 +11,16 @@ import {
   type InterviewSignal,
   interviewSignalSchema,
 } from '@/lib/chat/tools/onboarding-signals';
+import {
+  type CanonicalArtistMetrics,
+  normalizeArtistMetrics,
+} from '@/lib/onboarding/canonical-metrics';
+import {
+  type HandleAvailabilityResult,
+  normalizeHandleCandidate,
+  toHandleAvailabilityResult,
+} from '@/lib/onboarding/handle-availability';
+import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { buildSpotifyArtistUrl, getSpotifyArtist } from '@/lib/spotify';
 import { logger } from '@/lib/utils/logger';
 
@@ -59,7 +69,13 @@ export interface OnboardingTurnState {
   spotifyImageUrl: string | null;
   spotifyGenres: string[];
   spotifyPopularity: number | null;
+  /**
+   * Canonical Spotify follower count. Always derived via
+   * `normalizeArtistMetrics` — never dual-sourced against monthly listeners.
+   */
   spotifyFollowers: number | null;
+  /** Full metrics snapshot for UI surfaces that need source/updatedAt. */
+  artistMetrics: CanonicalArtistMetrics | null;
   /** Append-only log of recordInterviewSignal calls within this turn. */
   signals: InterviewSignal[];
   /** Cumulative LLM turn count (1-indexed). Drives the proposeNextStep eval. */
@@ -108,10 +124,36 @@ function restoreArtistFromOutput(
     typeof artist?.imageUrl === 'string'
       ? artist.imageUrl
       : state.spotifyImageUrl;
-  state.spotifyFollowers =
-    typeof artist?.followers === 'number' && Number.isFinite(artist.followers)
-      ? artist.followers
-      : state.spotifyFollowers;
+
+  // Prefer embedded metrics snapshot; fall back to loose artist fields.
+  // Always go through normalizeArtistMetrics so followers ≠ monthly listeners.
+  const metricsRecord = isRecord(output.metrics)
+    ? output.metrics
+    : isRecord(artist?.metrics)
+      ? artist.metrics
+      : null;
+  const preservedSource =
+    metricsRecord && typeof metricsRecord.source === 'string'
+      ? (metricsRecord.source as CanonicalArtistMetrics['source'])
+      : 'tool_output';
+  const metrics = normalizeArtistMetrics(
+    metricsRecord ?? {
+      followers: artist?.followers,
+      spotifyFollowers: artist?.spotifyFollowers,
+      monthlyListeners: artist?.monthlyListeners,
+      monthly_listeners: artist?.monthly_listeners,
+    },
+    {
+      source: preservedSource,
+      updatedAt:
+        metricsRecord && typeof metricsRecord.updatedAt === 'string'
+          ? metricsRecord.updatedAt
+          : undefined,
+    }
+  );
+  state.artistMetrics = metrics;
+  state.spotifyFollowers = metrics.spotifyFollowers;
+
   state.spotifyPopularity =
     typeof artist?.popularity === 'number' && Number.isFinite(artist.popularity)
       ? artist.popularity
@@ -150,6 +192,7 @@ export function createOnboardingTurnState(input: {
     spotifyGenres: [],
     spotifyPopularity: null,
     spotifyFollowers: null,
+    artistMetrics: null,
     signals: [],
     turnCount: input.turnCount,
   };
@@ -190,10 +233,30 @@ export interface ConfirmSpotifyArtistOutput {
     readonly name: string;
     readonly url: string;
     readonly imageUrl: string | null;
+    /** @deprecated Prefer metrics.spotifyFollowers — kept for rehydration. */
     readonly followers: number | null;
     readonly popularity: number | null;
     readonly genres: readonly string[];
+    readonly metrics: CanonicalArtistMetrics;
   } | null;
+  /** Top-level metrics mirror for consumers that do not unwrap artist. */
+  readonly metrics: CanonicalArtistMetrics | null;
+  readonly summary: string;
+}
+
+export interface CheckHandleOutput {
+  readonly action: 'check_handle';
+  readonly handle: string;
+  readonly availability: HandleAvailabilityResult;
+  readonly summary: string;
+}
+
+export interface ProposeSocialLinkOutput {
+  readonly action: 'propose_social_link';
+  readonly url: string | null;
+  readonly parseOk: boolean;
+  readonly reason?: string;
+  readonly platform?: string;
   readonly summary: string;
 }
 
@@ -213,6 +276,7 @@ export async function buildConfirmSpotifyArtistOutput(
   state.spotifyGenres = [];
   state.spotifyPopularity = null;
   state.spotifyFollowers = null;
+  state.artistMetrics = null;
   let artist: Awaited<ReturnType<typeof getSpotifyArtist>> = null;
 
   try {
@@ -225,30 +289,44 @@ export async function buildConfirmSpotifyArtistOutput(
   }
 
   if (artist) {
+    const metrics = normalizeArtistMetrics(
+      {
+        followersObject: artist.followers,
+        followers: artist.followers?.total,
+      },
+      { source: 'spotify_api' }
+    );
     state.spotifyArtistName = artist.name;
     state.spotifyImageUrl = artist.images?.[0]?.url ?? null;
     state.spotifyGenres = artist.genres ?? [];
     state.spotifyPopularity = artist.popularity ?? null;
-    state.spotifyFollowers = artist.followers?.total ?? null;
+    state.artistMetrics = metrics;
+    state.spotifyFollowers = metrics.spotifyFollowers;
+
+    return {
+      action: 'spotify_artist_confirmed' as const,
+      spotifyArtistId,
+      artist: {
+        id: artist.id,
+        name: artist.name,
+        url: buildSpotifyArtistUrl(artist.id),
+        imageUrl: artist.images?.[0]?.url ?? null,
+        followers: metrics.spotifyFollowers,
+        popularity: artist.popularity ?? null,
+        genres: artist.genres?.slice(0, 3) ?? [],
+        metrics,
+      },
+      metrics,
+      summary: `${artist.name} matched on Spotify.`,
+    };
   }
 
   return {
     action: 'spotify_artist_confirmed' as const,
     spotifyArtistId,
-    artist: artist
-      ? {
-          id: artist.id,
-          name: artist.name,
-          url: buildSpotifyArtistUrl(artist.id),
-          imageUrl: artist.images?.[0]?.url ?? null,
-          followers: artist.followers?.total ?? null,
-          popularity: artist.popularity ?? null,
-          genres: artist.genres?.slice(0, 3) ?? [],
-        }
-      : null,
-    summary: artist
-      ? `${artist.name} matched on Spotify.`
-      : 'Spotify artist selected.',
+    artist: null,
+    metrics: null,
+    summary: 'Spotify artist selected.',
   };
 }
 
@@ -292,14 +370,21 @@ export function buildOnboardingTools(state: OnboardingTurnState): ToolSet {
       description: TOOL_SCHEMAS.checkHandle.description,
       inputSchema: TOOL_SCHEMAS.checkHandle.inputSchema,
       execute: async ({ handle }) => {
-        // Client-side rendering hits /api/handle/check directly so the gate
-        // surfaces the same constant-time response budget regardless of who
-        // asks. The tool just emits the marker + the proposed handle.
-        return {
-          action: 'check_handle' as const,
-          handle: handle.toLowerCase(),
-          summary: `Checking @${handle.toLowerCase()}.`,
+        // Client-side rendering hits /api/handle/check for the live boolean.
+        // Emit the canonical availability shell (requested handle only — never
+        // a silent numbered swap). UI fills available via the shared helper.
+        const normalized = normalizeHandleCandidate(handle);
+        const availability = toHandleAvailabilityResult({
+          handle: normalized,
+          checking: true,
+        });
+        const payload: CheckHandleOutput = {
+          action: 'check_handle',
+          handle: normalized,
+          availability,
+          summary: `Checking @${normalized}.`,
         };
+        return payload;
       },
     }),
 
@@ -307,13 +392,28 @@ export function buildOnboardingTools(state: OnboardingTurnState): ToolSet {
       description: TOOL_SCHEMAS.proposeSocialLink.description,
       inputSchema: TOOL_SCHEMAS.proposeSocialLink.inputSchema,
       execute: async ({ url }) => {
-        // Preserve the exact URL so the UI can render a review state before
-        // any commitment.
-        return {
-          action: 'propose_social_link' as const,
-          url,
+        // Reject incomplete parses (e.g. bare instagram.com) so the rail and
+        // artifacts never attach a host without an account path.
+        const parsed = parseSocialLinkInput(url);
+        if (!parsed.ok) {
+          const payload: ProposeSocialLinkOutput = {
+            action: 'propose_social_link',
+            url: null,
+            parseOk: false,
+            reason: parsed.reason,
+            platform: parsed.platform,
+            summary: 'Link needs a full profile URL with account path.',
+          };
+          return payload;
+        }
+        const payload: ProposeSocialLinkOutput = {
+          action: 'propose_social_link',
+          url: parsed.url,
+          parseOk: true,
+          platform: parsed.platform,
           summary: 'Social link ready to review.',
         };
+        return payload;
       },
     }),
 
@@ -347,6 +447,7 @@ export function buildOnboardingTools(state: OnboardingTurnState): ToolSet {
             }))
           ),
           spotifyFollowers: state.spotifyFollowers,
+          metrics: state.artistMetrics,
           turnCount: state.turnCount,
         });
         const payload: NextStepCardPayload = {

--- a/apps/web/lib/onboarding/canonical-metrics.test.ts
+++ b/apps/web/lib/onboarding/canonical-metrics.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDisplaySpotifyFollowers,
+  normalizeArtistMetrics,
+  pickPreferredArtistMetrics,
+} from './canonical-metrics';
+
+describe('normalizeArtistMetrics', () => {
+  it('prefers spotifyFollowers over followers / followerCount', () => {
+    const metrics = normalizeArtistMetrics(
+      {
+        spotifyFollowers: 1000,
+        followers: 9999,
+        followerCount: 50,
+        monthlyListeners: 200_000,
+      },
+      { source: 'tool_output', updatedAt: '2026-07-01T00:00:00.000Z' }
+    );
+
+    expect(metrics).toEqual({
+      spotifyFollowers: 1000,
+      monthlyListeners: 200_000,
+      source: 'tool_output',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    });
+  });
+
+  it('does not treat monthly listeners as Spotify followers', () => {
+    const metrics = normalizeArtistMetrics({
+      monthlyListeners: 500_000,
+      monthly_listeners: 400_000,
+    });
+
+    expect(metrics.spotifyFollowers).toBeNull();
+    expect(metrics.monthlyListeners).toBe(500_000);
+  });
+
+  it('reads nested Spotify API followers.total via followersObject', () => {
+    const metrics = normalizeArtistMetrics(
+      { followersObject: { total: 28_000_000 } },
+      { source: 'spotify_api' }
+    );
+
+    expect(metrics.spotifyFollowers).toBe(28_000_000);
+    expect(metrics.source).toBe('spotify_api');
+  });
+
+  it('rejects non-finite and negative counts', () => {
+    const metrics = normalizeArtistMetrics({
+      followers: Number.NaN,
+      followerCount: -12,
+      monthlyListeners: Number.POSITIVE_INFINITY,
+    });
+
+    expect(metrics.spotifyFollowers).toBeNull();
+    expect(metrics.monthlyListeners).toBeNull();
+  });
+
+  it('truncates fractional counts to integers', () => {
+    const metrics = normalizeArtistMetrics({
+      followers: 12.9,
+      monthlyListeners: 99.1,
+    });
+
+    expect(metrics.spotifyFollowers).toBe(12);
+    expect(metrics.monthlyListeners).toBe(99);
+  });
+
+  it('falls back through follower field aliases without contradiction', () => {
+    expect(normalizeArtistMetrics({ followerCount: 42 }).spotifyFollowers).toBe(
+      42
+    );
+    expect(
+      normalizeArtistMetrics({ followersTotal: 77 }).spotifyFollowers
+    ).toBe(77);
+    expect(normalizeArtistMetrics(null).spotifyFollowers).toBeNull();
+  });
+});
+
+describe('pickPreferredArtistMetrics', () => {
+  it('prefers confirmed metrics over search metrics when both exist', () => {
+    const confirmed = normalizeArtistMetrics(
+      { spotifyFollowers: 28_000_000 },
+      { source: 'spotify_api' }
+    );
+    const search = normalizeArtistMetrics(
+      { followers: 27_500_000 },
+      { source: 'spotify_search' }
+    );
+
+    expect(
+      pickPreferredArtistMetrics(confirmed, search)?.spotifyFollowers
+    ).toBe(28_000_000);
+  });
+
+  it('uses fallback when primary has no follower count', () => {
+    const empty = normalizeArtistMetrics({}, { source: 'tool_output' });
+    const search = normalizeArtistMetrics(
+      { followers: 1000 },
+      { source: 'spotify_search' }
+    );
+
+    expect(pickPreferredArtistMetrics(empty, search)?.spotifyFollowers).toBe(
+      1000
+    );
+  });
+});
+
+describe('getDisplaySpotifyFollowers', () => {
+  it('returns only spotifyFollowers so UI cannot show monthly listeners as followers', () => {
+    const metrics = normalizeArtistMetrics({
+      spotifyFollowers: 1200,
+      monthlyListeners: 90_000,
+    });
+
+    expect(getDisplaySpotifyFollowers(metrics)).toBe(1200);
+    expect(getDisplaySpotifyFollowers(null)).toBeNull();
+  });
+});

--- a/apps/web/lib/onboarding/canonical-metrics.ts
+++ b/apps/web/lib/onboarding/canonical-metrics.ts
@@ -1,0 +1,129 @@
+/**
+ * Canonical artist metrics contract for onboarding surfaces.
+ *
+ * Profile rail, tool artifacts, and chat state must all read follower counts
+ * through `normalizeArtistMetrics` so the UI never displays two contradictory
+ * Spotify follower numbers (or confuses monthly listeners with followers).
+ */
+
+export type ArtistMetricsSource =
+  | 'spotify_api'
+  | 'spotify_search'
+  | 'tool_output'
+  | 'unknown';
+
+export interface CanonicalArtistMetrics {
+  /** Spotify follower total. Never equal to monthlyListeners. */
+  readonly spotifyFollowers: number | null;
+  /** Optional monthly listeners when a source provides them separately. */
+  readonly monthlyListeners: number | null;
+  readonly source: ArtistMetricsSource;
+  /** ISO-8601 timestamp of when this snapshot was produced. */
+  readonly updatedAt: string;
+}
+
+/**
+ * Loose input shapes we accept from Spotify API, search results, tool output,
+ * or partial rehydration payloads.
+ */
+export interface ArtistMetricsInput {
+  readonly followers?: number | null;
+  readonly followerCount?: number | null;
+  readonly followersTotal?: number | null;
+  readonly spotifyFollowers?: number | null;
+  /** Nested Spotify API shape: `{ total: number }`. */
+  readonly followersObject?: { readonly total?: number | null } | null;
+  readonly monthlyListeners?: number | null;
+  readonly monthly_listeners?: number | null;
+  readonly source?: ArtistMetricsSource | null;
+  readonly updatedAt?: string | Date | null;
+}
+
+export interface NormalizeArtistMetricsOptions {
+  readonly source?: ArtistMetricsSource;
+  readonly updatedAt?: string | Date | null;
+}
+
+function toNonNegativeInt(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value < 0) return null;
+  return Math.trunc(value);
+}
+
+function toIsoTimestamp(value: string | Date | null | undefined): string {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+/**
+ * Collapse heterogeneous artist metric fields into one snapshot.
+ *
+ * Precedence for Spotify followers (first non-null wins):
+ *   spotifyFollowers → followers → followerCount → followersTotal → followersObject.total
+ *
+ * Monthly listeners are read only from monthlyListeners / monthly_listeners —
+ * never from the followers fields — so UI cannot mix the two series.
+ */
+export function normalizeArtistMetrics(
+  input: ArtistMetricsInput | null | undefined,
+  options: NormalizeArtistMetricsOptions = {}
+): CanonicalArtistMetrics {
+  const source =
+    options.source ??
+    (input?.source && isArtistMetricsSource(input.source)
+      ? input.source
+      : 'unknown');
+
+  const spotifyFollowers =
+    toNonNegativeInt(input?.spotifyFollowers) ??
+    toNonNegativeInt(input?.followers) ??
+    toNonNegativeInt(input?.followerCount) ??
+    toNonNegativeInt(input?.followersTotal) ??
+    toNonNegativeInt(input?.followersObject?.total);
+
+  const monthlyListeners =
+    toNonNegativeInt(input?.monthlyListeners) ??
+    toNonNegativeInt(input?.monthly_listeners);
+
+  return {
+    spotifyFollowers,
+    monthlyListeners,
+    source,
+    updatedAt: toIsoTimestamp(options.updatedAt ?? input?.updatedAt),
+  };
+}
+
+function isArtistMetricsSource(value: string): value is ArtistMetricsSource {
+  return (
+    value === 'spotify_api' ||
+    value === 'spotify_search' ||
+    value === 'tool_output' ||
+    value === 'unknown'
+  );
+}
+
+/**
+ * Prefer a confirmed / tool-output snapshot over a search-result snapshot so
+ * profile rail and chat never disagree after confirmSpotifyArtist runs.
+ */
+export function pickPreferredArtistMetrics(
+  primary: CanonicalArtistMetrics | null | undefined,
+  fallback: CanonicalArtistMetrics | null | undefined
+): CanonicalArtistMetrics | null {
+  if (primary?.spotifyFollowers != null) return primary;
+  if (fallback?.spotifyFollowers != null) return fallback;
+  return primary ?? fallback ?? null;
+}
+
+/** Display helper: always the canonical follower field, never monthly listeners. */
+export function getDisplaySpotifyFollowers(
+  metrics: CanonicalArtistMetrics | null | undefined
+): number | null {
+  return metrics?.spotifyFollowers ?? null;
+}

--- a/apps/web/lib/onboarding/handle-availability-cache.ts
+++ b/apps/web/lib/onboarding/handle-availability-cache.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 
 import { captureWarning } from '@/lib/error-tracking';
+import {
+  type HandleAvailabilityResult,
+  normalizeHandleCandidate,
+  toHandleAvailabilityResult,
+} from '@/lib/onboarding/handle-availability';
 import { getRedis } from '@/lib/redis';
 
 const HANDLE_CACHE_KEY_PREFIX = 'onboarding:handle-availability:';
@@ -8,7 +13,7 @@ const HANDLE_AVAILABLE_TTL_SECONDS = 300; // 5 minutes — available handles can
 const HANDLE_UNAVAILABLE_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days — claimed handles rarely become unclaimed
 
 function getHandleCacheKey(handle: string): string {
-  return `${HANDLE_CACHE_KEY_PREFIX}${handle.toLowerCase()}`;
+  return `${HANDLE_CACHE_KEY_PREFIX}${normalizeHandleCandidate(handle)}`;
 }
 
 export async function getCachedHandleAvailability(
@@ -25,6 +30,18 @@ export async function getCachedHandleAvailability(
     captureWarning('[handle-availability] Redis read failed', { error });
     return null;
   }
+}
+
+/**
+ * Read cache and project through the canonical availability contract.
+ * Returns null on cache miss so callers can fall through to DB.
+ */
+export async function getCachedHandleAvailabilityResult(
+  handle: string
+): Promise<HandleAvailabilityResult | null> {
+  const cached = await getCachedHandleAvailability(handle);
+  if (cached === null) return null;
+  return toHandleAvailabilityResult({ handle, available: cached });
 }
 
 export async function cacheHandleAvailability(

--- a/apps/web/lib/onboarding/handle-availability.test.ts
+++ b/apps/web/lib/onboarding/handle-availability.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildNumberedHandleSuggestions,
+  isContradictoryHandleStatus,
+  SUGGESTED_AVAILABLE_HANDLE_LABEL,
+  toHandleAvailabilityResult,
+} from './handle-availability';
+
+describe('toHandleAvailabilityResult', () => {
+  it('returns a single available status without suggested alternatives', () => {
+    const result = toHandleAvailabilityResult({
+      handle: '@DavidGuetta',
+      available: true,
+      suggestedAlternatives: ['davidguetta1'],
+    });
+
+    expect(result).toEqual({
+      handle: 'davidguetta',
+      available: true,
+      reason: 'available',
+    });
+    expect(result.suggestedAlternatives).toBeUndefined();
+  });
+
+  it('never reports available while checking', () => {
+    const result = toHandleAvailabilityResult({
+      handle: 'takenhandle',
+      available: true,
+      checking: true,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('checking');
+  });
+
+  it('surfaces numbered alternatives when taken — never silent swap', () => {
+    const result = toHandleAvailabilityResult({
+      handle: 'calvin',
+      available: false,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('taken');
+    expect(result.handle).toBe('calvin');
+    expect(result.suggestedAlternatives).toEqual([
+      'calvin1',
+      'calvin2',
+      'calvin3',
+    ]);
+    // Primary handle stays the requested one
+    expect(result.handle).not.toBe(result.suggestedAlternatives?.[0]);
+    expect(SUGGESTED_AVAILABLE_HANDLE_LABEL).toBe('Suggested available handle');
+  });
+
+  it('marks invalid format as unavailable (not available+taken dual state)', () => {
+    const result = toHandleAvailabilityResult({
+      handle: 'ab',
+      available: true,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('invalid_format');
+  });
+
+  it('marks reserved handles as unavailable with alternatives', () => {
+    const result = toHandleAvailabilityResult({
+      handle: 'admin',
+      available: true,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('reserved');
+    expect(result.suggestedAlternatives?.length).toBeGreaterThan(0);
+  });
+
+  it('treats null availability as unknown (not available)', () => {
+    const result = toHandleAvailabilityResult({
+      handle: 'maybe',
+      available: null,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('unknown');
+  });
+});
+
+describe('buildNumberedHandleSuggestions', () => {
+  it('skips taken candidates when a taken set is provided', () => {
+    const suggestions = buildNumberedHandleSuggestions('artist', {
+      limit: 2,
+      taken: new Set(['artist1']),
+    });
+
+    expect(suggestions).toEqual(['artist2', 'artist3']);
+  });
+});
+
+describe('isContradictoryHandleStatus', () => {
+  it('detects available vs taken for the same handle', () => {
+    const a = toHandleAvailabilityResult({
+      handle: 'same',
+      available: true,
+    });
+    const b = toHandleAvailabilityResult({
+      handle: 'same',
+      available: false,
+    });
+
+    expect(isContradictoryHandleStatus(a, b)).toBe(true);
+    expect(isContradictoryHandleStatus(a, a)).toBe(false);
+  });
+});

--- a/apps/web/lib/onboarding/handle-availability.ts
+++ b/apps/web/lib/onboarding/handle-availability.ts
@@ -1,0 +1,260 @@
+/**
+ * Canonical handle-availability contract for onboarding.
+ *
+ * Every surface (handle check card, chat helpers, reserved-handle suggestions)
+ * must present availability through `toHandleAvailabilityResult` so the UI
+ * cannot show available + taken for the same handle, and numbered alternatives
+ * are always explicit `suggestedAlternatives` (never silent replacements).
+ */
+
+import {
+  normalizeUsername,
+  RESERVED_USERNAMES,
+  validateUsernameCore,
+} from '@/lib/validation/username-core';
+
+export type HandleAvailabilityReason =
+  | 'available'
+  | 'taken'
+  | 'invalid_format'
+  | 'reserved'
+  | 'error'
+  | 'checking'
+  | 'unknown';
+
+export interface HandleAvailabilityResult {
+  /** Normalized handle the result describes (no @). */
+  readonly handle: string;
+  /**
+   * Single boolean status. Guaranteed:
+   *   available === true  ⇔ reason === 'available'
+   *   available === false for every other reason (including checking/error).
+   */
+  readonly available: boolean;
+  readonly reason: HandleAvailabilityReason;
+  /**
+   * Numbered / alternate handles when the requested handle is taken.
+   * UI must label these as "Suggested available handle" — never swap silently.
+   */
+  readonly suggestedAlternatives?: readonly string[];
+  /** Optional machine/user message (validation or transport errors). */
+  readonly error?: string;
+}
+
+export interface ToHandleAvailabilityResultInput {
+  readonly handle: string;
+  /** When known from API/cache. Omit while loading. */
+  readonly available?: boolean | null;
+  readonly error?: string | null;
+  readonly suggestedAlternatives?: readonly string[] | null;
+  /** When true, treat as in-flight check (never available+taken). */
+  readonly checking?: boolean;
+}
+
+const RESERVED_SET = new Set(
+  RESERVED_USERNAMES.map(name => name.toLowerCase())
+);
+
+/** Max numbered alternatives surfaced to the UI. */
+export const HANDLE_SUGGESTION_LIMIT = 3;
+
+/**
+ * Normalize a handle for availability checks (strip @, lowercase, trim).
+ */
+export function normalizeHandleCandidate(
+  handle: string | null | undefined
+): string {
+  if (!handle) return '';
+  return normalizeUsername(handle.replace(/^@+/, '').trim());
+}
+
+/**
+ * Build numbered handle alternatives for a base handle (base1, base2, …).
+ * Does not claim availability — callers pass known-available ones when known.
+ */
+export function buildNumberedHandleSuggestions(
+  baseHandle: string,
+  options: {
+    readonly limit?: number;
+    readonly taken?: ReadonlySet<string>;
+    /** Start suffix (default 1). */
+    readonly start?: number;
+  } = {}
+): string[] {
+  const base = normalizeHandleCandidate(baseHandle);
+  if (!base) return [];
+
+  const limit = options.limit ?? HANDLE_SUGGESTION_LIMIT;
+  const taken = options.taken;
+  const start = options.start ?? 1;
+  const suggestions: string[] = [];
+
+  for (
+    let suffix = start;
+    suggestions.length < limit && suffix < start + 50;
+    suffix++
+  ) {
+    const candidate = `${base}${suffix}`;
+    const format = validateUsernameCore(candidate);
+    if (!format.isValid) continue;
+    if (taken?.has(candidate)) continue;
+    if (candidate === base) continue;
+    suggestions.push(candidate);
+  }
+
+  return suggestions;
+}
+
+/**
+ * Single source of truth for handle availability presentation.
+ *
+ * Invariants:
+ * - Never returns available:true with reason other than 'available'
+ * - Never returns available:true while checking
+ * - suggestedAlternatives only present when the requested handle is not available
+ * - Invalid/reserved handles are unavailable with an explicit reason
+ */
+export function toHandleAvailabilityResult(
+  input: ToHandleAvailabilityResultInput
+): HandleAvailabilityResult {
+  const handle = normalizeHandleCandidate(input.handle);
+
+  if (!handle) {
+    return {
+      handle: '',
+      available: false,
+      reason: 'invalid_format',
+      error: input.error ?? 'Handle is required',
+    };
+  }
+
+  // Reserved before format: validateUsernameCore also rejects reserved names,
+  // but we want the explicit `reserved` reason for UI alternatives.
+  if (RESERVED_SET.has(handle)) {
+    const suggestedAlternatives = sanitizeAlternatives(
+      handle,
+      input.suggestedAlternatives ??
+        buildNumberedHandleSuggestions(handle, {
+          limit: HANDLE_SUGGESTION_LIMIT,
+        })
+    );
+    return {
+      handle,
+      available: false,
+      reason: 'reserved',
+      suggestedAlternatives,
+      error: input.error ?? 'This handle is reserved',
+    };
+  }
+
+  const format = validateUsernameCore(handle);
+  if (!format.isValid) {
+    const reservedByValidator =
+      typeof format.error === 'string' && /reserved/i.test(format.error);
+    return {
+      handle,
+      available: false,
+      reason: reservedByValidator ? 'reserved' : 'invalid_format',
+      error: input.error ?? format.error ?? 'Invalid handle format',
+      ...(reservedByValidator
+        ? {
+            suggestedAlternatives: sanitizeAlternatives(
+              handle,
+              input.suggestedAlternatives ??
+                buildNumberedHandleSuggestions(handle, {
+                  limit: HANDLE_SUGGESTION_LIMIT,
+                })
+            ),
+          }
+        : {}),
+    };
+  }
+
+  if (input.checking || input.available == null) {
+    return {
+      handle,
+      available: false,
+      reason: input.checking ? 'checking' : 'unknown',
+      error: input.error ?? undefined,
+    };
+  }
+
+  if (input.error && input.available !== true) {
+    return {
+      handle,
+      available: false,
+      reason: 'error',
+      error: input.error,
+      suggestedAlternatives: sanitizeAlternatives(
+        handle,
+        input.suggestedAlternatives
+      ),
+    };
+  }
+
+  if (input.available === true) {
+    // Explicitly omit suggestedAlternatives when available — no dual status.
+    return {
+      handle,
+      available: true,
+      reason: 'available',
+    };
+  }
+
+  // Taken (or not available).
+  const suggestedAlternatives = sanitizeAlternatives(
+    handle,
+    input.suggestedAlternatives ??
+      buildNumberedHandleSuggestions(handle, { limit: HANDLE_SUGGESTION_LIMIT })
+  );
+
+  return {
+    handle,
+    available: false,
+    reason: 'taken',
+    suggestedAlternatives,
+    error: input.error ?? undefined,
+  };
+}
+
+function sanitizeAlternatives(
+  requested: string,
+  alternatives: readonly string[] | null | undefined
+): readonly string[] | undefined {
+  if (!alternatives || alternatives.length === 0) return undefined;
+
+  const seen = new Set<string>();
+  const cleaned: string[] = [];
+
+  for (const raw of alternatives) {
+    const candidate = normalizeHandleCandidate(raw);
+    if (!candidate || candidate === requested) continue;
+    if (seen.has(candidate)) continue;
+    if (!validateUsernameCore(candidate).isValid) continue;
+    seen.add(candidate);
+    cleaned.push(candidate);
+    if (cleaned.length >= HANDLE_SUGGESTION_LIMIT) break;
+  }
+
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
+ * UI copy constant — every auto-suffixed suggestion must use this label.
+ * Never silently replace the requested handle in the primary slot.
+ */
+export const SUGGESTED_AVAILABLE_HANDLE_LABEL = 'Suggested available handle';
+
+/**
+ * Whether two results describe contradictory status for the same handle.
+ * Used by tests and optional UI guards.
+ */
+export function isContradictoryHandleStatus(
+  a: HandleAvailabilityResult,
+  b: HandleAvailabilityResult
+): boolean {
+  if (a.handle !== b.handle) return false;
+  if (a.available === b.available) return false;
+  // available true vs false for same handle is a contradiction
+  return true;
+}

--- a/apps/web/lib/onboarding/reserved-handle.ts
+++ b/apps/web/lib/onboarding/reserved-handle.ts
@@ -3,6 +3,13 @@ import 'server-only';
 import { inArray } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
+import {
+  buildNumberedHandleSuggestions,
+  HANDLE_SUGGESTION_LIMIT,
+  type HandleAvailabilityResult,
+  normalizeHandleCandidate,
+  toHandleAvailabilityResult,
+} from '@/lib/onboarding/handle-availability';
 import { assertAuthenticatedOnboardingUser } from '@/lib/onboarding/ownership-gate';
 import { normalizeUsername, validateUsername } from '@/lib/validation/username';
 
@@ -50,6 +57,42 @@ async function findTakenHandles(candidates: string[]): Promise<Set<string>> {
     .from(creatorProfiles)
     .where(inArray(creatorProfiles.usernameNormalized, candidates));
   return new Set(rows.map(r => r.normalized));
+}
+
+/**
+ * Check a specific handle's availability and surface numbered alternatives
+ * when taken. Never silently replaces the requested handle — alternatives
+ * live only in `suggestedAlternatives` for explicit UI labeling.
+ */
+export async function checkOnboardingHandleAvailability(
+  requestedHandle: string
+): Promise<HandleAvailabilityResult> {
+  const handle = normalizeHandleCandidate(requestedHandle);
+  const formatGate = toHandleAvailabilityResult({ handle });
+  if (
+    formatGate.reason === 'invalid_format' ||
+    formatGate.reason === 'reserved'
+  ) {
+    return formatGate;
+  }
+
+  const numbered = buildNumberedHandleSuggestions(handle, {
+    limit: HANDLE_SUGGESTION_LIMIT + 5,
+  });
+  const taken = await findTakenHandles([handle, ...numbered]);
+  const available = !taken.has(handle);
+  const suggestedAlternatives = available
+    ? undefined
+    : buildNumberedHandleSuggestions(handle, {
+        limit: HANDLE_SUGGESTION_LIMIT,
+        taken,
+      });
+
+  return toHandleAvailabilityResult({
+    handle,
+    available,
+    suggestedAlternatives,
+  });
 }
 
 /**

--- a/apps/web/lib/onboarding/social-link-parse.test.ts
+++ b/apps/web/lib/onboarding/social-link-parse.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isCompleteSocialUrl,
+  parseInstagramInput,
+  parseSocialLinkInput,
+} from './social-link-parse';
+
+describe('parseInstagramInput', () => {
+  it('builds a full profile URL from a bare handle', () => {
+    expect(parseInstagramInput('davidguetta')).toEqual({
+      ok: true,
+      platform: 'instagram',
+      handle: 'davidguetta',
+      url: 'https://www.instagram.com/davidguetta/',
+    });
+  });
+
+  it('accepts @handles', () => {
+    const result = parseInstagramInput('@calvinharris');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.handle).toBe('calvinharris');
+      expect(result.url).toBe('https://www.instagram.com/calvinharris/');
+    }
+  });
+
+  it('rejects bare instagram.com without an account path', () => {
+    for (const input of [
+      'instagram.com',
+      'www.instagram.com',
+      'https://instagram.com',
+      'https://www.instagram.com',
+      'https://www.instagram.com/',
+      'http://instagram.com/',
+    ]) {
+      const result = parseInstagramInput(input);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('missing_account_path');
+      }
+    }
+  });
+
+  it('normalizes full URLs that include a path', () => {
+    const result = parseInstagramInput('https://instagram.com/timwhite/');
+    expect(result).toEqual({
+      ok: true,
+      platform: 'instagram',
+      handle: 'timwhite',
+      url: 'https://www.instagram.com/timwhite/',
+    });
+  });
+
+  it('rejects reserved Instagram path segments', () => {
+    const result = parseInstagramInput('https://www.instagram.com/reels/');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('parseSocialLinkInput', () => {
+  it('routes Instagram-looking inputs through the Instagram parser', () => {
+    expect(parseSocialLinkInput('https://instagram.com/foo').ok).toBe(true);
+    expect(parseSocialLinkInput('instagram.com').ok).toBe(false);
+  });
+
+  it('rejects other bare social hosts without a path', () => {
+    expect(parseSocialLinkInput('https://tiktok.com').ok).toBe(false);
+    expect(parseSocialLinkInput('https://x.com/').ok).toBe(false);
+  });
+
+  it('accepts TikTok and X profile paths', () => {
+    const tiktok = parseSocialLinkInput('https://www.tiktok.com/@artist');
+    expect(tiktok.ok).toBe(true);
+    if (tiktok.ok) {
+      expect(tiktok.platform).toBe('tiktok');
+      expect(tiktok.url).toContain('@artist');
+    }
+
+    const x = parseSocialLinkInput('https://twitter.com/artist');
+    expect(x.ok).toBe(true);
+    if (x.ok) {
+      expect(x.platform).toBe('x');
+      expect(x.url).toBe('https://x.com/artist');
+    }
+  });
+
+  it('isCompleteSocialUrl mirrors parse success', () => {
+    expect(isCompleteSocialUrl('https://www.instagram.com/a/')).toBe(true);
+    expect(isCompleteSocialUrl('instagram.com')).toBe(false);
+  });
+});

--- a/apps/web/lib/onboarding/social-link-parse.ts
+++ b/apps/web/lib/onboarding/social-link-parse.ts
@@ -1,0 +1,307 @@
+/**
+ * Canonical social-link parse for onboarding.
+ *
+ * Instagram handle / URL inputs become a full HTTPS URL with an account path.
+ * Bare hosts (`instagram.com`, `https://www.instagram.com/`) are rejected so
+ * profile rail and tool artifacts never attach incomplete links.
+ */
+
+export type SocialPlatform =
+  | 'instagram'
+  | 'tiktok'
+  | 'youtube'
+  | 'x'
+  | 'soundcloud'
+  | 'spotify'
+  | 'website';
+
+export type SocialParseSuccess = {
+  readonly ok: true;
+  readonly platform: SocialPlatform;
+  readonly handle: string | null;
+  /** Full HTTPS URL including account path when required. */
+  readonly url: string;
+};
+
+export type SocialParseFailure = {
+  readonly ok: false;
+  readonly platform?: SocialPlatform;
+  readonly reason: string;
+};
+
+export type SocialParseResult = SocialParseSuccess | SocialParseFailure;
+
+const INSTAGRAM_HANDLE_PATTERN = /^[A-Za-z0-9._]{1,30}$/;
+const TIKTOK_HANDLE_PATTERN = /^[A-Za-z0-9._]{2,24}$/;
+const X_HANDLE_PATTERN = /^[A-Za-z0-9_]{1,15}$/;
+
+const INSTAGRAM_RESERVED = new Set([
+  'p',
+  'reel',
+  'reels',
+  'stories',
+  'explore',
+  'accounts',
+  'about',
+  'developer',
+  'legal',
+  'privacy',
+  'direct',
+  'tv',
+]);
+
+function stripAt(value: string): string {
+  return value.replace(/^@+/, '').trim();
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^www\./i, '').toLowerCase();
+}
+
+/**
+ * Parse an Instagram handle or URL into a full profile URL with account path.
+ * Rejects bare `instagram.com` (with or without scheme/www/trailing slash).
+ */
+export function parseInstagramInput(input: string): SocialParseResult {
+  const raw = input.trim();
+  if (!raw) {
+    return { ok: false, platform: 'instagram', reason: 'empty' };
+  }
+
+  // Bare handle (optionally @-prefixed).
+  if (!raw.includes('/') && !raw.includes(':') && !raw.includes('.')) {
+    const handle = stripAt(raw);
+    if (!INSTAGRAM_HANDLE_PATTERN.test(handle)) {
+      return {
+        ok: false,
+        platform: 'instagram',
+        reason: 'invalid_handle',
+      };
+    }
+    return {
+      ok: true,
+      platform: 'instagram',
+      handle,
+      url: `https://www.instagram.com/${handle}/`,
+    };
+  }
+
+  // Host-only forms without a path segment: always reject.
+  const hostOnly =
+    /^(?:https?:\/\/)?(?:www\.)?instagram\.com\/?$/i.test(raw) ||
+    raw.toLowerCase() === 'instagram.com' ||
+    raw.toLowerCase() === 'www.instagram.com';
+  if (hostOnly) {
+    return {
+      ok: false,
+      platform: 'instagram',
+      reason: 'missing_account_path',
+    };
+  }
+
+  let url: URL;
+  try {
+    const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    url = new URL(withScheme);
+  } catch {
+    return { ok: false, platform: 'instagram', reason: 'invalid_url' };
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, platform: 'instagram', reason: 'invalid_protocol' };
+  }
+
+  const host = normalizeHostname(url.hostname);
+  if (host !== 'instagram.com') {
+    return { ok: false, platform: 'instagram', reason: 'wrong_host' };
+  }
+
+  const segments = url.pathname
+    .split('/')
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return {
+      ok: false,
+      platform: 'instagram',
+      reason: 'missing_account_path',
+    };
+  }
+
+  const handle = stripAt(segments[0] ?? '');
+  if (
+    !handle ||
+    INSTAGRAM_RESERVED.has(handle.toLowerCase()) ||
+    !INSTAGRAM_HANDLE_PATTERN.test(handle)
+  ) {
+    return {
+      ok: false,
+      platform: 'instagram',
+      reason: 'invalid_or_reserved_path',
+    };
+  }
+
+  return {
+    ok: true,
+    platform: 'instagram',
+    handle,
+    url: `https://www.instagram.com/${handle}/`,
+  };
+}
+
+/**
+ * Parse a social handle or URL for onboarding attach flows.
+ * Instagram is the strictest (must have account path). Other platforms get
+ * best-effort normalization; incomplete bare hosts are rejected.
+ */
+export function parseSocialLinkInput(input: string): SocialParseResult {
+  const raw = input.trim();
+  if (!raw) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  // Explicit Instagram host or @handle without domain → Instagram parser.
+  if (
+    /instagram\.com/i.test(raw) ||
+    (!raw.includes('/') && !raw.includes('.') && raw.startsWith('@'))
+  ) {
+    return parseInstagramInput(raw);
+  }
+
+  // Host-only bare domains without path.
+  if (
+    /^(?:https?:\/\/)?(?:www\.)?(instagram|tiktok|x|twitter|youtube|soundcloud)\.com\/?$/i.test(
+      raw
+    )
+  ) {
+    return { ok: false, reason: 'missing_account_path' };
+  }
+
+  if (
+    /instagram\.com/i.test(raw) ||
+    (!raw.includes('.') && !raw.includes('/'))
+  ) {
+    // Bare handle without @ also defaults to Instagram for onboarding.
+    return parseInstagramInput(raw);
+  }
+
+  let url: URL;
+  try {
+    const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    url = new URL(withScheme);
+  } catch {
+    return { ok: false, reason: 'invalid_url' };
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, reason: 'invalid_protocol' };
+  }
+
+  const host = normalizeHostname(url.hostname);
+  const pathSegments = url.pathname.split('/').filter(Boolean);
+
+  if (host === 'instagram.com') {
+    return parseInstagramInput(raw);
+  }
+
+  if (host === 'tiktok.com') {
+    if (pathSegments.length === 0) {
+      return { ok: false, platform: 'tiktok', reason: 'missing_account_path' };
+    }
+    const handle = stripAt(pathSegments[0] ?? '');
+    if (!TIKTOK_HANDLE_PATTERN.test(handle)) {
+      return { ok: false, platform: 'tiktok', reason: 'invalid_handle' };
+    }
+    return {
+      ok: true,
+      platform: 'tiktok',
+      handle,
+      url: `https://www.tiktok.com/@${handle}`,
+    };
+  }
+
+  if (host === 'x.com' || host === 'twitter.com') {
+    if (pathSegments.length === 0) {
+      return { ok: false, platform: 'x', reason: 'missing_account_path' };
+    }
+    const handle = stripAt(pathSegments[0] ?? '');
+    if (!X_HANDLE_PATTERN.test(handle)) {
+      return { ok: false, platform: 'x', reason: 'invalid_handle' };
+    }
+    return {
+      ok: true,
+      platform: 'x',
+      handle,
+      url: `https://x.com/${handle}`,
+    };
+  }
+
+  if (
+    host === 'youtube.com' ||
+    host === 'youtu.be' ||
+    host === 'music.youtube.com'
+  ) {
+    if (pathSegments.length === 0 && host !== 'youtu.be') {
+      return { ok: false, platform: 'youtube', reason: 'missing_account_path' };
+    }
+    url.protocol = 'https:';
+    return {
+      ok: true,
+      platform: 'youtube',
+      handle: pathSegments[0] ? stripAt(pathSegments[0]) : null,
+      url: url.toString(),
+    };
+  }
+
+  if (host === 'soundcloud.com') {
+    if (pathSegments.length === 0) {
+      return {
+        ok: false,
+        platform: 'soundcloud',
+        reason: 'missing_account_path',
+      };
+    }
+    url.protocol = 'https:';
+    return {
+      ok: true,
+      platform: 'soundcloud',
+      handle: pathSegments[0] ?? null,
+      url: url.toString(),
+    };
+  }
+
+  if (host === 'open.spotify.com' || host === 'spotify.com') {
+    if (pathSegments.length < 2) {
+      return { ok: false, platform: 'spotify', reason: 'missing_account_path' };
+    }
+    url.protocol = 'https:';
+    if (host === 'spotify.com') {
+      url.hostname = 'open.spotify.com';
+    }
+    return {
+      ok: true,
+      platform: 'spotify',
+      handle: pathSegments[1] ?? null,
+      url: url.toString(),
+    };
+  }
+
+  // Generic HTTPS website with a non-empty host.
+  if (host.includes('.')) {
+    url.protocol = 'https:';
+    return {
+      ok: true,
+      platform: 'website',
+      handle: null,
+      url: url.toString(),
+    };
+  }
+
+  return { ok: false, reason: 'unrecognized' };
+}
+
+/** True when the parse produced a complete, attachable URL. */
+export function isCompleteSocialUrl(input: string): boolean {
+  return parseSocialLinkInput(input).ok;
+}


### PR DESCRIPTION
## Summary
Canonical data contract for onboarding Spotify metrics, handle availability, and social-link parse so UI cannot show:
- contradictory follower counts (followers vs monthly listeners)
- simultaneous available + taken for the same handle
- bare `instagram.com` without an account path
- silent numbered handle swaps without disclosure

## Changes
- **`canonical-metrics.ts`**: `normalizeArtistMetrics` → `{ spotifyFollowers, monthlyListeners?, source, updatedAt }`; rail / artifacts / chat / access-eval all use the same field
- **`handle-availability.ts`**: `toHandleAvailabilityResult` → `{ handle, available, reason, suggestedAlternatives? }` with invariant `available === true ⇔ reason === 'available'`; numbered alts labeled **Suggested available handle**
- **`social-link-parse.ts`**: Instagram handle/URL → full URL with account path; rejects bare hosts
- Wired through tool impls, access eval, profile rail, tool artifacts, chat helpers
- `checkOnboardingHandleAvailability` on reserved-handle; cache helper projects through the contract

## Test plan
- [x] Unit tests (39) for metrics / handle / social parse + tool rehydration + access-eval
- [x] typecheck green
- [x] biome clean on touched files
- Log: `scratch/data-contract-tests.log`

## Size
Over the default line cap due to pure contract modules + fixture tests. Label `big-pr` for mechanical data-contract + co-located tests.