### PR TITLE
fix(ci): drop git-only --exclude-globs from pre-commit trufflehog filesystem scan

### DIFF
--- a/scripts/security/scan-secrets.sh
+++ b/scripts/security/scan-secrets.sh
@@ -140,12 +140,14 @@ run_trufflehog_pre_commit() {
   fi
 
   echo "Running trufflehog filesystem on ${#staged_files[@]} staged file(s)..."
+  # No $(trufflehog_exclude_args) here: --exclude-globs is git-mode-only and
+  # filesystem mode rejects it (unknown long flag), and the staged-file list
+  # above is already filtered through is_trufflehog_excluded.
   # shellcheck disable=SC2048,SC2086
   "$TRUFFLEHOG_BIN" filesystem \
     ${staged_files[@]} \
     --no-verification \
-    --fail \
-    $(trufflehog_exclude_args)
+    --fail
 }
 
 # trufflehog `git file://…` internally clones the local repo. On persistent


### PR DESCRIPTION
## What

The pre-commit trufflehog run uses `filesystem` mode, which rejects `--exclude-globs` (`unknown long flag` on 3.95.x — the flag only exists in `git` mode) and blocked **every** local commit.

The staged-file list in `run_trufflehog_pre_commit` is already filtered through `is_trufflehog_excluded`, so the flag was redundant here. This removes it from the filesystem invocation only; `git` mode (CI PR scan) keeps it.

## Verification

- `bash scripts/security/scan-secrets.sh pre-commit` passes locally (was a hard failure)
- gitleaks + trufflehog both run clean on the staged set