### PR TITLE
fix(insights): collapse spikeDate-window duplicate signal cards (JOV-3522)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1513,7 +1513,7 @@ function createPromoStrategyTool(
 function createShowTopInsightsTool(profileId: string | null) {
   return tool({
     description:
-      'Show the artist their top audience, release, track, and monetization signals as structured insight cards. Use this when they ask what is working, what to focus on, or how their audience and releases are performing.',
+      'Show the artist their top audience, release, track, and monetization signals as structured insight cards. Use ONLY when the turn is specifically about analytics or performance — e.g. "what is working", "how are my numbers", "how is this release/track doing". Do NOT use for unrelated turns: general conversation, onboarding answers, creative or strategy questions that are not about measured performance, or when the user has not asked about their numbers.',
     inputSchema: chatToolSchema({}),
     execute: async () => {
       if (!profileId) {

--- a/apps/web/lib/services/insights/lifecycle.ts
+++ b/apps/web/lib/services/insights/lifecycle.ts
@@ -483,11 +483,10 @@ function getInsightSourceKey(dataSnapshot: unknown): string | null {
     return `referrer:${referrer}`;
   }
 
-  const spikeDate = getSnapshotToken(snapshot, 'spikeDate');
-  if (spikeDate) {
-    return `spikeDate:${spikeDate}`;
-  }
-
+  // spikeDate is deliberately NOT a discriminator: it is the measurement
+  // window of the same developing event, not a distinct subject. Keying on
+  // it let every daily snapshot of one spike produce its own card
+  // (JOV-3522: 3x "3 New Subscribers").
   const deviceType = getSnapshotToken(snapshot, 'deviceType');
   if (deviceType) {
     return `deviceType:${deviceType}`;

--- a/apps/web/tests/unit/lib/services/insights/lifecycle.test.ts
+++ b/apps/web/tests/unit/lib/services/insights/lifecycle.test.ts
@@ -86,3 +86,42 @@ describe('insight lifecycle deduplication', () => {
     expect(result).toHaveLength(1);
   });
 });
+
+describe('JOV-3522 Top signals duplicate cards', () => {
+  it('collapses same-fact insights that differ only by spikeDate window', () => {
+    const result = dedupeVisibleInsights([
+      {
+        ...baseInsight,
+        insightType: 'subscriber_growth',
+        category: 'audience',
+        title: '3 New Subscribers',
+        description: 'You gained 3 subscribers.',
+        dataSnapshot: { spikeDate: '2026-06-22' },
+      },
+      {
+        ...baseInsight,
+        insightType: 'subscriber_growth',
+        category: 'audience',
+        title: '3 New Subscribers',
+        description: 'You gained 3 subscribers.',
+        dataSnapshot: { spikeDate: '2026-06-24' },
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps genuinely distinct subjects of the same category and family', () => {
+    const result = dedupeVisibleInsights([
+      baseInsight,
+      {
+        ...baseInsight,
+        insightType: 'new_market',
+        title: 'Denver is becoming a breakout market',
+        dataSnapshot: { city: 'Denver', country: 'US' },
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
The 'Top signals' card could show the same fact multiple times (screenshot: 3× "3 New Subscribers") because `buildInsightDedupKey` used `spikeDate` as a source-key discriminator — a measurement *window* keyed as a *subject*, so every daily snapshot of one developing event earned its own card. Also: the show-top-insights tool could fire on unrelated turns (its description invited usage on any 'what should I focus on' turn).

## Root cause
`getInsightSourceKey` (lifecycle.ts) treated `spikeDate` as a discriminating source key. Window variants of one event produced distinct dedup keys. Real subjects (city/market/release/referrer/deviceType/linkType) were and remain discriminating; the 'different insight types for the same source' contract is preserved via the family key.

## Fix
- Removed `spikeDate` from the discriminator set (with a comment documenting why).
- Tightened the tool description to analytics-only turns with explicit negative guidance — the honest contract-level guard: an LLM tool cannot see turn intent programmatically, so the guard belongs in the tool contract.

## Validation
- Failing-first tests: spikeDate window variants now collapse to one card; genuinely distinct subjects still survive. Suite: 6/6.
- Wider: 96/96 across insights + api/chat suites; biome clean; @jovie/web typecheck exit 0.

## Risk / rollback
Low — read-time dedup change only (no persistence-path behavior change). Rollback = revert.

## GBrain
Read: engineering/backlog-triage-2026-07-20. Written: engineering/top-signals-insight-dedup-guard (pending-merge).