### PR TITLE
refactor(marketing): reskin system A holdouts onto system B, shrink ratchet allowlist

### DIFF
--- a/apps/web/app/(dynamic)/playlists/layout.tsx
+++ b/apps/web/app/(dynamic)/playlists/layout.tsx
@@ -8,7 +8,7 @@ export default function PlaylistsLayout({
 }>) {
   return (
     <PublicPageShell
-      className='dark linear-marketing overflow-x-clip bg-black dark:bg-black text-primary-token'
+      className='system-b-marketing dark overflow-x-clip bg-base text-primary-token'
       logoSize='xs'
     >
       {children}

--- a/apps/web/app/brand/layout.tsx
+++ b/apps/web/app/brand/layout.tsx
@@ -11,7 +11,7 @@ export default function BrandLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className='linear-marketing dark system-b-brand-layout'>
+    <div className='system-b-marketing dark system-b-brand-layout'>
       <SkipToContent />
       <MarketingHeader
         logoSize='sm'

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -5,7 +5,7 @@ import { NotFoundPageContent } from '@/components/site/NotFoundPageContent';
 
 export default function NotFound() {
   return (
-    <div className='system-b-root-not-found-page dark linear-marketing min-h-screen'>
+    <div className='system-b-root-not-found-page system-b-marketing dark min-h-screen'>
       <MarketingHeader logoSize='xs' variant='minimal' />
 
       <main

--- a/apps/web/app/pitch/layout.tsx
+++ b/apps/web/app/pitch/layout.tsx
@@ -8,7 +8,7 @@ export default function PitchLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className='dark linear-marketing min-h-svh bg-black dark:bg-black text-primary-token'>
+    <div className='system-b-marketing dark min-h-svh bg-base text-primary-token'>
       {children}
     </div>
   );

--- a/apps/web/components/features/home/MarketingScrollUnlock.tsx
+++ b/apps/web/components/features/home/MarketingScrollUnlock.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 
 /**
  * JS fallback that ensures marketing pages can scroll even if
- * the CSS `:has(.linear-marketing)` override doesn't apply
+ * the CSS `:has(.system-b-marketing)` override doesn't apply
  * (older browsers, hydration timing, etc.).
  */
 export function MarketingScrollUnlock() {

--- a/apps/web/public/pitch/colors_and_type.css
+++ b/apps/web/public/pitch/colors_and_type.css
@@ -4,9 +4,9 @@
  * Baseline: Linear.app March 2026 refresh, evolved with Jovie's identity.
  * Aesthetic: Apple meets Rekordbox. Dark-first, restrained, product-as-hero.
  *
- * Two systems:
- *   System A (marketing) — Satoshi + DM Sans, dark only, no brand color.
- *   System B (app/product) — Inter, light + dark.
+ * One system, two languages (System B canonical, System A retired 2026-06-18):
+ *   Body + UI — Inter (DM Sans retired 2026-06-18).
+ *   Display/hero — Satoshi (approved display exception).
  */
 
 /* -------------------------------------------------------------------------
@@ -15,7 +15,7 @@
  * They are not redistributed here — we substitute the nearest Google Fonts
  * equivalent. Swap @font-face to the self-hosted files when shipping prod.
  * ------------------------------------------------------------------------- */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=DM+Sans:wght@400..700&family=Source+Serif+4:wght@300..700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Source+Serif+4:wght@300..700&display=swap");
 /* Satoshi is not on Google Fonts. We substitute Manrope (nearest geometric
  * sans w/ weight 800 variant). FLAG: swap for self-hosted Satoshi for prod. */
 @import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400..800&display=swap");
@@ -23,14 +23,13 @@
 :root {
   /* ——— Font stacks ——— */
   --font-satoshi: "Manrope", "Satoshi Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-dm-sans: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif;
   --font-inter: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-serif: "Source Serif 4", Georgia, serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   /* Marketing scoped */
   --marketing-font-display: var(--font-satoshi);
-  --marketing-font-body: var(--font-dm-sans);
+  --marketing-font-body: var(--font-inter);
 
   /* ——— Font weights (Linear-derived) ——— */
   --fw-normal: 400;

--- a/apps/web/tests/unit/app/brand/system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/app/brand/system-b-style-guard.test.ts
@@ -54,6 +54,15 @@ function extractBrandCss(source: string): string {
 }
 
 describe('brand page System B source contract', () => {
+  it('renders /brand on the System B marketing wrapper, not System A', () => {
+    const layout = readFileSync(
+      resolve(process.cwd(), layoutSourcePath),
+      'utf8'
+    );
+    expect(layout).toContain('system-b-marketing dark');
+    expect(layout).not.toContain('linear-marketing');
+  });
+
   it('keeps brand route visuals on named System B primitives', () => {
     const sources = [
       [

--- a/apps/web/tests/unit/app/not-found-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/not-found-system-b-source.test.ts
@@ -20,6 +20,13 @@ const rawVisualUtilityPattern =
 const negativeTrackingPattern = /\btracking-(?:tight|tighter)\b/;
 
 describe('root not-found System B source tokens', () => {
+  it('renders the root not-found on the System B marketing wrapper, not System A', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).toContain('system-b-marketing dark');
+    expect(source).not.toContain('linear-marketing');
+  });
+
   it('keeps the route free of route-local visual token drift', async () => {
     const source = await readFile(sourcePath, 'utf8');
 

--- a/apps/web/tests/unit/app/playlists-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/app/playlists-system-b-style-guard.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /playlists layout System B source contract. Part of the founder-directed
+ * System A -> System B marketing migration (DESIGN.md 2026-06-18). The route
+ * layout was reskinned from the legacy `.linear-marketing` System A wrapper
+ * onto the semantic `.system-b-marketing` wrapper (same token block, Inter
+ * body + Satoshi display). See the /about guard for the shared contract:
+ * named System B token utilities only, no arbitrary values / hex / rgba /
+ * gradients / raw color scales / inline styles in the layout's own source.
+ */
+
+const sources = ['app/(dynamic)/playlists/layout.tsx'] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('playlists layout System B source contract', () => {
+  it('keeps the /playlists layout visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('renders /playlists on the System B marketing wrapper, not System A', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      expect(source, `${sourcePath} must use .system-b-marketing`).toContain(
+        'system-b-marketing dark'
+      );
+      expect(
+        source,
+        `${sourcePath} must not use the retired .linear-marketing wrapper`
+      ).not.toContain('linear-marketing');
+    }
+  });
+});

--- a/apps/web/tests/unit/design-system/singular-system-b-ratchet.test.ts
+++ b/apps/web/tests/unit/design-system/singular-system-b-ratchet.test.ts
@@ -30,9 +30,6 @@ const SKIP: RegExp[] = [
   /\/node_modules\//,
   /\/\.next\//,
   /\/\.turbo\//,
-  // Self-contained pitch reference stylesheet: defines its own --font-dm-sans and
-  // imports the Google webfont. Tracked for cleanup in the System A teardown phase.
-  /\/public\/pitch\//,
   // Server-side OG-image Satori rendering is a build-time asset, not live page type.
   /opengraph-image\.tsx$/,
   /\/lib\/share\/image-utils\.ts$/,
@@ -130,13 +127,11 @@ describe('singular System B — design-system unification ratchet', () => {
   it('.linear-marketing wrapper is shrink-only (System A is being retired)', () => {
     // Baseline 2026-06-18. This set may only SHRINK. Removing the wrapper from a
     // surface (reskinning it onto System B tokens) must also remove it here.
-    const APPLIERS_ALLOWLIST = new Set<string>([
-      'app/(dynamic)/playlists/layout.tsx',
-      'app/brand/layout.tsx',
-      'app/not-found.tsx',
-      'app/pitch/layout.tsx',
-      'components/features/home/MarketingScrollUnlock.tsx',
-    ]);
+    // 2026-07-21: last holdouts (playlists, brand, not-found, pitch,
+    // MarketingScrollUnlock) reskinned onto System B — the wrapper has no live
+    // appliers left. Keep this set EMPTY; the `.linear-marketing` CSS teardown
+    // in design-system.css is the final System A retirement step (later wave).
+    const APPLIERS_ALLOWLIST = new Set<string>([]);
 
     const files = [
       ...walk(resolve(WEB_ROOT, 'app'), ['.tsx', '.ts']),

--- a/apps/web/tests/unit/marketing/pitch-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/pitch-system-b-style-guard.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * /pitch System B source contract. Part of the founder-directed System A ->
+ * System B marketing migration (DESIGN.md 2026-06-18). The route layout was
+ * reskinned from the legacy `.linear-marketing` System A wrapper onto the
+ * semantic `.system-b-marketing` wrapper, and the public pitch reference
+ * stylesheet was converted off DM Sans (retired 2026-06-18) onto Inter body +
+ * Satoshi display. See the /about guard for the shared contract: named
+ * System B token utilities only, no arbitrary values / hex / rgba /
+ * gradients / raw color scales / inline styles in the route's own source.
+ */
+
+const sources = [
+  'app/pitch/layout.tsx',
+  'components/features/pitch/InvestorBrief.tsx',
+] as const;
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  /\bmarketing-(?:h[1-6]|kicker|lead|body)-?linear\b|\bmarketing-kicker\b/,
+] as const;
+
+describe('pitch System B source contract', () => {
+  it('keeps /pitch visuals on named System B primitives', () => {
+    for (const sourcePath of sources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('renders /pitch on the System B marketing wrapper, not System A', () => {
+    const layout = readFileSync(
+      resolve(process.cwd(), 'app/pitch/layout.tsx'),
+      'utf8'
+    );
+    expect(layout).toContain('system-b-marketing dark');
+    expect(layout).not.toContain('linear-marketing');
+  });
+
+  it('keeps the public pitch reference stylesheet off DM Sans (retired)', () => {
+    const css = readFileSync(
+      resolve(process.cwd(), 'public/pitch/colors_and_type.css'),
+      'utf8'
+    );
+    expect(css).not.toMatch(/--font-dm-sans/);
+    expect(css).not.toMatch(/DM\+Sans|"DM Sans"/);
+    expect(css).toContain('--marketing-font-body: var(--font-inter);');
+  });
+});

--- a/apps/web/tests/unit/marketing/scroll-unlock-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/scroll-unlock-system-b-style-guard.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * MarketingScrollUnlock System B contract. Part of the founder-directed
+ * System A -> System B marketing migration (DESIGN.md 2026-06-18). The helper
+ * is the JS fallback for the CSS `:has(.system-b-marketing)` scroll override
+ * in globals.css; it must track the System B wrapper, not the retired
+ * `.linear-marketing` System A wrapper, and must keep touching only
+ * documentElement (setting overflow on body promotes overflow-x:clip to a
+ * scroll container that breaks position:sticky).
+ */
+
+const sourcePath = 'components/features/home/MarketingScrollUnlock.tsx';
+
+describe('MarketingScrollUnlock System B contract', () => {
+  it('tracks the System B marketing wrapper, not System A', () => {
+    const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+    expect(source).toContain('system-b-marketing');
+    expect(source).not.toContain('linear-marketing');
+  });
+
+  it('keeps the scroll unlock scoped to documentElement only', () => {
+    const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+    expect(source).toContain(
+      "document.documentElement.style.overflowY = 'auto'"
+    );
+    expect(source).not.toMatch(/document\.body\.style/);
+  });
+});


### PR DESCRIPTION
## Summary

Wave 4 of the marketing consolidation (founder-directed System A retirement, DESIGN.md 2026-06-18). Reskins the five remaining `.linear-marketing` (System A) holdouts onto System B tokens and empties the ratchet allowlist.

## Per-surface changes

- **`app/(dynamic)/playlists/layout.tsx`** (/playlists) — `linear-marketing` + `bg-black` → `system-b-marketing dark bg-base`, mirroring the migrated `(marketing)/layout.tsx` wrapper.
- **`app/brand/layout.tsx`** (/brand) — wrapper class only: `linear-marketing` → `system-b-marketing`. Footer wiring (`HomeLegalFooter`) untouched (owned by Wave 3).
- **`app/not-found.tsx`** (global 404) — `linear-marketing` → `system-b-marketing`; `system-b-root-not-found-*` primitives unchanged.
- **`app/pitch/layout.tsx`** (/pitch) — `linear-marketing` + `bg-black` → `system-b-marketing dark bg-base`. Also converted `public/pitch/colors_and_type.css` in place off the retired DM Sans: dropped the Google Fonts DM Sans import, removed `--font-dm-sans`, repointed `--marketing-font-body` to Inter (`--font-inter`); Satoshi remains the display exception.
- **`components/features/home/MarketingScrollUnlock.tsx`** — minimal change only: comment now references the `:has(.system-b-marketing)` override (behavior unchanged; still documentElement-only).

`.system-b-marketing` is the semantic alias in the same token block as `.linear-marketing` (`styles/design-system.css`), so these are wrapper-class swaps with no visual-token drift. The only intentional difference: System B buttons render Inter instead of the System A display face.

## Ratchet allowlist

- **Before:** 5 entries (playlists, brand, not-found, pitch, MarketingScrollUnlock)
- **After:** empty — no live `.linear-marketing` appliers remain in `.tsx`/ `.ts`. The stale `/public/pitch/` SKIP entry (for the old DM Sans reference stylesheet) was also removed.

**Left for the final teardown wave:** deleting the `.linear-marketing` CSS definitions in `styles/design-system.css` (and the legacy `[data-theme="linear"]` aliases). The standalone static deck HTML files in `public/pitch/` (index/compact/print/market-funnel-slide) inline their own Google Fonts links and are outside the Next app; not touched here.

## Tests

- New guards: `tests/unit/app/playlists-system-b-style-guard.test.ts`, `tests/unit/marketing/pitch-system-b-style-guard.test.ts`, `tests/unit/marketing/scroll-unlock-system-b-style-guard.test.ts`
- Extended guards: `tests/unit/app/brand/system-b-style-guard.test.ts`, `tests/unit/app/not-found-system-b-source.test.ts` (wrapper-contract assertions)
- Ratchet: `tests/unit/design-system/singular-system-b-ratchet.test.ts` — allowlist emptied, shrink-only invariant kept

## Verification

- `vitest run` on ratchet + all new/extended guards: 18/18 green
- Related suites (brand, investors, playlists, globals-ui-feel, about, static-revalidate): 33/33 green
- `tsc` typecheck (@jovie/web): clean
- `biome check --write` on touched files: clean (1 formatting fix applied)
- Pre-commit (eslint + typecheck) and pre-push (CI harness validate) gates: green

## Risks

- Near-black page tone shift on /playlists and /pitch (`#000` → System B `--linear-bg-page #06070a`), matching the already-migrated marketing wrapper.
- Standalone `public/pitch/*.html` decks still reference DM Sans via their own inlined font links (self-contained, outside the app); flagged for the teardown wave.