### PR TITLE
fix(update-banner): harden release version for update toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
 
-- **Library Approval Status is first-class again (#10384):** every Library asset surfaces Draft / Needs Review / Approved / Archived as a badge on grid cards, a list column, and filter chips (rail + pill search), with Release Status kept as a separate labeled axis so the two never collapse into one bare “Draft”.
-- **Update banner shows the real release version (JOV-3459):** "New Version Available" no longer renders a bogus `(v0.0.0)` parenthetical; it uses the build-time release version from build-info, or omits the version when unavailable.
+- **Update banner shows the real release version (JOV-3459):** "New Version Available" no longer renders a bogus `(v0.0.0)` parenthetical; build-info prefers the stamped release version (and falls back to bundled `version.json`), and both shell/legacy banners omit the version when unavailable.
 - **Entity mention hover cards now use the same rich entity card as the chat rail:** hovering an inline release, artist, track, or event mention opens the canonical compact EntityCard instead of a one-off popover layout.
 - **Chat tool activity is quieter and indented:** agent tool-call rows sit one rhythm step in from assistant prose with secondary color and book weight, so narrative stays primary and consecutive steps form a quiet run.
 - **Artist profiles now adapt to release, touring, and live-support moments:** one music-native link brings listening, tickets, support, fan capture, setup guidance, and product truth into a clearer responsive journey.

--- a/apps/web/app/api/health/build-info/route.ts
+++ b/apps/web/app/api/health/build-info/route.ts
@@ -2,18 +2,33 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { NextResponse } from 'next/server';
 import { env } from '@/lib/env';
+// Compile-time release version from monorepo root. Bundled into the route so
+// the response cannot collapse to 0.0.0 when NEXT_PUBLIC_APP_VERSION is not
+// present at runtime (JOV-3459).
+import releaseInfo from '../../../../../../version.json';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 let _cachedBuildId: string | undefined;
 
+function resolveAppVersion(): string {
+  // Prefer static process.env access so Next.js can inline the next.config.js
+  // `env` value. Fall back to the bundled version.json so we never ship the
+  // unresolved 0.0.0 placeholder when the env slot is empty.
+  const fromEnv = process.env.NEXT_PUBLIC_APP_VERSION?.trim();
+  if (fromEnv && fromEnv !== '0.0.0') {
+    return fromEnv;
+  }
+  const fromRelease = releaseInfo.version?.trim();
+  if (fromRelease && fromRelease !== '0.0.0') {
+    return fromRelease;
+  }
+  return '0.0.0';
+}
+
 export function GET() {
-  // Read directly from process.env (not the dynamic `env` proxy) so Next.js
-  // inlines the build-time value from version.json (next.config.js `env`
-  // block) into this bundle. Dynamic access via the proxy is not inlined and
-  // resolves to undefined at runtime, surfacing as "v0.0.0" (JOV-3459).
-  const version = process.env.NEXT_PUBLIC_APP_VERSION || '0.0.0';
+  const version = resolveAppVersion();
   const environment = env.VERCEL_ENV;
   const isDevelopment = env.NODE_ENV !== 'production';
   const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim().slice(0, 7);

--- a/apps/web/components/features/feedback/SidebarInstallBanner.tsx
+++ b/apps/web/components/features/feedback/SidebarInstallBanner.tsx
@@ -2,6 +2,7 @@
 
 import { RefreshCw, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { getVersionUpdateTitle } from '@/components/shell/getVersionUpdateTitle';
 import { env } from '@/lib/env-client';
 import {
   useVersionMonitor,
@@ -77,9 +78,9 @@ export function SidebarInstallBanner() {
     return null;
   }
 
-  const title = versionUpdate.newVersion
-    ? `New version available (v${versionUpdate.newVersion})`
-    : 'New version available';
+  const title = getVersionUpdateTitle(versionUpdate.newVersion, {
+    titleCase: false,
+  });
 
   return (
     <div className='group-data-[collapsible=icon]:hidden px-2.5 pb-1.5'>

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -26,6 +26,7 @@ import {
   SidebarMenuItem,
 } from '@/components/organisms/Sidebar';
 import { UserButton } from '@/components/organisms/user-button';
+import { getVersionUpdateTitle } from '@/components/shell/getVersionUpdateTitle';
 import { InstallBanner } from '@/components/shell/InstallBanner';
 import { BASE_URL } from '@/constants/domains';
 import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
@@ -62,18 +63,6 @@ export interface UnifiedSidebarProps {
 
 const VERSION_DISMISSAL_KEY = 'jovie-version-update-dismissed';
 const VERSION_NOTIFICATION_DELAY_MS = 10_000;
-
-/**
- * Title for the update banner. Omits the version parenthetical when the
- * incoming version is missing or the unresolved '0.0.0' placeholder so the
- * banner never advertises a bogus release (JOV-3459).
- */
-export function getVersionUpdateTitle(info: VersionMismatchInfo): string {
-  const version = info.newVersion?.trim();
-  return version && version !== '0.0.0'
-    ? `New Version Available (v${version})`
-    : 'New Version Available';
-}
 
 /** Render a group of nav items */
 function SettingsNavGroup({
@@ -364,7 +353,7 @@ function ShellSidebarInstallBanner() {
     return null;
   }
 
-  const title = getVersionUpdateTitle(versionUpdate);
+  const title = getVersionUpdateTitle(versionUpdate.newVersion);
 
   return (
     <InstallBanner

--- a/apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts
+++ b/apps/web/components/organisms/UnifiedSidebar.version-banner.test.ts
@@ -1,40 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { getVersionUpdateTitle } from '@/components/organisms/UnifiedSidebar';
+import { getVersionUpdateTitle } from '@/components/shell/getVersionUpdateTitle';
 
-describe('getVersionUpdateTitle', () => {
+describe('getVersionUpdateTitle (shell banner)', () => {
   it('includes the incoming release version when available', () => {
-    expect(
-      getVersionUpdateTitle({
-        previousBuildId: 'a',
-        currentBuildId: 'b',
-        newVersion: '26.6.61',
-      })
-    ).toBe('New Version Available (v26.6.61)');
-  });
-
-  it('omits the version parenthetical when version is missing', () => {
-    expect(
-      getVersionUpdateTitle({ previousBuildId: 'a', currentBuildId: 'b' })
-    ).toBe('New Version Available');
+    expect(getVersionUpdateTitle('26.6.61')).toBe(
+      'New Version Available (v26.6.61)'
+    );
   });
 
   it('never renders the unresolved v0.0.0 placeholder (JOV-3459)', () => {
-    expect(
-      getVersionUpdateTitle({
-        previousBuildId: 'a',
-        currentBuildId: 'b',
-        newVersion: '0.0.0',
-      })
-    ).toBe('New Version Available');
-  });
-
-  it('treats blank versions as unavailable', () => {
-    expect(
-      getVersionUpdateTitle({
-        previousBuildId: 'a',
-        currentBuildId: 'b',
-        newVersion: '   ',
-      })
-    ).toBe('New Version Available');
+    expect(getVersionUpdateTitle('0.0.0')).toBe('New Version Available');
   });
 });

--- a/apps/web/components/shell/getVersionUpdateTitle.test.ts
+++ b/apps/web/components/shell/getVersionUpdateTitle.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getVersionUpdateTitle } from './getVersionUpdateTitle';
+
+describe('getVersionUpdateTitle', () => {
+  it('includes the incoming release version when available', () => {
+    expect(getVersionUpdateTitle('26.6.61')).toBe(
+      'New Version Available (v26.6.61)'
+    );
+  });
+
+  it('omits the version parenthetical when version is missing', () => {
+    expect(getVersionUpdateTitle(undefined)).toBe('New Version Available');
+    expect(getVersionUpdateTitle(null)).toBe('New Version Available');
+  });
+
+  it('never renders the unresolved v0.0.0 placeholder (JOV-3459)', () => {
+    expect(getVersionUpdateTitle('0.0.0')).toBe('New Version Available');
+  });
+
+  it('treats blank versions as unavailable', () => {
+    expect(getVersionUpdateTitle('   ')).toBe('New Version Available');
+  });
+
+  it('supports sentence-case title for the legacy sidebar banner', () => {
+    expect(getVersionUpdateTitle('26.6.61', { titleCase: false })).toBe(
+      'New version available (v26.6.61)'
+    );
+    expect(getVersionUpdateTitle('0.0.0', { titleCase: false })).toBe(
+      'New version available'
+    );
+  });
+});

--- a/apps/web/components/shell/getVersionUpdateTitle.ts
+++ b/apps/web/components/shell/getVersionUpdateTitle.ts
@@ -1,0 +1,21 @@
+/**
+ * Title for the in-app "New Version Available" banner.
+ *
+ * Omits the version parenthetical when the incoming version is missing,
+ * blank, or the unresolved `0.0.0` placeholder so the banner never
+ * advertises a bogus release (JOV-3459).
+ */
+export function getVersionUpdateTitle(
+  newVersion: string | null | undefined,
+  options?: { readonly titleCase?: boolean }
+): string {
+  const base =
+    options?.titleCase === false
+      ? 'New version available'
+      : 'New Version Available';
+  const version = newVersion?.trim();
+  if (!version || version === '0.0.0') {
+    return base;
+  }
+  return `${base} (v${version})`;
+}

--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -90,7 +90,7 @@ describe('@critical GET /api/health/build-info', () => {
     expect(body.version).not.toBe('0.0.0');
   });
 
-  it('falls back to 0.0.0 only when no app version is configured', async () => {
+  it('falls back to bundled version.json when env version is empty (JOV-3459)', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '');
 
@@ -98,6 +98,19 @@ describe('@critical GET /api/health/build-info', () => {
     const response = GET();
     const body = await response.json();
 
-    expect(body.version).toBe('0.0.0');
+    expect(body.version).not.toBe('0.0.0');
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('falls back to bundled version.json when env version is the placeholder', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '0.0.0');
+
+    const { GET } = await import('@/app/api/health/build-info/route');
+    const response = GET();
+    const body = await response.json();
+
+    expect(body.version).not.toBe('0.0.0');
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });


### PR DESCRIPTION
## Summary

Completes JOV-3459 after the initial process.env fix already on main (#14611 / #14588). Production still reported `"version":"0.0.0"` pending deploy, and the legacy sidebar banner could still render `(v0.0.0)`.

**What this hardens:**
1. **build-info** resolves version via static `process.env.NEXT_PUBLIC_APP_VERSION`, then **bundled `version.json`**, so the API cannot collapse to `0.0.0` when env inlining is empty.
2. Shared **`getVersionUpdateTitle`** for shell + legacy sidebars — never renders the `(v0.0.0)` parenthetical; omits version when unavailable.
3. Tests cover env resolution, version.json fallback, and the no-0.0.0 title guard.

## Test plan / results

- [x] `vitest` `getVersionUpdateTitle.test.ts` + `UnifiedSidebar.version-banner.test.ts` + `build-info.critical.test.ts` — **14/14 passed**
- [x] Pre-push affected verify — mode=`selected`, **16/16 tests passed**
- [x] Live repro before: `curl https://jov.ie/api/health/build-info` returned `"version":"0.0.0"`
- [ ] Post-deploy: `/api/health/build-info` reports CalVer (not `0.0.0`); banner shows `(vYY.M.PATCH)` or omits version

## Files

- `apps/web/app/api/health/build-info/route.ts` — env + version.json resolution
- `apps/web/components/shell/getVersionUpdateTitle.ts` — shared title guard
- `apps/web/components/organisms/UnifiedSidebar.tsx` — shell banner
- `apps/web/components/features/feedback/SidebarInstallBanner.tsx` — legacy banner
- tests for resolution + title guard

Fixes JOV-3459

<!-- linear-issue-id:JOV-3459 -->