### PR TITLE
chore(mq): raise max_entries_to_build 2→8 (+ layout parallel)

### DIFF
--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -54,7 +54,7 @@ Checked-in source: `.github/rulesets/branch-protection.yml`.
 - Grouping strategy: `ALLGREEN`
 - Minimum entries to merge: `1`
 - Maximum entries per merge: `10`
-- Maximum entries building concurrently: `2`
+- Maximum entries building concurrently: `8` (sized for ~120 org job concurrency; ~10 peak jobs per merge_group)
 - Check response timeout: `60` minutes
 - Signed-commit and non-fast-forward rules: dormant/not applied. The checked-in
   payload intentionally matches live ruleset `10512119`; enabling either is a

--- a/.github/rulesets/branch-protection.yml
+++ b/.github/rulesets/branch-protection.yml
@@ -146,9 +146,10 @@ rules:
       grouping_strategy: 'ALLGREEN'
       min_entries_to_merge: 1
       max_entries_to_merge: 10
-      # At most two queued PRs may request checks concurrently, using expanded
-      # runner capacity without an unbounded merge-group fan-out.
-      max_entries_to_build: 2
+      # Eight concurrent merge_group builds (~10 peak jobs each) fit under the
+      # ~120 org Actions concurrency ceiling while leaving headroom for source
+      # PR CI and release. Raise toward 10–12 only after measured land waves.
+      max_entries_to_build: 8
       min_entries_to_merge_wait_minutes: 0
       check_response_timeout_minutes: 60
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1805,9 +1805,9 @@ jobs:
     env: { PLAYWRIGHT_ARTIFACT_REQUIRE_PRODUCER_STAGE: 'true' }
     strategy:
       fail-fast: false
-      # The expanded runner pool supports two widths while the third remains
-      # bounded; non-320 widths already wait for the shared seed explicitly.
-      max-parallel: 2
+      # All three widths can run in parallel under the expanded org job
+      # concurrency ceiling (~120). Seed wait still serializes non-320 setup.
+      max-parallel: 3
       matrix:
         width: [320, 390, 430]
     steps:

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -2354,7 +2354,7 @@ describe('CI bounded evidence parallelism', () => {
     expect(lighthouse).toContain("PUBLIC_LIGHTHOUSE_TOTAL_SHARDS: '4'");
   });
 
-  it('runs two mobile widths while retaining the three-width evidence set', () => {
+  it('runs all three mobile widths in parallel under expanded job headroom', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const mobile = getJobBlock(workflow, 'ci-mobile-overflow');
 

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -2358,7 +2358,7 @@ describe('CI bounded evidence parallelism', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const mobile = getJobBlock(workflow, 'ci-mobile-overflow');
 
-    expect(mobile).toContain('max-parallel: 2');
+    expect(mobile).toContain('max-parallel: 3');
     expect(mobile).toContain('width: [320, 390, 430]');
   });
 });

--- a/scripts/lib/__tests__/fixtures/main-ruleset-10512119.json
+++ b/scripts/lib/__tests__/fixtures/main-ruleset-10512119.json
@@ -46,7 +46,7 @@
       "parameters": {
         "check_response_timeout_minutes": 60,
         "grouping_strategy": "ALLGREEN",
-        "max_entries_to_build": 2,
+        "max_entries_to_build": 8,
         "max_entries_to_merge": 10,
         "merge_method": "SQUASH",
         "min_entries_to_merge": 1,

--- a/scripts/lib/__tests__/merge-queue-backend.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-backend.test.mjs
@@ -29,7 +29,7 @@ const VALID_REPOSITORY = Object.freeze(
 );
 const VALID_RULESET = Object.freeze(
   JSON.parse(
-    `{"id":${RULESET_ID},"enforcement":"active","target":"branch","conditions":{"ref_name":{"include":["refs/heads/main"],"exclude":[]}},"bypass_actors":[],"rules":[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"required_status_checks":[{"context":"PR Ready"},{"context":"Migration Guard"},{"context":"Fork PR Gate"},{"context":"PR Size Guard"}]}},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":60,"grouping_strategy":"ALLGREEN","max_entries_to_build":2,"max_entries_to_merge":10,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":0}}]}`
+    `{"id":${RULESET_ID},"enforcement":"active","target":"branch","conditions":{"ref_name":{"include":["refs/heads/main"],"exclude":[]}},"bypass_actors":[],"rules":[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":false,"required_status_checks":[{"context":"PR Ready"},{"context":"Migration Guard"},{"context":"Fork PR Gate"},{"context":"PR Size Guard"}]}},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":60,"grouping_strategy":"ALLGREEN","max_entries_to_build":8,"max_entries_to_merge":10,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":0}}]}`
   )
 );
 const VALID_WORKFLOW = `name: CI

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -33,7 +33,11 @@ export const GRAPHITE_QUEUE_POLICY = Object.freeze({
 export const NATIVE_QUEUE_POLICY = Object.freeze({
   check_response_timeout_minutes: 60,
   grouping_strategy: 'ALLGREEN',
-  max_entries_to_build: 2,
+  // 2→8 on 2026-07-21: org Actions concurrency headroom ~120 jobs.
+  // merge_group peak ~10 concurrent jobs/entry → 8 builds ≈ 80 peak MQ jobs,
+  // leaving room for source-PR CI + release. Re-evaluate toward 10–12 if
+  // queue depth stays >8 while runner/job queue wait stays <3m.
+  max_entries_to_build: 8,
   max_entries_to_merge: 10,
   merge_method: 'SQUASH',
   min_entries_to_merge: 1,


### PR DESCRIPTION
## Why
Native MQ currently has `max_entries_to_build: 2`. With 11 entries queued, only the front 2 are `AWAITING_CHECKS`; the rest sit `QUEUED`. Each merge_group peaks ~10 concurrent jobs and finishes ~11m — build concurrency is the throttle, not runners.

Org Actions headroom is ~120 concurrent jobs. 8 × ~10 ≈ 80 peak MQ jobs leaves room for source-PR CI + release.

## Changes
- `NATIVE_QUEUE_POLICY.max_entries_to_build`: 2 → **8** (source of record + yaml + fixtures + docs)
- `ci.yml` mobile-overflow matrix: `max-parallel` 2 → **3** (workflow_dispatch only; uses headroom)

## Operator follow-up (required same session as land)
After this merges to main, PUT live ruleset `10512119` merge_queue params to match (`max_entries_to_build: 8`) immediately so `ci:merge-queue:verify` / autoenroll preflight stay green.

## Test plan
- [x] `node scripts/ci-merge-queue-check.mjs validate`
- [ ] CI PR Ready green
- [ ] Post-merge: live ruleset shows build=8; queue shows >2 `AWAITING_CHECKS` under load