### PR TITLE
fix(onboarding): set completion cookie for direct_profile claims (JOV-2996)

### DIFF
--- a/apps/web/app/onboarding/actions/index.ts
+++ b/apps/web/app/onboarding/actions/index.ts
@@ -420,19 +420,22 @@ export async function completeOnboarding({
       );
     }
 
-    // Steps 8-9: Durable bounded sync + trial activation, then completion cookie
+    // ENG-002: Set completion cookie to prevent redirect loop race condition.
+    // Onboarding is complete at this point regardless of the finalization
+    // path — direct_profile claims skip finalizePostOnboarding but still
+    // need the cookie so the proxy doesn't bounce the user back to /start.
+    const cookieStore = await cookies();
+    cookieStore.set('jovie_onboarding_complete', '1', {
+      httpOnly: true,
+      secure: isSecureEnv(),
+      sameSite: 'lax',
+      maxAge: 120,
+      path: '/',
+    });
+
+    // Steps 8-9: Durable bounded sync + trial activation
     if (shouldFinalizeOnboarding) {
       await finalizePostOnboarding(userId, completion.username);
-
-      // ENG-002: Set completion cookie to prevent redirect loop race condition
-      const cookieStore = await cookies();
-      cookieStore.set('jovie_onboarding_complete', '1', {
-        httpOnly: true,
-        secure: isSecureEnv(),
-        sameSite: 'lax',
-        maxAge: 120,
-        path: '/',
-      });
     }
 
     // Invalidate dashboard data cache to prevent stale data causing redirect loops

--- a/apps/web/tests/unit/actions/onboarding/complete-onboarding.test.ts
+++ b/apps/web/tests/unit/actions/onboarding/complete-onboarding.test.ts
@@ -431,6 +431,20 @@ describe('completeOnboarding', () => {
     expect(mockClaimPrebuiltProfileForUser).not.toHaveBeenCalled();
     expect(mockMarkWaitlistSignedUpInTx).not.toHaveBeenCalled();
     expect(mockClearPendingClaimContext).not.toHaveBeenCalled();
+    // Finalization stays gated for direct_profile claims...
+    expect(mockFinalizePostOnboarding).not.toHaveBeenCalled();
+    // ...but the completion cookie must still be set (JOV-2996) so the
+    // proxy doesn't redirect the completed user back to onboarding.
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      'jovie_onboarding_complete',
+      '1',
+      expect.objectContaining({
+        httpOnly: true,
+        maxAge: 120,
+        path: '/',
+        sameSite: 'lax',
+      })
+    );
   });
 
   it('creates a new user profile, caches completion, and keeps side effects non-blocking', async () => {


### PR DESCRIPTION
## Summary

- Hoist the ENG-002 `jovie_onboarding_complete` cookie write above the `shouldFinalizeOnboarding` gate in `completeOnboarding` so `direct_profile` claims also mark onboarding complete.
- `finalizePostOnboarding` (durable bounded sync + trial activation) stays gated exactly as before.
- Extend the colocated `direct_profile` unit test to pin both behaviors: finalization skipped, cookie still set.

## Issue

JOV-2996 — onboarding completion cookie skipped for `direct_profile` claims.

## Root cause / evidence

On main, `apps/web/app/onboarding/actions/index.ts:413` computed
`shouldFinalizeOnboarding = pendingClaim?.mode !== 'direct_profile'`, and the
`cookieStore.set('jovie_onboarding_complete', …)` block lived **inside** that
`if` (:424-436). `direct_profile` claims therefore completed onboarding
(profile reserved + caches invalidated + redirect to dashboard) without the
completion cookie. The proxy uses that cookie to avoid rewriting a freshly
onboarded user back to `/start` during the state-propagation window (the
redirect-loop race ENG-002 was added for), so `direct_profile` users were
exposed to exactly that loop.

The cookie means "onboarding complete" regardless of finalization path —
`connect-spotify.ts:280-294` already sets it unconditionally before calling
`finalizePostOnboarding`. This change aligns `completeOnboarding` with that
pattern: cookie unconditional, finalization gated.

## Scope

- `apps/web/app/onboarding/actions/index.ts` — ~10-line move (cookie block hoisted above the gate; comments updated).
- `apps/web/tests/unit/actions/onboarding/complete-onboarding.test.ts` — assert cookie set + `finalizePostOnboarding` not called for `direct_profile`.

No changes to exit paths, redirects, or finalization logic.

## Validation

- `pnpm --filter web exec vitest run tests/unit/actions/onboarding/complete-onboarding.test.ts` — 10/10 pass.
- `pnpm biome check --write` on both files — clean, no fixes.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean (exit 0).
- Full pre-commit gate ladder (secret scan, repo hygiene, skill governance, proxy guard, lint-staged incl. eslint + typecheck) passed on commit.

## Risk

Low. The only behavior change is that the short-lived (120s) `jovie_onboarding_complete` marker cookie is now also set for `direct_profile` completions — the same value, options, and timing as every other completion path. No DB, finalization, or routing changes.

## Rollback

Revert commit `407377beee1` (`git revert 407377beee1`) — restores the previous gating; no data or schema changes to unwind.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20`
- Written: `engineering/onboarding-cookie-direct-profile` (root cause + fix evidence)
