### PR TITLE
fix(sentry): dispatch autofix to JovieInc/Jovie

### DIFF
--- a/apps/web/app/api/webhooks/sentry/route.ts
+++ b/apps/web/app/api/webhooks/sentry/route.ts
@@ -175,7 +175,8 @@ export async function POST(request: NextRequest) {
       : '';
 
     // Fire GitHub repository_dispatch
-    const owner = env.VERCEL_GIT_REPO_OWNER || 'TheBlackFuture';
+    // Canonical product repo. Never fall back to a legacy org/name — silent misfires.
+    const owner = env.VERCEL_GIT_REPO_OWNER || 'JovieInc';
     const repo = env.VERCEL_GIT_REPO_SLUG || 'Jovie';
 
     const dispatchResponse = await serverFetch(

--- a/apps/web/tests/unit/api/webhooks/sentry.test.ts
+++ b/apps/web/tests/unit/api/webhooks/sentry.test.ts
@@ -250,7 +250,7 @@ describe('POST /api/webhooks/sentry', () => {
 
     expect(response.status).toBe(200);
     expect(mockServerFetch).toHaveBeenCalledWith(
-      'https://api.github.com/repos/TheBlackFuture/Jovie/dispatches',
+      'https://api.github.com/repos/JovieInc/Jovie/dispatches',
       expect.objectContaining({
         method: 'POST',
         timeoutMs: 10000,


### PR DESCRIPTION
Webhook defaulted to TheBlackFuture/Jovie when Vercel git env unset, so Sentry Autofix never fired on the live repo. Defaults to JovieInc/Jovie.