### PR TITLE
fix(onboarding): guarded steps widget events and explicit CTAs

### DIFF
--- a/apps/web/components/features/onboarding/ChatProposeNextStepCard.tsx
+++ b/apps/web/components/features/onboarding/ChatProposeNextStepCard.tsx
@@ -74,11 +74,14 @@ export function ChatProposeNextStepCard({
   }
 
   if (kind === 'waitlist') {
+    // Never promise email delivery until the visitor has a confirmed email
+    // (sign-in/sign-up). Success language is the list confirmation only.
+    const waitlistBody = isSignedIn
+      ? `You're on the list. We'll email you when you're up. We can pick up right here.`
+      : `You're on the list. We pick up right here — nothing gets lost. Add an email at sign-in if you want a heads-up when access opens.`;
     return (
       <div className='px-1 py-1'>
-        <p className='text-mid leading-7 text-primary-token'>
-          {`You're on the list. I'll email you when you're up. We can pick up right here.`}
-        </p>
+        <p className='text-mid leading-7 text-primary-token'>{waitlistBody}</p>
       </div>
     );
   }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -27,6 +27,10 @@ import {
   getPreferredErrorMessage,
 } from '@/components/jovie/utils';
 import { track } from '@/lib/analytics';
+import {
+  ONBOARDING_WIDGET_EVENTS,
+  widgetEventDisplayText,
+} from '@/lib/chat/onboarding-script/widget-events';
 import { useAppFlag } from '@/lib/flags/client';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
 import { cn } from '@/lib/utils';
@@ -106,6 +110,9 @@ type OnboardingToolRendererArgs = {
   readonly key: string;
   readonly isBusy: boolean;
   readonly onHandleCandidateChange: (handle: string | null) => void;
+  readonly onConfirmHandle: (handle: string) => void;
+  readonly onAttachAccount: (url: string) => void;
+  readonly onNoneOfTheseArtists: () => void;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
   readonly selectedArtistId: string | null;
 };
@@ -119,6 +126,7 @@ const renderSearchSpotifyArtist: OnboardingToolRenderer = ({
   key,
   isBusy,
   onSelectArtist,
+  onNoneOfTheseArtists,
   selectedArtistId,
 }) => {
   if (selectedArtistId) return null;
@@ -136,6 +144,7 @@ const renderSearchSpotifyArtist: OnboardingToolRenderer = ({
       inputQuery={getInputQuery(part)}
       disabled={isBusy}
       onSelectArtist={onSelectArtist}
+      onNoneOfThese={onNoneOfTheseArtists}
     />
   );
 };
@@ -157,8 +166,10 @@ const renderConfirmSpotifyArtist: OnboardingToolRenderer = ({ part, key }) => {
 
 const renderCheckHandle: OnboardingToolRenderer = ({
   onHandleCandidateChange,
+  onConfirmHandle,
   part,
   key,
+  isBusy,
 }) => {
   const output = part.output;
   if (!(isHandleCheckOutput(output) || output === undefined)) {
@@ -171,11 +182,18 @@ const renderCheckHandle: OnboardingToolRenderer = ({
       state={part.state}
       output={isHandleCheckOutput(output) ? output : null}
       onHandleCandidateChange={onHandleCandidateChange}
+      onConfirmHandle={onConfirmHandle}
+      disabled={isBusy}
     />
   );
 };
 
-const renderProposeSocialLink: OnboardingToolRenderer = ({ part, key }) => {
+const renderProposeSocialLink: OnboardingToolRenderer = ({
+  part,
+  key,
+  isBusy,
+  onAttachAccount,
+}) => {
   const output = part.output;
   if (!(isSocialLinkOutput(output) || output === undefined)) {
     return null;
@@ -186,6 +204,8 @@ const renderProposeSocialLink: OnboardingToolRenderer = ({ part, key }) => {
       key={key}
       state={part.state}
       output={isSocialLinkOutput(output) ? output : null}
+      onAttachAccount={onAttachAccount}
+      disabled={isBusy}
     />
   );
 };
@@ -231,6 +251,9 @@ function renderOnboardingTools({
   hasMessageText,
   isBusy,
   onHandleCandidateChange,
+  onConfirmHandle,
+  onAttachAccount,
+  onNoneOfTheseArtists,
   onSelectArtist,
   selectedArtistId,
 }: {
@@ -239,6 +262,9 @@ function renderOnboardingTools({
   readonly hasMessageText: boolean;
   readonly isBusy: boolean;
   readonly onHandleCandidateChange: (handle: string | null) => void;
+  readonly onConfirmHandle: (handle: string) => void;
+  readonly onAttachAccount: (url: string) => void;
+  readonly onNoneOfTheseArtists: () => void;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
   readonly selectedArtistId: string | null;
 }) {
@@ -264,6 +290,9 @@ function renderOnboardingTools({
         key,
         isBusy,
         onHandleCandidateChange,
+        onConfirmHandle,
+        onAttachAccount,
+        onNoneOfTheseArtists,
         onSelectArtist,
         selectedArtistId,
       });
@@ -299,6 +328,9 @@ function OnboardingMessageList({
   isStreaming,
   lastAssistantMessageId,
   onHandleCandidateChange,
+  onConfirmHandle,
+  onAttachAccount,
+  onNoneOfTheseArtists,
   isBusy,
   onSelectArtist,
   selectedArtistId,
@@ -307,6 +339,9 @@ function OnboardingMessageList({
   readonly isStreaming: boolean;
   readonly lastAssistantMessageId: string | null;
   readonly onHandleCandidateChange: (handle: string | null) => void;
+  readonly onConfirmHandle: (handle: string) => void;
+  readonly onAttachAccount: (url: string) => void;
+  readonly onNoneOfTheseArtists: () => void;
   readonly isBusy: boolean;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
   readonly selectedArtistId: string | null;
@@ -344,6 +379,9 @@ function OnboardingMessageList({
                   hasMessageText: Boolean(text),
                   isBusy,
                   onHandleCandidateChange,
+                  onConfirmHandle,
+                  onAttachAccount,
+                  onNoneOfTheseArtists,
                   onSelectArtist,
                   selectedArtistId,
                 })
@@ -482,6 +520,9 @@ interface OnboardingMessageRegionProps {
   readonly lastAssistantMessageId: string | null;
   readonly onboardingComposerSurface: ReactNode;
   readonly onHandleCandidateChange: (handle: string | null) => void;
+  readonly onConfirmHandle: (handle: string) => void;
+  readonly onAttachAccount: (url: string) => void;
+  readonly onNoneOfTheseArtists: () => void;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
   readonly onSelectStarterSuggestion: (prompt: string) => void;
   readonly profileBuilderState: OnboardingProfileBuilderState;
@@ -499,6 +540,9 @@ function OnboardingMessageRegion({
   lastAssistantMessageId,
   onboardingComposerSurface,
   onHandleCandidateChange,
+  onConfirmHandle,
+  onAttachAccount,
+  onNoneOfTheseArtists,
   onSelectArtist,
   onSelectStarterSuggestion,
   profileBuilderState,
@@ -514,6 +558,9 @@ function OnboardingMessageRegion({
           lastAssistantMessageId={lastAssistantMessageId}
           isBusy={isBusy}
           onHandleCandidateChange={onHandleCandidateChange}
+          onConfirmHandle={onConfirmHandle}
+          onAttachAccount={onAttachAccount}
+          onNoneOfTheseArtists={onNoneOfTheseArtists}
           onSelectArtist={onSelectArtist}
           selectedArtistId={profileBuilderState.artist?.id ?? null}
         />
@@ -550,6 +597,9 @@ function OnboardingMessageRegion({
         lastAssistantMessageId={lastAssistantMessageId}
         isBusy={isBusy}
         onHandleCandidateChange={onHandleCandidateChange}
+        onConfirmHandle={onConfirmHandle}
+        onAttachAccount={onAttachAccount}
+        onNoneOfTheseArtists={onNoneOfTheseArtists}
         onSelectArtist={onSelectArtist}
         selectedArtistId={profileBuilderState.artist?.id ?? null}
       />
@@ -773,6 +823,36 @@ export function OnboardingChat({
     [formatArtistSelectionMessage, submitText]
   );
 
+  const handleConfirmHandle = useCallback(
+    (handle: string) => {
+      const payload = {
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED,
+        handle,
+      } as const;
+      submitText(widgetEventDisplayText(payload), payload);
+    },
+    [submitText]
+  );
+
+  const handleAttachAccount = useCallback(
+    (url: string) => {
+      const payload = {
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED,
+        url,
+      } as const;
+      submitText(widgetEventDisplayText(payload), payload);
+    },
+    [submitText]
+  );
+
+  const handleNoneOfTheseArtists = useCallback(() => {
+    const payload = {
+      onboardingEvent: ONBOARDING_WIDGET_EVENTS.ARTIST_NONE_OF_THESE,
+    } as const;
+    setSelectedArtist(null);
+    submitText(widgetEventDisplayText(payload), payload);
+  }, [submitText]);
+
   const profileBuilderState = useMemo(
     () => deriveProfileBuilderState({ handleDraft, messages, selectedArtist }),
     [handleDraft, messages, selectedArtist]
@@ -992,6 +1072,9 @@ export function OnboardingChat({
             lastAssistantMessageId={lastAssistantMessageId}
             onboardingComposerSurface={onboardingComposerSurface}
             onHandleCandidateChange={setHandleDraft}
+            onConfirmHandle={handleConfirmHandle}
+            onAttachAccount={handleAttachAccount}
+            onNoneOfTheseArtists={handleNoneOfTheseArtists}
             onSelectArtist={handleArtistSelect}
             onSelectStarterSuggestion={submitText}
             profileBuilderState={profileBuilderState}

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -11,6 +11,11 @@ import {
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import {
+  ATTACH_ACCOUNT_CTA_LABEL,
+  CONFIRM_HANDLE_CTA_LABEL,
+  NONE_OF_THESE_CTA_LABEL,
+} from '@/lib/chat/onboarding-script/widget-events';
 import type { SpotifyArtistResult } from '@/lib/contracts/api';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useHandleAvailabilityQuery } from '@/lib/queries/useHandleAvailabilityQuery';
@@ -52,13 +57,13 @@ export interface ArtistConfirmedOutput {
 }
 
 export interface HandleCheckOutput {
-  readonly action?: 'check_handle';
+  readonly action?: 'check_handle' | 'handle_confirmed';
   readonly handle?: string;
 }
 
 export interface SocialLinkOutput {
-  readonly action?: 'propose_social_link';
-  readonly url?: string;
+  readonly action?: 'propose_social_link' | 'social_attached';
+  readonly url?: string | null;
 }
 
 export interface OnboardingArtistSelection {
@@ -278,11 +283,13 @@ export function OnboardingSpotifyArtistPickerCard({
   inputQuery,
   disabled = false,
   onSelectArtist,
+  onNoneOfThese,
 }: ToolArtifactProps & {
   readonly output?: ArtistPickerOutput | null;
   readonly inputQuery?: string | null;
   readonly disabled?: boolean;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
+  readonly onNoneOfThese?: () => void;
 }) {
   const initialQuery = output?.query ?? inputQuery ?? '';
   const [query, setQuery] = useState(initialQuery);
@@ -293,6 +300,13 @@ export function OnboardingSpotifyArtistPickerCard({
     minQueryLength: 1,
   });
   const { search, searchImmediate, clear } = artistSearch;
+
+  // Keep the field prefilled when the tool re-opens with a new query from chat.
+  useEffect(() => {
+    if (initialQuery && !query) {
+      setQuery(initialQuery);
+    }
+  }, [initialQuery, query]);
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -419,6 +433,21 @@ export function OnboardingSpotifyArtistPickerCard({
             }}
           />
         ))}
+
+        {!isSearching && results.length > 0 && onNoneOfThese ? (
+          <button
+            type='button'
+            onClick={() => {
+              if (disabled) return;
+              onNoneOfThese();
+            }}
+            disabled={disabled || selectedId !== null}
+            className='flex w-full items-center justify-center rounded-lg px-2.5 py-2 text-xs font-medium text-secondary-token transition-colors duration-fast hover:bg-white/[0.045] hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 disabled:opacity-50'
+            data-testid='onboarding-artist-none-of-these'
+          >
+            {NONE_OF_THESE_CTA_LABEL}
+          </button>
+        ) : null}
       </div>
     </div>
   );
@@ -516,14 +545,19 @@ export function OnboardingArtistConfirmedCard({
 
 export function OnboardingHandleCheckCard({
   onHandleCandidateChange,
+  onConfirmHandle,
   state,
   output,
+  disabled = false,
 }: ToolArtifactProps & {
   readonly onHandleCandidateChange?: (handle: string | null) => void;
+  readonly onConfirmHandle?: (handle: string) => void;
   readonly output?: HandleCheckOutput | null;
+  readonly disabled?: boolean;
 }) {
   const handle = output?.handle?.replace(/^@/, '').toLowerCase() ?? null;
   const [draftHandle, setDraftHandle] = useState(handle ?? '');
+  const [confirmed, setConfirmed] = useState(false);
   const normalizedDraft = draftHandle.replace(/^@/, '').trim().toLowerCase();
   const availability = useHandleAvailabilityQuery({
     handle: normalizedDraft || null,
@@ -565,6 +599,12 @@ export function OnboardingHandleCheckCard({
   const available = availability.data?.available;
   const error = availability.data?.error;
   const profilePath = normalizedDraft ? `jov.ie/${normalizedDraft}` : null;
+  const canConfirm =
+    Boolean(normalizedDraft) &&
+    available === true &&
+    !loading &&
+    !disabled &&
+    !confirmed;
 
   return (
     <div
@@ -609,16 +649,17 @@ export function OnboardingHandleCheckCard({
             <span className='text-app text-tertiary-token' aria-hidden>
               @
             </span>
-            <span className='sr-only'>Edit proposed handle</span>
+            <span className='sr-only'>Edit Proposed Handle</span>
             <input
-              aria-label='Edit proposed handle'
+              aria-label='Edit Proposed Handle'
               value={draftHandle}
               onChange={event => setDraftHandle(event.target.value)}
               className='min-w-0 flex-1 bg-transparent px-0.5 text-app leading-5 text-primary-token placeholder:text-quaternary-token focus:outline-none'
-              placeholder='handle'
+              placeholder='Handle'
               inputMode='text'
               autoCapitalize='none'
               spellCheck={false}
+              disabled={disabled || confirmed}
             />
           </label>
           <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
@@ -627,6 +668,26 @@ export function OnboardingHandleCheckCard({
                 ? 'Try a sharper variant.'
                 : (profilePath ?? 'Edit the handle before it is claimed.'))}
           </p>
+          {onConfirmHandle ? (
+            <button
+              type='button'
+              data-testid='onboarding-confirm-handle'
+              disabled={!canConfirm}
+              onClick={() => {
+                if (!canConfirm || !normalizedDraft) return;
+                setConfirmed(true);
+                onConfirmHandle(normalizedDraft);
+              }}
+              className={cn(
+                'mt-3 inline-flex h-9 items-center justify-center rounded-full px-3.5 text-app font-semibold transition-colors duration-fast focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+                canConfirm
+                  ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
+                  : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
+              )}
+            >
+              {confirmed ? 'Handle Confirmed' : CONFIRM_HANDLE_CTA_LABEL}
+            </button>
+          ) : null}
         </div>
       </div>
     </div>
@@ -636,9 +697,21 @@ export function OnboardingHandleCheckCard({
 export function OnboardingSocialLinkCard({
   state,
   output,
+  onAttachAccount,
+  disabled = false,
 }: ToolArtifactProps & {
   readonly output?: SocialLinkOutput | null;
+  readonly onAttachAccount?: (url: string) => void;
+  readonly disabled?: boolean;
 }) {
+  const initialUrl = output?.url ?? '';
+  const [draftUrl, setDraftUrl] = useState(initialUrl);
+  const [attached, setAttached] = useState(false);
+
+  useEffect(() => {
+    if (initialUrl) setDraftUrl(initialUrl);
+  }, [initialUrl]);
+
   if (isFailed(state)) {
     return (
       <StatusShell
@@ -650,7 +723,7 @@ export function OnboardingSocialLinkCard({
     );
   }
 
-  if (isRunning(state) || !output?.url) {
+  if (isRunning(state) && !output) {
     return (
       <StatusShell
         icon={
@@ -661,15 +734,72 @@ export function OnboardingSocialLinkCard({
     );
   }
 
-  const host = hostnameFor(output.url);
+  const trimmed = draftUrl.trim();
+  const host = hostnameFor(trimmed || undefined);
+  const canAttach =
+    Boolean(trimmed) &&
+    Boolean(host) &&
+    !disabled &&
+    !attached &&
+    Boolean(onAttachAccount);
 
   return (
-    <StatusShell
-      icon={<Link2 className='h-3.5 w-3.5' />}
-      title='Link ready to attach'
-      body={host ?? output.url}
-      tone='success'
-    />
+    <div
+      className='w-full max-w-110 px-1 py-2 text-primary-token'
+      data-testid='onboarding-social-link'
+      role='status'
+    >
+      <div className='flex items-start gap-3'>
+        <span
+          className='mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-secondary-token'
+          aria-hidden
+        >
+          <Link2 className='h-3.5 w-3.5' />
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='text-sm font-semibold leading-5 tracking-[-0.01em] text-primary-token'>
+            {host ? 'Link ready to attach' : 'Attach a public social account'}
+          </p>
+          <label className='mt-2 flex h-9 items-center rounded-lg border border-subtle bg-surface-0 px-2.5 focus-within:border-white/[0.16] focus-within:shadow-[0_0_0_3px_rgba(255,255,255,0.035)]'>
+            <span className='sr-only'>Social Profile URL</span>
+            <input
+              aria-label='Social Profile URL'
+              value={draftUrl}
+              onChange={event => setDraftUrl(event.target.value)}
+              className='min-w-0 flex-1 bg-transparent text-app leading-5 text-primary-token placeholder:text-quaternary-token focus:outline-none'
+              placeholder='https://instagram.com/yourname'
+              inputMode='url'
+              autoCapitalize='none'
+              spellCheck={false}
+              disabled={disabled || attached}
+            />
+          </label>
+          <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
+            {host ?? 'Paste the full URL fans already use.'}
+          </p>
+          {onAttachAccount ? (
+            <button
+              type='button'
+              data-testid='onboarding-attach-account'
+              disabled={!canAttach}
+              onClick={() => {
+                if (!canAttach || !trimmed) return;
+                setAttached(true);
+                onAttachAccount(trimmed);
+              }}
+              className={cn(
+                'mt-3 inline-flex h-9 items-center justify-center rounded-full px-3.5 text-app font-semibold transition-colors duration-fast focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+                canAttach
+                  ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
+                  : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
+              )}
+            >
+              {attached ? 'Account Attached' : ATTACH_ACCOUNT_CTA_LABEL}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import {
   AlertCircle,
   AtSign,
@@ -435,18 +436,19 @@ export function OnboardingSpotifyArtistPickerCard({
         ))}
 
         {!isSearching && results.length > 0 && onNoneOfThese ? (
-          <button
+          <Button
             type='button'
+            variant='ghost'
             onClick={() => {
               if (disabled) return;
               onNoneOfThese();
             }}
             disabled={disabled || selectedId !== null}
-            className='flex w-full items-center justify-center rounded-lg px-2.5 py-2 text-xs font-medium text-secondary-token transition-colors duration-fast hover:bg-white/[0.045] hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 disabled:opacity-50'
+            className='flex h-auto w-full items-center justify-center rounded-lg px-2.5 py-2 text-xs font-medium text-secondary-token hover:bg-white/[0.045] hover:text-primary-token'
             data-testid='onboarding-artist-none-of-these'
           >
             {NONE_OF_THESE_CTA_LABEL}
-          </button>
+          </Button>
         ) : null}
       </div>
     </div>
@@ -669,7 +671,7 @@ export function OnboardingHandleCheckCard({
                 : (profilePath ?? 'Edit the handle before it is claimed.'))}
           </p>
           {onConfirmHandle ? (
-            <button
+            <Button
               type='button'
               data-testid='onboarding-confirm-handle'
               disabled={!canConfirm}
@@ -679,14 +681,14 @@ export function OnboardingHandleCheckCard({
                 onConfirmHandle(normalizedDraft);
               }}
               className={cn(
-                'mt-3 inline-flex h-9 items-center justify-center rounded-full px-3.5 text-app font-semibold transition-colors duration-fast focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+                'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',
                 canConfirm
                   ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
                   : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
               )}
             >
               {confirmed ? 'Handle Confirmed' : CONFIRM_HANDLE_CTA_LABEL}
-            </button>
+            </Button>
           ) : null}
         </div>
       </div>
@@ -778,7 +780,7 @@ export function OnboardingSocialLinkCard({
             {host ?? 'Paste the full URL fans already use.'}
           </p>
           {onAttachAccount ? (
-            <button
+            <Button
               type='button'
               data-testid='onboarding-attach-account'
               disabled={!canAttach}
@@ -788,14 +790,14 @@ export function OnboardingSocialLinkCard({
                 onAttachAccount(trimmed);
               }}
               className={cn(
-                'mt-3 inline-flex h-9 items-center justify-center rounded-full px-3.5 text-app font-semibold transition-colors duration-fast focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+                'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',
                 canAttach
                   ? 'bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black'
                   : 'cursor-not-allowed border border-subtle bg-surface-0 text-tertiary-token'
               )}
             >
               {attached ? 'Account Attached' : ATTACH_ACCOUNT_CTA_LABEL}
-            </button>
+            </Button>
           ) : null}
         </div>
       </div>

--- a/apps/web/components/features/onboarding/onboardingChatHelpers.ts
+++ b/apps/web/components/features/onboarding/onboardingChatHelpers.ts
@@ -109,13 +109,15 @@ export function isArtistConfirmedOutput(
 export function isHandleCheckOutput(
   output: unknown
 ): output is HandleCheckOutput {
-  return asRecord(output)?.action === 'check_handle';
+  const action = asRecord(output)?.action;
+  return action === 'check_handle' || action === 'handle_confirmed';
 }
 
 export function isSocialLinkOutput(
   output: unknown
 ): output is SocialLinkOutput {
-  return asRecord(output)?.action === 'propose_social_link';
+  const action = asRecord(output)?.action;
+  return action === 'propose_social_link' || action === 'social_attached';
 }
 
 export function getInputQuery(part: ToolPart): string | null {

--- a/apps/web/components/features/waitlist/WaitlistIntakeChat.tsx
+++ b/apps/web/components/features/waitlist/WaitlistIntakeChat.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Loader2, SendHorizontal } from 'lucide-react';
 import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { getPlanIntent } from '@/lib/auth/plan-intent';
+import { isMeaningfulIntakeAnswer } from '@/lib/chat/onboarding-script/widget-events';
 import { cn } from '@/lib/utils';
 import type { WaitlistAccessOutcome } from '@/lib/waitlist/access-request';
 import type { WaitlistDisplayOutcome } from './WaitlistOutcomeView';
@@ -128,7 +129,7 @@ export function WaitlistIntakeChat({
       {
         id: 'intro-1',
         role: 'jovie' as const,
-        text: "Hey. I'm Jovie. I will save your release context first, then show the access result.",
+        text: "Hey. I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I will save your release context first, then show the access result.",
       },
       {
         id: 'intro-2',
@@ -242,6 +243,27 @@ export function WaitlistIntakeChat({
       return;
     }
 
+    // Incomplete acks ("k", "ok") must not advance required intake steps
+    // or complete waitlist/reservation.
+    if (
+      !skipped &&
+      !step.optional &&
+      !isMeaningfulIntakeAnswer(trimmed) &&
+      step.id !== 'primarySocialUrl' &&
+      step.id !== 'spotifyUrl'
+    ) {
+      setError('Add a real answer to continue — short acks do not count.');
+      return;
+    }
+
+    if (step.id === 'handle' && !skipped) {
+      const handle = normalizeHandle(trimmed);
+      if (handle.length < 2 || !isMeaningfulIntakeAnswer(handle)) {
+        setError('Enter a real handle (at least 2 characters).');
+        return;
+      }
+    }
+
     if (
       !skipped &&
       (step.id === 'primarySocialUrl' || step.id === 'spotifyUrl') &&
@@ -283,7 +305,11 @@ export function WaitlistIntakeChat({
 
   if (outcome) {
     return (
-      <WaitlistSuccessView outcome={outcome} onRetry={() => setOutcome(null)} />
+      <WaitlistSuccessView
+        outcome={outcome}
+        onRetry={() => setOutcome(null)}
+        confirmedEmail={userEmail}
+      />
     );
   }
 
@@ -311,8 +337,8 @@ export function WaitlistIntakeChat({
                 Request Access
               </h1>
               <p className='mt-1 text-app leading-5 text-white/52'>
-                Answer a few launch questions. We save only the fields needed to
-                decide access.
+                Early access is limited. Answer a few launch questions — we save
+                only the fields needed to decide access or waitlist placement.
               </p>
             </div>
 

--- a/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
+++ b/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
@@ -15,10 +15,12 @@ export type WaitlistDisplayOutcome =
 interface WaitlistOutcomeViewProps {
   readonly outcome: WaitlistDisplayOutcome;
   readonly onRetry?: () => void;
+  /** Confirmed email already collected — required before email promises. */
+  readonly confirmedEmail?: string | null;
 }
 
-const OUTCOME_COPY: Record<
-  WaitlistOutcomeViewProps['outcome'],
+function buildOutcomeCopy(hasConfirmedEmail: boolean): Record<
+  WaitlistDisplayOutcome,
   {
     readonly title: string;
     readonly body: string;
@@ -26,58 +28,72 @@ const OUTCOME_COPY: Record<
     readonly actionLabel?: string;
     readonly actionHref?: string;
   }
-> = {
-  accepted: {
-    title: 'You Have Access',
-    body: 'We saved your release context. Continue setup to finish your profile and open Jovie.',
-    icon: CheckCircle2,
-    actionLabel: 'Continue Setup',
-    actionHref: APP_ROUTES.START,
-  },
-  already_accepted: {
-    title: 'You Have Access',
-    body: 'Your request has already been approved. Continue setup to finish your profile.',
-    icon: CheckCircle2,
-    actionLabel: 'Continue Setup',
-    actionHref: APP_ROUTES.START,
-  },
-  waitlisted_gate_on: {
-    title: 'Request Saved',
-    body: 'We saved your release context and profile details. Jovie is in a private rollout, and we will email you when access opens.',
-    icon: Clock3,
-  },
-  waitlisted_capacity_full: {
-    title: "Today's Access Is Full",
-    body: "Your request is complete and saved. Today's access slots are full, so you are on the waitlist.",
-    icon: Clock3,
-  },
-  already_waitlisted: {
-    title: 'Request Already Received',
-    body: 'Your request is already saved. We will keep your latest answers attached to your access request.',
-    icon: Clock3,
-  },
-  pending: {
-    title: "You're on the list",
-    body: "We'll email you when your account is ready.",
-    icon: Clock3,
-  },
-  save_failed: {
-    title: "We Couldn't Save This",
-    body: 'Your answers are still on this device. Try again so we can save the required fields before reviewing access.',
-    icon: RotateCcw,
-  },
-  rate_limited: {
-    title: 'Too Many Attempts',
-    body: 'Please wait a moment before trying again. Your answers are still on this device.',
-    icon: Clock3,
-  },
-};
+> {
+  const emailWhenReady = hasConfirmedEmail
+    ? ' We will email you when access opens.'
+    : ' Add an email on your account if you want a heads-up when access opens.';
+
+  return {
+    accepted: {
+      title: 'You Have Access',
+      body: 'We saved your release context. Continue setup to finish your profile and open Jovie.',
+      icon: CheckCircle2,
+      actionLabel: 'Continue Setup',
+      actionHref: APP_ROUTES.START,
+    },
+    already_accepted: {
+      title: 'You Have Access',
+      body: 'Your request has already been approved. Continue setup to finish your profile.',
+      icon: CheckCircle2,
+      actionLabel: 'Continue Setup',
+      actionHref: APP_ROUTES.START,
+    },
+    waitlisted_gate_on: {
+      title: 'Request Saved',
+      body: `We saved your release context and profile details. Jovie is in a private rollout.${emailWhenReady}`,
+      icon: Clock3,
+    },
+    waitlisted_capacity_full: {
+      title: "Today's Access Is Full",
+      body: `Your request is complete and saved. Today's access slots are full, so you are on the waitlist.${
+        hasConfirmedEmail ? emailWhenReady : ''
+      }`,
+      icon: Clock3,
+    },
+    already_waitlisted: {
+      title: 'Request Already Received',
+      body: 'Your request is already saved. We will keep your latest answers attached to your access request.',
+      icon: Clock3,
+    },
+    pending: {
+      title: "You're on the list",
+      body: hasConfirmedEmail
+        ? "We'll email you when your account is ready."
+        : 'Your request is saved. Add an email on your account if you want a heads-up when access opens.',
+      icon: Clock3,
+    },
+    save_failed: {
+      title: "We Couldn't Save This",
+      body: 'Your answers are still on this device. Try again so we can save the required fields before reviewing access.',
+      icon: RotateCcw,
+    },
+    rate_limited: {
+      title: 'Too Many Attempts',
+      body: 'Please wait a moment before trying again. Your answers are still on this device.',
+      icon: Clock3,
+    },
+  };
+}
 
 export function WaitlistOutcomeView({
   outcome,
   onRetry,
+  confirmedEmail = null,
 }: Readonly<WaitlistOutcomeViewProps>) {
-  const copy = OUTCOME_COPY[outcome];
+  const hasConfirmedEmail = Boolean(
+    confirmedEmail && confirmedEmail.includes('@')
+  );
+  const copy = buildOutcomeCopy(hasConfirmedEmail)[outcome];
   const Icon = copy.icon;
   const canRetry =
     (outcome === 'save_failed' || outcome === 'rate_limited') && onRetry;

--- a/apps/web/components/features/waitlist/WaitlistSuccessView.tsx
+++ b/apps/web/components/features/waitlist/WaitlistSuccessView.tsx
@@ -9,11 +9,13 @@ import {
 interface WaitlistSuccessViewProps {
   readonly outcome?: WaitlistDisplayOutcome;
   readonly onRetry?: () => void;
+  readonly confirmedEmail?: string | null;
 }
 
 export function WaitlistSuccessView({
   outcome = 'pending',
   onRetry,
+  confirmedEmail = null,
 }: Readonly<WaitlistSuccessViewProps>) {
   return (
     <AuthLayout
@@ -21,7 +23,11 @@ export function WaitlistSuccessView({
       showFormTitle={false}
       showFooterPrompt={false}
     >
-      <WaitlistOutcomeView outcome={outcome} onRetry={onRetry} />
+      <WaitlistOutcomeView
+        outcome={outcome}
+        onRetry={onRetry}
+        confirmedEmail={confirmedEmail}
+      />
     </AuthLayout>
   );
 }

--- a/apps/web/lib/chat/onboarding-script/engine.ts
+++ b/apps/web/lib/chat/onboarding-script/engine.ts
@@ -12,6 +12,13 @@ import {
 } from '@/lib/chat/tools/onboarding-tool-impls';
 import { loadScriptBank, pickFromBank } from './line-source';
 import { renderLine, type ScriptLine, type ScriptStepId } from './script';
+import {
+  isIncompleteAdvanceMessage,
+  ONBOARDING_WIDGET_EVENTS,
+  type OnboardingGuardedStep,
+  parseWidgetEventFromMetadata,
+  WIDGET_COMPLETION_ACTIONS,
+} from './widget-events';
 
 /**
  * Deterministic onboarding fallback engine (JOV-3806).
@@ -19,10 +26,10 @@ import { renderLine, type ScriptLine, type ScriptStepId } from './script';
  * Stateless per-request: everything it needs is recovered from the inbound
  * UIMessage history (tool outputs persist across turns on the client and in
  * `chat_messages.tool_calls`). When the LLM is down, this walks the same
- * intake rail the LLM walks: greet → pick artist → confirm → handle →
- * access decision → checkout/waitlist. The words come from `script.ts`;
- * the access decision comes from the same `evaluateAccessSignal` the LLM
- * tool uses — the fallback never invents its own scoring.
+ * intake rail the LLM walks with explicit guards:
+ * Role → ArtistSearch → ArtistSelect → Handle → Social → Contact →
+ * Waitlist/Complete. Widget completions emit structured events; free-text
+ * acks ("ok", "k") never complete waitlist/reservation.
  */
 
 export interface FallbackToolEvent {
@@ -35,6 +42,8 @@ export interface FallbackTurn {
   readonly line: ScriptLine;
   readonly text: string;
   readonly toolEvents: readonly FallbackToolEvent[];
+  /** Resolved guarded step for this turn (audit / tests). */
+  readonly guardedStep?: OnboardingGuardedStep;
 }
 
 interface LoosePart {
@@ -82,6 +91,86 @@ function messageText(message: UIMessage): string {
     .filter(part => part.type === 'text' && typeof part.text === 'string')
     .map(part => part.text)
     .join('');
+}
+
+function findWidgetEventInHistory(
+  messages: readonly UIMessage[],
+  eventType: string
+): ReturnType<typeof parseWidgetEventFromMetadata> {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message || message.role !== 'user') continue;
+    const event = parseWidgetEventFromMetadata(message.metadata);
+    if (event?.onboardingEvent === eventType) return event;
+  }
+  return null;
+}
+
+function hasHandleConfirmed(messages: readonly UIMessage[]): boolean {
+  if (
+    findLatestToolOutput(messages, WIDGET_COMPLETION_ACTIONS.HANDLE_CONFIRMED)
+  ) {
+    return true;
+  }
+  return Boolean(
+    findWidgetEventInHistory(
+      messages,
+      ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED
+    )
+  );
+}
+
+function indexOfLatestToolAction(
+  messages: readonly UIMessage[],
+  action: string
+): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message) continue;
+    for (const part of partsOf(message)) {
+      if (isRecord(part.output) && part.output.action === action) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Social is complete when the Attach Account widget fired, OR the visitor
+ * sent a meaningful free-text reply after the social card was proposed
+ * (explicit skip of social attach).
+ */
+function hasSocialAttached(messages: readonly UIMessage[]): boolean {
+  if (
+    findLatestToolOutput(messages, WIDGET_COMPLETION_ACTIONS.SOCIAL_ATTACHED)
+  ) {
+    return true;
+  }
+  if (
+    findWidgetEventInHistory(messages, ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED)
+  ) {
+    return true;
+  }
+
+  const socialProposedAt = indexOfLatestToolAction(
+    messages,
+    'propose_social_link'
+  );
+  if (socialProposedAt < 0) return false;
+
+  for (let i = socialProposedAt + 1; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (!message || message.role !== 'user') continue;
+    const event = parseWidgetEventFromMetadata(message.metadata);
+    if (event?.onboardingEvent === ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED) {
+      return true;
+    }
+    if (!event && !isIncompleteAdvanceMessage(messageText(message))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 const SPOTIFY_ARTIST_URL_PATTERN = /open\.spotify\.com\/artist\/([A-Za-z0-9]+)/;
@@ -143,6 +232,53 @@ export function handleFromArtistName(name: string): string {
   return slug || 'artist';
 }
 
+/**
+ * Resolve the current guarded step from conversation history + turn state.
+ * Pure — used by the engine and unit tests.
+ */
+export function resolveGuardedStep(input: {
+  readonly uiMessages: readonly UIMessage[];
+  readonly state: OnboardingTurnState;
+  readonly selectedArtistId?: string | null;
+}): OnboardingGuardedStep {
+  const { uiMessages, state, selectedArtistId = null } = input;
+
+  if (
+    findLatestToolOutput(uiMessages, 'propose_next_step') &&
+    (() => {
+      const decision = findLatestToolOutput(uiMessages, 'propose_next_step');
+      const kind = isRecord(decision?.decision) ? decision.decision.kind : null;
+      return kind === 'instant_access' || kind === 'waitlist';
+    })()
+  ) {
+    return 'waitlist_or_complete';
+  }
+
+  if (!state.spotifyArtistId && !selectedArtistId) {
+    if (
+      findLatestToolOutput(uiMessages, 'open_artist_picker') ||
+      state.turnCount > 1
+    ) {
+      return 'artist_search';
+    }
+    return 'role';
+  }
+
+  if (selectedArtistId && state.spotifyArtistId !== selectedArtistId) {
+    return 'artist_select';
+  }
+
+  if (!hasHandleConfirmed(uiMessages)) {
+    return 'handle';
+  }
+
+  if (!hasSocialAttached(uiMessages)) {
+    return 'social';
+  }
+
+  return 'contact';
+}
+
 function proposeNextStepEvent(decision: AccessDecision): FallbackToolEvent {
   return {
     toolName: 'proposeNextStep',
@@ -157,18 +293,50 @@ function proposeNextStepEvent(decision: AccessDecision): FallbackToolEvent {
 
 function decideAccess(
   state: OnboardingTurnState,
-  extraBand: AudienceBand | null
+  extraBand: AudienceBand | null,
+  options?: { readonly forceTurnCap?: boolean }
 ): AccessDecision {
   const recordedAt = new Date().toISOString();
   const signals = state.signals.map(signal => ({ ...signal, recordedAt }));
   if (extraBand) {
     signals.push({ audienceBand: extraBand, recordedAt });
   }
+  // Incomplete acks must not force waitlist via turn cap — freeze turnCount
+  // under the force threshold unless we have real signal this turn.
+  const turnCount =
+    options?.forceTurnCap === false
+      ? Math.min(state.turnCount, 2)
+      : state.turnCount;
   return evaluateAccessSignal({
     signal: collapseInterviewSignals(signals),
     spotifyFollowers: state.spotifyFollowers,
-    turnCount: state.turnCount,
+    turnCount,
   });
+}
+
+function handleConfirmedEventFromLatest(
+  latest: UIMessage | null
+): { handle: string } | null {
+  if (!latest) return null;
+  const event = parseWidgetEventFromMetadata(latest.metadata);
+  if (event?.onboardingEvent !== ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED) {
+    return null;
+  }
+  if (typeof event.handle === 'string' && event.handle.length > 0) {
+    return { handle: event.handle };
+  }
+  return { handle: '' };
+}
+
+function socialAttachedEventFromLatest(
+  latest: UIMessage | null
+): { url: string } | null {
+  if (!latest) return null;
+  const event = parseWidgetEventFromMetadata(latest.metadata);
+  if (event?.onboardingEvent !== ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED) {
+    return null;
+  }
+  return { url: event.url ?? '' };
 }
 
 function decisionTurn(
@@ -200,11 +368,33 @@ function decisionTurn(
       });
     }
     const line = pick('done');
-    return { line, text: renderLine(line, {}), toolEvents: events };
+    return {
+      line,
+      text: renderLine(line, {}),
+      toolEvents: events,
+      guardedStep: 'waitlist_or_complete',
+    };
   }
 
   const latest = lastUserMessage(uiMessages);
-  const parsedBand = latest ? parseAudienceBand(messageText(latest)) : null;
+  const latestText = latest ? messageText(latest) : '';
+  const latestEvent = latest
+    ? parseWidgetEventFromMetadata(latest.metadata)
+    : null;
+  const incomplete = !latestEvent && isIncompleteAdvanceMessage(latestText);
+
+  // Incomplete free-text never advances to waitlist/success.
+  if (incomplete) {
+    const line = pick('ask_audience');
+    return {
+      line,
+      text: renderLine(line, {}),
+      toolEvents: [],
+      guardedStep: 'contact',
+    };
+  }
+
+  const parsedBand = parseAudienceBand(latestText);
   const events: FallbackToolEvent[] = [];
   if (parsedBand) {
     events.push({
@@ -219,7 +409,10 @@ function decisionTurn(
     });
   }
 
-  const decision = decideAccess(state, parsedBand);
+  // Only apply turn-cap force when we have a real (non-ack) reply.
+  const decision = decideAccess(state, parsedBand, {
+    forceTurnCap: Boolean(parsedBand) || latestText.trim().length >= 8,
+  });
   if (decision.kind === 'instant_access') {
     events.push(proposeNextStepEvent(decision));
     events.push({
@@ -233,15 +426,31 @@ function decisionTurn(
       },
     });
     const line = pick('instant_access');
-    return { line, text: renderLine(line, {}), toolEvents: events };
+    return {
+      line,
+      text: renderLine(line, {}),
+      toolEvents: events,
+      guardedStep: 'waitlist_or_complete',
+    };
   }
   if (decision.kind === 'waitlist') {
     events.push(proposeNextStepEvent(decision));
     const line = pick('waitlist');
-    return { line, text: renderLine(line, {}), toolEvents: events };
+    // Success / email language is owned by the client card once email exists.
+    return {
+      line,
+      text: renderLine(line, {}),
+      toolEvents: events,
+      guardedStep: 'waitlist_or_complete',
+    };
   }
   const line = pick('ask_audience');
-  return { line, text: renderLine(line, {}), toolEvents: events };
+  return {
+    line,
+    text: renderLine(line, {}),
+    toolEvents: events,
+    guardedStep: 'contact',
+  };
 }
 
 /**
@@ -264,6 +473,34 @@ export async function decideFallbackTurn(
     pickFromBank(bank, stepId, sessionId);
   const latest = lastUserMessage(uiMessages);
   const selectedArtistId = parseArtistSelection(latest);
+  const latestEvent = latest
+    ? parseWidgetEventFromMetadata(latest.metadata)
+    : null;
+
+  // "None of these" — re-open artist search without treating as selection.
+  if (
+    latestEvent?.onboardingEvent ===
+    ONBOARDING_WIDGET_EVENTS.ARTIST_NONE_OF_THESE
+  ) {
+    const query = '';
+    const line = pick('get_artist');
+    return {
+      line,
+      text: renderLine(line, {}),
+      toolEvents: [
+        {
+          toolName: 'searchSpotifyArtist',
+          input: { query },
+          output: {
+            action: 'open_artist_picker',
+            query: null,
+            summary: 'Pick the matching Spotify artist.',
+          },
+        },
+      ],
+      guardedStep: 'artist_search',
+    };
+  }
 
   // The visitor just picked an artist — confirm it (Spotify enrichment).
   if (selectedArtistId && state.spotifyArtistId !== selectedArtistId) {
@@ -288,6 +525,7 @@ export async function decideFallbackTurn(
           output: output as unknown as Record<string, unknown>,
         },
       ],
+      guardedStep: 'artist_select',
     };
   }
 
@@ -295,9 +533,16 @@ export async function decideFallbackTurn(
   if (!state.spotifyArtistId) {
     if (state.turnCount <= 1) {
       const line = pick('greet');
-      return { line, text: renderLine(line, {}), toolEvents: [] };
+      return {
+        line,
+        text: renderLine(line, {}),
+        toolEvents: [],
+        guardedStep: 'role',
+      };
     }
-    const query = latest ? messageText(latest).slice(0, 50) : '';
+    // Prefill from prior user message; skip incomplete acks.
+    const rawQuery = latest ? messageText(latest).slice(0, 50) : '';
+    const query = isIncompleteAdvanceMessage(rawQuery) ? '' : rawQuery;
     const line = pick('get_artist');
     return {
       line,
@@ -313,11 +558,18 @@ export async function decideFallbackTurn(
           },
         },
       ],
+      guardedStep: 'artist_search',
     };
   }
 
-  // Artist confirmed but handle not checked yet.
-  if (!findLatestToolOutput(uiMessages, 'check_handle')) {
+  // Artist confirmed but handle widget not shown yet (neither check nor confirm).
+  const existingHandleCheck =
+    findLatestToolOutput(uiMessages, 'check_handle') ??
+    findLatestToolOutput(
+      uiMessages,
+      WIDGET_COMPLETION_ACTIONS.HANDLE_CONFIRMED
+    );
+  if (!existingHandleCheck) {
     const handle = handleFromArtistName(state.spotifyArtistName ?? '');
     const line = pick('handle');
     return {
@@ -334,10 +586,125 @@ export async function decideFallbackTurn(
           },
         },
       ],
+      guardedStep: 'handle',
     };
   }
 
-  // Access decision phase.
+  // Handle shown but not confirmed via widget event — stay on handle.
+  // Free-text "ok" / "k" does not advance.
+  if (!hasHandleConfirmed(uiMessages)) {
+    const confirmedNow = handleConfirmedEventFromLatest(latest);
+    if (confirmedNow) {
+      const handle =
+        confirmedNow.handle ||
+        (typeof existingHandleCheck.handle === 'string'
+          ? String(existingHandleCheck.handle)
+          : handleFromArtistName(state.spotifyArtistName ?? ''));
+      // Emit handle_confirmed completion + advance to social.
+      const line = pick('ask_audience');
+      return {
+        line,
+        text: renderLine(line, {}),
+        toolEvents: [
+          {
+            toolName: 'checkHandle',
+            input: { handle },
+            output: {
+              action: WIDGET_COMPLETION_ACTIONS.HANDLE_CONFIRMED,
+              handle,
+              summary: `Handle @${handle} confirmed.`,
+            },
+          },
+          {
+            toolName: 'proposeSocialLink',
+            input: { url: '' },
+            output: {
+              action: 'propose_social_link',
+              url: null,
+              summary: 'Attach a public social account.',
+            },
+          },
+        ],
+        guardedStep: 'social',
+      };
+    }
+    // Re-surface handle step; do not decide access.
+    const handle =
+      typeof existingHandleCheck.handle === 'string'
+        ? existingHandleCheck.handle
+        : handleFromArtistName(state.spotifyArtistName ?? '');
+    const line = pick('handle');
+    return {
+      line,
+      text: renderLine(line, { handle }),
+      toolEvents: [],
+      guardedStep: 'handle',
+    };
+  }
+
+  // Social step: require Attach Account event (or meaningful free-text skip).
+  // hasSocialAttached is false until one of those happens.
+  if (!hasSocialAttached(uiMessages)) {
+    const attachedNow = socialAttachedEventFromLatest(latest);
+    if (attachedNow) {
+      const url = attachedNow.url;
+      const line = pick('ask_audience');
+      return {
+        line,
+        text: renderLine(line, {}),
+        toolEvents: [
+          {
+            toolName: 'proposeSocialLink',
+            input: { url },
+            output: {
+              action: WIDGET_COMPLETION_ACTIONS.SOCIAL_ATTACHED,
+              url: url || null,
+              summary: url ? `Attached ${url}.` : 'Social account attached.',
+            },
+          },
+        ],
+        guardedStep: 'contact',
+      };
+    }
+
+    if (!findLatestToolOutput(uiMessages, 'propose_social_link')) {
+      const line = pick('ask_audience');
+      return {
+        line,
+        text: renderLine(line, {}),
+        toolEvents: [
+          {
+            toolName: 'proposeSocialLink',
+            input: { url: '' },
+            output: {
+              action: 'propose_social_link',
+              url: null,
+              summary: 'Attach a public social account.',
+            },
+          },
+        ],
+        guardedStep: 'social',
+      };
+    }
+
+    // Social proposed; incomplete ack stays put.
+    const latestText = latest ? messageText(latest) : '';
+    if (!latestEvent && isIncompleteAdvanceMessage(latestText)) {
+      const line = pick('ask_audience');
+      return {
+        line,
+        text: renderLine(line, {}),
+        toolEvents: [],
+        guardedStep: 'social',
+      };
+    }
+
+    // Meaningful free-text after social card: skip social → contact/access.
+    // Fall through to decisionTurn; hasSocialAttached will be true next turn
+    // because this user message sits after propose_social_link.
+  }
+
+  // Access decision phase (contact → waitlist/complete).
   const existingDecision = findLatestToolOutput(
     uiMessages,
     'propose_next_step'

--- a/apps/web/lib/chat/onboarding-script/script.ts
+++ b/apps/web/lib/chat/onboarding-script/script.ts
@@ -40,12 +40,12 @@ export const SCRIPT_LINES: readonly ScriptLine[] = [
   line(
     'greet',
     'v1',
-    "Hey — I'm Jovie. Heads up, I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?"
+    "Hey — I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?"
   ),
   line(
     'greet',
     'v2',
-    "Hey, I'm Jovie. I run the release side so you can stay on the music. Quick heads up: I'll remember this chat if you sign up. What are you working on right now?"
+    "Hey, I'm Jovie. I run the release side so you can stay on the music. Early access is limited — some artists waitlist first. I'll remember this chat if you sign up. What are you working on right now?"
   ),
 
   line(
@@ -97,7 +97,7 @@ export const SCRIPT_LINES: readonly ScriptLine[] = [
   line(
     'waitlist',
     'v1',
-    "Putting you on the early list — I'll ping you when you're up, and we pick this up exactly where we left off. Nothing gets lost."
+    'Putting you on the early list. We pick this up exactly where we left off — nothing gets lost. Share an email at sign-in if you want a heads-up when access opens.'
   ),
 
   line(

--- a/apps/web/lib/chat/onboarding-script/widget-events.ts
+++ b/apps/web/lib/chat/onboarding-script/widget-events.ts
@@ -1,0 +1,137 @@
+/**
+ * Structured onboarding widget events.
+ *
+ * Widget completions (handle confirm, social attach, "none of these") advance
+ * the guarded onboarding state machine via message metadata — never free-text
+ * acks like "ok" / "k". The fallback engine and LLM path both read these.
+ */
+
+export const ONBOARDING_WIDGET_EVENTS = {
+  HANDLE_CONFIRMED: 'handle_confirmed',
+  SOCIAL_ATTACHED: 'social_attached',
+  ARTIST_NONE_OF_THESE: 'artist_none_of_these',
+} as const;
+
+export type OnboardingWidgetEventType =
+  (typeof ONBOARDING_WIDGET_EVENTS)[keyof typeof ONBOARDING_WIDGET_EVENTS];
+
+export const ONBOARDING_WIDGET_EVENT_VALUES = Object.values(
+  ONBOARDING_WIDGET_EVENTS
+) as readonly OnboardingWidgetEventType[];
+
+/**
+ * Explicit guarded steps for the onboarding intake rail.
+ * Advances only when the prior step's guard is satisfied.
+ */
+export const ONBOARDING_GUARDED_STEPS = [
+  'role',
+  'artist_search',
+  'artist_select',
+  'handle',
+  'social',
+  'contact',
+  'waitlist_or_complete',
+] as const;
+
+export type OnboardingGuardedStep = (typeof ONBOARDING_GUARDED_STEPS)[number];
+
+export interface OnboardingWidgetEventPayload {
+  readonly onboardingEvent: OnboardingWidgetEventType;
+  readonly handle?: string;
+  readonly url?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isOnboardingWidgetEventType(
+  value: unknown
+): value is OnboardingWidgetEventType {
+  return (
+    typeof value === 'string' &&
+    (ONBOARDING_WIDGET_EVENT_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/** Read a structured widget event from UIMessage metadata. */
+export function parseWidgetEventFromMetadata(
+  metadata: unknown
+): OnboardingWidgetEventPayload | null {
+  if (!isRecord(metadata)) return null;
+  if (!isOnboardingWidgetEventType(metadata.onboardingEvent)) return null;
+  const payload: OnboardingWidgetEventPayload = {
+    onboardingEvent: metadata.onboardingEvent,
+  };
+  if (typeof metadata.handle === 'string' && metadata.handle.trim()) {
+    return {
+      ...payload,
+      handle: metadata.handle.replace(/^@/, '').trim().toLowerCase(),
+    };
+  }
+  if (typeof metadata.url === 'string' && metadata.url.trim()) {
+    return { ...payload, url: metadata.url.trim() };
+  }
+  return payload;
+}
+
+/**
+ * Ack-only / empty free-text that must not advance waitlist/reservation or
+ * complete access decisions. Widget events bypass this check.
+ */
+const INCOMPLETE_ACK_PATTERN =
+  /^(k+|ok|okay|yes|y|yep|yeah|sure|cool|nice|thanks|thx|thnx|got it|done|next|kk+|mhm|mm+|uh\s*huh|alright|right|fine)$/i;
+
+export function isIncompleteAdvanceMessage(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return true;
+  if (trimmed.length < 2) return true;
+  return INCOMPLETE_ACK_PATTERN.test(trimmed);
+}
+
+/** Minimum length for free-text waitlist intake answers on required steps. */
+export const MIN_MEANINGFUL_INTAKE_ANSWER_LENGTH = 2;
+
+export function isMeaningfulIntakeAnswer(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length < MIN_MEANINGFUL_INTAKE_ANSWER_LENGTH) return false;
+  return !isIncompleteAdvanceMessage(trimmed);
+}
+
+/** User-visible copy for Confirm Handle CTA (Title Case). */
+export const CONFIRM_HANDLE_CTA_LABEL = 'Confirm Handle';
+
+/** User-visible copy for Attach Account CTA (Title Case). */
+export const ATTACH_ACCOUNT_CTA_LABEL = 'Attach Account';
+
+/** User-visible copy for artist picker escape hatch. */
+export const NONE_OF_THESE_CTA_LABEL = 'None of These';
+
+/**
+ * Display text submitted with a widget event (human-readable transcript;
+ * the engine keys off metadata, not this string).
+ */
+export function widgetEventDisplayText(
+  event: OnboardingWidgetEventPayload
+): string {
+  switch (event.onboardingEvent) {
+    case ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED:
+      return event.handle
+        ? `Confirmed handle @${event.handle}`
+        : 'Confirmed handle';
+    case ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED:
+      return event.url ? `Attached ${event.url}` : 'Attached account';
+    case ONBOARDING_WIDGET_EVENTS.ARTIST_NONE_OF_THESE:
+      return 'None of these artists match';
+    default: {
+      const _exhaustive: never = event.onboardingEvent;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Tool-output action markers for completed widget steps. */
+export const WIDGET_COMPLETION_ACTIONS = {
+  HANDLE_CONFIRMED: 'handle_confirmed',
+  SOCIAL_ATTACHED: 'social_attached',
+} as const;

--- a/apps/web/lib/chat/prompts/onboarding.ts
+++ b/apps/web/lib/chat/prompts/onboarding.ts
@@ -8,12 +8,12 @@ import { buildOnboardingPromptSecuritySection } from '@/lib/chat/prompt-disclosu
  */
 export const ONBOARDING_CALIBRATION_EXAMPLES = {
   opener:
-    "Hey — I'm Jovie. Heads up, I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?",
+    "Hey — I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?",
   afterSpotifyPick:
     "Pulled you up. 47k Spotify followers, last release dropped 2 weeks ago, you've been releasing on Universal since 2018. The gap is interesting — you have the audience of a 200k+ artist but the release setup of someone who just signed last month. Nobody told you the bio-link layer is broken downstream of the DSP. What's making you want to fix this now?",
   softCommit: 'Want me to set this up? You ready?',
   waitlist:
-    "Got it. Putting you on the early list — I'll ping you when you're up. We can pick up right here.",
+    'Got it. Putting you on the early list. We pick up right here — nothing gets lost.',
   checkoutCloser:
     "That's the move. Pro is $39/mo, free tier exists if you'd rather start there. How does that sound?",
 } as const;

--- a/apps/web/lib/onboarding/empty-state.test.ts
+++ b/apps/web/lib/onboarding/empty-state.test.ts
@@ -5,8 +5,9 @@ import {
 } from './empty-state';
 
 describe('onboarding empty state copy', () => {
-  it('includes memory disclosure and one intake question', () => {
+  it('includes memory disclosure, early-access disclosure, and one intake question', () => {
     expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/remember/i);
+    expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/early access|waitlist/i);
     expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/what are you working on/i);
     expect((ONBOARDING_WELCOME_MESSAGE.match(/\?/g) ?? []).length).toBe(1);
   });

--- a/apps/web/lib/onboarding/empty-state.ts
+++ b/apps/web/lib/onboarding/empty-state.ts
@@ -6,7 +6,7 @@ import type { ChatSuggestion } from '@/components/jovie/types';
  * model stay aligned on memory disclosure + one intake question.
  */
 export const ONBOARDING_WELCOME_MESSAGE =
-  "Hey — I'm Jovie. Heads up, I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?";
+  "Hey — I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?";
 
 /** Starter pills for the anonymous /start empty state. */
 export const ONBOARDING_STARTER_SUGGESTIONS: readonly ChatSuggestion[] = [

--- a/apps/web/tests/unit/components/features/waitlist/WaitlistIntakeChat.test.tsx
+++ b/apps/web/tests/unit/components/features/waitlist/WaitlistIntakeChat.test.tsx
@@ -33,6 +33,20 @@ describe('WaitlistIntakeChat', () => {
     fetchMock.mockReset();
   });
 
+  it('does not advance required steps on incomplete ack answers', async () => {
+    render(<WaitlistIntakeChat userEmail='artist@example.com' />);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'k');
+    await userEvent.click(screen.getByRole('button', { name: /send answer/i }));
+
+    expect(
+      screen.getByText(/real answer|short acks|real handle/i)
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('surfaces rate-limited intake responses from non-OK submissions', async () => {
     fetchMock.mockResolvedValue(
       new Response(

--- a/apps/web/tests/unit/lib/chat/onboarding-script/engine.test.ts
+++ b/apps/web/tests/unit/lib/chat/onboarding-script/engine.test.ts
@@ -25,7 +25,9 @@ import {
   handleFromArtistName,
   parseArtistSelection,
   parseAudienceBand,
+  resolveGuardedStep,
 } from '@/lib/chat/onboarding-script/engine';
+import { ONBOARDING_WIDGET_EVENTS } from '@/lib/chat/onboarding-script/widget-events';
 import { createOnboardingTurnState } from '@/lib/chat/tools/onboarding-tool-impls';
 
 const SESSION = '00112233-4455-6677-8899-aabbccddeeff';
@@ -90,6 +92,47 @@ const CONFIRMED_OUTPUT = {
   },
 };
 
+const HANDLE_CHECKED = {
+  toolName: 'checkHandle',
+  output: { action: 'check_handle', handle: 'testartist' },
+} as const;
+
+const HANDLE_CONFIRMED = {
+  toolName: 'checkHandle',
+  output: {
+    action: 'handle_confirmed',
+    handle: 'testartist',
+    summary: 'Handle @testartist confirmed.',
+  },
+} as const;
+
+const SOCIAL_PROPOSED = {
+  toolName: 'proposeSocialLink',
+  output: {
+    action: 'propose_social_link',
+    url: null,
+    summary: 'Attach a public social account.',
+  },
+} as const;
+
+const SOCIAL_ATTACHED = {
+  toolName: 'proposeSocialLink',
+  output: {
+    action: 'social_attached',
+    url: 'https://instagram.com/testartist',
+    summary: 'Attached https://instagram.com/testartist.',
+  },
+} as const;
+
+function baseThroughArtist() {
+  return [
+    user('hey'),
+    assistant('Pulled you up.', [
+      { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
+    ]),
+  ] as const;
+}
+
 describe('parseArtistSelection', () => {
   it('reads the spotifyArtistId from message metadata', () => {
     expect(
@@ -135,11 +178,13 @@ describe('decideFallbackTurn', () => {
     vi.resetAllMocks();
   });
 
-  it('greets on the first turn', async () => {
+  it('greets on the first turn with early-access disclosure', async () => {
     const turn = await decide([user('hey')]);
     expect(turn.line.stepId).toBe('greet');
     expect(turn.toolEvents).toHaveLength(0);
     expect(turn.text).toContain("I'm Jovie");
+    expect(turn.text.toLowerCase()).toMatch(/early access|waitlist/);
+    expect(turn.guardedStep).toBe('role');
   });
 
   it('opens the artist picker on later turns without an artist', async () => {
@@ -153,6 +198,17 @@ describe('decideFallbackTurn', () => {
     expect(turn.toolEvents[0]?.toolName).toBe('searchSpotifyArtist');
     expect(turn.toolEvents[0]?.output.action).toBe('open_artist_picker');
     expect(turn.toolEvents[0]?.input.query).toBe('I am Test Artist');
+    expect(turn.guardedStep).toBe('artist_search');
+  });
+
+  it('prefills empty query when prior message is incomplete ack', async () => {
+    const turn = await decide([
+      user('hey'),
+      assistant('What are you working on?'),
+      user('k'),
+    ]);
+    expect(turn.toolEvents[0]?.input.query).toBe('');
+    expect(turn.toolEvents[0]?.output.query).toBeNull();
   });
 
   it('confirms the artist when the user picks one (metadata id)', async () => {
@@ -192,37 +248,70 @@ describe('decideFallbackTurn', () => {
 
   it('moves to the handle check once the artist is confirmed', async () => {
     const turn = await decide([
-      user('hey'),
-      assistant('Pulled you up.', [
-        { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
-      ]),
+      ...baseThroughArtist(),
       user('nice, what next?'),
     ]);
     expect(turn.line.stepId).toBe('handle');
     expect(turn.toolEvents[0]?.toolName).toBe('checkHandle');
     expect(turn.toolEvents[0]?.input.handle).toBe('testartist');
     expect(turn.text).toContain('@testartist');
+    expect(turn.guardedStep).toBe('handle');
   });
 
-  it('routes to instant access + checkout when followers clear the bar', async () => {
+  it('does not advance past handle on free-text ok/k', async () => {
+    const turn = await decide([
+      ...baseThroughArtist(),
+      assistant('Claiming @testartist.', [HANDLE_CHECKED]),
+      user('ok'),
+    ]);
+    expect(turn.guardedStep).toBe('handle');
+    expect(turn.toolEvents.map(e => e.output.action)).not.toContain(
+      'propose_next_step'
+    );
+    expect(turn.toolEvents.map(e => e.output.action)).not.toContain(
+      'handle_confirmed'
+    );
+  });
+
+  it('advances on structured handle_confirmed widget event', async () => {
+    const turn = await decide([
+      ...baseThroughArtist(),
+      assistant('Claiming @testartist.', [HANDLE_CHECKED]),
+      user('Confirmed handle @testartist', {
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED,
+        handle: 'testartist',
+      }),
+    ]);
+    // Metadata event satisfies the handle guard; next step opens social.
+    expect(turn.guardedStep).toBe('social');
+    expect(turn.toolEvents.map(e => e.output.action)).toContain(
+      'propose_social_link'
+    );
+  });
+
+  it('advances social on Attach Account widget event', async () => {
+    const lowSignal = {
+      ...CONFIRMED_OUTPUT,
+      artist: { ...CONFIRMED_OUTPUT.artist, followers: 120 },
+    };
     const turn = await decide([
       user('hey'),
-      assistant('Pulled you up.', [
-        { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
-        {
-          toolName: 'checkHandle',
-          output: { action: 'check_handle', handle: 'testartist' },
-        },
+      assistant('Handle locked.', [
+        { toolName: 'confirmSpotifyArtist', output: lowSignal },
+        HANDLE_CONFIRMED,
+        SOCIAL_PROPOSED,
       ]),
-      user('ok done'),
+      user('Attached https://instagram.com/testartist', {
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED,
+        url: 'https://instagram.com/testartist',
+      }),
     ]);
-    expect(turn.line.stepId).toBe('instant_access');
-    const actions = turn.toolEvents.map(event => event.output.action);
-    expect(actions).toContain('propose_next_step');
-    expect(actions).toContain('propose_checkout');
+    // Low signal + attach → contact (audience) rather than forced waitlist.
+    expect(turn.guardedStep).toBe('contact');
+    expect(turn.line.stepId).toBe('ask_audience');
   });
 
-  it('waitlists low-signal visitors once the turn cap forces a decision', async () => {
+  it('does not waitlist on incomplete k after handle+social', async () => {
     const lowSignal = {
       ...CONFIRMED_OUTPUT,
       artist: { ...CONFIRMED_OUTPUT.artist, followers: 120 },
@@ -231,21 +320,51 @@ describe('decideFallbackTurn', () => {
       user('hey'),
       assistant('Pulled you up.', [
         { toolName: 'confirmSpotifyArtist', output: lowSignal },
-        {
-          toolName: 'checkHandle',
-          output: { action: 'check_handle', handle: 'testartist' },
-        },
+        HANDLE_CONFIRMED,
+        SOCIAL_ATTACHED,
       ]),
-      user('turn two'),
+      user('k'),
+    ]);
+    expect(turn.line.stepId).toBe('ask_audience');
+    expect(turn.toolEvents.map(e => e.output.action)).not.toContain(
+      'propose_next_step'
+    );
+    expect(turn.guardedStep).toBe('contact');
+  });
+
+  it('routes to instant access after widget confirms + real audience signal', async () => {
+    const turn = await decide([
+      ...baseThroughArtist(),
+      assistant('Handle locked.', [HANDLE_CONFIRMED, SOCIAL_ATTACHED]),
+      user('around 20k on instagram'),
+    ]);
+    // High Spotify followers already clear the bar once handle+social complete.
+    expect(turn.line.stepId).toBe('instant_access');
+    const actions = turn.toolEvents.map(event => event.output.action);
+    expect(actions).toContain('propose_next_step');
+    expect(actions).toContain('propose_checkout');
+  });
+
+  it('waitlists only with meaningful signal after turn cap', async () => {
+    const lowSignal = {
+      ...CONFIRMED_OUTPUT,
+      artist: { ...CONFIRMED_OUTPUT.artist, followers: 120 },
+    };
+    const turn = await decide([
+      user('hey'),
+      assistant('Pulled you up.', [
+        { toolName: 'confirmSpotifyArtist', output: lowSignal },
+        HANDLE_CONFIRMED,
+        SOCIAL_ATTACHED,
+      ]),
+      user('turn two — planning a single'),
       assistant('One thing before I route you: audience size?'),
       user('like 300 people'),
     ]);
-    // turnCount 3 forces a decision; 300 listeners → waitlist.
     expect(turn.line.stepId).toBe('waitlist');
     expect(turn.toolEvents.map(event => event.output.action)).toContain(
       'propose_next_step'
     );
-    // The parsed audience answer is recorded as a signal.
     expect(turn.toolEvents.map(event => event.toolName)).toContain(
       'recordInterviewSignal'
     );
@@ -260,14 +379,30 @@ describe('decideFallbackTurn', () => {
       user('hey'),
       assistant('Pulled you up.', [
         { toolName: 'confirmSpotifyArtist', output: lowSignal },
-        {
-          toolName: 'checkHandle',
-          output: { action: 'check_handle', handle: 'testartist' },
-        },
+        HANDLE_CONFIRMED,
+        SOCIAL_ATTACHED,
       ]),
       user('around 20k on instagram'),
     ]);
     expect(turn.line.stepId).toBe('instant_access');
+  });
+
+  it('reopens artist search on none-of-these widget event', async () => {
+    const turn = await decide([
+      user('hey'),
+      assistant('Pick your artist below.', [
+        {
+          toolName: 'searchSpotifyArtist',
+          output: { action: 'open_artist_picker', query: 'test' },
+        },
+      ]),
+      user('None of these artists match', {
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.ARTIST_NONE_OF_THESE,
+      }),
+    ]);
+    expect(turn.guardedStep).toBe('artist_search');
+    expect(turn.toolEvents[0]?.toolName).toBe('searchSpotifyArtist');
+    expect(turn.toolEvents[0]?.output.query).toBeNull();
   });
 
   it('points back at the card once a terminal decision exists', async () => {
@@ -275,10 +410,8 @@ describe('decideFallbackTurn', () => {
       user('hey'),
       assistant('On the list.', [
         { toolName: 'confirmSpotifyArtist', output: CONFIRMED_OUTPUT },
-        {
-          toolName: 'checkHandle',
-          output: { action: 'check_handle', handle: 'testartist' },
-        },
+        HANDLE_CONFIRMED,
+        SOCIAL_ATTACHED,
         {
           toolName: 'proposeNextStep',
           output: {
@@ -291,5 +424,31 @@ describe('decideFallbackTurn', () => {
     ]);
     expect(turn.line.stepId).toBe('done');
     expect(turn.toolEvents).toHaveLength(0);
+  });
+});
+
+describe('resolveGuardedStep', () => {
+  it('returns role before any artist signal', () => {
+    const messages = [user('hey')];
+    expect(
+      resolveGuardedStep({
+        uiMessages: messages,
+        state: stateFor(messages),
+      })
+    ).toBe('role');
+  });
+
+  it('returns handle until handle_confirmed fires', () => {
+    const messages = [
+      ...baseThroughArtist(),
+      assistant('Claiming.', [HANDLE_CHECKED]),
+      user('ok'),
+    ];
+    expect(
+      resolveGuardedStep({
+        uiMessages: messages,
+        state: stateFor(messages),
+      })
+    ).toBe('handle');
   });
 });

--- a/apps/web/tests/unit/lib/chat/onboarding-script/widget-events.test.ts
+++ b/apps/web/tests/unit/lib/chat/onboarding-script/widget-events.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ATTACH_ACCOUNT_CTA_LABEL,
+  CONFIRM_HANDLE_CTA_LABEL,
+  isIncompleteAdvanceMessage,
+  isMeaningfulIntakeAnswer,
+  isOnboardingWidgetEventType,
+  NONE_OF_THESE_CTA_LABEL,
+  ONBOARDING_GUARDED_STEPS,
+  ONBOARDING_WIDGET_EVENTS,
+  parseWidgetEventFromMetadata,
+  widgetEventDisplayText,
+} from '@/lib/chat/onboarding-script/widget-events';
+
+describe('onboarding widget events', () => {
+  it('exposes the guarded step rail in order', () => {
+    expect(ONBOARDING_GUARDED_STEPS).toEqual([
+      'role',
+      'artist_search',
+      'artist_select',
+      'handle',
+      'social',
+      'contact',
+      'waitlist_or_complete',
+    ]);
+  });
+
+  it('uses Title Case CTAs', () => {
+    expect(CONFIRM_HANDLE_CTA_LABEL).toBe('Confirm Handle');
+    expect(ATTACH_ACCOUNT_CTA_LABEL).toBe('Attach Account');
+    expect(NONE_OF_THESE_CTA_LABEL).toBe('None of These');
+  });
+
+  it('parses handle_confirmed metadata', () => {
+    expect(
+      parseWidgetEventFromMetadata({
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED,
+        handle: '@TestArtist',
+      })
+    ).toEqual({
+      onboardingEvent: 'handle_confirmed',
+      handle: 'testartist',
+    });
+  });
+
+  it('parses social_attached metadata', () => {
+    expect(
+      parseWidgetEventFromMetadata({
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED,
+        url: 'https://instagram.com/x',
+      })
+    ).toEqual({
+      onboardingEvent: 'social_attached',
+      url: 'https://instagram.com/x',
+    });
+  });
+
+  it('rejects unknown events', () => {
+    expect(isOnboardingWidgetEventType('nope')).toBe(false);
+    expect(
+      parseWidgetEventFromMetadata({ onboardingEvent: 'nope' })
+    ).toBeNull();
+  });
+
+  it('treats incomplete acks as non-advancing', () => {
+    expect(isIncompleteAdvanceMessage('')).toBe(true);
+    expect(isIncompleteAdvanceMessage('k')).toBe(true);
+    expect(isIncompleteAdvanceMessage('ok')).toBe(true);
+    expect(isIncompleteAdvanceMessage('  OK  ')).toBe(true);
+    expect(isIncompleteAdvanceMessage('like 300 people')).toBe(false);
+    expect(isIncompleteAdvanceMessage('planning a single')).toBe(false);
+  });
+
+  it('requires meaningful intake answers', () => {
+    expect(isMeaningfulIntakeAnswer('k')).toBe(false);
+    expect(isMeaningfulIntakeAnswer('ok')).toBe(false);
+    expect(isMeaningfulIntakeAnswer('a')).toBe(false);
+    expect(isMeaningfulIntakeAnswer('artist')).toBe(true);
+  });
+
+  it('builds display text for widget events', () => {
+    expect(
+      widgetEventDisplayText({
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.HANDLE_CONFIRMED,
+        handle: 'tim',
+      })
+    ).toBe('Confirmed handle @tim');
+    expect(
+      widgetEventDisplayText({
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED,
+        url: 'https://x.com/t',
+      })
+    ).toBe('Attached https://x.com/t');
+    expect(
+      widgetEventDisplayText({
+        onboardingEvent: ONBOARDING_WIDGET_EVENTS.ARTIST_NONE_OF_THESE,
+      })
+    ).toBe('None of these artists match');
+  });
+});

--- a/apps/web/tests/unit/onboarding/OnboardingToolArtifacts.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingToolArtifacts.test.tsx
@@ -247,26 +247,46 @@ describe('onboarding tool artifacts', () => {
 
     expect(screen.getByText('@testartist')).toBeDefined();
     expect(screen.getByText('is available')).toBeDefined();
-    expect(screen.getByLabelText('Edit proposed handle')).toHaveValue(
+    expect(screen.getByLabelText('Edit Proposed Handle')).toHaveValue(
       'testartist'
     );
     expect(screen.getByText('jov.ie/testartist')).toBeDefined();
     expect(screen.queryByText('checkHandle')).toBeNull();
 
-    fireEvent.change(screen.getByLabelText('Edit proposed handle'), {
+    fireEvent.change(screen.getByLabelText('Edit Proposed Handle'), {
       target: { value: 'test' },
     });
 
     expect(onHandleCandidateChange).toHaveBeenLastCalledWith('test');
 
-    fireEvent.change(screen.getByLabelText('Edit proposed handle'), {
+    fireEvent.change(screen.getByLabelText('Edit Proposed Handle'), {
       target: { value: '' },
     });
 
     expect(onHandleCandidateChange).toHaveBeenLastCalledWith('');
   });
 
-  it('renders proposed social links as reviewable artifacts', () => {
+  it('emits Confirm Handle widget event when the CTA is pressed', () => {
+    mocks.handleAvailability.data = { available: true };
+    const onConfirmHandle = vi.fn();
+
+    fastRender(
+      <OnboardingHandleCheckCard
+        state='output-available'
+        output={{ action: 'check_handle', handle: 'testartist' }}
+        onConfirmHandle={onConfirmHandle}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Handle' }));
+    expect(onConfirmHandle).toHaveBeenCalledWith('testartist');
+    expect(
+      screen.getByRole('button', { name: 'Handle Confirmed' })
+    ).toBeDefined();
+  });
+
+  it('renders proposed social links with Attach Account CTA', () => {
+    const onAttachAccount = vi.fn();
     fastRender(
       <OnboardingSocialLinkCard
         state='output-available'
@@ -274,11 +294,42 @@ describe('onboarding tool artifacts', () => {
           action: 'propose_social_link',
           url: 'https://instagram.com/testartist',
         }}
+        onAttachAccount={onAttachAccount}
       />
     );
 
     expect(screen.getByText('Link ready to attach')).toBeDefined();
-    expect(screen.getByText('instagram.com')).toBeDefined();
+    expect(
+      screen.getByDisplayValue('https://instagram.com/testartist')
+    ).toBeDefined();
     expect(screen.queryByText('proposeSocialLink')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Attach Account' }));
+    expect(onAttachAccount).toHaveBeenCalledWith(
+      'https://instagram.com/testartist'
+    );
+  });
+
+  it('offers None of These when artist results are present', () => {
+    mocks.artistSearch.results = [
+      {
+        id: 'artist-1',
+        name: 'Test Artist',
+        url: 'https://open.spotify.com/artist/artist-1',
+        followers: 12_300,
+        popularity: 48,
+      },
+    ];
+    const onNoneOfThese = vi.fn();
+    fastRender(
+      <OnboardingSpotifyArtistPickerCard
+        state='output-available'
+        output={{ action: 'open_artist_picker', query: 'Test Artist' }}
+        onSelectArtist={vi.fn()}
+        onNoneOfThese={onNoneOfThese}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'None of These' }));
+    expect(onNoneOfThese).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add guarded onboarding step rail (`role → artist_search → artist_select → handle → social → contact → waitlist_or_complete`) with explicit advance rules.
- Widget completions emit structured metadata (`handle_confirmed`, `social_attached`, `artist_none_of_these`) so free-text “ok”/“k” cannot complete waitlist/reservation.
- Visible **Confirm Handle** / **Attach Account** CTAs; artist picker prefills query and offers **None of These**.
- Early-access / waitlist disclosure in empty intro, greet lines, and waitlist intake.
- Email notification promises only when a confirmed email is present.

## Audit coverage
#4, #6, #7, #9, #12–14, #17–20, #23 (onboarding SM / waitlist success language / incomplete advances)

## Test plan
- [x] `vitest` engine + widget-events + tool artifacts + waitlist intake (77 tests green)
- [x] Evidence: `scratch/onboarding-sm-tests.log`
- [x] Pre-commit: biome, eslint, typecheck
- [ ] CI PR Ready

## Bug-to-test
Regression tests for widget event advance, incomplete “k” guard, Confirm Handle CTA, Attach Account CTA, None of These.