### PR TITLE
fix(library): unify status vocabulary, search, version-stack (JOV-3089)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -56,6 +56,7 @@ import { LibraryAssetShareUrlCell } from '@/components/features/library-asset-sh
 import { LibraryShareDropCreator } from '@/components/features/library-share/LibraryShareDropCreator';
 import { ReleaseAudioAssetPanel } from '@/components/features/release/ReleaseAudioAssetPanel';
 import { toast } from '@/components/feedback';
+import { AppSearchField } from '@/components/molecules/AppSearchField';
 import {
   DrawerHeader,
   DrawerSection,
@@ -129,6 +130,7 @@ import {
   type LibraryView,
   type LibraryViewMode,
   libraryAssetMatchesView,
+  stackLibraryReleaseVersions,
 } from './library-data';
 import {
   LIBRARY_GRID_DENSITY_OPTIONS,
@@ -190,7 +192,6 @@ const LibraryPreviewContext = createContext<{
 
 type LibraryFilters = {
   readonly statuses: Set<LibraryReleaseAsset['status']>;
-  readonly approvalStatuses: Set<LibraryApprovalStatus>;
   readonly releaseTypes: Set<LibraryReleaseAsset['releaseType']>;
   readonly assetKinds: Set<LibraryAssetKind>;
   readonly providers: Set<string>;
@@ -268,7 +269,6 @@ const PRESETS: readonly {
 function emptyFilters(): LibraryFilters {
   return {
     statuses: new Set(),
-    approvalStatuses: new Set(),
     releaseTypes: new Set(),
     assetKinds: new Set(),
     providers: new Set(),
@@ -315,12 +315,6 @@ function assetMatchesFilters(
   filters: LibraryFilters
 ): boolean {
   if (filters.statuses.size > 0 && !filters.statuses.has(asset.status)) {
-    return false;
-  }
-  if (
-    filters.approvalStatuses.size > 0 &&
-    !filters.approvalStatuses.has(asset.approvalStatus)
-  ) {
     return false;
   }
   if (
@@ -385,7 +379,6 @@ function assetMatchesPills(
 function hasActiveFilters(filters: LibraryFilters): boolean {
   return (
     filters.statuses.size +
-      filters.approvalStatuses.size +
       filters.releaseTypes.size +
       filters.assetKinds.size +
       filters.providers.size >
@@ -504,25 +497,20 @@ const StatusCell = memo(function StatusCell({
   );
 });
 
-const ApprovalStatusCell = memo(function ApprovalStatusCell({
-  asset,
-}: {
-  readonly asset: LibraryReleaseAsset;
-}) {
+/**
+ * Approval Status stays out of the library rail/columns until a real review
+ * workflow exists (JOV-3089) — one visible status vocabulary: release status.
+ */
+function assetMatchesSearchQuery(
+  asset: LibraryReleaseAsset,
+  normalizedQuery: string
+): boolean {
+  if (!normalizedQuery) return true;
   return (
-    <span
-      role='status'
-      className={cn(
-        'system-b-library-status-pill inline-flex h-6 w-fit items-center border px-2 leading-4',
-        libraryApprovalStatusClasses(asset.approvalStatus)
-      )}
-      data-testid={`library-approval-status-${asset.id}`}
-      aria-label={`Approval Status: ${formatLibraryApprovalStatus(asset.approvalStatus)}`}
-    >
-      {formatLibraryApprovalStatus(asset.approvalStatus)}
-    </span>
+    asset.title.toLowerCase().includes(normalizedQuery) ||
+    asset.artist.toLowerCase().includes(normalizedQuery)
   );
-});
+}
 
 /**
  * Neutral fallback avatar color for provider keys missing from
@@ -672,14 +660,6 @@ const LIBRARY_TABLE_COLUMNS = [
     size: 112,
     minSize: 96,
     meta: { className: 'hidden xl:table-cell px-2' },
-  }),
-  libraryColumnHelper.display({
-    id: 'approval',
-    header: 'Approval',
-    cell: ({ row }) => <ApprovalStatusCell asset={row.original} />,
-    size: 128,
-    minSize: 108,
-    meta: { className: 'hidden md:table-cell px-2' },
   }),
   createLibraryTypeColumn('hidden lg:table-cell px-2', 104, 88),
   libraryColumnHelper.display({
@@ -875,9 +855,6 @@ function LibraryRail({
 }) {
   const releaseTypes = uniqueSorted(assets.map(asset => asset.releaseType));
   const statuses = uniqueSorted(assets.map(asset => asset.status));
-  const approvalStatuses = uniqueSorted(
-    assets.map(asset => asset.approvalStatus)
-  );
   const providerKeys = uniqueSorted(
     assets.flatMap(asset => asset.providers.map(provider => provider.key))
   );
@@ -894,7 +871,6 @@ function LibraryRail({
   const counts = {
     releaseTypes: countBy(assets, asset => [asset.releaseType]),
     statuses: countBy(assets, asset => [asset.status]),
-    approvalStatuses: countBy(assets, asset => [asset.approvalStatus]),
     providers: countBy(
       assets,
       asset => asset.providers.map(provider => provider.key) as string[]
@@ -903,7 +879,6 @@ function LibraryRail({
   };
   const activeFilterCount =
     filters.statuses.size +
-    filters.approvalStatuses.size +
     filters.releaseTypes.size +
     filters.assetKinds.size +
     filters.providers.size;
@@ -946,24 +921,6 @@ function LibraryRail({
             </Button>
           ) : null}
         </div>
-
-        <FilterSection label='Approval Status'>
-          {approvalStatuses.map(status => (
-            <FilterRow
-              key={status}
-              active={filters.approvalStatuses.has(status)}
-              count={counts.approvalStatuses.get(status) ?? 0}
-              label={formatLibraryApprovalStatus(status)}
-              dotClassName={libraryApprovalStatusDotClasses(status)}
-              onClick={() =>
-                onFilters({
-                  ...filters,
-                  approvalStatuses: toggleSet(filters.approvalStatuses, status),
-                })
-              }
-            />
-          ))}
-        </FilterSection>
 
         <FilterSection label='Release Status'>
           {statuses.map(status => (
@@ -1263,6 +1220,8 @@ function LibraryToolbar({
   onView,
   gridDensity,
   onGridDensity,
+  searchQuery,
+  onSearchQuery,
   visibleCount,
   totalCount,
   mobileFiltersOpen,
@@ -1278,6 +1237,8 @@ function LibraryToolbar({
   readonly onView: (view: LibraryViewMode) => void;
   readonly gridDensity: LibraryGridDensity;
   readonly onGridDensity: (density: LibraryGridDensity) => void;
+  readonly searchQuery: string;
+  readonly onSearchQuery: (query: string) => void;
   readonly visibleCount: number;
   readonly totalCount: number;
   readonly mobileFiltersOpen: boolean;
@@ -1301,6 +1262,13 @@ function LibraryToolbar({
       }
       end={
         <>
+          <AppSearchField
+            value={searchQuery}
+            onChange={onSearchQuery}
+            placeholder='Search library'
+            ariaLabel='Search library by title'
+            className='w-36 sm:w-48'
+          />
           <PageToolbarActionButton
             label={
               activeFilterCount > 0
@@ -1419,11 +1387,20 @@ const AssetCard = memo(function AssetCard({
                   {asset.artist}
                 </p>
               </div>
-              <span className='system-b-library-card-count shrink-0 tabular-nums'>
-                {getLibraryItemKind(asset) === 'merch'
-                  ? (asset.salePriceLabel ?? 'Merch')
-                  : formatCompactCount(asset.providerCount)}
-              </span>
+              {getLibraryItemKind(asset) === 'merch' ? (
+                <span className='system-b-library-card-count shrink-0 tabular-nums'>
+                  {asset.salePriceLabel ?? 'Merch'}
+                </span>
+              ) : (
+                <span
+                  className='system-b-library-card-count shrink-0 tabular-nums'
+                  role='img'
+                  aria-label={`${asset.providerCount} Providers`}
+                  title={`${asset.providerCount} Providers`}
+                >
+                  {formatCompactCount(asset.providerCount)}
+                </span>
+              )}
             </div>
             <div className='system-b-library-card-summary mt-2 flex min-w-0 items-center gap-1.5'>
               {getLibraryItemKind(asset) === 'merch' ? (
@@ -2344,6 +2321,7 @@ export function LibrarySurface({
     readPersistedLibrarySavedView()
   );
   const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
+  const [searchQuery, setSearchQuery] = useState('');
   const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
   const { view, setView } = useLibraryViewMode();
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -2358,14 +2336,17 @@ export function LibrarySurface({
   const deferredSavedView = useDeferredValue(savedView);
   const deferredPills = useDeferredValue(pills);
   const deferredSort = useDeferredValue(sort);
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   useEffect(() => {
     setPreset(parseLibraryViewParam(searchParams.get('view')));
   }, [searchParams]);
 
+  // Version-stack duplicate ingests so each release renders as one row
+  // (JOV-3089); overrides then layer on top of the surviving canonical row.
   const effectiveAssets = useMemo<readonly LibraryReleaseAsset[]>(
     () =>
-      assets.map((asset): LibraryReleaseAsset => {
+      stackLibraryReleaseVersions(assets).map((asset): LibraryReleaseAsset => {
         const previewUrl = audioOverrides[asset.id];
         const approvalStatus =
           approvalStatusOverrides[asset.id] ?? asset.approvalStatus;
@@ -2399,18 +2380,21 @@ export function LibrarySurface({
       PRESETS.find(item => item.id === deferredPreset)?.predicate ??
       (() => true);
     const savedViewPredicate = getLibrarySavedViewPredicate(deferredSavedView);
+    const normalizedQuery = deferredSearchQuery.trim().toLowerCase();
 
     return effectiveAssets
       .filter(presetPredicate)
       .filter(savedViewPredicate)
       .filter(asset => assetMatchesFilters(asset, deferredFilters))
       .filter(asset => assetMatchesPills(asset, deferredPills))
+      .filter(asset => assetMatchesSearchQuery(asset, normalizedQuery))
       .toSorted(compareAssets(deferredSort));
   }, [
     deferredFilters,
     deferredPills,
     deferredPreset,
     deferredSavedView,
+    deferredSearchQuery,
     deferredSort,
     effectiveAssets,
   ]);
@@ -2425,10 +2409,6 @@ export function LibrarySurface({
   );
   const statusOptions = useMemo(
     () => uniqueSorted(effectiveAssets.map(asset => asset.status)),
-    [effectiveAssets]
-  );
-  const approvalOptions = useMemo(
-    () => uniqueSorted(effectiveAssets.map(asset => asset.approvalStatus)),
     [effectiveAssets]
   );
   const hasOptions = useMemo(
@@ -2526,6 +2506,7 @@ export function LibrarySurface({
     handleSavedViewChange('all');
     setFilters(emptyFilters());
     setPills([]);
+    setSearchQuery('');
   }
 
   function openAsset(id: string) {
@@ -2605,7 +2586,6 @@ export function LibrarySurface({
 
   const activeFilterCount =
     filters.statuses.size +
-    filters.approvalStatuses.size +
     filters.releaseTypes.size +
     filters.assetKinds.size +
     filters.providers.size;
@@ -2622,7 +2602,6 @@ export function LibrarySurface({
             titleOptions,
             albumOptions: [],
             statusOptions,
-            approvalOptions,
             hasOptions,
             totalCount: effectiveAssets.length,
             visibleCount: visibleAssets.length,
@@ -2632,16 +2611,9 @@ export function LibrarySurface({
                 : 'Filter Library',
             ariaLabel: 'Filter library assets',
             placeholder: 'Search library',
-            allowedFields: [
-              'artist',
-              'title',
-              'status',
-              'approval',
-              'has',
-            ] as const,
+            allowedFields: ['artist', 'title', 'status', 'has'] as const,
           },
     [
-      approvalOptions,
       artistOptions,
       effectiveAssets.length,
       hasOptions,
@@ -2716,6 +2688,8 @@ export function LibrarySurface({
           onView={setView}
           gridDensity={gridDensity}
           onGridDensity={setGridDensity}
+          searchQuery={searchQuery}
+          onSearchQuery={setSearchQuery}
           visibleCount={visibleAssets.length}
           totalCount={effectiveAssets.length}
           mobileFiltersOpen={mobileFiltersOpen}

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -339,3 +339,88 @@ export function formatLibraryDuration(value: number | null): string {
 
   return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
+
+// Version suffixes that mark the same release re-ingested under a variant
+// title — "All This Noise (Remixed)", "All This Noise EP", "Song - Deluxe".
+const LIBRARY_VERSION_TAG_PATTERN = /\s*[[(][^\])]*[\])]\s*/g;
+const LIBRARY_VERSION_SUFFIX_PATTERN =
+  /[\s–—-]+(ep|single|album|lp|deluxe|remix|remixed|remaster|remastered|edit|version|acoustic|live)$/i;
+
+/**
+ * Normalize a release title so version variants of one release share a key.
+ * Bracketed tags ("(Remixed)") and trailing format/version words ("EP",
+ * "- Deluxe") are stripped; case and whitespace are collapsed.
+ */
+export function normalizeLibraryVersionTitle(title: string): string {
+  let normalized = title
+    .toLowerCase()
+    .replace(LIBRARY_VERSION_TAG_PATTERN, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  for (
+    let stripped = normalized
+      .replace(LIBRARY_VERSION_SUFFIX_PATTERN, '')
+      .trim();
+    stripped.length > 0 && stripped !== normalized;
+    stripped = normalized.replace(LIBRARY_VERSION_SUFFIX_PATTERN, '').trim()
+  ) {
+    normalized = stripped;
+  }
+
+  return normalized || title.trim().toLowerCase();
+}
+
+function libraryVersionGroupKey(asset: LibraryReleaseAsset): string {
+  return `${asset.artist.trim().toLowerCase()}::${normalizeLibraryVersionTitle(asset.title)}`;
+}
+
+function libraryReleaseDateTime(asset: LibraryReleaseAsset): number {
+  if (!asset.releaseDate) return 0;
+  const time = new Date(asset.releaseDate).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+/**
+ * The canonical row for a version group is the most complete ingest: most
+ * tracks, then most provider links, then the newest release date.
+ */
+function isMoreCanonicalVersion(
+  candidate: LibraryReleaseAsset,
+  current: LibraryReleaseAsset
+): boolean {
+  if (candidate.trackCount !== current.trackCount) {
+    return candidate.trackCount > current.trackCount;
+  }
+  if (candidate.providerCount !== current.providerCount) {
+    return candidate.providerCount > current.providerCount;
+  }
+  return libraryReleaseDateTime(candidate) > libraryReleaseDateTime(current);
+}
+
+/**
+ * Version-stack duplicate ingests of the same release into one row (JOV-3089).
+ * Release-kind assets grouped by artist + normalized title collapse to their
+ * most complete row; merch and other item kinds pass through untouched, and
+ * the surviving row keeps its original list position.
+ */
+export function stackLibraryReleaseVersions(
+  assets: readonly LibraryReleaseAsset[]
+): LibraryReleaseAsset[] {
+  const canonicalByKey = new Map<string, LibraryReleaseAsset>();
+
+  for (const asset of assets) {
+    if (getLibraryItemKind(asset) !== 'release') continue;
+    const key = libraryVersionGroupKey(asset);
+    const current = canonicalByKey.get(key);
+    if (!current || isMoreCanonicalVersion(asset, current)) {
+      canonicalByKey.set(key, asset);
+    }
+  }
+
+  return assets.filter(
+    asset =>
+      getLibraryItemKind(asset) !== 'release' ||
+      canonicalByKey.get(libraryVersionGroupKey(asset))?.id === asset.id
+  );
+}

--- a/apps/web/app/app/(shell)/library/library-saved-views.ts
+++ b/apps/web/app/app/(shell)/library/library-saved-views.ts
@@ -4,9 +4,7 @@ export type LibrarySavedViewId =
   | 'all'
   | 'scheduled'
   | 'drafts'
-  | 'missing-audio'
-  | 'missing-artwork'
-  | 'no-providers'
+  | 'needs-attention'
   | 'recent'
   | 'live-merch';
 
@@ -22,7 +20,7 @@ export const LIBRARY_SAVED_VIEW_STORAGE_KEY = 'jovie:library:saved-view';
 export const LIBRARY_SAVED_VIEWS: readonly LibrarySavedView[] = [
   {
     id: 'all',
-    label: 'All items',
+    label: 'All Items',
     description: 'Full catalog',
     predicate: () => true,
   },
@@ -39,34 +37,23 @@ export const LIBRARY_SAVED_VIEWS: readonly LibrarySavedView[] = [
     predicate: asset => asset.status === 'draft',
   },
   {
-    id: 'missing-audio',
-    label: 'Missing audio',
-    description: 'Releases without a preview',
+    id: 'needs-attention',
+    label: 'Needs Attention',
+    description: 'Items missing audio, artwork, or DSP links',
     predicate: asset =>
-      getLibraryItemKind(asset) === 'release' && !asset.previewUrl,
-  },
-  {
-    id: 'missing-artwork',
-    label: 'Missing artwork',
-    description: 'Items without cover art',
-    predicate: asset => !asset.hasArtwork,
-  },
-  {
-    id: 'no-providers',
-    label: 'No providers',
-    description: 'Releases without DSP links',
-    predicate: asset =>
-      getLibraryItemKind(asset) === 'release' && asset.providerCount === 0,
+      !asset.hasArtwork ||
+      (getLibraryItemKind(asset) === 'release' &&
+        (!asset.previewUrl || asset.providerCount === 0)),
   },
   {
     id: 'recent',
-    label: 'Updated this week',
+    label: 'Updated This Week',
     description: 'Touched in the last 7 days',
     predicate: asset => isWithinDays(asset.updatedAt ?? asset.releaseDate, 7),
   },
   {
     id: 'live-merch',
-    label: 'Live merch',
+    label: 'Live Merch',
     description: 'Merch cards currently for sale',
     predicate: asset =>
       getLibraryItemKind(asset) === 'merch' && asset.status === 'released',

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -351,7 +351,7 @@ describe('LibrarySurface', () => {
     expect(portraitCard?.className).toContain('aspect-[9/16]');
   });
 
-  it('shows release status on cards/rows and never conflates approval Draft with release state', async () => {
+  it('shows release status on cards/rows and keeps the approval axis out of the filter rail', async () => {
     renderLibraryWithSidebarOverride([
       buildAsset({
         status: 'released',
@@ -366,7 +366,7 @@ describe('LibrarySurface', () => {
       buildAsset({
         id: 'release-3',
         title: 'Third Track',
-        status: 'released',
+        status: 'draft',
         approvalStatus: 'approved',
       }),
     ]);
@@ -384,18 +384,27 @@ describe('LibrarySurface', () => {
       screen.queryByTestId('library-approval-status-release-1')
     ).not.toBeInTheDocument();
 
+    // Approval Status stays hidden until a review workflow exists (JOV-3089):
+    // the rail offers exactly one status vocabulary — Release Status.
     fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
-    fireEvent.click(screen.getByRole('button', { name: /Needs Review/u }));
+    const rail = screen.getByRole('navigation', { name: 'Library Filters' });
+    expect(within(rail).getByText('Release Status')).toBeInTheDocument();
+    expect(within(rail).queryByText('Approval Status')).not.toBeInTheDocument();
+    expect(
+      within(rail).queryByRole('button', { name: /Needs Review/u })
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Draft /u }));
 
     await waitFor(() => {
       expect(
-        screen.getByTestId('library-release-status-release-2')
+        screen.getByTestId('library-release-status-release-3')
       ).toBeInTheDocument();
       expect(
         screen.queryByTestId('library-release-status-release-1')
       ).toBeNull();
       expect(
-        screen.queryByTestId('library-release-status-release-3')
+        screen.queryByTestId('library-release-status-release-2')
       ).toBeNull();
     });
   });
@@ -881,14 +890,14 @@ describe('LibrarySurface', () => {
     expect(
       screen.getByTestId('library-saved-filter-views')
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Missing audio/u }));
+    fireEvent.click(screen.getByRole('button', { name: /Needs Attention/u }));
 
     await waitFor(() => {
       expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
       expect(screen.queryByText('Take Me Over')).not.toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /^All items/u }));
+    fireEvent.click(screen.getByRole('button', { name: /^All Items/u }));
 
     expect(screen.getByText('Take Me Over')).toBeInTheDocument();
     expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
@@ -923,6 +932,62 @@ describe('LibrarySurface', () => {
 
     expect(screen.getByText('Take Me Over')).toBeInTheDocument();
     expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
+  });
+
+  it('filters library rows by title search', async () => {
+    renderLibrary([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Never Say A Word',
+        artist: 'Other Artist',
+      }),
+    ]);
+
+    fireEvent.change(screen.getByLabelText('Search library by title'), {
+      target: { value: 'never' },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('library-release-row-release-2')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('library-release-row-release-1')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('labels the grid-card provider count badge', () => {
+    renderLibrary([buildAsset({ providerCount: 3 })]);
+    clickGridView();
+
+    expect(screen.getByRole('img', { name: '3 Providers' })).toHaveTextContent(
+      '3'
+    );
+  });
+
+  it('stacks duplicate release versions into one row (JOV-3089)', () => {
+    renderLibrary([
+      buildAsset({
+        id: 'release-1',
+        title: 'All This Noise EP',
+        trackCount: 6,
+      }),
+      buildAsset({
+        id: 'release-2',
+        title: 'All This Noise (Remixed)',
+        trackCount: 0,
+      }),
+    ]);
+
+    // The most complete ingest survives; the near-duplicate stacks behind it.
+    expect(
+      screen.getByTestId('library-release-row-release-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('library-release-row-release-2')
+    ).not.toBeInTheDocument();
   });
 
   it('keeps Library inside the standard app shell without a route sidebar takeover', async () => {

--- a/apps/web/tests/unit/library/library-data.test.ts
+++ b/apps/web/tests/unit/library/library-data.test.ts
@@ -9,6 +9,8 @@ import {
   getLibraryAssetAspectRatio,
   getLibraryDrawerHeroClass,
   LIBRARY_GRID_DENSITY_LAYOUT,
+  normalizeLibraryVersionTitle,
+  stackLibraryReleaseVersions,
 } from '@/app/app/(shell)/library/library-data';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import type { LibraryMerchCard } from '@/lib/merch/types';
@@ -303,5 +305,64 @@ describe('library data', () => {
     expect(LIBRARY_GRID_DENSITY_LAYOUT.spacious).toContain(
       'sm:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-3'
     );
+  });
+});
+
+describe('library version stacking (JOV-3089)', () => {
+  it('normalizes version variant titles to one key', () => {
+    expect(normalizeLibraryVersionTitle('All This Noise EP')).toBe(
+      'all this noise'
+    );
+    expect(normalizeLibraryVersionTitle('All This Noise (Remixed)')).toBe(
+      'all this noise'
+    );
+    expect(normalizeLibraryVersionTitle('All This Noise [Deluxe]')).toBe(
+      'all this noise'
+    );
+    expect(normalizeLibraryVersionTitle('All This Noise - Remastered')).toBe(
+      'all this noise'
+    );
+    expect(normalizeLibraryVersionTitle('  All   This   Noise  ')).toBe(
+      'all this noise'
+    );
+    // Distinct titles stay distinct.
+    expect(normalizeLibraryVersionTitle('All This Noise')).not.toBe(
+      normalizeLibraryVersionTitle('Some Other Song')
+    );
+  });
+
+  it('stacks near-duplicate ingests and keeps the most complete row', () => {
+    const assets = buildLibraryReleaseAssets([
+      buildRelease({
+        id: 'sparse',
+        title: 'All This Noise EP',
+        totalTracks: 0,
+        releaseDate: '2026-01-01T00:00:00.000Z',
+      }),
+      buildRelease({
+        id: 'full',
+        title: 'All This Noise (Remixed)',
+        totalTracks: 6,
+        releaseDate: '2026-02-01T00:00:00.000Z',
+      }),
+      buildRelease({
+        id: 'other',
+        title: 'Different Song',
+        totalTracks: 1,
+      }),
+    ]);
+
+    const stacked = stackLibraryReleaseVersions(assets);
+
+    expect(stacked.map(asset => asset.id)).toEqual(['full', 'other']);
+  });
+
+  it('keeps same-title releases by different artists unstacked', () => {
+    const assets = buildLibraryReleaseAssets([
+      buildRelease({ id: 'a', title: 'Intro', artistNames: ['Artist A'] }),
+      buildRelease({ id: 'b', title: 'Intro', artistNames: ['Artist B'] }),
+    ]);
+
+    expect(stackLibraryReleaseVersions(assets)).toHaveLength(2);
   });
 });

--- a/apps/web/tests/unit/library/library-saved-views.test.ts
+++ b/apps/web/tests/unit/library/library-saved-views.test.ts
@@ -49,27 +49,37 @@ function buildAsset(
 
 describe('library saved views', () => {
   it('recognizes canonical smart filter ids', () => {
-    expect(isLibrarySavedViewId('missing-audio')).toBe(true);
+    expect(isLibrarySavedViewId('needs-attention')).toBe(true);
+    expect(isLibrarySavedViewId('missing-audio')).toBe(false);
     expect(isLibrarySavedViewId('unknown-view')).toBe(false);
   });
 
-  it('matches missing audio and no-provider smart filters', () => {
-    const missingAudio = getLibrarySavedViewPredicate('missing-audio');
-    const noProviders = getLibrarySavedViewPredicate('no-providers');
+  it('matches the consolidated needs-attention smart filter', () => {
+    const needsAttention = getLibrarySavedViewPredicate('needs-attention');
 
+    // Release missing audio.
     expect(
-      missingAudio(
+      needsAttention(
         buildAsset({
           previewUrl: null,
           assetKinds: ['artwork', 'lyrics', 'providers'],
         })
       )
     ).toBe(true);
-    expect(missingAudio(buildAsset())).toBe(false);
-    expect(noProviders(buildAsset({ providerCount: 0, providers: [] }))).toBe(
-      true
-    );
-    expect(noProviders(buildAsset())).toBe(false);
+    // Release without DSP links.
+    expect(
+      needsAttention(buildAsset({ providerCount: 0, providers: [] }))
+    ).toBe(true);
+    // Anything missing artwork.
+    expect(
+      needsAttention(buildAsset({ artworkUrl: null, hasArtwork: false }))
+    ).toBe(true);
+    // Fully-loaded release is fine.
+    expect(needsAttention(buildAsset())).toBe(false);
+    // Merch with artwork never needs audio/providers attention.
+    expect(
+      needsAttention(buildAsset({ id: 'merch-1', itemKind: 'merch' }))
+    ).toBe(false);
   });
 
   it('counts smart filter matches across the catalog', () => {
@@ -89,7 +99,7 @@ describe('library saved views', () => {
       }),
     ];
 
-    expect(countLibrarySavedViewMatches(assets, 'missing-audio')).toBe(1);
+    expect(countLibrarySavedViewMatches(assets, 'needs-attention')).toBe(1);
     expect(countLibrarySavedViewMatches(assets, 'live-merch')).toBe(1);
   });
 
@@ -105,9 +115,9 @@ describe('library saved views', () => {
       },
     });
 
-    persistLibrarySavedView('missing-audio');
-    expect(readPersistedLibrarySavedView()).toBe('missing-audio');
-    expect(storage.get(LIBRARY_SAVED_VIEW_STORAGE_KEY)).toBe('missing-audio');
+    persistLibrarySavedView('needs-attention');
+    expect(readPersistedLibrarySavedView()).toBe('needs-attention');
+    expect(storage.get(LIBRARY_SAVED_VIEW_STORAGE_KEY)).toBe('needs-attention');
 
     persistLibrarySavedView('all');
     expect(readPersistedLibrarySavedView()).toBe('all');


### PR DESCRIPTION
## Summary

Fixes library status incoherence on `/app/library` (JOV-3089):

- **One visible status vocabulary** — hide Approval Status from the filter rail, list-table column, and header-search fields until a real review workflow exists. Release Status remains the single sidebar status axis.
- **Needs Attention** — consolidate Missing audio / Missing artwork / No providers smart filters into one data-quality view.
- **One row per release** — version-stack near-duplicate ingests (artist + normalized title, e.g. `All This Noise EP` / `All This Noise (Remixed)`) into the most complete row.
- **Search** — toolbar title/artist search via `AppSearchField`.
- **Labeled provider count** — grid-card numeric badge is explicitly “N Providers” (aria-label + title).

Approval remains editable in the detail drawer only (not competing as a second “Draft” in the rail).

Fixes JOV-3089

<!-- linear-issue-id: JOV-3089 -->

## Test plan

- [x] `pnpm --filter web exec vitest run tests/unit/library/library-data.test.ts tests/unit/library/library-saved-views.test.ts tests/unit/library/LibrarySurface.test.tsx tests/unit/library/library-system-b-compliance.test.ts tests/unit/library/approval-status.test.ts` — 58 passed
- [x] `pnpm biome check` on touched files — clean
- [x] `pnpm --filter @jovie/web run typecheck` — clean
- [x] Pre-push affected verify + unit tests for library surface/data/saved-views — passed

### Manual / acceptance checks

- [ ] `/app/library` sidebar shows Release Status only (no Approval Status section)
- [ ] Smart filters show Needs Attention instead of three data-quality rows
- [ ] Near-duplicate release titles collapse to one row
- [ ] Toolbar search filters by title/artist
- [ ] Grid card provider count has accessible name “N Providers”