### PR TITLE
fix(update-banner): never show v0.0.0 in new-version toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
+- **Update banner shows the real release version (JOV-3459):** "New Version Available" no longer renders a bogus `(v0.0.0)` parenthetical; it uses the build-time release version from build-info, or omits the version when unavailable.
 - **Entity mention hover cards now use the same rich entity card as the chat rail:** hovering an inline release, artist, track, or event mention opens the canonical compact EntityCard instead of a one-off popover layout.
 - **Chat tool activity is quieter and indented:** agent tool-call rows sit one rhythm step in from assistant prose with secondary color and book weight, so narrative stays primary and consecutive steps form a quiet run.
 - **Artist profiles now adapt to release, touring, and live-support moments:** one music-native link brings listening, tickets, support, fan capture, setup guidance, and product truth into a clearer responsive journey.

--- a/apps/web/app/api/health/build-info/route.ts
+++ b/apps/web/app/api/health/build-info/route.ts
@@ -9,7 +9,11 @@ export const dynamic = 'force-dynamic';
 let _cachedBuildId: string | undefined;
 
 export function GET() {
-  const version = env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
+  // Read directly from process.env (not the dynamic `env` proxy) so Next.js
+  // inlines the build-time value from version.json (next.config.js `env`
+  // block) into this bundle. Dynamic access via the proxy is not inlined and
+  // resolves to undefined at runtime, surfacing as "v0.0.0" (JOV-3459).
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || '0.0.0';
   const environment = env.VERCEL_ENV;
   const isDevelopment = env.NODE_ENV !== 'production';
   const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim().slice(0, 7);

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -63,6 +63,18 @@ export interface UnifiedSidebarProps {
 const VERSION_DISMISSAL_KEY = 'jovie-version-update-dismissed';
 const VERSION_NOTIFICATION_DELAY_MS = 10_000;
 
+/**
+ * Title for the update banner. Omits the version parenthetical when the
+ * incoming version is missing or the unresolved '0.0.0' placeholder so the
+ * banner never advertises a bogus release (JOV-3459).
+ */
+export function getVersionUpdateTitle(info: VersionMismatchInfo): string {
+  const version = info.newVersion?.trim();
+  return version && version !== '0.0.0'
+    ? `New Version Available (v${version})`
+    : 'New Version Available';
+}
+
 /** Render a group of nav items */
 function SettingsNavGroup({
   items,
@@ -352,9 +364,7 @@ function ShellSidebarInstallBanner() {
     return null;
   }
 
-  const title = versionUpdate.newVersion
-    ? `New Version Available (v${versionUpdate.newVersion})`
-    : 'New Version Available';
+  const title = getVersionUpdateTitle(versionUpdate);
 
   return (
     <InstallBanner

--- a/apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts
+++ b/apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getVersionUpdateTitle } from '@/components/organisms/UnifiedSidebar';
+
+describe('getVersionUpdateTitle', () => {
+  it('includes the incoming release version when available', () => {
+    expect(
+      getVersionUpdateTitle({
+        previousBuildId: 'a',
+        currentBuildId: 'b',
+        newVersion: '26.6.61',
+      })
+    ).toBe('New Version Available (v26.6.61)');
+  });
+
+  it('omits the version parenthetical when version is missing', () => {
+    expect(
+      getVersionUpdateTitle({ previousBuildId: 'a', currentBuildId: 'b' })
+    ).toBe('New Version Available');
+  });
+
+  it('never renders the unresolved v0.0.0 placeholder (JOV-3459)', () => {
+    expect(
+      getVersionUpdateTitle({
+        previousBuildId: 'a',
+        currentBuildId: 'b',
+        newVersion: '0.0.0',
+      })
+    ).toBe('New Version Available');
+  });
+
+  it('treats blank versions as unavailable', () => {
+    expect(
+      getVersionUpdateTitle({
+        previousBuildId: 'a',
+        currentBuildId: 'b',
+        newVersion: '   ',
+      })
+    ).toBe('New Version Available');
+  });
+});

--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -77,4 +77,27 @@ describe('@critical GET /api/health/build-info', () => {
     const body = await response.json();
     expect(body.buildId).toBe('development');
   });
+
+  it('returns the build-time app version instead of the 0.0.0 fallback (JOV-3459)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '26.6.61');
+
+    const { GET } = await import('@/app/api/health/build-info/route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(body.version).toBe('26.6.61');
+    expect(body.version).not.toBe('0.0.0');
+  });
+
+  it('falls back to 0.0.0 only when no app version is configured', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '');
+
+    const { GET } = await import('@/app/api/health/build-info/route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(body.version).toBe('0.0.0');
+  });
 });


### PR DESCRIPTION
## Summary

The in-app **New Version Available** banner was rendering **(v0.0.0)** on every deploy. Production `/api/health/build-info` confirmed `"version":"0.0.0"`.

**Root cause:** the build-info route read `NEXT_PUBLIC_APP_VERSION` through the dynamic `env` proxy (`process.env[prop]`). Next.js only inlines `NEXT_PUBLIC_*` values on **static** access (`process.env.NEXT_PUBLIC_APP_VERSION`). Dynamic access is not inlined, so the value was `undefined` at runtime and the route fell back to `'0.0.0'`.

**Fix:**
1. Read `process.env.NEXT_PUBLIC_APP_VERSION` directly in `/api/health/build-info` so the `version.json` value from `next.config.js` is inlined into the server bundle.
2. Guard the banner title: omit the version parenthetical when the version is missing, blank, or `0.0.0`.

## Test plan / results

- [x] `pnpm biome check` on touched files — clean
- [x] `vitest run` `UnifiedSidebar.version-banner.test.ts` + `build-info.critical.test.ts` — **10/10 passed**
- [x] Pre-push typecheck + affected tests — passed (includes both new regression tests)
- [x] Live repro before fix: `curl https://jov.ie/api/health/build-info` returned `"version":"0.0.0"`
- [ ] Post-deploy: `/api/health/build-info` should report the stamped CalVer (not `0.0.0`); banner should show `(vYY.M.PATCH)` or omit version entirely

## Files

- `apps/web/app/api/health/build-info/route.ts` — static env access for version
- `apps/web/components/organisms/UnifiedSidebar.tsx` — `getVersionUpdateTitle` no-0.0.0 guard
- `apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts` — title resolution tests
- `apps/web/tests/unit/api/health/build-info.critical.test.ts` — version payload tests

Fixes JOV-3459

<!-- linear-issue-id:JOV-3459 -->