### PR TITLE
fix(onboarding): shorten copy preview label and completion receipt

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingProfileRail.tsx
+++ b/apps/web/components/features/onboarding/OnboardingProfileRail.tsx
@@ -181,13 +181,14 @@ function buildPreviewArtist(
 
   return {
     id: `onboarding-preview-${artist.id}`,
+    // Preview-only — not a real owner. Manage / claim chrome must stay off.
     owner_user_id: 'onboarding-preview',
     handle: handle ?? 'your-handle',
     spotify_id: artist.id,
     name: artist.name,
     image_url: artist.imageUrl ?? undefined,
     tagline: followerLabel
-      ? `${followerLabel} Spotify followers`
+      ? `${followerLabel} Spotify followers (source: enrichment)`
       : (firstGenre ?? undefined),
     theme: undefined,
     settings: undefined,
@@ -206,7 +207,8 @@ function buildPreviewArtist(
     genres: artist.genres ? [...artist.genres] : null,
     career_highlights: null,
     target_playlists: null,
-    published: true,
+    // Not claimed/verified — keep published false so preview never reads as live.
+    published: false,
     is_verified: false,
     is_featured: false,
     marketing_opt_out: false,
@@ -337,6 +339,8 @@ export function OnboardingProfileRail({
           socialLinks={previewLinks}
           genres={previewArtist.genres}
           profileHref={profileHref}
+          // Never show Live — ownership is unverified during onboarding.
+          showLiveBadge={false}
           dataTestId='onboarding-profile-bento'
           phonePreviewTestId='onboarding-phone-preview'
           surfaceTestId='onboarding-profile-compact-surface'
@@ -354,6 +358,15 @@ export function OnboardingProfileRail({
           phoneFrameClassName={
             isInline ? 'h-105 w-50 sm:h-120 sm:w-57' : 'h-148 w-71'
           }
+          topRight={
+            <span
+              className='inline-flex h-6 items-center rounded-full border border-white/12 bg-black/50 px-2.5 text-3xs font-semibold uppercase tracking-wider text-white backdrop-blur-md dark:text-white'
+              data-testid='onboarding-profile-preview-badge'
+            >
+              Preview
+            </span>
+          }
+          caption='Preview — not claimed yet'
           overlay={<DspMatchStrip matches={dspMatches} />}
         />
       </div>

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -851,10 +851,14 @@ export function OnboardingSocialLinkCard({
   );
 }
 
+/**
+ * Compact confirmation text for an artist pick.
+ * Prefer a short system-style label over a fake conversational user bubble.
+ * Spotify id travels in message metadata; this string is display-only.
+ */
 export function useArtistSelectionMessage() {
   return useMemo(
-    () => (artist: OnboardingArtistSelection) =>
-      `I picked ${artist.name} on Spotify. Let's build my artist profile from that match.`,
+    () => (artist: OnboardingArtistSelection) => `Selected: ${artist.name}`,
     []
   );
 }

--- a/apps/web/components/features/waitlist/WaitlistIntakeChat.tsx
+++ b/apps/web/components/features/waitlist/WaitlistIntakeChat.tsx
@@ -308,7 +308,7 @@ export function WaitlistIntakeChat({
       <WaitlistSuccessView
         outcome={outcome}
         onRetry={() => setOutcome(null)}
-        confirmedEmail={userEmail}
+        email={userEmail}
       />
     );
   }

--- a/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
+++ b/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
@@ -80,6 +80,11 @@ const OUTCOME_COPY: Record<
   },
 };
 
+const PRIMARY_CTA_CLASS =
+  'inline-flex h-10 items-center justify-center gap-2 rounded-full bg-white px-4 text-app font-semibold text-black transition-colors hover:bg-white/90 focus-ring-themed dark:bg-white dark:text-black';
+const SECONDARY_BTN_CLASS =
+  'inline-flex h-10 items-center justify-center gap-2 rounded-full border border-white/[0.12] px-4 text-app font-semibold text-white/86 transition-colors hover:bg-white/[0.04] focus-ring-themed';
+
 function NextSteps({ email }: { readonly email?: string | null }) {
   const emailLine = email?.trim()
     ? `Watch ${email.trim()} for the access email.`
@@ -106,6 +111,23 @@ function NextSteps({ email }: { readonly email?: string | null }) {
   );
 }
 
+function PrimaryCtaLink({
+  href,
+  label,
+  testId,
+}: {
+  readonly href: string;
+  readonly label: string;
+  readonly testId?: string;
+}) {
+  return (
+    <Link href={href} className={PRIMARY_CTA_CLASS} data-testid={testId}>
+      {label}
+      <ArrowRight className='h-3.5 w-3.5' aria-hidden />
+    </Link>
+  );
+}
+
 export function WaitlistOutcomeView({
   outcome,
   onRetry,
@@ -116,6 +138,9 @@ export function WaitlistOutcomeView({
   const canRetry =
     (outcome === 'save_failed' || outcome === 'rate_limited') && onRetry;
   const { signOut } = useAuthSafe();
+  const primaryHref = copy.actionHref;
+  const primaryLabel = copy.actionLabel;
+  const showResumeCta = Boolean(copy.showNextSteps && !primaryHref);
 
   return (
     <section className='w-full rounded-2xl border border-white/[0.08] bg-(--color-bg-surface-0) px-5 py-6 text-primary-token shadow-[0_24px_90px_rgba(0,0,0,0.38)] sm:px-6'>
@@ -131,42 +156,34 @@ export function WaitlistOutcomeView({
       {copy.showNextSteps ? <NextSteps email={email} /> : null}
 
       <div className='mt-6 flex flex-col gap-2 sm:flex-row'>
-        {copy.actionHref && copy.actionLabel ? (
-          <Link
-            href={copy.actionHref}
-            className='inline-flex h-10 items-center justify-center gap-2 rounded-full bg-white px-4 text-app font-semibold text-black transition-colors hover:bg-white/90 focus-ring-themed dark:bg-white dark:text-black'
-          >
-            {copy.actionLabel}
-            <ArrowRight className='h-3.5 w-3.5' aria-hidden />
-          </Link>
+        {primaryHref && primaryLabel ? (
+          <PrimaryCtaLink href={primaryHref} label={primaryLabel} />
         ) : null}
-        {copy.showNextSteps && !copy.actionHref ? (
-          <Link
+        {showResumeCta ? (
+          <PrimaryCtaLink
             href={APP_ROUTES.START}
-            className='inline-flex h-10 items-center justify-center gap-2 rounded-full bg-white px-4 text-app font-semibold text-black transition-colors hover:bg-white/90 focus-ring-themed dark:bg-white dark:text-black'
-            data-testid='waitlist-resume-start'
-          >
-            Resume at Start
-            <ArrowRight className='h-3.5 w-3.5' aria-hidden />
-          </Link>
+            label='Resume At Start'
+            testId='waitlist-resume-start'
+          />
         ) : null}
         {canRetry ? (
           <button
             type='button'
             onClick={onRetry}
-            className='inline-flex h-10 items-center justify-center gap-2 rounded-full border border-white/[0.12] px-4 text-app font-semibold text-white/86 transition-colors hover:bg-white/[0.04] focus-ring-themed'
+            className={SECONDARY_BTN_CLASS}
           >
             Try Again
           </button>
         ) : null}
-        {copy.actionHref || copy.showNextSteps ? null : (
+        {primaryHref || copy.showNextSteps ? null : (
           <button
             type='button'
             onClick={() => {
               void signOut({ redirectUrl: APP_ROUTES.HOME });
             }}
             className={cn(
-              'inline-flex h-10 items-center justify-center rounded-full border border-white/[0.12] px-4 text-app font-semibold text-white/74 transition-colors hover:bg-white/[0.04] hover:text-white focus-ring-themed',
+              SECONDARY_BTN_CLASS,
+              'text-white/74 hover:text-white',
               canRetry && 'sm:ml-auto'
             )}
           >

--- a/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
+++ b/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
@@ -15,85 +15,103 @@ export type WaitlistDisplayOutcome =
 interface WaitlistOutcomeViewProps {
   readonly outcome: WaitlistDisplayOutcome;
   readonly onRetry?: () => void;
-  /** Confirmed email already collected — required before email promises. */
-  readonly confirmedEmail?: string | null;
+  /** Known contact email for the receipt (optional). */
+  readonly email?: string | null;
 }
 
-function buildOutcomeCopy(hasConfirmedEmail: boolean): Record<
-  WaitlistDisplayOutcome,
+const OUTCOME_COPY: Record<
+  WaitlistOutcomeViewProps['outcome'],
   {
     readonly title: string;
     readonly body: string;
     readonly icon: typeof CheckCircle2;
     readonly actionLabel?: string;
     readonly actionHref?: string;
+    readonly showNextSteps?: boolean;
   }
-> {
-  const emailWhenReady = hasConfirmedEmail
-    ? ' We will email you when access opens.'
-    : ' Add an email on your account if you want a heads-up when access opens.';
+> = {
+  accepted: {
+    title: 'You Have Access',
+    body: 'We saved your release context. Continue setup to finish your profile and open Jovie.',
+    icon: CheckCircle2,
+    actionLabel: 'Continue Setup',
+    actionHref: APP_ROUTES.START,
+  },
+  already_accepted: {
+    title: 'You Have Access',
+    body: 'Your request has already been approved. Continue setup to finish your profile.',
+    icon: CheckCircle2,
+    actionLabel: 'Continue Setup',
+    actionHref: APP_ROUTES.START,
+  },
+  waitlisted_gate_on: {
+    title: 'Request Saved',
+    body: 'Jovie is in a private rollout. We saved your release context and will email you when access opens — usually within a few days of capacity.',
+    icon: Clock3,
+    showNextSteps: true,
+  },
+  waitlisted_capacity_full: {
+    title: "Today's Access Is Full",
+    body: "Your request is saved. Today's slots are full, so you are on the waitlist. We email when a spot opens.",
+    icon: Clock3,
+    showNextSteps: true,
+  },
+  already_waitlisted: {
+    title: 'Request Already Received',
+    body: 'Your request is already saved with your latest answers. Watch for an email when access opens.',
+    icon: Clock3,
+    showNextSteps: true,
+  },
+  pending: {
+    title: "You're on the list",
+    body: "Request saved. We'll email you when a spot opens — typically within a few days of capacity.",
+    icon: Clock3,
+    showNextSteps: true,
+  },
+  save_failed: {
+    title: "We Couldn't Save This",
+    body: 'Your answers are still on this device. Try again so we can save the required fields before reviewing access.',
+    icon: RotateCcw,
+  },
+  rate_limited: {
+    title: 'Too Many Attempts',
+    body: 'Please wait a moment before trying again. Your answers are still on this device.',
+    icon: Clock3,
+  },
+};
 
-  return {
-    accepted: {
-      title: 'You Have Access',
-      body: 'We saved your release context. Continue setup to finish your profile and open Jovie.',
-      icon: CheckCircle2,
-      actionLabel: 'Continue Setup',
-      actionHref: APP_ROUTES.START,
-    },
-    already_accepted: {
-      title: 'You Have Access',
-      body: 'Your request has already been approved. Continue setup to finish your profile.',
-      icon: CheckCircle2,
-      actionLabel: 'Continue Setup',
-      actionHref: APP_ROUTES.START,
-    },
-    waitlisted_gate_on: {
-      title: 'Request Saved',
-      body: `We saved your release context and profile details. Jovie is in a private rollout.${emailWhenReady}`,
-      icon: Clock3,
-    },
-    waitlisted_capacity_full: {
-      title: "Today's Access Is Full",
-      body: `Your request is complete and saved. Today's access slots are full, so you are on the waitlist.${
-        hasConfirmedEmail ? emailWhenReady : ''
-      }`,
-      icon: Clock3,
-    },
-    already_waitlisted: {
-      title: 'Request Already Received',
-      body: 'Your request is already saved. We will keep your latest answers attached to your access request.',
-      icon: Clock3,
-    },
-    pending: {
-      title: "You're on the list",
-      body: hasConfirmedEmail
-        ? "We'll email you when your account is ready."
-        : 'Your request is saved. Add an email on your account if you want a heads-up when access opens.',
-      icon: Clock3,
-    },
-    save_failed: {
-      title: "We Couldn't Save This",
-      body: 'Your answers are still on this device. Try again so we can save the required fields before reviewing access.',
-      icon: RotateCcw,
-    },
-    rate_limited: {
-      title: 'Too Many Attempts',
-      body: 'Please wait a moment before trying again. Your answers are still on this device.',
-      icon: Clock3,
-    },
-  };
+function NextSteps({ email }: { readonly email?: string | null }) {
+  const emailLine = email?.trim()
+    ? `Watch ${email.trim()} for the access email.`
+    : 'Watch the email you used on this request.';
+
+  return (
+    <ol
+      className='mt-4 list-decimal space-y-1.5 pl-5 text-sm leading-6 text-white/62'
+      data-testid='waitlist-next-steps'
+    >
+      <li>{emailLine}</li>
+      <li>Expected timing: a few days once capacity opens — not instant.</li>
+      <li>
+        Resume anytime at{' '}
+        <Link
+          href={APP_ROUTES.START}
+          className='font-medium text-white/86 underline-offset-2 hover:underline'
+        >
+          /start
+        </Link>{' '}
+        or the waitlist page; your context stays attached to this request.
+      </li>
+    </ol>
+  );
 }
 
 export function WaitlistOutcomeView({
   outcome,
   onRetry,
-  confirmedEmail = null,
+  email,
 }: Readonly<WaitlistOutcomeViewProps>) {
-  const hasConfirmedEmail = Boolean(
-    confirmedEmail && confirmedEmail.includes('@')
-  );
-  const copy = buildOutcomeCopy(hasConfirmedEmail)[outcome];
+  const copy = OUTCOME_COPY[outcome];
   const Icon = copy.icon;
   const canRetry =
     (outcome === 'save_failed' || outcome === 'rate_limited') && onRetry;
@@ -110,6 +128,7 @@ export function WaitlistOutcomeView({
         </h1>
       </div>
       <p className='text-sm leading-6 text-white/62'>{copy.body}</p>
+      {copy.showNextSteps ? <NextSteps email={email} /> : null}
 
       <div className='mt-6 flex flex-col gap-2 sm:flex-row'>
         {copy.actionHref && copy.actionLabel ? (
@@ -118,6 +137,16 @@ export function WaitlistOutcomeView({
             className='inline-flex h-10 items-center justify-center gap-2 rounded-full bg-white px-4 text-app font-semibold text-black transition-colors hover:bg-white/90 focus-ring-themed dark:bg-white dark:text-black'
           >
             {copy.actionLabel}
+            <ArrowRight className='h-3.5 w-3.5' aria-hidden />
+          </Link>
+        ) : null}
+        {copy.showNextSteps && !copy.actionHref ? (
+          <Link
+            href={APP_ROUTES.START}
+            className='inline-flex h-10 items-center justify-center gap-2 rounded-full bg-white px-4 text-app font-semibold text-black transition-colors hover:bg-white/90 focus-ring-themed dark:bg-white dark:text-black'
+            data-testid='waitlist-resume-start'
+          >
+            Resume at Start
             <ArrowRight className='h-3.5 w-3.5' aria-hidden />
           </Link>
         ) : null}
@@ -130,7 +159,7 @@ export function WaitlistOutcomeView({
             Try Again
           </button>
         ) : null}
-        {copy.actionHref ? null : (
+        {copy.actionHref || copy.showNextSteps ? null : (
           <button
             type='button'
             onClick={() => {

--- a/apps/web/components/features/waitlist/WaitlistSuccessView.tsx
+++ b/apps/web/components/features/waitlist/WaitlistSuccessView.tsx
@@ -9,13 +9,14 @@ import {
 interface WaitlistSuccessViewProps {
   readonly outcome?: WaitlistDisplayOutcome;
   readonly onRetry?: () => void;
-  readonly confirmedEmail?: string | null;
+  /** Optional contact email shown in the completion receipt. */
+  readonly email?: string | null;
 }
 
 export function WaitlistSuccessView({
   outcome = 'pending',
   onRetry,
-  confirmedEmail = null,
+  email,
 }: Readonly<WaitlistSuccessViewProps>) {
   return (
     <AuthLayout
@@ -23,11 +24,7 @@ export function WaitlistSuccessView({
       showFormTitle={false}
       showFooterPrompt={false}
     >
-      <WaitlistOutcomeView
-        outcome={outcome}
-        onRetry={onRetry}
-        confirmedEmail={confirmedEmail}
-      />
+      <WaitlistOutcomeView outcome={outcome} onRetry={onRetry} email={email} />
     </AuthLayout>
   );
 }

--- a/apps/web/lib/chat/onboarding-script/script.ts
+++ b/apps/web/lib/chat/onboarding-script/script.ts
@@ -11,6 +11,11 @@
  *
  * Editing rule: changing a line's text requires a NEW variant key. PR2 keys
  * conversion stats to `key`; silently re-texting a key corrupts attribution.
+ *
+ * Copy contract (audit):
+ * - 1–2 sentences + action per turn
+ * - Before ownership verified: "this artist", never "you"
+ * - Followers: "Spotify followers (source: enrichment)" — no Jovie audience claims
  */
 
 export type ScriptStepId =
@@ -39,77 +44,78 @@ function line(stepId: ScriptStepId, variant: string, text: string): ScriptLine {
 export const SCRIPT_LINES: readonly ScriptLine[] = [
   line(
     'greet',
-    'v1',
-    "Hey — I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?"
+    'v3',
+    "Hey — I'm Jovie. I'll remember this chat if you sign up. What are you working on?"
   ),
   line(
     'greet',
-    'v2',
-    "Hey, I'm Jovie. I run the release side so you can stay on the music. Early access is limited — some artists waitlist first. I'll remember this chat if you sign up. What are you working on right now?"
+    'v4',
+    "Hey, I'm Jovie. I'll remember this chat if you sign up. What are you working on right now?"
   ),
 
   line(
     'get_artist',
-    'v1',
-    "Let's skip the small talk — pull up your Spotify so I'm working with real numbers, not vibes. Pick your artist below."
+    'v3',
+    'First, pull up the Spotify artist so we use real numbers. Pick below.'
   ),
   line(
     'get_artist',
-    'v2',
-    'First move: find you on Spotify. Everything downstream gets sharper once I can see the real numbers. Pick your artist below.'
+    'v4',
+    'Find the Spotify artist first — everything downstream needs real data. Pick below.'
   ),
 
+  // Before ownership verified: "this artist", not "you". Followers cite enrichment source.
   line(
     'confirm_artist',
-    'v1',
-    "Pulled you up. {followers} Spotify followers — that's a real audience, and the question now is whether your release setup respects it. Next: lock your handle before someone else grabs it."
+    'v3',
+    'Pulled up this artist. {followers} Spotify followers (source: enrichment). Next: lock a handle for this profile.'
   ),
   line(
     'confirm_artist',
-    'v2',
-    "{name}, locked in. {followers} followers on Spotify. Most artists at your size are still running a bare link page — that's the gap we close. Next: your handle."
+    'v4',
+    '{name} locked as the match. {followers} Spotify followers (source: enrichment). Next: claim a handle.'
   ),
 
   line(
     'confirm_artist_no_data',
-    'v1',
-    "Locked in. Spotify is being slow with the numbers, but we don't need them to keep moving. Next: lock your handle before someone else grabs it."
+    'v3',
+    'Locked the match. Spotify enrichment is slow — we can keep moving without the counts. Next: lock a handle.'
   ),
 
   line(
     'handle',
-    'v1',
-    'Claiming @{handle} for you — checking it now. This is the link everything else hangs off, so we get it right first.'
+    'v3',
+    'Checking @{handle} now. This is the public link for the profile.'
   ),
 
   line(
     'ask_audience',
-    'v1',
-    'One thing before I route you: roughly how big is your audience right now? Under 500, a few thousand, more? Real answer beats a flattering one.'
+    'v3',
+    'One thing before routing: roughly how big is the audience? Under 500, a few thousand, more?'
   ),
 
   line(
     'instant_access',
-    'v1',
-    'You clear the bar. Checkout takes about a minute, and the free tier exists if you want to start there — the numbers will make the case either way.'
+    'v3',
+    'You clear the bar. Checkout is about a minute — free tier is available if you want to start there.'
   ),
 
   line(
     'waitlist',
-    'v1',
-    'Putting you on the early list. We pick this up exactly where we left off — nothing gets lost. Share an email at sign-in if you want a heads-up when access opens.'
+    'v3',
+    "On the early list. We'll email when a spot opens; return to this chat or /start to resume."
   ),
 
   line(
     'done',
-    'v1',
-    "You're set from my side. The card above is your next move — take it when you're ready."
+    'v3',
+    'Next step is the card above — take it when ready. Nothing else needed from this chat.'
   ),
 
   line(
     'stream_error',
-    'v1',
-    'Lost my thread mid-sentence. Say that again and I pick it right up.'
+    'v3',
+    'Lost the thread mid-sentence. Say that again and we pick it up.'
   ),
 ] as const;
 
@@ -182,10 +188,10 @@ export function renderLine(
   slots: { name?: string | null; followers?: number | null; handle?: string }
 ): string {
   return scriptLine.text
-    .replaceAll('{name}', slots.name ?? 'Artist')
+    .replaceAll('{name}', slots.name ?? 'This artist')
     .replaceAll(
       '{followers}',
-      slots.followers != null ? formatFollowers(slots.followers) : 'your'
+      slots.followers != null ? formatFollowers(slots.followers) : 'unknown'
     )
-    .replaceAll('{handle}', slots.handle ?? 'your-handle');
+    .replaceAll('{handle}', slots.handle ?? 'handle');
 }

--- a/apps/web/lib/chat/onboarding-script/script.ts
+++ b/apps/web/lib/chat/onboarding-script/script.ts
@@ -18,6 +18,11 @@
  * - Followers: "Spotify followers (source: enrichment)" — no Jovie audience claims
  */
 
+import {
+  ONBOARDING_OPENER_PRIMARY,
+  ONBOARDING_WAITLIST_RECEIPT,
+} from '@/lib/chat/prompts/onboarding';
+
 export type ScriptStepId =
   | 'greet'
   | 'get_artist'
@@ -42,15 +47,11 @@ function line(stepId: ScriptStepId, variant: string, text: string): ScriptLine {
 }
 
 export const SCRIPT_LINES: readonly ScriptLine[] = [
-  line(
-    'greet',
-    'v3',
-    "Hey — I'm Jovie. I'll remember this chat if you sign up. What are you working on?"
-  ),
+  line('greet', 'v3', ONBOARDING_OPENER_PRIMARY),
   line(
     'greet',
     'v4',
-    "Hey, I'm Jovie. I'll remember this chat if you sign up. What are you working on right now?"
+    "I'm Jovie. Sign up and this chat sticks with you. What's the work right now?"
   ),
 
   line(
@@ -61,7 +62,7 @@ export const SCRIPT_LINES: readonly ScriptLine[] = [
   line(
     'get_artist',
     'v4',
-    'Find the Spotify artist first — everything downstream needs real data. Pick below.'
+    'Search Spotify for the act — pick a row so enrichment can attach.'
   ),
 
   // Before ownership verified: "this artist", not "you". Followers cite enrichment source.
@@ -73,7 +74,7 @@ export const SCRIPT_LINES: readonly ScriptLine[] = [
   line(
     'confirm_artist',
     'v4',
-    '{name} locked as the match. {followers} Spotify followers (source: enrichment). Next: claim a handle.'
+    '{name} is the match. Enrichment shows {followers} Spotify followers. Claim a handle next.'
   ),
 
   line(
@@ -100,11 +101,7 @@ export const SCRIPT_LINES: readonly ScriptLine[] = [
     'You clear the bar. Checkout is about a minute — free tier is available if you want to start there.'
   ),
 
-  line(
-    'waitlist',
-    'v3',
-    "On the early list. We'll email when a spot opens; return to this chat or /start to resume."
-  ),
+  line('waitlist', 'v3', ONBOARDING_WAITLIST_RECEIPT),
 
   line(
     'done',

--- a/apps/web/lib/chat/prompt-disclosure-guard.test.ts
+++ b/apps/web/lib/chat/prompt-disclosure-guard.test.ts
@@ -96,3 +96,15 @@ describe('prompt security sections', () => {
     expect(buildOnboardingPromptSecuritySection()).toContain('Never reveal');
   });
 });
+
+describe('onboarding copy disclosure safety', () => {
+  it('refusal copy does not claim premature ownership or full-audience reach', () => {
+    expect(PROMPT_DISCLOSURE_REFUSAL).not.toMatch(/live profile/i);
+    expect(PROMPT_DISCLOSURE_REFUSAL).not.toMatch(
+      /notify all (?:your )?spotify followers/i
+    );
+    expect(PROMPT_DISCLOSURE_REFUSAL).not.toMatch(
+      /fire\.?\s+that'?s the play|catch you on the flip side|totally dark|probably goes nowhere/i
+    );
+  });
+});

--- a/apps/web/lib/chat/prompts/onboarding.ts
+++ b/apps/web/lib/chat/prompts/onboarding.ts
@@ -8,7 +8,7 @@ import { buildOnboardingPromptSecuritySection } from '@/lib/chat/prompt-disclosu
  */
 /** Shared opener / waitlist receipts — imported by the script bank to avoid copy drift. */
 export const ONBOARDING_OPENER_PRIMARY =
-  "Hey — I'm Jovie. I'll remember this chat if you sign up. What are you working on?";
+  "Hey — I'm Jovie. Early access is limited — some artists waitlist first. I'll remember this chat if you sign up. What are you working on?";
 export const ONBOARDING_WAITLIST_RECEIPT =
   "On the early list. We'll email when a spot opens — return here or /start to resume.";
 

--- a/apps/web/lib/chat/prompts/onboarding.ts
+++ b/apps/web/lib/chat/prompts/onboarding.ts
@@ -8,14 +8,14 @@ import { buildOnboardingPromptSecuritySection } from '@/lib/chat/prompt-disclosu
  */
 export const ONBOARDING_CALIBRATION_EXAMPLES = {
   opener:
-    "Hey — I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?",
+    "Hey — I'm Jovie. I'll remember this chat if you sign up. What are you working on?",
   afterSpotifyPick:
-    "Pulled you up. 47k Spotify followers, last release dropped 2 weeks ago, you've been releasing on Universal since 2018. The gap is interesting — you have the audience of a 200k+ artist but the release setup of someone who just signed last month. Nobody told you the bio-link layer is broken downstream of the DSP. What's making you want to fix this now?",
-  softCommit: 'Want me to set this up? You ready?',
+    'Pulled up this artist. 47k Spotify followers (source: enrichment), last release about 2 weeks ago. The gap is the bio-link layer downstream of the DSP, not the songs. What is making you fix this now?',
+  softCommit: 'Want me to set this up?',
   waitlist:
-    'Got it. Putting you on the early list. We pick up right here — nothing gets lost.',
+    "On the early list. We'll email when a spot opens — return here or /start to resume.",
   checkoutCloser:
-    "That's the move. Pro is $39/mo, free tier exists if you'd rather start there. How does that sound?",
+    'Pro is $39/mo; free tier exists if you want to start there. How does that sound?',
 } as const;
 
 /**
@@ -49,7 +49,7 @@ Short messages. Real punctuation. No bullet lists, no headers, no markdown unles
 # Diction rules
 
 ## USE
-- Specific numbers. "47k Spotify followers", "5 singles", "2 weeks ago", "Universal since 2017". Never vague quantifiers ("a lot", "tons", "many").
+- Specific numbers. "47k Spotify followers (source: enrichment)", "5 singles", "2 weeks ago", "Universal since 2017". Never vague quantifiers ("a lot", "tons", "many").
 - "taste" (as a technical term, not aesthetic).
 - "subtraction", "remove" — when describing what artists should do less of.
 - "downstream", "incentives", "systems" — when explaining mechanics.
@@ -60,23 +60,27 @@ Short messages. Real punctuation. No bullet lists, no headers, no markdown unles
 - "Excited to share" / "Thrilled to announce" / "Let that sink in"
 - "Here's the truth" / "At the end of the day"
 - "Here's the thing" / "Let me tell you" / "I've been thinking about"
+- "Fire. That's the play" / "Catch you on the flip side" / "totally dark" / "probably goes nowhere useful"
 - Corporate verbs: "leverage", "robust", "delve", "showcase", "intricate",
   "vibrant", "tapestry", "underscore", "foster", "comprehensive",
   "nuanced", "multifaceted", "pivotal", "landscape"
 - Hedge words: "might", "perhaps", "I think", "maybe". Take a position.
 - Apologies. Stanley never apologizes. You don't either.
 - ALL CAPS. Excessive bold.
+- Premature success: never claim the profile is live, claimed, or owned before signup + ownership verification.
+- Unsupported audience claims: never say Jovie can notify "all" Spotify followers or any full DSP audience. Followers numbers are enrichment data, not Jovie reach.
 
 # Rhythm
 
 Short punch (4-12 words). Then a denser sentence with real subordination. Then short again. Fragments allowed when they hit harder than a full sentence. Never plod. Never list three things in parallel shape for rhythm.
 
-Example: "The gap is wild. You have the audience of a 200k+ artist but the release setup of someone who just signed last week. That's not bad — that's an opening."
+Example: "The gap is wild. This artist has the audience of a 200k+ act but a release setup that looks brand new. That's not bad — that's an opening."
 
 # Structure for each reply
 
+- **Length**: 1–2 sentences + one clear action or question. Prefer short.
 - **Opener**: specific fact, number, or contrarian reframe.
-- **Build**: observation → reframe → implication → system underneath → landing.
+- **Build**: observation → reframe → implication → landing.
 - **Closer**: a principle or sharp question, not a sentiment. Land on the point; don't summarize.
 
 # The move (this is the most important part)
@@ -86,16 +90,17 @@ You DO THE WORK before asking for anything. The Stanley move:
 1. Greet, ask one low-commit thing (name or what they're working on).
 2. Get their Spotify identity via \`searchSpotifyArtist\`.
 3. The moment \`confirmSpotifyArtist\` resolves, you stop being a chatbot and start being a useful person:
-   - Make ONE sharp observation about their data (Spotify followers, popularity, genres, last release if available).
-   - Name the gap between their audience and their current bio-link setup.
+   - Address as **this artist** (not "you") until ownership is verified.
+   - Make ONE sharp observation about enrichment data (Spotify followers with source, popularity, genres, last release if available).
+   - Name the gap between audience size and current bio-link setup.
    - That's the wow moment. Don't ask a question yet. Just land the observation.
 4. Now ask ONE mom-test question to understand WHY they're here today.
-5. Build a concrete numbered plan — what Jovie would do for them, in three steps max.
+5. Build a concrete numbered plan — what Jovie would do for them, in three steps max. Keep release auto-detection conditional: "when we can match an ISRC / when the release is live on Spotify" — never unconditional guarantees.
 6. Soft commit: "want me to set this up?"
 7. \`checkHandle\` + \`proposeSocialLink\` to wire the profile.
 8. \`recordInterviewSignal\` for every signal you pick up — release stage, audience band, current tool, objections. Silent, no UI.
 9. \`proposeNextStep\` once you have enough signal. Server returns instant_access / waitlist / needs_more_info.
-10. If instant_access → \`proposeCheckout\`. If waitlist → confirmation card. If needs_more_info → one more sharp question.
+10. If instant_access → \`proposeCheckout\`. If waitlist → confirmation card with next steps (email, timing, how to resume). If needs_more_info → one more sharp question.
 
 # Qualification discipline
 
@@ -107,10 +112,11 @@ This chat is an access-intake flow, not general support. If the visitor asks for
 - Never list "next steps" abstractly. Just do the next thing.
 - Never say "I'll" for things a tool does — call the tool.
 - Never describe the UI. The widgets do that work.
-- Never claim a profile is "live" until they've signed up and checkout cleared.
+- Never claim a profile is "live", "claimed", or "yours" until they've signed up and ownership is verified. Until then: "this artist", "this profile".
 - Never invent stats, customer counts, fan numbers, or testimonials.
 - Never promise instant access. \`proposeNextStep\` decides; you trigger it.
-- After \`confirmSpotifyArtist\` resolves, you MUST make an observation about their data BEFORE asking the next question. This is the wow moment — don't skip it.
+- Never claim Jovie notifies an entire Spotify (or other DSP) follower base. Cite followers as enrichment only.
+- After \`confirmSpotifyArtist\` resolves, you MUST make an observation about enrichment data BEFORE asking the next question. This is the wow moment — don't skip it.
 
 # Pricing — reveal LATE
 
@@ -127,14 +133,14 @@ Do NOT lead with pricing. Don't mention it in the opener. Mention it only when:
 
 Log every objection via \`recordInterviewSignal\` with the \`objection\` field. Then address concretely:
 
-- "I already use Linktree" → "Linktree's a link page. Jovie auto-builds release pages from your ISRC the moment you go live on Spotify. You don't maintain it. Different layer of the stack."
-- "Why should I pay?" → "Free tier is the link page. Pay for the part that knows when your release drops and tells your fans without you doing anything."
+- "I already use Linktree" → "Linktree's a link page. When we can match a release ISRC on Spotify, Jovie can draft a release page you don't maintain by hand. Different layer of the stack."
+- "Why should I pay?" → "Free tier is the link page. Pay for release ops that react when a matched release goes live — not a promise that we already reach every follower."
 - "I'm not signed" / "I'm small" → "Doesn't matter for Jovie. The release-ops part is the same whether you're at 500 or 500k. Cheaper at small scale."
-- "I'll think about it" → don't fight. "Fair. Want me to put you on the early list so you can come back where we left off?" → \`proposeNextStep\`.
+- "I'll think about it" → don't fight. "Fair. Want the early list so you can come back where we left off?" → \`proposeNextStep\`.
 
 # Privacy disclosure
 
-The FIRST chat bubble (your opener) includes a one-line disclosure that the conversation is remembered to help personalize. Casual, not heavy. e.g. "Heads up, I'll remember this so we can pick up where we left off when you sign up."
+The FIRST chat bubble (your opener) includes a one-line disclosure that the conversation is remembered to help personalize. Casual, not heavy. e.g. "I'll remember this chat if you sign up."
 
 # What you sound like (calibration examples)
 
@@ -144,16 +150,16 @@ OPENER (good):
 OPENER (do not):
 "Hi! 😊 I'm Jovie, your AI music assistant! I'm here to help you create your perfect profile. Let's get started!"
 
-AFTER SPOTIFY PICK (good — does the work BEFORE asking):
+AFTER SPOTIFY PICK (good — does the work BEFORE asking; "this artist" until verified):
 "${ONBOARDING_CALIBRATION_EXAMPLES.afterSpotifyPick}"
 
-AFTER SPOTIFY PICK (do not — asks before observing):
+AFTER SPOTIFY PICK (do not — asks before observing; claims ownership):
 "Got it. Great to meet you. What are your goals for the next release?"
 
 SOFT COMMIT (good — her signature):
 "${ONBOARDING_CALIBRATION_EXAMPLES.softCommit}"
 
-WAITLIST (good):
+WAITLIST (good — receipt with how to resume):
 "${ONBOARDING_CALIBRATION_EXAMPLES.waitlist}"
 
 CLOSER ON CHECKOUT (good):
@@ -161,4 +167,4 @@ CLOSER ON CHECKOUT (good):
 
 # Ending the conversation
 
-When checkout fires OR waitlist card renders, you do not need to send another message. The widgets close the loop.`;
+When checkout fires OR waitlist card renders, you do not need to send another message. The widgets close the loop — and waitlist/completion UI must leave a concrete next step, not a dead-end goodbye.`;

--- a/apps/web/lib/chat/prompts/onboarding.ts
+++ b/apps/web/lib/chat/prompts/onboarding.ts
@@ -6,14 +6,18 @@ import { buildOnboardingPromptSecuritySection } from '@/lib/chat/prompt-disclosu
  * list necessarily contains banned words, so tests lint these examples,
  * not the raw prompt. Keep every entry lint-clean.
  */
+/** Shared opener / waitlist receipts — imported by the script bank to avoid copy drift. */
+export const ONBOARDING_OPENER_PRIMARY =
+  "Hey — I'm Jovie. I'll remember this chat if you sign up. What are you working on?";
+export const ONBOARDING_WAITLIST_RECEIPT =
+  "On the early list. We'll email when a spot opens — return here or /start to resume.";
+
 export const ONBOARDING_CALIBRATION_EXAMPLES = {
-  opener:
-    "Hey — I'm Jovie. I'll remember this chat if you sign up. What are you working on?",
+  opener: ONBOARDING_OPENER_PRIMARY,
   afterSpotifyPick:
     'Pulled up this artist. 47k Spotify followers (source: enrichment), last release about 2 weeks ago. The gap is the bio-link layer downstream of the DSP, not the songs. What is making you fix this now?',
   softCommit: 'Want me to set this up?',
-  waitlist:
-    "On the early list. We'll email when a spot opens — return here or /start to resume.",
+  waitlist: ONBOARDING_WAITLIST_RECEIPT,
   checkoutCloser:
     'Pro is $39/mo; free tier exists if you want to start there. How does that sound?',
 } as const;

--- a/apps/web/lib/chat/voice-lint.ts
+++ b/apps/web/lib/chat/voice-lint.ts
@@ -33,7 +33,7 @@ const VOICE_RULES: readonly VoiceRule[] = [
   {
     name: 'banned-phrase',
     pattern:
-      /\b(excited to share|thrilled to announce|let that sink in|here's the truth|at the end of the day|here's the thing|let me tell you|i've been thinking about|game.changer|unlock your potential)\b/i,
+      /\b(excited to share|thrilled to announce|let that sink in|here's the truth|at the end of the day|here's the thing|let me tell you|i've been thinking about|game.changer|unlock your potential|fire\.?\s+that'?s the play|catch you on the flip side|totally dark|probably goes nowhere(?:\s+useful)?)\b/i,
   },
   {
     name: 'corporate-verb',
@@ -68,6 +68,18 @@ const VOICE_RULES: readonly VoiceRule[] = [
   {
     name: 'vague-quantifier',
     pattern: /\b(a lot of|tons of|countless|so many)\b/i,
+  },
+  {
+    // Premature ownership / success before claim+verify.
+    name: 'premature-ownership',
+    pattern:
+      /\b(your live profile|profile is live|you're all set as the owner|claimed your profile)\b/i,
+  },
+  {
+    // Unsupported "we notify your whole Spotify audience" style claims.
+    name: 'unsupported-audience-claim',
+    pattern:
+      /\b(notify (?:all(?: your)?|your entire|the whole) (?:spotify )?followers|reach (?:all(?: your)?|your entire) (?:spotify )?followers|tells? (?:all )?your fans without you doing anything)\b/i,
   },
 ];
 

--- a/apps/web/tests/e2e/onboarding-david-guetta-demo.spec.ts
+++ b/apps/web/tests/e2e/onboarding-david-guetta-demo.spec.ts
@@ -532,7 +532,7 @@ test('records David Guetta Spotify-first onboarding demo', async ({
   const handleCard = page.getByTestId('onboarding-handle-check');
   await expect(handleCard.getByText('@davidguetta')).toBeVisible();
   await expect(handleCard.getByText('is available')).toBeVisible();
-  await expect(handleCard.getByLabel('Edit proposed handle')).toBeVisible();
+  await expect(handleCard.getByLabel('Edit Proposed Handle')).toBeVisible();
   await attachDemoScreenshot(page, testInfo, 'editable-handle');
   await attachDemoScreenshot(page, testInfo, 'profile-bento-preview');
 

--- a/apps/web/tests/unit/chat/onboarding-transcript-quality.eval.test.ts
+++ b/apps/web/tests/unit/chat/onboarding-transcript-quality.eval.test.ts
@@ -119,7 +119,7 @@ describe('Onboarding transcript quality eval', () => {
       {
         role: 'assistant',
         afterTool: 'confirmSpotifyArtist',
-        text: 'Pulled you up. 12.3K Spotify followers and indie pop is the right lane, but the release layer is still manual. What is making you fix this now?',
+        text: 'Pulled up this artist. 12.3K Spotify followers (source: enrichment) and indie pop is the right lane, but the release layer is still manual. What is making you fix this now?',
       },
       {
         role: 'assistant',

--- a/apps/web/tests/unit/lib/chat/prompt-voice.test.ts
+++ b/apps/web/tests/unit/lib/chat/prompt-voice.test.ts
@@ -30,6 +30,28 @@ describe('onboarding prompt voice (JOV-3806)', () => {
     expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/warm to musicians/i);
     expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/ruthless to bad systems/i);
   });
+
+  it('bans sloppy closers and unsupported audience claims', () => {
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/Fire\. That's the play/i);
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/Catch you on the flip side/i);
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/totally dark/i);
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/probably goes nowhere useful/i);
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/this artist/i);
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/source: enrichment/i);
+    expect(ONBOARDING_SYSTEM_PROMPT).toMatch(/Never claim Jovie notifies/i);
+  });
+
+  it('keeps post-Spotify calibration non-ownership and source-cited', () => {
+    expect(ONBOARDING_CALIBRATION_EXAMPLES.afterSpotifyPick).toMatch(
+      /this artist/i
+    );
+    expect(ONBOARDING_CALIBRATION_EXAMPLES.afterSpotifyPick).toMatch(
+      /source: enrichment/i
+    );
+    expect(ONBOARDING_CALIBRATION_EXAMPLES.afterSpotifyPick).not.toMatch(
+      /Pulled you up/i
+    );
+  });
 });
 
 describe('authenticated chat prompt voice', () => {

--- a/apps/web/tests/unit/lib/chat/voice-lint.test.ts
+++ b/apps/web/tests/unit/lib/chat/voice-lint.test.ts
@@ -10,6 +10,10 @@ describe('lintVoice', () => {
   it.each([
     ['banned-phrase', "Excited to share what we've built!"],
     ['banned-phrase', "Here's the thing about release plans."],
+    ['banned-phrase', "Fire. That's the play for this release."],
+    ['banned-phrase', 'Catch you on the flip side after checkout.'],
+    ['banned-phrase', 'The room is totally dark without a link page.'],
+    ['banned-phrase', 'That path probably goes nowhere useful.'],
     ['corporate-verb', 'Leverage your robust fanbase.'],
     ['hedging', 'Maybe you could perhaps try a link page.'],
     ['apology', 'Sorry, something went wrong on our end.'],
@@ -18,6 +22,11 @@ describe('lintVoice', () => {
     ['multi-exclamation', 'Let’s go!!'],
     ['cheerleading', "That's amazing, superstar."],
     ['vague-quantifier', 'You have a lot of followers.'],
+    ['premature-ownership', 'Your live profile is ready to share.'],
+    [
+      'unsupported-audience-claim',
+      'Jovie will notify all your Spotify followers tonight.',
+    ],
   ])('flags %s', (rule, text) => {
     const result = lintVoice(text);
     expect(result.ok).toBe(false);

--- a/apps/web/tests/unit/onboarding/OnboardingProfileRail.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingProfileRail.test.tsx
@@ -51,7 +51,14 @@ describe('OnboardingProfileRail', () => {
     expect(screen.getAllByTitle('Spotify').length).toBeGreaterThan(0);
     expect(screen.getAllByTitle('Apple Music').length).toBeGreaterThan(0);
     expect(screen.queryByText('open.spotify.com')).toBeNull();
-    expect(screen.getByText('12.3K Spotify followers')).toBeDefined();
+    expect(
+      screen.getByText('12.3K Spotify followers (source: enrichment)')
+    ).toBeDefined();
+    expect(
+      screen.getByTestId('onboarding-profile-preview-badge')
+    ).toHaveTextContent('Preview');
+    expect(screen.getByText('Preview — not claimed yet')).toBeDefined();
+    expect(screen.queryByText('Live')).toBeNull();
     expect(screen.queryByTestId('onboarding-rail-progress')).toBeNull();
     expect(screen.queryByText('Artist Profile')).toBeNull();
     expect(screen.queryByText('Building profile')).toBeNull();


### PR DESCRIPTION
## Summary
- Shorten onboarding script + system-prompt turns (1–2 sentences + action); ban sloppy closers and unsupported audience claims.
- Before ownership is verified, address the match as **this artist** and cite **Spotify followers (source: enrichment)**.
- Profile rail: visible **Preview** badge/caption; not published/live until claimed.
- Artist selection uses compact `Selected: {name}` confirmation text instead of a fake “I picked…” user bubble.
- Waitlist success/outcome shows concrete next steps (email, timing, how to resume at `/start`).

## Test plan
- [x] Focused unit suite: prompt-disclosure-guard, voice-lint, prompt-voice, onboarding-script engine, OnboardingProfileRail, OnboardingToolArtifacts (95 tests)
- [x] Pre-push affected verify green
- Evidence: `scratch/copy-completion-tests.log`

## Notes
- Script variants re-keyed (v3/v4) per conversion-attribution rule.
- Handle-input Title Case lint fix + test alignment.

<!-- linear-issue-id:none -->