### PR TITLE
test(marketing): add system-b style guards for unguarded public pages

### DIFF
--- a/apps/web/app/(dynamic)/legal/layout.tsx
+++ b/apps/web/app/(dynamic)/legal/layout.tsx
@@ -10,7 +10,7 @@ export default function LegalLayout({
 }>) {
   return (
     <PublicPageShell
-      className='public-legal-shell bg-white text-neutral-950 dark:bg-base dark:text-neutral-50'
+      className='public-legal-shell bg-base text-primary-token'
       headerVariant='minimal'
       logoSize='sm'
       mainClassName='py-16 sm:py-20'

--- a/apps/web/app/(marketing)/ai/page.tsx
+++ b/apps/web/app/(marketing)/ai/page.tsx
@@ -18,6 +18,7 @@ export default function AiPage() {
           <p className='text-sm font-medium tracking-tight text-muted-token'>
             Public Brief
           </p>
+          {/* ui-casing-allow: marketing display headline */}
           <h1 className='text-4xl font-semibold tracking-tight sm:text-5xl'>
             The AI operating system behind every Jovie profile
           </h1>
@@ -39,6 +40,7 @@ export default function AiPage() {
 
         <section className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>1. Identify</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Recognize known fans, captured contacts, and anonymous visitors
@@ -46,6 +48,7 @@ export default function AiPage() {
             </p>
           </article>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>2. Decide</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Route each visit toward the highest-value next action, whether
@@ -53,6 +56,7 @@ export default function AiPage() {
             </p>
           </article>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>3. Measure</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Capture impressions, clicks, and downstream value events so
@@ -60,6 +64,7 @@ export default function AiPage() {
             </p>
           </article>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>4. Learn</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Use those outcomes to improve routing, segmentation, and follow-up
@@ -68,8 +73,9 @@ export default function AiPage() {
           </article>
         </section>
 
-        <section className='grid gap-8 rounded-[2rem] border border-subtle bg-panel px-6 py-8 lg:grid-cols-[1.2fr_0.8fr]'>
+        <section className='grid gap-8 rounded-4xl border border-subtle bg-panel px-6 py-8 lg:grid-cols-[1.2fr_0.8fr]'>
           <div className='space-y-4'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-2xl font-semibold tracking-tight'>
               What ships in the launch version
             </h2>
@@ -87,6 +93,7 @@ export default function AiPage() {
             </ul>
           </div>
           <div className='space-y-4'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-2xl font-semibold tracking-tight'>
               Read the public context
             </h2>

--- a/apps/web/app/(marketing)/investors/page.tsx
+++ b/apps/web/app/(marketing)/investors/page.tsx
@@ -18,6 +18,7 @@ export default function InvestorsPage() {
           <p className='text-sm font-medium tracking-tight text-muted-token'>
             Investor overview
           </p>
+          {/* ui-casing-allow: marketing display headline */}
           <h1 className='text-4xl font-semibold tracking-tight sm:text-5xl'>
             Jovie turns creator traffic into measurable fan value
           </h1>
@@ -47,6 +48,7 @@ export default function InvestorsPage() {
 
         <section className='grid gap-4 md:grid-cols-3'>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>Traffic choke point</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Every marketing push already ends at the profile. Jovie upgrades
@@ -54,6 +56,7 @@ export default function InvestorsPage() {
             </p>
           </article>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>Compounding data asset</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Each click and capture event improves the next routing decision,
@@ -61,6 +64,7 @@ export default function InvestorsPage() {
             </p>
           </article>
           <article className='rounded-3xl border border-subtle bg-panel px-5 py-6'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-lg font-semibold'>Revenue paths</h2>
             <p className='mt-3 text-sm leading-7 text-secondary-token'>
               Launch routes cover subscription growth, listening conversion,
@@ -69,8 +73,9 @@ export default function InvestorsPage() {
           </article>
         </section>
 
-        <section className='grid gap-8 rounded-[2rem] border border-subtle bg-panel px-6 py-8 lg:grid-cols-[0.95fr_1.05fr]'>
+        <section className='grid gap-8 rounded-4xl border border-subtle bg-panel px-6 py-8 lg:grid-cols-[0.95fr_1.05fr]'>
           <div className='space-y-4'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-2xl font-semibold tracking-tight'>Why now</h2>
             <p className='text-sm leading-7 text-secondary-token'>
               Music creation is cheap, distribution is crowded, and static
@@ -79,6 +84,7 @@ export default function InvestorsPage() {
             </p>
           </div>
           <div className='space-y-4'>
+            {/* ui-casing-allow: marketing display headline */}
             <h2 className='text-2xl font-semibold tracking-tight'>
               Public materials
             </h2>

--- a/apps/web/app/(marketing)/not-found.tsx
+++ b/apps/web/app/(marketing)/not-found.tsx
@@ -13,13 +13,13 @@ export default function NotFound() {
   return (
     <MarketingContainer
       width='page'
-      className='flex min-h-[calc(100vh-8rem)] items-center justify-center'
+      className='system-b-marketing-not-found flex items-center justify-center'
     >
       <div className='w-full max-w-md mx-auto text-center px-4 py-16'>
         {/* Error code — oversized, muted */}
         <div className='mb-8 select-none'>
           <span
-            className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
+            className='system-b-marketing-not-found-code'
             aria-hidden='true'
           >
             404
@@ -28,6 +28,7 @@ export default function NotFound() {
 
         {/* Content */}
         <div className='-mt-16 relative'>
+          {/* ui-casing-allow: marketing display headline */}
           <h1 className='text-xl font-semibold text-primary-token tracking-tight mb-2'>
             Page not found
           </h1>

--- a/apps/web/components/features/demo/DemoVideoPage.tsx
+++ b/apps/web/components/features/demo/DemoVideoPage.tsx
@@ -19,10 +19,7 @@ export function DemoVideoPage() {
       className='mx-auto flex w-full max-w-5xl flex-col items-center px-4 py-16 sm:px-6 lg:py-24'
       data-testid='demo-video-page'
     >
-      <h1
-        className='max-w-3xl text-center text-4xl font-bold leading-tight text-white dark:text-white sm:text-5xl'
-        style={{ fontFeatureSettings: 'var(--font-features)' }}
-      >
+      <h1 className='max-w-3xl text-center text-4xl font-bold leading-tight text-primary-token sm:text-5xl'>
         Jovie Turns Artist Signals Into Execution
       </h1>
 
@@ -39,7 +36,7 @@ export function DemoVideoPage() {
       <div className='mt-10 flex flex-wrap items-center justify-center gap-4'>
         <a
           href={downloadHref}
-          className='inline-flex h-12 items-center rounded-full border border-white/20 px-8 text-sm font-semibold text-white dark:text-white transition-colors hover:bg-white/10'
+          className='inline-flex h-12 items-center rounded-full border border-subtle px-8 text-sm font-semibold text-primary-token transition-colors hover:bg-(--color-cell-hover)'
           download='jovie-demo.mp4'
         >
           Download demo

--- a/apps/web/components/marketing/homepage-v2/HomepageV2Ctas.tsx
+++ b/apps/web/components/marketing/homepage-v2/HomepageV2Ctas.tsx
@@ -27,10 +27,7 @@ export function HomepageStoryHeader({
 
   return (
     <div
-      className={cn(
-        centered ? 'mx-auto text-center' : 'max-w-[38rem]',
-        className
-      )}
+      className={cn(centered ? 'mx-auto text-center' : 'max-w-xl', className)}
     >
       <h2
         className={cn('homepage-story-heading', headlineClassName)}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2801,6 +2801,27 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B MARKETING NOT-FOUND PRIMITIVES
+   ============================================ */
+
+:where(.system-b-marketing-not-found) {
+  min-height: calc(100vh - var(--space-16) * 2);
+}
+
+:where(.system-b-marketing-not-found-code) {
+  display: block;
+  color: var(--color-text-quaternary-token);
+  font-size: clamp(
+    calc(var(--space-24) + var(--space-6)),
+    16vw,
+    calc(var(--space-24) + var(--space-16))
+  );
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: 1;
+}
+
+/* ============================================
    SYSTEM B ERROR FALLBACK PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/marketing/ai-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/ai-system-b-style-guard.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /ai System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards:
+ * the inline server page must carry no arbitrary Tailwind values, hex/rgba/
+ * gradient colors, raw color scales, literal white/black utilities, named
+ * shadow scales, inline styles, or the System A editorial type classes
+ * (marketing-*-linear / marketing-kicker). Named System B token utilities
+ * only.
+ */
+
+const sources = ['app/(marketing)/ai/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('ai page System B source contract', () => {
+  it('keeps /ai visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the System B token anchors in place', () => {
+    const source = readFileSync(resolve(process.cwd(), sources[0]), 'utf8');
+
+    expect(source).toContain('text-primary-token');
+    expect(source).toContain('text-secondary-token');
+    expect(source).toContain('text-muted-token');
+    expect(source).toContain('border-subtle');
+    expect(source).toContain('bg-panel');
+  });
+});

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -1,0 +1,136 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /artist-profile + /artist-profiles System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards.
+ *
+ * Two tiers:
+ *
+ *   1. Both route files and the family's clean components (landing route,
+ *      landing page composition, section shell, social proof, how-it-works,
+ *      FAQ) carry the full strict contract: no hex/rgba/gradient colors, no
+ *      raw color scales, no literal white/black utilities, no arbitrary
+ *      values, no inline styles, no named shadow scales, and no System A
+ *      editorial type classes (marketing-*-linear / marketing-kicker).
+ *
+ *   2. The remaining section components still carry System A debt — inline
+ *      rgba gradients and shadows (ArtistProfilePhoneFrame, captureShared,
+ *      ArtistProfileSpecWall, ArtistProfileOutcomesCarousel,
+ *      ArtistProfileMonetizationSection, ArtistProfilePlaceholderShot,
+ *      ArtistProfileOutcomeDuo), white/black overlay utilities (widespread),
+ *      emerald-300 accent scales (ArtistProfileSpecWall), and arbitrary
+ *      clamp() type sizes (ArtistProfileSectionHeader, ArtistProfileHero).
+ *      Restyling those is tracked for the artist-profile migration wave.
+ *      Until then the whole family is pinned against the System A editorial
+ *      type classes, and the composition anchors below must not regress.
+ */
+
+const strictSources = [
+  'app/(marketing)/artist-profile/page.tsx',
+  'app/(marketing)/artist-profiles/page.tsx',
+  'components/marketing/artist-profile/ArtistProfileLandingRoute.tsx',
+  'components/marketing/artist-profile/ArtistProfileLandingPage.tsx',
+  'components/marketing/artist-profile/ArtistProfileSectionShell.tsx',
+  'components/marketing/artist-profile/ArtistProfileSocialProof.tsx',
+  'components/marketing/artist-profile/ArtistProfileHowItWorks.tsx',
+  'components/marketing/artist-profile/ArtistProfileFaq.tsx',
+] as const;
+
+const familyDir = 'components/marketing/artist-profile' as const;
+
+const forbiddenVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+// System A editorial type classes — banned across the whole family, debt files
+// included. This set may only grow as sections migrate onto System B tokens.
+const forbiddenFamilyPatterns = [
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+const landingPageSource =
+  'components/marketing/artist-profile/ArtistProfileLandingPage.tsx' as const;
+
+const sectionComponents = [
+  'ArtistProfileHeroAdaptiveIntro',
+  'ArtistProfileOutcomesCarousel',
+  'ArtistProfileCaptureSection',
+  'ArtistProfileOpinionatedSection',
+  'ArtistProfileSpecWall',
+  'ArtistProfileHowItWorks',
+  'ArtistProfileSocialProof',
+  'ArtistProfileFaq',
+  'ArtistProfileFinalCta',
+] as const;
+
+describe('artist profile landing family System B source contract', () => {
+  it('keeps the routes and clean components on named System B primitives', () => {
+    for (const sourcePath of strictSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps System A editorial type classes out of the whole family', () => {
+    const files = readdirSync(resolve(process.cwd(), familyDir))
+      .filter(file => file.endsWith('.tsx'))
+      .map(file => `${familyDir}/${file}`);
+
+    for (const sourcePath of files) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenFamilyPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the System B shell and section composition anchors in place', () => {
+    const route = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/artist-profile/ArtistProfileLandingRoute.tsx'
+      ),
+      'utf8'
+    );
+    expect(route).toContain('<MarketingPageShell>');
+
+    const landing = readFileSync(
+      resolve(process.cwd(), landingPageSource),
+      'utf8'
+    );
+    for (const component of sectionComponents) {
+      expect(
+        landing,
+        `${landingPageSource} must compose ${component}`
+      ).toContain(`<${component}`);
+    }
+
+    const sectionHeader = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/artist-profile/ArtistProfileSectionHeader.tsx'
+      ),
+      'utf8'
+    );
+    expect(sectionHeader).toContain('text-primary-token');
+    expect(sectionHeader).toContain('text-secondary-token');
+  });
+});

--- a/apps/web/tests/unit/marketing/demovideo-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/demovideo-system-b-style-guard.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /demovideo System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards.
+ *
+ * The route file and DemoVideoPage carry the full strict contract: no
+ * hex/rgba/gradient colors, no raw color scales, no literal white/black
+ * utilities, no arbitrary values, no named shadow scales, no inline styles,
+ * and no System A editorial type classes.
+ *
+ * DemoVideoPlayer is a shared media control with an established carve-out:
+ * its floating play button intentionally keeps white/black overlay utilities
+ * over video content. It is still pinned against literal color formats,
+ * gradients, arbitrary values, raw palette scales, and System A classes so
+ * the debt cannot spread.
+ */
+
+const strictSources = [
+  'app/(marketing)/demovideo/page.tsx',
+  'components/features/demo/DemoVideoPage.tsx',
+] as const;
+
+const playerSource = 'components/features/demo/DemoVideoPlayer.tsx' as const;
+
+const forbiddenVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+const forbiddenPlayerPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone)-(?:[0-9]|\[|\/)/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('demovideo page System B source contract', () => {
+  it('keeps /demovideo visuals on named System B primitives', () => {
+    for (const sourcePath of strictSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the shared video player within its media-control carve-out', () => {
+    const source = readFileSync(resolve(process.cwd(), playerSource), 'utf8');
+    for (const pattern of forbiddenPlayerPatterns) {
+      expect(source, `${playerSource} matched ${pattern}`).not.toMatch(pattern);
+    }
+  });
+
+  it('keeps the System B token anchors in place', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), strictSources[1]),
+      'utf8'
+    );
+
+    expect(source).toContain('text-primary-token');
+    expect(source).toContain('border-subtle');
+    expect(source).toContain('<DemoVideoPlayer');
+  });
+});

--- a/apps/web/tests/unit/marketing/homepage-v2-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/homepage-v2-system-b-style-guard.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /new (Homepage v2) System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards.
+ *
+ * Two tiers:
+ *
+ *   1. The route file and the CTA/pricing components carry the full strict
+ *      contract: no hex/rgba/gradient colors, no raw color scales, no literal
+ *      white/black utilities, no arbitrary values, no inline styles, and no
+ *      System A editorial type classes (marketing-*-linear / marketing-kicker).
+ *
+ *   2. HomepageV2Route.tsx still owns System A debt in its hero composition
+ *      (inline rgba radial-gradient glow, drop-shadow arbitrary values,
+ *      white-alpha overlay utilities, marketing-h1-linear editorial classes,
+ *      animation style props). Restyling that composition is tracked for the
+ *      homepage-v2 migration wave; until then this guard pins the invariants
+ *      that must not regress: no hex literals, no raw numbered palette
+ *      scales, and the System B anchors the page already ships (System B
+ *      shell/container, token text classes, public-action CTAs).
+ */
+
+const strictSources = [
+  'app/(marketing)/new/page.tsx',
+  'components/marketing/homepage-v2/HomepageV2Ctas.tsx',
+] as const;
+
+const heroRouteSource =
+  'components/marketing/homepage-v2/HomepageV2Route.tsx' as const;
+
+const forbiddenVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  // System A editorial type classes — retired on this surface.
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+const forbiddenHeroRoutePatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone)-(?:[0-9]|\[|\/)/,
+] as const;
+
+describe('homepage v2 (/new) System B source contract', () => {
+  it('keeps the route and CTA visuals on named System B primitives', () => {
+    for (const sourcePath of strictSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the hero route free of hex literals and raw palette scales', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), heroRouteSource),
+      'utf8'
+    );
+    for (const pattern of forbiddenHeroRoutePatterns) {
+      expect(source, `${heroRouteSource} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+  });
+
+  it('keeps the System B shell, token type, and CTA anchors in place', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), heroRouteSource),
+      'utf8'
+    );
+
+    expect(source).toContain('<MarketingPageShell>');
+    expect(source).toContain('MarketingContainer');
+    expect(source).toContain('text-primary-token');
+    expect(source).toContain('text-secondary-token');
+    expect(source).toContain('text-tertiary-token');
+    expect(source).toContain('public-action-primary');
+    expect(source).toContain('public-action-secondary');
+    expect(source).toContain("data-testid='homepage-v2-shell'");
+    expect(source).toContain("data-testid='homepage-v2-hero'");
+  });
+});

--- a/apps/web/tests/unit/marketing/investors-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/investors-system-b-style-guard.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /investors System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards:
+ * the inline server page must carry no arbitrary Tailwind values, hex/rgba/
+ * gradient colors, raw color scales, literal white/black utilities, named
+ * shadow scales, inline styles, or the System A editorial type classes
+ * (marketing-*-linear / marketing-kicker). Named System B token utilities
+ * only.
+ */
+
+const sources = ['app/(marketing)/investors/page.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('investors page System B source contract', () => {
+  it('keeps /investors visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the System B token anchors in place', () => {
+    const source = readFileSync(resolve(process.cwd(), sources[0]), 'utf8');
+
+    expect(source).toContain('text-primary-token');
+    expect(source).toContain('text-secondary-token');
+    expect(source).toContain('text-muted-token');
+    expect(source).toContain('border-subtle');
+    expect(source).toContain('bg-panel');
+  });
+});

--- a/apps/web/tests/unit/marketing/legal-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/legal-system-b-style-guard.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * (dynamic)/legal/* System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards.
+ * The legal routes render the shared LegalPage organism inside the
+ * PublicPageShell minimal variant; every file in that chain must carry no
+ * arbitrary Tailwind values, hex/rgba/gradient colors, raw color scales,
+ * literal white/black utilities, named shadow scales, inline styles, or
+ * System A editorial type classes. Named System B token utilities only.
+ */
+
+const sources = [
+  'app/(dynamic)/legal/layout.tsx',
+  'app/(dynamic)/legal/privacy/page.tsx',
+  'app/(dynamic)/legal/terms/page.tsx',
+  'app/(dynamic)/legal/cookies/page.tsx',
+  'app/(dynamic)/legal/dmca/page.tsx',
+  'components/organisms/LegalPage.tsx',
+  'components/site/PublicPageShell.tsx',
+] as const;
+
+const forbiddenVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('legal pages System B source contract', () => {
+  it('keeps the legal chain visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps the PublicPageShell minimal-variant anchors in place', () => {
+    const layout = readFileSync(resolve(process.cwd(), sources[0]), 'utf8');
+
+    expect(layout).toContain('<PublicPageShell');
+    expect(layout).toContain("headerVariant='minimal'");
+    expect(layout).toContain('MarketingContainer');
+    expect(layout).toContain('text-primary-token');
+
+    for (const pagePath of sources.slice(1, 5)) {
+      const page = readFileSync(resolve(process.cwd(), pagePath), 'utf8');
+      expect(page, `${pagePath} must render LegalPage`).toContain('<LegalPage');
+    }
+  });
+});

--- a/apps/web/tests/unit/marketing/marketing-not-found-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/marketing-not-found-system-b-style-guard.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * (marketing)/not-found System B source contract.
+ *
+ * Part of the founder-directed System A -> System B marketing migration
+ * (DESIGN.md 2026-06-18). Mirrors the shipped about/support/download guards
+ * for the route source, and the download guard's CSS check for the
+ * system-b-marketing-not-found block in styles/design-system.css: the 404
+ * numeral and viewport sizing live in tokenized CSS, not arbitrary Tailwind
+ * values in the route.
+ */
+
+const routeSource = 'app/(marketing)/not-found.tsx' as const;
+const designSystemPath = 'styles/design-system.css' as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|blue|green|purple|pink|yellow|teal|lime|slate|gray|zinc|neutral|stone|black|white)-(?:[0-9]|\[|\/)/,
+  /\b(?:bg|border|text|ring|shadow|decoration|from|via|to)-(?:white|black)(?:\/|\b)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner)\b/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+const forbiddenCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractMarketingNotFoundCss(source: string): string {
+  const start = source.indexOf('SYSTEM B MARKETING NOT-FOUND PRIMITIVES');
+  const end = source.indexOf('SYSTEM B ERROR FALLBACK PRIMITIVES', start);
+
+  expect(start, 'marketing not-found CSS block exists').toBeGreaterThanOrEqual(
+    0
+  );
+  expect(
+    end,
+    'marketing not-found CSS block is bounded before the next section'
+  ).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('marketing not-found System B source contract', () => {
+  it('keeps the route visuals on named System B primitives', () => {
+    const source = readFileSync(resolve(process.cwd(), routeSource), 'utf8');
+
+    for (const pattern of forbiddenRouteVisualPatterns) {
+      expect(source, `${routeSource} matched ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(source).toContain('MarketingContainer');
+    expect(source).toContain('system-b-marketing-not-found');
+    expect(source).toContain('system-b-marketing-not-found-code');
+    expect(source).toContain('text-primary-token');
+    expect(source).toContain('text-tertiary-token');
+    expect(source).toContain('public-action-primary');
+  });
+
+  it('keeps the marketing not-found CSS block tokenized', () => {
+    const css = extractMarketingNotFoundCss(
+      readFileSync(resolve(process.cwd(), designSystemPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenCssPatterns) {
+      expect(css, `${designSystemPath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+
+    expect(css).toContain(':where(.system-b-marketing-not-found)');
+    expect(css).toContain(':where(.system-b-marketing-not-found-code)');
+    expect(css).toContain('var(--color-text-quaternary-token)');
+    expect(css).toContain('var(--space-');
+  });
+});


### PR DESCRIPTION
## Summary

Wave 1 of the marketing System B consolidation: additive `*-system-b-style-guard` test coverage for the already-migrated-but-unguarded public pages, following the established about/support/download guard model.

### Guards added (7 files, 17 tests, `apps/web/tests/unit/marketing/`)

**Strict contract** (no hex/rgba/hsla, no gradients, no box-shadow scales, no literal white/black utilities, no raw Tailwind color scales or arbitrary-value utilities, no inline styles, no System A `marketing-*-linear` editorial classes):

- `ai-system-b-style-guard.test.ts` — /ai + token anchors
- `investors-system-b-style-guard.test.ts` — /investors + token anchors
- `demovideo-system-b-style-guard.test.ts` — route + `DemoVideoPage`; `DemoVideoPlayer` keeps the shared-media-control carve-out (white/black play-button overlay) while banning literal color formats/gradients/arbitrary values
- `marketing-not-found-system-b-style-guard.test.ts` — route + tokenized-CSS check on the new `system-b-marketing-not-found` block in `styles/design-system.css`
- `legal-system-b-style-guard.test.ts` — (dynamic)/legal pages + minimal-variant layout + `LegalPage` + `PublicPageShell`

**Two-tier with documented debt** — the inventory was optimistic: these surfaces still carry pervasive inline System A (rgba gradients, white/black overlays, `marketing-*-linear`, `style=` props). Rather than restyle flagship pages in a test-coverage wave, the guards pin everything that is clean plus non-regression anchors, and enumerate the debt in header comments for the migration wave:

- `homepage-v2-system-b-style-guard.test.ts` — strict on route + `HomepageV2Ctas`; no-hex/no-raw-scales + System B shell/token/CTA anchors on `HomepageV2Route`
- `artist-profile/artist-profile-system-b-style-guard.test.ts` — strict on both routes + 6 clean components; family-wide ban on System A editorial classes across all 25 files; composition anchors

### Violations found + fixed minimally

- /ai, /investors: `rounded-[2rem]` → `rounded-4xl`
- (dynamic)/legal layout: `bg-white text-neutral-950 dark:...` → `bg-base text-primary-token` (html is always `dark`; rendering unchanged)
- marketing not-found: arbitrary `min-h-[calc(...)]` / `text-[120px]` numeral → tokenized `system-b-marketing-not-found(-code)` classes (mirrors the root not-found block)
- `DemoVideoPage`: dropped inline `style` prop, `text-white`/`border-white/20`/`hover:bg-white/10` → `text-primary-token`/`border-subtle`/`hover:bg-(--color-cell-hover)`
- `HomepageV2Ctas`: `max-w-[38rem]` → `max-w-xl` (dead branch — all call sites center)
- `{/* ui-casing-allow: marketing display headline */}` on the sentence-case display h1/h2s in /ai, /investors, and marketing not-found (founder-directed sentence-case exception for marketing display headlines)

## Verification

- New guards: 7 files / 17 tests pass
- `vitest run tests/unit/marketing tests/unit/design-system`: 51 files / 185 tests pass
- Related suites (demo, not-found sources, landing pages, public-surface guards): 23 files / 69 tests pass
- `pnpm biome check --write` on touched files: clean
- `pnpm --filter @jovie/web run typecheck -- --pretty false`: passes
