### PR TITLE
dx(pre-commit): conflict-marker check prints success + affected files (JOV-1962)

### DIFF
--- a/scripts/check-conflict-markers.sh
+++ b/scripts/check-conflict-markers.sh
@@ -6,11 +6,17 @@ set -euo pipefail
 output=$(LC_ALL=C git diff --cached --check 2>&1 || true)
 
 if echo "$output" | LC_ALL=C grep -q "leftover conflict marker"; then
-  echo "ERROR: Merge conflict markers found in staged files:"
+  echo "ERROR: Merge conflict markers found in staged files."
+  echo ""
+  echo "Affected files:"
+  echo "$output" | grep "leftover conflict marker" | cut -d: -f1 | sort -u | awk '{printf "  %d. %s\n", NR, $0}'
+  echo ""
+  echo "Details:"
   echo "$output" | grep "leftover conflict marker"
   echo ""
   echo "Remove the <<<<<<< / ======= / >>>>>>> markers before committing."
   exit 1
 fi
 
+echo "PASS: conflict-marker check completed with no findings"
 exit 0

--- a/scripts/tests/test_check_conflict_markers.py
+++ b/scripts/tests/test_check_conflict_markers.py
@@ -1,0 +1,83 @@
+"""
+Regression tests for scripts/check-conflict-markers.sh (JOV-1962).
+
+The pre-commit gate must print a one-line PASS confirmation on success and,
+on failure, a clean numbered list of the affected files before the raw
+`git diff --cached --check` output. Exit codes must remain unchanged.
+
+Run with:
+    python -m pytest scripts/tests/test_check_conflict_markers.py -v
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check-conflict-markers.sh"
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+
+
+def _stage(repo: Path, name: str, content: str) -> None:
+    (repo / name).write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", name], cwd=repo, check=True)
+
+
+def _run(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(_SCRIPT)],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class TestCheckConflictMarkers:
+    def test_clean_staged_tree_prints_pass_line(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        _stage(tmp_path, "clean.txt", "all good\n")
+
+        result = _run(tmp_path)
+
+        assert result.returncode == 0
+        assert "PASS: conflict-marker check" in result.stdout
+
+    def test_conflict_markers_list_affected_files_before_details(
+        self, tmp_path: Path
+    ) -> None:
+        _init_repo(tmp_path)
+        _stage(tmp_path, "clean.txt", "all good\n")
+        _stage(
+            tmp_path,
+            "conflicted.txt",
+            "before\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\nafter\n",
+        )
+
+        result = _run(tmp_path)
+
+        assert result.returncode == 1
+        # Numbered affected-file list appears before the raw detail lines...
+        assert "Affected files:" in result.stdout
+        assert "  1. conflicted.txt" in result.stdout
+        assert result.stdout.index("Affected files:") < result.stdout.index(
+            "leftover conflict marker"
+        )
+        # ...and only the affected file is listed, not every staged file.
+        assert "clean.txt" not in result.stdout.split("Details:")[0]
+        # Raw detector output is still printed for context.
+        assert "leftover conflict marker" in result.stdout
+
+    def test_multiple_conflicted_files_are_numbered(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        _stage(tmp_path, "b.txt", "<<<<<<< HEAD\n")
+        _stage(tmp_path, "a.txt", ">>>>>>> branch\n")
+
+        result = _run(tmp_path)
+
+        assert result.returncode == 1
+        assert "  1. a.txt" in result.stdout
+        assert "  2. b.txt" in result.stdout


### PR DESCRIPTION
## Summary

- `scripts/check-conflict-markers.sh` (pre-commit gate ladder rung 1, `.husky/pre-commit:6`) now prints a one-line `PASS:` confirmation on success instead of staying silent.
- On failure it prints a clean numbered list of the affected files before the raw `git diff --cached --check` details.
- Exit codes and detection logic are unchanged.

## Issue

JOV-1962 — pre-commit conflict-marker check UX: silent on success, raw-only output on failure.

## Root cause / evidence

The script captured `git diff --cached --check`, grepped for "leftover conflict marker", and on failure echoed only the raw detector lines (`file:line: leftover conflict marker`) — no summary of which files need fixing — and printed nothing at all on success, so developers could not tell the rung ran.

## Scope

- `scripts/check-conflict-markers.sh` — +8/-1 lines: PASS line on success; `Affected files:` numbered list (derived from the detector output, so only files that actually contain markers are listed, not every staged file) ahead of the existing raw `Details:` block.
- `scripts/tests/test_check_conflict_markers.py` — new pytest harness (follows the existing `scripts/tests/test_gh_retry.py` subprocess pattern): PASS line, list ordering/content, multi-file numbering.

## Validation

- `bash -n scripts/check-conflict-markers.sh` — syntax OK.
- `python3 -m pytest scripts/tests/test_check_conflict_markers.py -v` — 3/3 pass.
- Manual scratch-repo runs: (a) clean staged tree → `PASS: conflict-marker check completed with no findings`, exit 0; (b) staged file with `<<<<<<<`/`=======`/`>>>>>>>` markers → numbered `Affected files:` list before raw details, exit 1.
- This commit's own pre-commit gate ladder (running the new script) passed.

## Risk

None functional: detection, gating, and exit codes are identical; only stdout changed. The PASS line matches the existing `scan-secrets.sh` convention (`PASS: secret scan (pre-commit) completed with no findings`).

## Rollback

Revert commit `658744a735d` — restores the previous silent/raw behavior; no other coupling.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20`
- Written: `engineering/conflict-marker-check-ux` (fix evidence + validation)
