### PR TITLE
fix(web): fail soft on invalid Upstash Redis URL (prod controller)

### DIFF
--- a/apps/web/lib/redis.ts
+++ b/apps/web/lib/redis.ts
@@ -11,6 +11,23 @@ let _redisLastAttempt = 0;
 let _redisMissingConfigWarned = false;
 const REDIS_RETRY_INTERVAL_MS = 30000; // 30 seconds between retry attempts
 
+function isValidUpstashRestUrl(url: string | undefined | null): url is string {
+  if (!url) return false;
+  const trimmed = url.trim();
+  // Upstash REST client requires https. Invalid placeholders / empty / rediss://
+  // must fail soft — never throw during Next page data collection / build.
+  return /^https:\/\//i.test(trimmed);
+}
+
+function getUpstashConfig(): { url: string; token: string } | null {
+  const url = env.UPSTASH_REDIS_REST_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN;
+  if (!isValidUpstashRestUrl(url) || !token?.trim()) {
+    return null;
+  }
+  return { url: url.trim(), token: token.trim() };
+}
+
 export interface GetRedisOptions {
   signal?: AbortSignal;
 }
@@ -34,15 +51,16 @@ function captureMissingRedisConfigWarningOnce(): void {
  */
 export function getRedis(options?: GetRedisOptions): Redis | null {
   if (options?.signal) {
-    if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
+    const cfg = getUpstashConfig();
+    if (!cfg) {
       captureMissingRedisConfigWarningOnce();
       return null;
     }
 
     try {
       return new Redis({
-        url: env.UPSTASH_REDIS_REST_URL,
-        token: env.UPSTASH_REDIS_REST_TOKEN,
+        url: cfg.url,
+        token: cfg.token,
         signal: options.signal,
       });
     } catch (error) {
@@ -70,15 +88,16 @@ export function getRedis(options?: GetRedisOptions): Redis | null {
   _redisLastAttempt = now;
 
   // Check if Redis is configured (both URL and token are required)
-  if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
+  const cfg = getUpstashConfig();
+  if (!cfg) {
     captureMissingRedisConfigWarningOnce();
     return null;
   }
 
   try {
     _redis = new Redis({
-      url: env.UPSTASH_REDIS_REST_URL,
-      token: env.UPSTASH_REDIS_REST_TOKEN,
+      url: cfg.url,
+      token: cfg.token,
     });
     Sentry.addBreadcrumb({
       category: 'redis',


### PR DESCRIPTION
## Summary
Production Controller failing at **deploy-staging** with:
\`Upstash Redis client was passed an invalid URL (must start with https)\`
→ build dies collecting \`/[username]/claim\` page data.

Harden \`getRedis()\` to treat non-https / empty / placeholder URLs as unconfigured (return null) instead of throwing during build.

## Test plan
- [ ] CI green
- [ ] Next Production Controller run gets past deploy-staging (or fails later with a different root cause)
- [ ] Still fix real Upstash env in Vercel/Doppler to a valid https REST URL