### PR TITLE
fix(exp): unblock design studio scrolling, toolbar, and toggles

### DIFF
--- a/apps/web/app/exp/page-builder/PageBuilderClient.tsx
+++ b/apps/web/app/exp/page-builder/PageBuilderClient.tsx
@@ -13,7 +13,7 @@ import {
   Plus,
   X,
 } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { MarketingFinalCTA } from '@/components/site/MarketingFinalCTA';
 import { MarketingFooter } from '@/components/site/MarketingFooter';
@@ -46,12 +46,12 @@ type StudioMode = 'pages' | 'sections' | 'product' | 'screenshots';
 
 /**
  * Default body composition. Mirrors a "complete" landing page so reviewers
- * see header → hero → trust → feature → testimonial → FAQ → CTA → footer
- * without configuring anything.
+ * see header → hero → feature → testimonial → FAQ → CTA → footer without
+ * configuring anything. No separate logo-bar section: `marketing-hero`
+ * already embeds the distributor logo-bar proof.
  */
 const DEFAULT_BODY: readonly string[] = [
   'marketing-hero',
-  'home-trust-default',
   'feature-card-grid-3up',
   'testimonial-card-3up',
   'faq-section-default',
@@ -93,7 +93,6 @@ export function PageBuilderClient({
 }: Readonly<{
   designV1Enabled: boolean;
 }>) {
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const mode = designV1Enabled ? parseMode(searchParams.get('mode')) : 'pages';
@@ -116,9 +115,16 @@ export function PageBuilderClient({
         if (v === undefined) params.delete(k);
         else params.set(k, v);
       }
-      router.replace(`/exp/page-builder?${params.toString()}`);
+      // Native History API, not router.replace: updates `useSearchParams`
+      // without a server round-trip, so chrome toggles stay instant and the
+      // router never re-fetches the route or resets scroll position.
+      window.history.replaceState(
+        null,
+        '',
+        `/exp/page-builder?${params.toString()}`
+      );
     },
-    [router, searchParams]
+    [searchParams]
   );
 
   const setBody = useCallback(
@@ -153,6 +159,13 @@ export function PageBuilderClient({
 
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // Mode switches swap the entire workspace, so a preserved mid-page scroll
+  // offset would land the reviewer in the middle of an unrelated view.
+  // Chrome toggles (header/footer/cta/body) keep scroll untouched.
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [mode]);
+
   // Resolve body section variants. Skip ids that aren't in the registry
   // (e.g. typed manually into the URL) so the page always renders.
   const bodyVariants = useMemo(
@@ -169,7 +182,13 @@ export function PageBuilderClient({
   );
 
   return (
-    <div className='relative min-h-screen w-full overflow-x-hidden bg-(--linear-app-content-surface)'>
+    /*
+      `system-b-marketing dark` opts the route into document scrolling (the
+      app-shell global locks `body` to the viewport) and gives the composed
+      marketing sections their token/font context. `overflow-x-clip` (not
+      `-hidden`) avoids creating a scroll container that would break sticky.
+    */
+    <div className='page-builder-root system-b-marketing dark relative min-h-screen w-full overflow-x-clip bg-(--linear-app-content-surface)'>
       <Toolbar
         headerMode={headerMode}
         footerMode={footerMode}
@@ -188,10 +207,12 @@ export function PageBuilderClient({
 
       {mode === 'pages' ? (
         /*
-          The composed landing page. Padding-top = toolbar height so the
-          header always renders below the toolbar without overlap.
+          The composed landing page. `pt-14` clears exactly the toolbar
+          height; page-builder.css offsets the fixed marketing header by the
+          same amount, so header and content stack exactly like production
+          and toggling chrome never shifts layout.
         */
-        <div className='pt-16'>
+        <div className='page-builder-stage pt-14'>
           <MarketingHeader
             variant={headerMode === 'transparent' ? 'homepage' : 'landing'}
           />
@@ -255,12 +276,12 @@ function Toolbar({
   onOpenDrawer,
 }: ToolbarProps) {
   return (
-    <div className='fixed left-0 right-0 top-0 z-50 flex h-14 items-center gap-4 border-b border-white/10 bg-black/85 px-4 text-white dark:text-white shadow-lg backdrop-blur-md'>
+    <div className='page-builder-toolbar fixed left-0 right-0 top-0 z-50 flex h-14 items-center gap-4 overflow-x-auto border-b border-white/10 bg-black/85 px-4 text-white dark:text-white shadow-lg backdrop-blur-md'>
       <span
         className={
           designV1Enabled
-            ? 'text-xs font-semibold text-white/80'
-            : 'text-2xs font-semibold uppercase tracking-wider text-white/70'
+            ? 'shrink-0 whitespace-nowrap text-xs font-semibold text-white/80'
+            : 'shrink-0 whitespace-nowrap text-2xs font-semibold uppercase tracking-wider text-white/70'
         }
       >
         {designV1Enabled ? 'Design Studio' : 'Page Builder'}
@@ -704,7 +725,7 @@ function SectionDrawer({
 
   return (
     <div
-      className='fixed right-0 top-0 z-[60] flex h-screen w-full max-w-95 flex-col border-l border-white/10 bg-black dark:bg-black text-white dark:text-white shadow-2xl'
+      className='page-builder-drawer fixed right-0 top-0 flex h-screen w-full max-w-95 flex-col border-l border-white/10 bg-black dark:bg-black text-white dark:text-white shadow-2xl'
       role='dialog'
       aria-modal='true'
       aria-label='Body section composer'

--- a/apps/web/app/exp/page-builder/page-builder.css
+++ b/apps/web/app/exp/page-builder/page-builder.css
@@ -1,0 +1,44 @@
+/*
+ * Page-builder studio chrome.
+ *
+ * The composed page renders the production marketing header, which is
+ * `position: fixed; top: 0` with an inline `z-index: 100`. The studio
+ * toolbar is also fixed at the top, so without an offset the header paints
+ * over the toolbar and intercepts its clicks. These rules keep the two
+ * stacked exactly like production (header directly above content, content
+ * directly below the toolbar) with zero layout shift between chrome states.
+ */
+.page-builder-root {
+  /* Matches the toolbar's h-14 utility (3.5rem). */
+  --page-builder-toolbar-height: 3.5rem;
+}
+
+/* Push the fixed marketing header below the studio toolbar. The
+   homepage-embedded ("transparent") bar is a plain fixed element, so a
+   direct top override works. */
+.page-builder-stage [data-testid="header-nav"] {
+  top: var(--page-builder-toolbar-height);
+}
+
+/* The marketing-glass ("solid") pill sets `top` from --marketing-glass-top
+   with !important (see organisms/HeaderNav.css), and its flyout menu derives
+   its position from the same variable. Overriding the variable moves both
+   below the toolbar without fighting the !important declaration. */
+.page-builder-stage .marketing-glass-header {
+  --marketing-glass-top: calc(
+    var(--page-builder-toolbar-height) +
+    clamp(0.42rem, 0.8vw, 0.62rem)
+  );
+}
+
+/* The section drawer is modal and must sit above the fixed marketing
+   header (z-index 100). */
+.page-builder-drawer {
+  z-index: 120;
+}
+
+/* On narrow viewports the toolbar scrolls horizontally instead of
+   squishing its controls below their content size. */
+.page-builder-toolbar > * {
+  flex-shrink: 0;
+}

--- a/apps/web/app/exp/page-builder/page.tsx
+++ b/apps/web/app/exp/page-builder/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import { getOptionalAuth } from '@/lib/auth/cached';
 import { getAppFlagValue } from '@/lib/flags/server';
 import { PageBuilderClient } from './PageBuilderClient';
+import './page-builder.css';
 
 export const metadata: Metadata = {
   title: 'Page builder — Jovie',

--- a/apps/web/lib/design-studio/registry.tsx
+++ b/apps/web/lib/design-studio/registry.tsx
@@ -108,7 +108,7 @@ function StudioFrame({
   return (
     <div
       className={cn(
-        'min-h-[360px] overflow-hidden rounded-lg border border-white/10 bg-background text-white dark:text-white shadow-[0_24px_80px_rgba(0,0,0,0.35)]',
+        'min-h-[360px] overflow-hidden rounded-lg border border-white/10 bg-background text-white dark:text-white shadow-2xl',
         className
       )}
     >
@@ -490,7 +490,20 @@ function AudioBarPreview() {
 
 function SectionPreview({ variant }: Readonly<{ variant: SectionVariant }>) {
   return (
-    <div className='max-h-[360px] overflow-hidden rounded-lg border border-white/10 bg-(--linear-app-content-surface)'>
+    /*
+      `transform-gpu` establishes a containing block so fixed-position
+      sections (the marketing header is `position: fixed; z-index: 100`)
+      pin inside the preview card instead of escaping to the viewport and
+      painting over the studio toolbar.
+    */
+    <div
+      className={cn(
+        'max-h-[360px] transform-gpu overflow-hidden rounded-lg border border-white/10 bg-(--linear-app-content-surface)',
+        // Fixed-position headers contribute no height, so reserve room for
+        // the floating glass pill (~54px) to keep the preview card visible.
+        variant.category === 'header' && 'min-h-20'
+      )}
+    >
       {variant.render()}
     </div>
   );


### PR DESCRIPTION
## What

The design studio (/exp/page-builder) was broken in several compounding ways:

- **Page couldn't scroll at all** — globals.css locks body overflow app-shell style; the page had no marketing marker class, so everything below 100vh was clipped. Toggles appeared to 'do nothing' because changes happened below the fold.
- **Fixed marketing header painted over the studio toolbar** and intercepted its clicks.
- **Duplicate trust strip** — marketing-hero already embeds the distributor logo bar.
- **Section previews escaped their cards** — fixed-position headers pinned to the viewport and covered the toolbar.
- **Every toggle did a server round-trip** (router.replace refetched RSC + reset scroll).

Fixes: scoped page-builder.css with toolbar-height token + header/drawer z-order, system-b-marketing marker on the root, transform-gpu containing block for previews, history.replaceState for toggles, mobile toolbar overflow.

## Verification

- 76/76 design-studio + DevToolbar tests; typecheck, biome clean
- Playwright (real clicks, 1440 + 390): scroll works, CLS 0.000 on every transition (header solid↔transparent, CTA on/off, drawer, mode switches)