### PR TITLE
fix(ui): composer padding chip overflow and dev toolbar gating

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -102,7 +102,7 @@ function hasConnectedMusicCatalog(profile: ChatActionProfile): boolean {
 /**
  * First-run / empty-thread scaffolding (JOV-3547). Always returns ≥3
  * profile-aware starter actions so the empty chat never renders a bare
- * "Ask jovie..." box. Setup-gap cards lead when the profile is incomplete.
+ * "Ask Jovie..." box. Setup-gap cards lead when the profile is incomplete.
  */
 export function buildChatActionCards({
   profile,

--- a/apps/web/components/features/dev/DevToolbarGate.tsx
+++ b/apps/web/components/features/dev/DevToolbarGate.tsx
@@ -26,8 +26,19 @@ const DEV_TOOLBAR_SUPPRESSED_PATHS = new Set([
   '/demo',
   '/demo/video',
   '/start',
+  '/onboarding',
 ]);
-const DEV_TOOLBAR_SUPPRESSED_PREFIXES = ['/demo/'];
+const DEV_TOOLBAR_SUPPRESSED_PREFIXES = [
+  '/demo/',
+  '/onboarding/',
+  '/app/onboarding',
+];
+
+/** Zero the layout CSS var so customer metrics never include toolbar chrome. */
+export function resetDevToolbarHeight(): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.style.setProperty('--dev-toolbar-height', '0px');
+}
 
 function hasDevToolbarCookie(): boolean {
   if (typeof document === 'undefined') return false;
@@ -44,13 +55,37 @@ export function isDevToolbarSuppressedPath(pathname: string): boolean {
   );
 }
 
-function isSuppressedClientContext(pathname: string): boolean {
-  return (
-    isDemoRecordingClient() ||
-    isDevChromeDisabledClient() ||
-    document.documentElement.dataset.desktopRuntime === 'electron' ||
-    isDevToolbarSuppressedPath(pathname)
-  );
+/**
+ * Production customer sessions never show the toolbar unless an explicit
+ * `__dev_toolbar=1` cookie opt-in is present (emergency prod debugging).
+ */
+export function shouldRenderDevToolbar({
+  env,
+  disabled = false,
+  pathname,
+  hasCookie = false,
+  isDemoRecording = false,
+  isDevChromeDisabled = false,
+  isElectron = false,
+  nodeEnv = process.env.NODE_ENV,
+}: {
+  readonly env: string;
+  readonly disabled?: boolean;
+  readonly pathname: string;
+  readonly hasCookie?: boolean;
+  readonly isDemoRecording?: boolean;
+  readonly isDevChromeDisabled?: boolean;
+  readonly isElectron?: boolean;
+  readonly nodeEnv?: string | undefined;
+}): boolean {
+  if (disabled) return false;
+  if (isDemoRecording || isDevChromeDisabled || isElectron) return false;
+  if (isDevToolbarSuppressedPath(pathname)) return false;
+
+  const isProduction = nodeEnv === 'production' && env === 'production';
+  if (isProduction) return hasCookie;
+
+  return true;
 }
 
 export function DevToolbarGate({
@@ -66,24 +101,36 @@ export function DevToolbarGate({
     let cancelled = false;
 
     const hideToolbar = () => {
-      document.documentElement.style.setProperty('--dev-toolbar-height', '0px');
+      resetDevToolbarHeight();
       setShouldRender(false);
     };
 
     const syncToolbarVisibility = () => {
       if (cancelled) return;
 
-      if (disabled || isSuppressedClientContext(pathname)) {
+      const nextShouldRender = shouldRenderDevToolbar({
+        env,
+        disabled,
+        pathname,
+        hasCookie: hasDevToolbarCookie(),
+        isDemoRecording: isDemoRecordingClient(),
+        isDevChromeDisabled: isDevChromeDisabledClient(),
+        isElectron:
+          document.documentElement.dataset.desktopRuntime === 'electron',
+      });
+
+      if (!nextShouldRender) {
+        // Always zero height when hidden so layout metrics and sticky docks
+        // never reserve space for admin/persona chrome on customer surfaces.
         hideToolbar();
         return;
       }
 
-      const isProduction =
-        process.env.NODE_ENV === 'production' && env === 'production';
-
-      setShouldRender(!isProduction || hasDevToolbarCookie());
+      setShouldRender(true);
     };
 
+    // Fail closed on first paint: zero height until we confirm render.
+    resetDevToolbarHeight();
     syncToolbarVisibility();
 
     const animationFrame = globalThis.requestAnimationFrame?.(
@@ -112,6 +159,8 @@ export function DevToolbarGate({
       }
       document.removeEventListener('DOMContentLoaded', handleDomReady);
       observer?.disconnect();
+      // Leaving a gated surface must not leave residual height for metrics.
+      resetDevToolbarHeight();
     };
   }, [disabled, env, pathname]);
 

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -942,8 +942,11 @@ export function OnboardingChat({
     isStreaming,
     onStop: stop,
     // Raw "Securing chat..." text is replaced in follow-up pass with
-    // statusBanner skeleton treatment; placeholder stays stable.
-    placeholder: 'Artist, release, or link...',
+    // statusBanner skeleton treatment. Handle step gets a confirm-oriented
+    // placeholder so incomplete free-text is less tempting.
+    placeholder: handleDraft
+      ? 'Confirm handle or type a different one…'
+      : 'Artist, release, or link...',
     onPickerOpenChange: setComposerPickerOpen,
     chips: chipTray.chips,
     onRemoveChipAt: chipTray.removeAt,

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -128,6 +128,13 @@ export function JovieChat({
     return actionCards.filter(card => !dismissedActionCardIds.has(card.id));
   }, [actionCards, dismissedActionCardIds]);
 
+  // Rail chips that duplicate a visible action card would show conflicting
+  // enabled/disabled states (e.g. Generate Album Art card vs capability-gated chip).
+  const promptRailExcludeLabels = useMemo(
+    () => visibleActionCards.map(card => card.title),
+    [visibleActionCards]
+  );
+
   const handleDismissActionCard = useCallback((cardId: string) => {
     setDismissedActionCardIds(prev => {
       const next = new Set(prev);
@@ -720,7 +727,14 @@ export function JovieChat({
           >
             {!showThreadView ? (
               <div
-                className='flex flex-1 flex-col items-center justify-center'
+                className={cn(
+                  'flex flex-1 flex-col',
+                  // Docked scaffolds (cards/opportunity) fill the viewport so the
+                  // composer can sit at the bottom; welcome state stays centered.
+                  showEmptyActionCards || showEmptyOpportunityCards
+                    ? 'min-h-0'
+                    : 'items-center justify-center'
+                )}
                 data-testid='chat-empty-state-viewport'
               >
                 <ChatEmptyStateComposerRegion
@@ -761,6 +775,7 @@ export function JovieChat({
                         isFirstSession={isFirstSession}
                         layout='rail'
                         dimmed={composerPickerOpen}
+                        excludeLabels={promptRailExcludeLabels}
                       />
                     </div>
                   ) : null}

--- a/apps/web/components/jovie/JovieChatSections.tsx
+++ b/apps/web/components/jovie/JovieChatSections.tsx
@@ -110,7 +110,7 @@ export function ChatComposerSurface({
 
       <ChatInput
         {...chatInputProps}
-        placeholder='Ask jovie...'
+        placeholder='Ask Jovie...' // ui-casing-allow: brand placeholder
         variant={showThreadView ? 'compact' : 'hero'}
       />
     </div>

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
@@ -62,4 +62,36 @@ describe('ChatEmptyStateComposerRegion', () => {
     expect(screen.queryByTestId('chat-empty-state-logo')).toBeNull();
     expect(screen.queryByTestId('chat-empty-state-greeting')).toBeNull();
   });
+
+  it('docks the composer below a scrollable above slot (no mid-viewport absolute clip)', () => {
+    render(
+      <ChatEmptyStateComposerRegion
+        above={
+          <div data-testid='above-slot'>
+            <div>First Task Card</div>
+            <div>Second Task Card</div>
+          </div>
+        }
+      >
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    const region = screen.getByTestId('chat-empty-state-composer-region');
+    expect(region.getAttribute('data-layout')).toBe('docked');
+    expect(region.className).toContain('flex-col');
+    expect(region.className).not.toContain('justify-center');
+
+    const aboveScroll = screen.getByTestId('chat-empty-state-above-scroll');
+    expect(aboveScroll.className).toContain('overflow-y-auto');
+    expect(aboveScroll.className).toContain('flex-1');
+    // Absolute mid-viewport stacking was the clip source — must not return.
+    expect(aboveScroll.className).not.toContain('absolute');
+    expect(aboveScroll.className).not.toContain('bottom-1/2');
+
+    const composer = screen.getByTestId('chat-empty-state-centered-composer');
+    expect(composer.getAttribute('data-dock')).toBe('bottom');
+    expect(composer.className).toContain('shrink-0');
+    expect(screen.getByTestId('composer-child')).toBeTruthy();
+  });
 });

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -7,6 +7,15 @@ import { CHAT_CONTENT_SHELL_CLASSNAME } from '../chat-layout';
 
 const AMBIENT_LOGO_OPACITY = 0.18;
 
+/**
+ * Empty-chat scaffold.
+ *
+ * - Welcome (no `above`): logo + greeting + composer centered in the viewport.
+ * - Task/scaffold (`above`): cards scroll in the upper region; the composer
+ *   (and any quick-action rail passed as children) docks to the bottom of the
+ *   usable area so the first card is never clipped by mid-viewport absolute
+ *   positioning and chips stay reachable without overlapping the dock.
+ */
 export function ChatEmptyStateComposerRegion({
   above,
   children,
@@ -20,16 +29,38 @@ export function ChatEmptyStateComposerRegion({
   const greeting = trimmedName ? `Hi, ${trimmedName}` : 'Hi there';
   const showWelcomeHeader = !above;
 
+  if (above) {
+    return (
+      <div
+        className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative flex min-h-full flex-col px-1 py-4 sm:py-5`}
+        data-testid='chat-empty-state-composer-region'
+        data-layout='docked'
+      >
+        {/* Scrollable card stack — first item starts at top, never absolute-clipped */}
+        <div
+          className='min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pb-3'
+          data-testid='chat-empty-state-above-scroll'
+        >
+          {above}
+        </div>
+        {/* Bottom-docked composer + quick-action chips (passed as children) */}
+        <div
+          className='relative z-10 w-full shrink-0 pt-2'
+          data-testid='chat-empty-state-centered-composer'
+          data-dock='bottom'
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={`${CHAT_CONTENT_SHELL_CLASSNAME} chat-stagger relative flex min-h-full flex-col items-center justify-center px-1 py-8`}
       data-testid='chat-empty-state-composer-region'
+      data-layout='centered'
     >
-      {above ? (
-        <div className='absolute inset-x-0 bottom-1/2 z-10 mb-12 max-h-[min(46vh,24rem)] overflow-y-auto overscroll-contain px-1 pb-1'>
-          {above}
-        </div>
-      ) : null}
       {showWelcomeHeader ? (
         <div
           aria-hidden='true'

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -52,6 +52,11 @@ interface SuggestedPromptsProps {
   readonly albumArtCapability?: PromptCapability;
   /** When true, hides the "Build artist profile" chip — profile setup is done. */
   readonly isProfileComplete?: boolean;
+  /**
+   * Labels already covered by empty-state action cards (or other scaffolds).
+   * Prevents a chip from advertising a conflicting enabled state vs a card.
+   */
+  readonly excludeLabels?: readonly string[];
   readonly layout?: 'rail' | 'grid' | 'flat';
   /**
    * Variant F: while the slash picker is open, fade chips out (don't unmount)
@@ -76,6 +81,9 @@ function SuggestionPill({
   readonly disabledReason?: string | null;
 }) {
   const IconComponent = ICON_MAP[suggestion.icon];
+  // Always expose full title via native tooltip so truncated labels
+  // ("What's Working Fo…") remain discoverable.
+  const title = disabledReason ?? suggestion.label;
 
   return (
     <button
@@ -92,7 +100,7 @@ function SuggestionPill({
       )}
       aria-label={suggestion.label}
       aria-disabled={disabled}
-      title={disabledReason ?? undefined}
+      title={title}
     >
       <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
         {IconComponent && <IconComponent className='h-3.5 w-3.5 shrink-0' />}
@@ -104,6 +112,17 @@ function SuggestionPill({
   );
 }
 
+function filterExcludedLabels(
+  suggestions: readonly ChatSuggestion[],
+  excludeLabels: readonly string[] | undefined
+): readonly ChatSuggestion[] {
+  if (!excludeLabels || excludeLabels.length === 0) return suggestions;
+  const excluded = new Set(excludeLabels.map(label => label.toLowerCase()));
+  return suggestions.filter(
+    suggestion => !excluded.has(suggestion.label.toLowerCase())
+  );
+}
+
 export function SuggestedPrompts({
   onSelect,
   isFirstSession = false,
@@ -111,15 +130,18 @@ export function SuggestedPrompts({
   canUseAdvancedTools = false,
   albumArtCapability,
   isProfileComplete = false,
+  excludeLabels,
   layout = 'rail',
   dimmed = false,
 }: SuggestedPromptsProps) {
-  const filterProfileSuggestion = (suggestions: readonly ChatSuggestion[]) =>
-    isProfileComplete
+  const filterProfileSuggestion = (suggestions: readonly ChatSuggestion[]) => {
+    const withoutProfile = isProfileComplete
       ? suggestions.filter(
           suggestion => suggestion.label !== 'Build Artist Profile'
         )
       : suggestions;
+    return filterExcludedLabels(withoutProfile, excludeLabels);
+  };
 
   const promptSuggestions = isFirstSession
     ? filterProfileSuggestion(FIRST_SESSION_SUGGESTIONS).map(suggestion => {
@@ -160,7 +182,6 @@ export function SuggestedPrompts({
     resolvedAlbumArtCapability.availability === 'unavailable'
       ? {
           icon: 'Camera',
-          // eslint-disable-next-line @jovie/canonical-ui-label-casing -- title-case hyphen false positive
           label: 'Draft Album-art Brief',
           prompt:
             'Draft an album-art brief for my latest release with visual direction, mood, palette, typography, and production notes.',
@@ -212,6 +233,11 @@ export function SuggestedPrompts({
     FEEDBACK_SUGGESTION,
   ];
 
+  const isAlbumArtSuggestion = (label: string) =>
+    label === 'Generate Album Art';
+  const albumArtPillDisabledReason = (label: string) =>
+    isAlbumArtSuggestion(label) ? resolvedAlbumArtCapability.reason : null;
+
   // `inert` removes the subtree from the tab order AND blocks pointer events,
   // so dimmed chips can't be reached by Tab/Shift+Tab while the slash picker
   // is open. `aria-hidden` on the wrapper hides them from SR.
@@ -241,9 +267,9 @@ export function SuggestedPrompts({
               onSelect={onSelect}
               className='min-w-0 max-w-none justify-start px-3.5 py-2'
               disabled={
-                suggestion.label === 'Generate Album Art' && albumArtDisabled
+                isAlbumArtSuggestion(suggestion.label) && albumArtDisabled
               }
-              disabledReason={resolvedAlbumArtCapability.reason}
+              disabledReason={albumArtPillDisabledReason(suggestion.label)}
             />
           ))}
         </div>
@@ -258,9 +284,9 @@ export function SuggestedPrompts({
                 density='compact'
                 className='min-w-0 max-w-none px-3'
                 disabled={
-                  suggestion.label === 'Generate Album Art' && albumArtDisabled
+                  isAlbumArtSuggestion(suggestion.label) && albumArtDisabled
                 }
-                disabledReason={resolvedAlbumArtCapability.reason}
+                disabledReason={albumArtPillDisabledReason(suggestion.label)}
               />
             ))}
           </div>
@@ -302,9 +328,9 @@ export function SuggestedPrompts({
               className='group h-auto w-full justify-start rounded-full px-3 py-2 text-left text-secondary-token hover:bg-surface-0 hover:text-primary-token disabled:cursor-not-allowed disabled:opacity-50'
               aria-label={suggestion.label}
               title={
-                suggestion.label === 'Generate Album Art'
-                  ? (resolvedAlbumArtCapability.reason ?? undefined)
-                  : undefined
+                isAlbumArtSuggestion(suggestion.label)
+                  ? (resolvedAlbumArtCapability.reason ?? suggestion.label)
+                  : suggestion.label
               }
             >
               <span className='flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
@@ -346,9 +372,9 @@ export function SuggestedPrompts({
               onSelect={onSelect}
               className='snap-start'
               disabled={
-                suggestion.label === 'Generate Album Art' && albumArtDisabled
+                isAlbumArtSuggestion(suggestion.label) && albumArtDisabled
               }
-              disabledReason={resolvedAlbumArtCapability.reason}
+              disabledReason={albumArtPillDisabledReason(suggestion.label)}
             />
           ))}
           {pitchSuggestion && (

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -309,7 +309,9 @@ export const DEFAULT_SUGGESTIONS: readonly ChatSuggestion[] = [
   },
   {
     icon: 'Link2',
-    label: "What's Working For Me Right Now?",
+    // Shorter label avoids “What’s Working Fo…” truncation in the rail;
+    // full prompt remains available as the submitted text + pill title.
+    label: "What's Working Right Now?",
     prompt:
       "What's working for me right now? Help me see what's gaining traction.",
     accent: 'blue',

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -137,8 +137,10 @@
     transparent
   );
   --system-b-chat-composer-max-width: 45rem;
-  --system-b-chat-composer-thread-scroll-padding: 9rem;
-  --system-b-chat-composer-scroll-fade-height: 7rem;
+  /* Content-safe inset so sticky composer dock never covers last messages/cards.
+     Sized for compact dock (input + padding + safe-area); keep ≥ dock height. */
+  --system-b-chat-composer-thread-scroll-padding: 11rem;
+  --system-b-chat-composer-scroll-fade-height: 8rem;
   --system-b-chat-loading-composer-height: 88px;
   --system-b-duration-fast: var(--ds-motion-subtle-duration);
   --system-b-ease: var(--ds-motion-subtle-easing);
@@ -8764,25 +8766,37 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: none;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  /* End padding so the last chip can scroll fully past the edge fade. */
+  scroll-padding-inline: var(--space-3);
   mask-image: linear-gradient(
     to right,
     transparent 0,
-    black 18px,
-    black calc(100% - 18px),
+    black 12px,
+    black calc(100% - 28px),
     transparent 100%
   );
   -webkit-mask-image: linear-gradient(
     to right,
     transparent 0,
-    black 18px,
-    black calc(100% - 18px),
+    black 12px,
+    black calc(100% - 28px),
     transparent 100%
   );
 }
 
 :where(.system-b-chat-prompt-rail-scroll::-webkit-scrollbar) {
-  display: none;
+  height: 3px;
+}
+
+:where(.system-b-chat-prompt-rail-scroll::-webkit-scrollbar-thumb) {
+  background: color-mix(
+    in oklab,
+    var(--color-text-tertiary-token) 40%,
+    transparent
+  );
+  border-radius: var(--radius-full);
 }
 
 :where(.system-b-chat-prompt-rail) {
@@ -8791,6 +8805,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   flex-wrap: nowrap;
   align-items: stretch;
   gap: var(--space-1-5);
+  /* Trailing spacer: last chip fully reachable under the edge mask. */
+  padding-inline: 2px calc(var(--space-6) + var(--space-2));
 }
 
 :where(.system-b-chat-prompt-pill) {
@@ -8842,8 +8858,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(.system-b-chat-prompt-pill-default) {
-  min-width: 168px;
-  max-width: 228px;
+  min-width: 11.5rem;
+  max-width: 16.5rem;
   padding: var(--space-1-5) var(--space-3);
   font-size: var(--text-xs);
 }

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -201,7 +201,7 @@ describe('JovieChat empty state', () => {
     expect(getByTestId('suggested-prompts-rail')).toBeTruthy();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
-      'Ask jovie...'
+      'Ask Jovie...'
     );
     expect(getByTestId('chat-input').getAttribute('data-variant')).toBe('hero');
     // ≥3 profile-aware starters (rail pills use aria-label = suggestion label).
@@ -251,8 +251,20 @@ describe('JovieChat empty state', () => {
     expect(
       screen.getByTestId('chat-empty-state-centered-composer')
     ).toBeTruthy();
+    // Docked layout: cards scroll above, composer at bottom of usable area.
+    const region = screen.getByTestId('chat-empty-state-composer-region');
+    expect(region.getAttribute('data-layout')).toBe('docked');
+    expect(screen.getByTestId('chat-empty-state-above-scroll')).toBeTruthy();
+    expect(
+      screen
+        .getByTestId('chat-empty-state-centered-composer')
+        .getAttribute('data-dock')
+    ).toBe('bottom');
     expect(screen.getByTestId('suggested-prompts-rail')).toBeTruthy();
     expect(screen.getAllByTestId('chat-action-card')).toHaveLength(3);
+    // Cards own these intents — rail must not re-advertise conflicting chips.
+    expect(screen.queryByLabelText('Plan A Release')).toBeNull();
+    expect(screen.queryByLabelText("What's Working Right Now?")).toBeNull();
   });
 
   it('hides scaffolding while typing so the composer owns attention', () => {
@@ -353,7 +365,7 @@ describe('JovieChat empty state', () => {
     expect(getAllByTestId('chat-message')).toHaveLength(2);
     expect(
       screen.getByTestId('chat-input').getAttribute('data-placeholder')
-    ).toBe('Ask jovie...');
+    ).toBe('Ask Jovie...');
     expect(screen.getByTestId('chat-input').getAttribute('data-variant')).toBe(
       'compact'
     );

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -16,7 +16,11 @@ describe('SuggestedPrompts', () => {
     expect(generateAlbumArt).toBeTruthy();
     expect(generateAlbumArt).toBeDisabled();
     expect(getByText('Build Artist Profile')).toBeTruthy();
-    expect(getByText("What's Working For Me Right Now?")).toBeTruthy();
+    expect(getByText("What's Working Right Now?")).toBeTruthy();
+    // Full title is always on the pill for truncated overflow discoverability.
+    expect(
+      getByText("What's Working Right Now?").closest('button')
+    ).toHaveAttribute('title', "What's Working Right Now?");
 
     // Old task-list entries should be gone — they belong in the profile switcher.
     expect(queryByText('Preview profile')).toBeNull();
@@ -39,6 +43,20 @@ describe('SuggestedPrompts', () => {
     expect(row?.className).toContain('snap-x');
     expect(row?.className).not.toContain('flex-wrap');
     expect(row?.className).toContain('whitespace-nowrap');
+  });
+
+  it('hides chips that duplicate empty-state action card labels', () => {
+    const onSelect = vi.fn();
+    const { queryByText, getByText } = fastRender(
+      <SuggestedPrompts
+        onSelect={onSelect}
+        excludeLabels={['Generate Album Art', 'Plan A Release']}
+      />
+    );
+
+    expect(queryByText('Generate Album Art')).toBeNull();
+    expect(queryByText('Plan A Release')).toBeNull();
+    expect(getByText("What's Working Right Now?")).toBeTruthy();
   });
 
   it('uses flat prompt icons without always-on icon backgrounds', () => {

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -101,6 +101,8 @@ describe('DevToolbar', () => {
       expect(isDevToolbarSuppressedPath('/demo/video')).toBe(true);
       expect(isDevToolbarSuppressedPath('/demo/founder-video')).toBe(true);
       expect(isDevToolbarSuppressedPath('/start')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/onboarding')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/onboarding/checkout')).toBe(true);
       expect(isDevToolbarSuppressedPath('/app/dashboard/releases')).toBe(false);
     });
   });

--- a/apps/web/tests/unit/dev/DevToolbarGate.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbarGate.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isDevToolbarSuppressedPath,
+  resetDevToolbarHeight,
+  shouldRenderDevToolbar,
+} from '@/components/features/dev/DevToolbarGate';
+
+describe('DevToolbarGate production + path gating', () => {
+  it('suppresses demo, start, and onboarding customer surfaces', () => {
+    expect(isDevToolbarSuppressedPath('/demovideo')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/demo')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/demo/founder-video')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/start')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/onboarding')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/onboarding/checkout')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/app/onboarding')).toBe(true);
+    expect(isDevToolbarSuppressedPath('/app/onboarding/claim')).toBe(true);
+  });
+
+  it('does not suppress normal app routes used by authenticated creators', () => {
+    expect(isDevToolbarSuppressedPath('/app/chat')).toBe(false);
+    expect(isDevToolbarSuppressedPath('/app/dashboard/releases')).toBe(false);
+  });
+
+  it('never renders for production customers without the opt-in cookie', () => {
+    expect(
+      shouldRenderDevToolbar({
+        env: 'production',
+        pathname: '/app/chat',
+        hasCookie: false,
+        nodeEnv: 'production',
+      })
+    ).toBe(false);
+  });
+
+  it('allows production only with explicit __dev_toolbar cookie opt-in', () => {
+    expect(
+      shouldRenderDevToolbar({
+        env: 'production',
+        pathname: '/app/chat',
+        hasCookie: true,
+        nodeEnv: 'production',
+      })
+    ).toBe(true);
+  });
+
+  it('still hides production opt-in toolbar on suppressed product paths', () => {
+    expect(
+      shouldRenderDevToolbar({
+        env: 'production',
+        pathname: '/start',
+        hasCookie: true,
+        nodeEnv: 'production',
+      })
+    ).toBe(false);
+    expect(
+      shouldRenderDevToolbar({
+        env: 'production',
+        pathname: '/onboarding/checkout',
+        hasCookie: true,
+        nodeEnv: 'production',
+      })
+    ).toBe(false);
+  });
+
+  it('renders for non-production (dev/preview) on normal app routes', () => {
+    expect(
+      shouldRenderDevToolbar({
+        env: 'development',
+        pathname: '/app/chat',
+        nodeEnv: 'development',
+      })
+    ).toBe(true);
+    expect(
+      shouldRenderDevToolbar({
+        env: 'preview',
+        pathname: '/app/dashboard',
+        nodeEnv: 'production',
+      })
+    ).toBe(true);
+  });
+
+  it('respects disabled / demo / electron / dev-chrome-disabled flags', () => {
+    expect(
+      shouldRenderDevToolbar({
+        env: 'development',
+        pathname: '/app/chat',
+        disabled: true,
+        nodeEnv: 'development',
+      })
+    ).toBe(false);
+    expect(
+      shouldRenderDevToolbar({
+        env: 'development',
+        pathname: '/app/chat',
+        isDemoRecording: true,
+        nodeEnv: 'development',
+      })
+    ).toBe(false);
+    expect(
+      shouldRenderDevToolbar({
+        env: 'development',
+        pathname: '/app/chat',
+        isDevChromeDisabled: true,
+        nodeEnv: 'development',
+      })
+    ).toBe(false);
+    expect(
+      shouldRenderDevToolbar({
+        env: 'development',
+        pathname: '/app/chat',
+        isElectron: true,
+        nodeEnv: 'development',
+      })
+    ).toBe(false);
+  });
+
+  it('resets --dev-toolbar-height to 0px so customer layout metrics exclude chrome', () => {
+    document.documentElement.style.setProperty('--dev-toolbar-height', '48px');
+    resetDevToolbarHeight();
+    expect(
+      document.documentElement.style.getPropertyValue('--dev-toolbar-height')
+    ).toBe('0px');
+  });
+});


### PR DESCRIPTION
## Summary
- Dock empty-state action cards in a scrollable upper region with the composer + quick-action rail at the bottom of the usable area (no mid-viewport absolute clip of the first card).
- Increase thread composer scroll padding / fade so sticky dock does not cover trailing content.
- Quick-action rail: trailing scroll padding + thin scrollbar affordance, full `title` tooltips, shorter “What’s Working Right Now?” label; exclude chips that duplicate visible action-card titles (Generate Album Art / Plan A Release conflicts).
- DevToolbarGate: always zero `--dev-toolbar-height` when hidden; production stays cookie opt-in only; suppress `/start`, `/onboarding/**`, `/app/onboarding*`.
- Composer placeholder brand casing: `Ask Jovie...`; onboarding handle step uses confirm-oriented placeholder.

## Test plan
- [x] `vitest` DevToolbarGate, DevToolbar, SuggestedPrompts, JovieChat.empty-state, ChatEmptyStateComposerRegion (109 tests)
- [x] chat-composer-system-b-style-guard
- [x] pre-commit typecheck + eslint + biome
- [ ] CI green
- Evidence: `scratch/layout-dev-gate.log`

## Notes
- Root layout already omits DevToolbar mount when `VERCEL_ENV=production`; gate hardening covers cookie opt-in + residual CSS height for layout metrics.
- no Linear issue — ad-hoc audit wave (layout/dev chrome)
- Pre-push affected suite flaked under multi-agent vitest cache ENOENT; local focused suite green; CI is source of truth.

<!-- linear-issue-id:none -->