### PR TITLE
fix(dashboard): FunnelStage skeleton/loaded layout parity (JOV-4158)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.test.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AnalyticsSidebar,
   calculateConversionRate,
+  FUNNEL_STAGE_METRIC_ROW_CLASS,
+  FUNNEL_STAGE_OUTER_CLASS,
   FunnelStage,
 } from './AnalyticsSidebar';
 
@@ -154,16 +156,16 @@ describe('AnalyticsSidebar', () => {
   });
 });
 
-describe('FunnelStage (regression: #13819 skeleton padding parity)', () => {
+describe('FunnelStage (regression: JOV-4158 / #13819 skeleton layout parity)', () => {
   const stageProps = {
     label: 'Profile Views',
     value: 120,
-    rate: null,
+    rate: null as string | null,
     barPercent: 50,
     barIndex: 0,
   };
 
-  it('uses identical outer padding in loading and loaded states', () => {
+  it('uses identical outer padding + metric-row chrome in loading and loaded states', () => {
     const { container: loadingContainer } = render(
       <FunnelStage {...stageProps} loading />
     );
@@ -171,10 +173,43 @@ describe('FunnelStage (regression: #13819 skeleton padding parity)', () => {
       <FunnelStage {...stageProps} loading={false} />
     );
 
-    const loadingRow = loadingContainer.firstElementChild;
-    const loadedRow = loadedContainer.firstElementChild;
+    const loadingOuter = loadingContainer.firstElementChild;
+    const loadedOuter = loadedContainer.firstElementChild;
+    const loadingMetricRow = loadingOuter?.firstElementChild;
+    const loadedMetricRow = loadedOuter?.firstElementChild;
 
-    expect(loadingRow).toHaveClass('px-3.5', 'py-2.5');
-    expect(loadedRow).toHaveClass('px-3.5', 'py-2.5');
+    // Full className equality — shared constants cannot drift independently
+    expect(loadingOuter?.className).toBe(FUNNEL_STAGE_OUTER_CLASS);
+    expect(loadedOuter?.className).toBe(FUNNEL_STAGE_OUTER_CLASS);
+    expect(loadingMetricRow?.className).toBe(FUNNEL_STAGE_METRIC_ROW_CLASS);
+    expect(loadedMetricRow?.className).toBe(FUNNEL_STAGE_METRIC_ROW_CLASS);
+
+    // Explicit padding tokens from the original bug report
+    expect(loadingOuter).toHaveClass('px-3.5', 'py-2.5');
+    expect(loadedOuter).toHaveClass('px-3.5', 'py-2.5');
+    expect(loadingOuter).not.toHaveClass('px-3', 'py-2');
+    expect(loadedOuter).not.toHaveClass('px-3', 'py-2');
+  });
+
+  it('keeps outer className stable when a conversion rate is present', () => {
+    const { container: withoutRate } = render(
+      <FunnelStage {...stageProps} rate={null} loading={false} />
+    );
+    const { container: withRate } = render(
+      <FunnelStage {...stageProps} rate='40%' loading={false} />
+    );
+
+    expect(withoutRate.firstElementChild?.className).toBe(
+      FUNNEL_STAGE_OUTER_CLASS
+    );
+    expect(withRate.firstElementChild?.className).toBe(
+      FUNNEL_STAGE_OUTER_CLASS
+    );
+    expect(withoutRate.firstElementChild?.firstElementChild?.className).toBe(
+      FUNNEL_STAGE_METRIC_ROW_CLASS
+    );
+    expect(withRate.firstElementChild?.firstElementChild?.className).toBe(
+      FUNNEL_STAGE_METRIC_ROW_CLASS
+    );
   });
 });

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -72,6 +72,17 @@ function formatRankedLabel(label: string): string {
   }
 }
 
+/**
+ * Shared outer + metric-row chrome for FunnelStage loading/loaded.
+ * Must stay identical across branches — padding drift (px-3/py-2 vs
+ * px-3.5/py-2.5) caused every funnel row to micro-shift when loading
+ * resolved (JOV-4158 / #13819).
+ */
+export const FUNNEL_STAGE_OUTER_CLASS = 'space-y-1.5 px-3.5 py-2.5';
+/** min-h-4 reserves space for text-mid value (0.9375rem) so skeleton → loaded is height-stable */
+export const FUNNEL_STAGE_METRIC_ROW_CLASS =
+  'flex min-h-4 items-center justify-between gap-2';
+
 /** Single stage in the vertical funnel waterfall */
 export function FunnelStage({
   label,
@@ -90,10 +101,10 @@ export function FunnelStage({
 }) {
   if (loading) {
     return (
-      <div className='space-y-1.5 px-3.5 py-2.5'>
-        <div className='flex items-center justify-between'>
+      <div className={FUNNEL_STAGE_OUTER_CLASS}>
+        <div className={FUNNEL_STAGE_METRIC_ROW_CLASS}>
           <LoadingSkeleton height='h-3' width='w-20' rounded='sm' />
-          <LoadingSkeleton height='h-3' width='w-12' rounded='sm' />
+          <LoadingSkeleton height='h-4' width='w-12' rounded='sm' />
         </div>
         <div className={cn('h-1.5 rounded-full', TRACK_BG, 'animate-pulse')} />
       </div>
@@ -101,20 +112,20 @@ export function FunnelStage({
   }
 
   return (
-    <div className='space-y-1.5 px-3.5 py-2.5'>
-      <div className='flex items-baseline justify-between gap-2'>
+    <div className={FUNNEL_STAGE_OUTER_CLASS}>
+      <div className={FUNNEL_STAGE_METRIC_ROW_CLASS}>
         <span className='text-xs font-caption text-secondary-token'>
           {label}
         </span>
-        <span className='flex items-baseline gap-1.5'>
+        <span className='flex min-h-4 items-center gap-1.5'>
           <span className='tabular-nums text-mid font-semibold leading-none tracking-tighter text-primary-token'>
             {numberFormatter.format(value)}
           </span>
-          {rate && (
+          {rate ? (
             <span className='tabular-nums text-3xs font-caption text-tertiary-token'>
               {rate}
             </span>
-          )}
+          ) : null}
         </span>
       </div>
       <div className={cn('h-1.5 rounded-full', TRACK_BG)}>


### PR DESCRIPTION
## Summary

Locks AnalyticsSidebar `FunnelStage` loading and loaded chrome so funnel rows cannot micro-shift when loading resolves.

- Shared `FUNNEL_STAGE_OUTER_CLASS` (`space-y-1.5 px-3.5 py-2.5`) for both branches — eliminates the reported `px-3 py-2` vs `px-3.5 py-2.5` padding drift and any future class drift.
- Shared `FUNNEL_STAGE_METRIC_ROW_CLASS` (`flex min-h-4 items-center justify-between gap-2`) so metric-row alignment, gap, and min-height stay identical.
- Value skeleton uses `h-4` to match `text-mid` / `min-h-4` loaded metrics.

## Test plan / results

- [x] Unit: `FunnelStage` loading vs loaded outer + metric-row `className` equality
- [x] Unit: outer/metric-row chrome stable when conversion rate is present
- [x] Explicit regression: neither branch uses `px-3` / `py-2`
- [x] `pnpm --filter web exec vitest run components/features/dashboard/organisms/AnalyticsSidebar.test.tsx tests/unit/dashboard/AnalyticsSidebar.test.ts` — **17 passed**
- [x] Biome check on touched files — clean
- [x] Pre-push typecheck / affected verify — green

```
✓ components/features/dashboard/organisms/AnalyticsSidebar.test.tsx (5 tests)
✓ tests/unit/dashboard/AnalyticsSidebar.test.ts (12 tests)
Test Files  2 passed (2)
Tests  17 passed (17)
```

## Linear

Fixes JOV-4158

<!-- linear-issue-id: JOV-4158 -->