### PR TITLE
fix(spotify): downgrade expected transient vendor-failure captures to warning (JOV-4354)

### DIFF
--- a/apps/web/lib/spotify/retry.ts
+++ b/apps/web/lib/spotify/retry.ts
@@ -12,6 +12,7 @@
 
 import 'server-only';
 import * as Sentry from '@sentry/nextjs';
+import { CircuitOpenError } from './circuit-breaker';
 
 // ============================================================================
 // Types
@@ -141,6 +142,58 @@ function extractRetryAfter(error: unknown): number | undefined {
 }
 
 /**
+ * HTTP statuses that represent an expected transient vendor outage.
+ * Matches the 5xx subset of the default retryable statuses.
+ */
+const TRANSIENT_VENDOR_STATUSES = new Set([500, 502, 503, 504]);
+
+/**
+ * Check whether an error is an expected transient vendor failure:
+ * - Circuit breaker open (fail-fast while the vendor is known to be down)
+ * - Vendor 5xx still failing after retries (SPOTIFY_UNAVAILABLE / 5xx status)
+ * - Rate limit still in effect after retries (429 / rate-limit error codes)
+ *
+ * Classification mirrors circuit-breaker.ts isRateLimitError. These failures
+ * are captured at warning level because the circuit breaker already alerts
+ * once per outage episode; everything else keeps error level.
+ */
+function isExpectedTransientVendorError(error: unknown): boolean {
+  if (error instanceof CircuitOpenError) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  // IngestError / SpotifyError with a `code` field
+  if ('code' in error) {
+    const code = (error as Error & { code: string }).code;
+    if (
+      code === 'SPOTIFY_UNAVAILABLE' ||
+      code === 'SPOTIFY_RATE_LIMITED' ||
+      code === 'RATE_LIMITED'
+    ) {
+      return true;
+    }
+  }
+
+  // SpotifyError (dsp-enrichment provider) with a `statusCode` field
+  if ('statusCode' in error) {
+    const status = (error as Error & { statusCode: number }).statusCode;
+    if (status === 429 || TRANSIENT_VENDOR_STATUSES.has(status)) return true;
+  }
+
+  // Generic error with a `status` field
+  if ('status' in error) {
+    const status = (error as Error & { status: number }).status;
+    if (status === 429 || TRANSIENT_VENDOR_STATUSES.has(status)) return true;
+  }
+
+  return false;
+}
+
+/**
  * Execute a function with retry logic.
  *
  * @param fn - The async function to execute
@@ -214,10 +267,14 @@ export async function withRetry<T>(
     }
   }
 
-  // Capture to Sentry when all retries are exhausted
+  // Capture to Sentry when all retries are exhausted.
+  // Expected transient vendor failures (vendor 5xx, rate limit after retry,
+  // breaker-open) are downgraded to warning: the circuit breaker already
+  // alerts once per outage episode, so per-call error captures would drown
+  // real defects. Genuine unexpected failures keep error level.
   if (lastError) {
     Sentry.captureException(lastError, {
-      level: 'error',
+      level: isExpectedTransientVendorError(lastError) ? 'warning' : 'error',
       tags: { component: 'spotify-retry' },
       extra: {
         attempts: actualAttempts,

--- a/apps/web/tests/unit/lib/spotify/retry.test.ts
+++ b/apps/web/tests/unit/lib/spotify/retry.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sentry/nextjs', () => ({
+  getClient: vi.fn(() => undefined),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+import {
+  type CircuitBreakerStats,
+  CircuitOpenError,
+} from '@/lib/spotify/circuit-breaker';
+import { withRetry } from '@/lib/spotify/retry';
+
+/**
+ * Zero-delay config so tests exercise the full retry loop without sleeping.
+ */
+const FAST_CONFIG = {
+  maxRetries: 2,
+  baseDelay: 0,
+  maxDelay: 0,
+  jitter: 0,
+} as const;
+
+function openCircuitStats(): CircuitBreakerStats {
+  return {
+    state: 'OPEN',
+    failures: 10,
+    successes: 0,
+    lastFailureTime: Date.now(),
+    lastStateChange: Date.now(),
+    totalFailures: 10,
+    totalSuccesses: 0,
+    requestsInWindow: 20,
+  };
+}
+
+describe('withRetry exhaustion capture severity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('captures exhausted vendor 5xx failures at warning level', async () => {
+    const error = Object.assign(new Error('Spotify returned 503'), {
+      status: 503,
+    });
+
+    const result = await withRetry(() => Promise.reject(error), FAST_CONFIG);
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(FAST_CONFIG.maxRetries + 1);
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        level: 'warning',
+        tags: { component: 'spotify-retry' },
+      })
+    );
+  });
+
+  it('captures rate-limit failures still present after retry at warning level', async () => {
+    const error = Object.assign(new Error('Spotify rate limited'), {
+      status: 429,
+      retryAfter: 0,
+    });
+
+    const result = await withRetry(() => Promise.reject(error), FAST_CONFIG);
+
+    expect(result.success).toBe(false);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ level: 'warning' })
+    );
+  });
+
+  it('captures IngestError-style transient codes at warning level', async () => {
+    for (const code of [
+      'SPOTIFY_UNAVAILABLE',
+      'SPOTIFY_RATE_LIMITED',
+      'RATE_LIMITED',
+    ]) {
+      vi.clearAllMocks();
+      const error = Object.assign(new Error(`coded failure: ${code}`), {
+        code,
+      });
+
+      const result = await withRetry(() => Promise.reject(error), FAST_CONFIG);
+
+      expect(result.success).toBe(false);
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ level: 'warning' })
+      );
+    }
+  });
+
+  it('captures circuit-breaker-open errors at warning level', async () => {
+    const error = new CircuitOpenError(
+      'Circuit breaker is OPEN. Service unavailable.',
+      openCircuitStats()
+    );
+
+    const result = await withRetry(() => Promise.reject(error), FAST_CONFIG);
+
+    expect(result.success).toBe(false);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ level: 'warning' })
+    );
+  });
+
+  it('keeps error level for unexpected non-retryable failures', async () => {
+    const error = new Error('unexpected boom');
+
+    const result = await withRetry(() => Promise.reject(error), FAST_CONFIG);
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ level: 'error' })
+    );
+  });
+
+  it('keeps error level for non-transient HTTP statuses', async () => {
+    const error = Object.assign(new Error('Spotify returned 400'), {
+      status: 400,
+      code: 'SPOTIFY_API_ERROR',
+    });
+
+    const result = await withRetry(() => Promise.reject(error), FAST_CONFIG);
+
+    expect(result.success).toBe(false);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ level: 'error' })
+    );
+  });
+
+  it('does not capture when a retry recovers', async () => {
+    const error = Object.assign(new Error('Spotify returned 503'), {
+      status: 503,
+    });
+    let calls = 0;
+    const operation = vi.fn(() => {
+      calls++;
+      return calls < 3 ? Promise.reject(error) : Promise.resolve('ok');
+    });
+
+    const result = await withRetry(operation, FAST_CONFIG);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBe('ok');
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Workstream: downgrade expected transient vendor-failure Sentry captures so real defects stand out during vendor outages.

**Issue:** [JOV-4354](https://linear.app/jovie/issue/JOV-4354/fixspotify-downgrade-expected-transient-vendor-failure-captures-from) (follow-up from JOV-3740/3741 WAI triage).

**Evidence on record:** during a Spotify 5xx outage the circuit breaker behaves correctly — opens after 10 real failures / 20 requests in a 2-min window, excludes 429s (`circuit-breaker.ts:438-445`), auto-probes after ~60s, closes after 2 successes — and ingestion classifies the failure as transient (`scheduler.ts:79-81` → backoff). The 17-event error-level fan-out came from `withRetry`'s exhaustion capture at `apps/web/lib/spotify/retry.ts:217-228`: `captureException(level: 'error')` fired per exhausted call even for expected transient vendor failures.

## The distinction, and why

Checked for a dedup-per-breaker-episode helper first — none exists; the breaker already emits exactly one warning `captureMessage` per open episode (`circuit-breaker.ts:324-332`), which is the per-episode signal. So the minimal correct fix is a severity downgrade at the capture chokepoint, not new dedup state.

`isExpectedTransientVendorError` (new, `apps/web/lib/spotify/retry.ts`, mirroring `isRateLimitError`'s classification style):

- **Transient → warning:** `CircuitOpenError` (breaker-open fail-fast); `code` ∈ {`SPOTIFY_UNAVAILABLE`, `SPOTIFY_RATE_LIMITED`, `RATE_LIMITED`}; `status`/`statusCode` of 429 or 500/502/503/504.
- **Unexpected → error (unchanged):** everything else — plain errors, non-transient statuses (400/401/403/404 via `SPOTIFY_API_ERROR`/`SPOTIFY_NOT_FOUND`), non-Error throwables.

## Scope

- Changed: `apps/web/lib/spotify/retry.ts` (classifier + computed capture level), `apps/web/tests/unit/lib/spotify/retry.test.ts` (new, 7 tests).
- Not changed: breaker thresholds, scheduler behavior, capture volume (no events dropped — tags/extra unchanged), anything outside the expected-transient class.

## Validation

- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/spotify/retry.test.ts` → 7/7 pass (5xx→warning, 429-after-retry→warning, coded transients→warning, `CircuitOpenError`→warning, plain error→error, 400/`SPOTIFY_API_ERROR`→error, recovered retry→no capture).
- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/spotify/ tests/unit/api/spotify/search.test.ts` → 29/29 pass.
- `pnpm biome check --write` on changed files → clean.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` → clean.

## Risk

Low. Warning-level events still reach Sentry (visible, alertable, grouped); only severity changes for the transient class. Worst case a misclassified error appears at warning instead of error — no runtime behavior change.

## Rollback

Revert this commit; capture levels return to all-error on exhaustion.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20` (coordination preflight: no conflicting owner for this area).
- Written: `engineering/spotify-transient-capture-severity` (type: engineering-decision — distinction, application point, preservation, tests).
