### PR TITLE
fix(onboarding): close skeptic gaps on social attach handle check email

### DIFF
--- a/apps/web/app/api/handle/check/route.ts
+++ b/apps/web/app/api/handle/check/route.ts
@@ -1,18 +1,19 @@
 import crypto from 'node:crypto';
-import { eq } from 'drizzle-orm';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
-import { db } from '@/lib/db';
-import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { captureError } from '@/lib/error-tracking';
 import { RETRY_AFTER_TRANSIENT } from '@/lib/http/headers';
+import {
+  type HandleAvailabilityResult,
+  toHandleAvailabilityResult,
+} from '@/lib/onboarding/handle-availability';
 import {
   cacheHandleAvailability,
   getCachedHandleAvailability,
 } from '@/lib/onboarding/handle-availability-cache';
 import { enforceHandleCheckRateLimit } from '@/lib/onboarding/rate-limit';
+import { checkOnboardingHandleAvailability } from '@/lib/onboarding/reserved-handle';
 import { extractClientIP } from '@/lib/utils/ip-extraction';
-import { validateUsername } from '@/lib/validation/username';
 
 const NO_STORE_HEADERS = {
   'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
@@ -28,10 +29,8 @@ const NO_STORE_HEADERS = {
  * 2. Constant-time responses: All responses padded to ~100ms to prevent timing attacks
  * 3. Cryptographically secure random jitter: ±10ms jitter to prevent statistical analysis
  *
- * This prevents:
- * - Username enumeration attacks
- * - Timing-based username discovery
- * - Brute-force handle checking
+ * Availability semantics come from `checkOnboardingHandleAvailability` so taken
+ * handles always surface explicit `suggestedAlternatives` (never silent swaps).
  */
 
 // Target response time in ms (with ±10ms jitter)
@@ -66,6 +65,18 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function serializeHandleCheck(result: HandleAvailabilityResult) {
+  return {
+    available: result.available,
+    handle: result.handle,
+    reason: result.reason,
+    ...(result.error ? { error: result.error } : {}),
+    ...(result.suggestedAlternatives && result.suggestedAlternatives.length > 0
+      ? { suggestedAlternatives: result.suggestedAlternatives }
+      : {}),
+  };
+}
+
 export async function GET(request: Request) {
   const startTime = Date.now();
   const { searchParams } = new URL(request.url);
@@ -88,44 +99,12 @@ export async function GET(request: Request) {
 
   if (!handle) {
     return respondWithConstantTime(
-      { available: false, error: 'Handle is required' },
-      { status: 400 }
-    );
-  }
-
-  // Validate handle format using the canonical shared validator so this API
-  // accepts the same inputs as the onboarding form and completeOnboarding
-  // server action. Previously this route used a stricter local regex that
-  // rejected dots and underscores, even though those characters are allowed
-  // throughout the rest of the system — users would see a "green" client-side
-  // validation for "my.handle" but then get blocked here with a confusing
-  // "letters, numbers, and hyphens" error.
-  //
-  // Wrapped in try/catch so that an unexpected throw from the validator
-  // (e.g. content-filter loaded at runtime) still produces a constant-time
-  // response rather than bypassing the constant-time guarantee with a 500.
-  //
-  // A validator throw is a transient internal failure, not bad client input,
-  // so return 503 — a 400 here would mislead clients into believing their
-  // input was rejected and hide incident semantics from monitoring.
-  let formatCheck: { isValid: boolean; error?: string };
-  try {
-    formatCheck = validateUsername(handle);
-  } catch (error) {
-    await captureError('validateUsername threw', error, {
-      handle,
-      route: '/api/handle/check',
-    });
-    return respondWithConstantTime(
-      { available: false, error: 'Handle check temporarily unavailable' },
-      { status: 503 }
-    );
-  }
-  if (!formatCheck.isValid) {
-    // `validateUsername` always populates `error` on the `isValid: false`
-    // branch (see `validateUsernameCore`), so no runtime fallback is needed.
-    return respondWithConstantTime(
-      { available: false, error: formatCheck.error },
+      serializeHandleCheck(
+        toHandleAvailabilityResult({
+          handle: '',
+          error: 'Handle is required',
+        })
+      ),
       { status: 400 }
     );
   }
@@ -138,37 +117,45 @@ export async function GET(request: Request) {
 
     const handleLower = handle.toLowerCase();
 
+    // Fast path: cached boolean availability still goes through the canonical
+    // contract so taken handles expose suggestedAlternatives consistently.
     const cachedAvailability = await getCachedHandleAvailability(handleLower);
     if (cachedAvailability !== null) {
-      return respondWithConstantTime({ available: cachedAvailability });
+      const cachedResult = toHandleAvailabilityResult({
+        handle: handleLower,
+        available: cachedAvailability,
+      });
+      return respondWithConstantTime(serializeHandleCheck(cachedResult));
     }
 
-    // Add timeout to prevent hanging on database issues
+    // Canonical check (format/reserved/taken + explicit alternatives).
+    // Timeout protects against hanging DB issues while preserving constant-time
+    // response shape.
     let timerId: ReturnType<typeof setTimeout> | undefined;
-    let data: Array<{ username: string }>;
+    let result: HandleAvailabilityResult;
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
-        timerId = setTimeout(() => reject(new Error('Database timeout')), 3000); // 3 second timeout
+        timerId = setTimeout(() => reject(new Error('Database timeout')), 3000);
       });
-
-      data = await Promise.race([
-        db
-          .select({ username: creatorProfiles.username })
-          .from(creatorProfiles)
-          .where(eq(creatorProfiles.usernameNormalized, handleLower))
-          .limit(1),
+      result = await Promise.race([
+        checkOnboardingHandleAvailability(handle),
         timeoutPromise,
       ]);
     } finally {
       if (timerId !== undefined) clearTimeout(timerId);
     }
 
-    const isAvailable = !data || data.length === 0;
-    await cacheHandleAvailability(handleLower, isAvailable);
+    // Only cache definitive available/taken outcomes.
+    if (result.reason === 'available' || result.reason === 'taken') {
+      await cacheHandleAvailability(result.handle, result.available);
+    }
 
-    // SECURITY: Return with constant timing to prevent timing attacks
-    // An attacker cannot determine if a handle exists based on response time
-    return respondWithConstantTime({ available: isAvailable });
+    const status =
+      result.reason === 'invalid_format' || result.reason === 'reserved'
+        ? 400
+        : 200;
+
+    return respondWithConstantTime(serializeHandleCheck(result), { status });
   } catch (error: unknown) {
     await captureError('Error checking handle availability', error, {
       handle,
@@ -178,7 +165,13 @@ export async function GET(request: Request) {
     // Handle rate limiting - still use constant time
     if (error instanceof Error && error.message.includes('RATE_LIMITED')) {
       return respondWithConstantTime(
-        { available: false, error: 'Too many requests. Please wait.' },
+        serializeHandleCheck(
+          toHandleAvailabilityResult({
+            handle,
+            available: false,
+            error: 'Too many requests. Please wait.',
+          })
+        ),
         { status: 429 }
       );
     }
@@ -189,13 +182,25 @@ export async function GET(request: Request) {
       (error as Error)?.message?.includes('Database timeout')
     ) {
       return respondWithConstantTime(
-        { available: false, error: 'Service temporarily unavailable' },
+        serializeHandleCheck(
+          toHandleAvailabilityResult({
+            handle,
+            available: false,
+            error: 'Service temporarily unavailable',
+          })
+        ),
         { status: 503, headers: { 'Retry-After': RETRY_AFTER_TRANSIENT } }
       );
     }
 
     return respondWithConstantTime(
-      { available: false, error: 'Database connection failed' },
+      serializeHandleCheck(
+        toHandleAvailabilityResult({
+          handle,
+          available: false,
+          error: 'Database connection failed',
+        })
+      ),
       { status: 500 }
     );
   }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/lib/chat/onboarding-script/widget-events';
 import { useAppFlag } from '@/lib/flags/client';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
+import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { cn } from '@/lib/utils';
 import { ChatProposeCheckoutCard } from './ChatProposeCheckoutCard';
 import { ChatProposeNextStepCard } from './ChatProposeNextStepCard';
@@ -836,9 +837,12 @@ export function OnboardingChat({
 
   const handleAttachAccount = useCallback(
     (url: string) => {
+      // Fail closed: incomplete hosts (e.g. instagram.com/) never advance the SM.
+      const parsed = parseSocialLinkInput(url);
+      if (!parsed.ok) return;
       const payload = {
         onboardingEvent: ONBOARDING_WIDGET_EVENTS.SOCIAL_ATTACHED,
-        url,
+        url: parsed.url,
       } as const;
       submitText(widgetEventDisplayText(payload), payload);
     },

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -27,6 +27,7 @@ import {
   SUGGESTED_AVAILABLE_HANDLE_LABEL,
   toHandleAvailabilityResult,
 } from '@/lib/onboarding/handle-availability';
+import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useHandleAvailabilityQuery } from '@/lib/queries/useHandleAvailabilityQuery';
 import { cn } from '@/lib/utils';
@@ -636,6 +637,7 @@ export function OnboardingHandleCheckCard({
     handle: normalizedDraft || handle || '',
     available: loading ? null : (availabilityQuery.data?.available ?? null),
     error: availabilityQuery.data?.error,
+    suggestedAlternatives: availabilityQuery.data?.suggestedAlternatives,
     checking: loading,
   });
   const available =
@@ -783,10 +785,19 @@ export function OnboardingSocialLinkCard({
   }
 
   const trimmed = draftUrl.trim();
-  const host = hostnameFor(trimmed || undefined);
+  const parsed = parseSocialLinkInput(trimmed);
+  const attachableUrl = parsed.ok ? parsed.url : null;
+  const host = attachableUrl
+    ? hostnameFor(attachableUrl)
+    : hostnameFor(trimmed || undefined);
+  const parseHint =
+    !trimmed || parsed.ok
+      ? null
+      : parsed.reason === 'missing_account_path'
+        ? 'Add the account path (e.g. instagram.com/yourname).'
+        : 'Paste a full profile URL with the account path.';
   const canAttach =
-    Boolean(trimmed) &&
-    Boolean(host) &&
+    Boolean(attachableUrl) &&
     !disabled &&
     !attached &&
     Boolean(onAttachAccount);
@@ -806,7 +817,9 @@ export function OnboardingSocialLinkCard({
         </span>
         <div className='min-w-0 flex-1'>
           <p className='text-sm font-semibold leading-5 tracking-[-0.01em] text-primary-token'>
-            {host ? 'Link ready to attach' : 'Attach a public social account'}
+            {attachableUrl
+              ? 'Link ready to attach'
+              : 'Attach a public social account'}
           </p>
           <label className='mt-2 flex h-9 items-center rounded-lg border border-subtle bg-surface-0 px-2.5 focus-within:border-white/[0.16] focus-within:shadow-[0_0_0_3px_rgba(255,255,255,0.035)]'>
             <span className='sr-only'>Social Profile URL</span>
@@ -823,7 +836,7 @@ export function OnboardingSocialLinkCard({
             />
           </label>
           <p className='mt-1.5 text-xs leading-5 text-secondary-token'>
-            {host ?? 'Paste the full URL fans already use.'}
+            {parseHint ?? host ?? 'Paste the full URL fans already use.'}
           </p>
           {onAttachAccount ? (
             <Button
@@ -831,9 +844,9 @@ export function OnboardingSocialLinkCard({
               data-testid='onboarding-attach-account'
               disabled={!canAttach}
               onClick={() => {
-                if (!canAttach || !trimmed) return;
+                if (!canAttach || !attachableUrl) return;
                 setAttached(true);
-                onAttachAccount(trimmed);
+                onAttachAccount(attachableUrl);
               }}
               className={cn(
                 'mt-3 h-9 rounded-full px-3.5 text-app font-semibold',

--- a/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
+++ b/apps/web/components/features/waitlist/WaitlistOutcomeView.tsx
@@ -19,63 +19,79 @@ interface WaitlistOutcomeViewProps {
   readonly email?: string | null;
 }
 
-const OUTCOME_COPY: Record<
-  WaitlistOutcomeViewProps['outcome'],
-  {
-    readonly title: string;
-    readonly body: string;
-    readonly icon: typeof CheckCircle2;
-    readonly actionLabel?: string;
-    readonly actionHref?: string;
-    readonly showNextSteps?: boolean;
-  }
-> = {
+type OutcomeCopy = {
+  readonly title: string;
+  /** Body may depend on whether a contact email is known (never invent one). */
+  readonly body: (hasEmail: boolean) => string;
+  readonly icon: typeof CheckCircle2;
+  readonly actionLabel?: string;
+  readonly actionHref?: string;
+  readonly showNextSteps?: boolean;
+};
+
+const OUTCOME_COPY: Record<WaitlistOutcomeViewProps['outcome'], OutcomeCopy> = {
   accepted: {
     title: 'You Have Access',
-    body: 'We saved your release context. Continue setup to finish your profile and open Jovie.',
+    body: () =>
+      'We saved your release context. Continue setup to finish your profile and open Jovie.',
     icon: CheckCircle2,
     actionLabel: 'Continue Setup',
     actionHref: APP_ROUTES.START,
   },
   already_accepted: {
     title: 'You Have Access',
-    body: 'Your request has already been approved. Continue setup to finish your profile.',
+    body: () =>
+      'Your request has already been approved. Continue setup to finish your profile.',
     icon: CheckCircle2,
     actionLabel: 'Continue Setup',
     actionHref: APP_ROUTES.START,
   },
   waitlisted_gate_on: {
     title: 'Request Saved',
-    body: 'Jovie is in a private rollout. We saved your release context and will email you when access opens — usually within a few days of capacity.',
+    body: hasEmail =>
+      hasEmail
+        ? 'Jovie is in a private rollout. We saved your release context and will email you when access opens — usually within a few days of capacity.'
+        : 'Jovie is in a private rollout. We saved your release context. Return to /start when a spot opens — usually within a few days of capacity.',
     icon: Clock3,
     showNextSteps: true,
   },
   waitlisted_capacity_full: {
     title: "Today's Access Is Full",
-    body: "Your request is saved. Today's slots are full, so you are on the waitlist. We email when a spot opens.",
+    body: hasEmail =>
+      hasEmail
+        ? "Your request is saved. Today's slots are full, so you are on the waitlist. We email when a spot opens."
+        : "Your request is saved. Today's slots are full, so you are on the waitlist. Check back via /start when capacity opens.",
     icon: Clock3,
     showNextSteps: true,
   },
   already_waitlisted: {
     title: 'Request Already Received',
-    body: 'Your request is already saved with your latest answers. Watch for an email when access opens.',
+    body: hasEmail =>
+      hasEmail
+        ? 'Your request is already saved with your latest answers. Watch for an email when access opens.'
+        : 'Your request is already saved with your latest answers. Return via /start when access opens.',
     icon: Clock3,
     showNextSteps: true,
   },
   pending: {
     title: "You're on the list",
-    body: "Request saved. We'll email you when a spot opens — typically within a few days of capacity.",
+    body: hasEmail =>
+      hasEmail
+        ? "Request saved. We'll email you when a spot opens — typically within a few days of capacity."
+        : 'Request saved. Return via /start when a spot opens — typically within a few days of capacity.',
     icon: Clock3,
     showNextSteps: true,
   },
   save_failed: {
     title: "We Couldn't Save This",
-    body: 'Your answers are still on this device. Try again so we can save the required fields before reviewing access.',
+    body: () =>
+      'Your answers are still on this device. Try again so we can save the required fields before reviewing access.',
     icon: RotateCcw,
   },
   rate_limited: {
     title: 'Too Many Attempts',
-    body: 'Please wait a moment before trying again. Your answers are still on this device.',
+    body: () =>
+      'Please wait a moment before trying again. Your answers are still on this device.',
     icon: Clock3,
   },
 };
@@ -86,16 +102,17 @@ const SECONDARY_BTN_CLASS =
   'inline-flex h-10 items-center justify-center gap-2 rounded-full border border-white/[0.12] px-4 text-app font-semibold text-white/86 transition-colors hover:bg-white/[0.04] focus-ring-themed';
 
 function NextSteps({ email }: { readonly email?: string | null }) {
-  const emailLine = email?.trim()
-    ? `Watch ${email.trim()} for the access email.`
-    : 'Watch the email you used on this request.';
+  const knownEmail = email?.trim() || null;
+  const contactLine = knownEmail
+    ? `Watch ${knownEmail} for the access email.`
+    : 'Add a contact email at sign-in if you want a heads-up when access opens.';
 
   return (
     <ol
       className='mt-4 list-decimal space-y-1.5 pl-5 text-sm leading-6 text-white/62'
       data-testid='waitlist-next-steps'
     >
-      <li>{emailLine}</li>
+      <li>{contactLine}</li>
       <li>Expected timing: a few days once capacity opens — not instant.</li>
       <li>
         Resume anytime at{' '}
@@ -135,6 +152,8 @@ export function WaitlistOutcomeView({
 }: Readonly<WaitlistOutcomeViewProps>) {
   const copy = OUTCOME_COPY[outcome];
   const Icon = copy.icon;
+  const hasEmail = Boolean(email?.trim());
+  const body = copy.body(hasEmail);
   const canRetry =
     (outcome === 'save_failed' || outcome === 'rate_limited') && onRetry;
   const { signOut } = useAuthSafe();
@@ -152,7 +171,7 @@ export function WaitlistOutcomeView({
           {copy.title}
         </h1>
       </div>
-      <p className='text-sm leading-6 text-white/62'>{copy.body}</p>
+      <p className='text-sm leading-6 text-white/62'>{body}</p>
       {copy.showNextSteps ? <NextSteps email={email} /> : null}
 
       <div className='mt-6 flex flex-col gap-2 sm:flex-row'>

--- a/apps/web/lib/chat/prompts/onboarding.ts
+++ b/apps/web/lib/chat/prompts/onboarding.ts
@@ -9,8 +9,24 @@ import { buildOnboardingPromptSecuritySection } from '@/lib/chat/prompt-disclosu
 /** Shared opener / waitlist receipts — imported by the script bank to avoid copy drift. */
 export const ONBOARDING_OPENER_PRIMARY =
   "Hey — I'm Jovie. Early access is limited — some artists waitlist first. I'll remember this chat if you sign up. What are you working on?";
+/** Waitlist receipt without promising email (no contact address confirmed yet). */
 export const ONBOARDING_WAITLIST_RECEIPT =
+  'On the early list. Return here or /start to resume when a spot opens.';
+/** Waitlist receipt only when a concrete email is known. */
+export const ONBOARDING_WAITLIST_RECEIPT_WITH_EMAIL =
   "On the early list. We'll email when a spot opens — return here or /start to resume.";
+
+/**
+ * Choose waitlist receipt copy. Email promise is gated on a known contact.
+ */
+export function waitlistReceiptForEmail(
+  email: string | null | undefined
+): string {
+  const trimmed = email?.trim();
+  return trimmed
+    ? ONBOARDING_WAITLIST_RECEIPT_WITH_EMAIL
+    : ONBOARDING_WAITLIST_RECEIPT;
+}
 
 export const ONBOARDING_CALIBRATION_EXAMPLES = {
   opener: ONBOARDING_OPENER_PRIMARY,

--- a/apps/web/lib/chat/prompts/onboarding.waitlist-receipt.test.ts
+++ b/apps/web/lib/chat/prompts/onboarding.waitlist-receipt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ONBOARDING_WAITLIST_RECEIPT,
+  ONBOARDING_WAITLIST_RECEIPT_WITH_EMAIL,
+  waitlistReceiptForEmail,
+} from './onboarding';
+
+describe('waitlistReceiptForEmail', () => {
+  it('does not promise email when contact is unknown', () => {
+    const text = waitlistReceiptForEmail(null);
+    expect(text).toBe(ONBOARDING_WAITLIST_RECEIPT);
+    expect(text.toLowerCase()).not.toMatch(/email/);
+  });
+
+  it('promises email only when contact is known', () => {
+    const text = waitlistReceiptForEmail('artist@example.com');
+    expect(text).toBe(ONBOARDING_WAITLIST_RECEIPT_WITH_EMAIL);
+    expect(text.toLowerCase()).toMatch(/email/);
+  });
+});

--- a/apps/web/lib/queries/useHandleAvailabilityQuery.ts
+++ b/apps/web/lib/queries/useHandleAvailabilityQuery.ts
@@ -6,10 +6,15 @@ import { queryKeys } from './keys';
 
 /**
  * Response from the handle availability check API.
+ * Mirrors the canonical `HandleAvailabilityResult` contract fields used by UI.
  */
 export interface HandleAvailabilityResponse {
   available: boolean;
+  handle?: string;
+  reason?: string;
   error?: string;
+  /** Explicit alternatives when taken — never silent renames. */
+  suggestedAlternatives?: readonly string[];
 }
 
 /**

--- a/apps/web/tests/unit/api/handle/check.test.ts
+++ b/apps/web/tests/unit/api/handle/check.test.ts
@@ -1,20 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockDbSelect = vi.hoisted(() => vi.fn());
 const mockEnforceHandleCheckRateLimit = vi.hoisted(() => vi.fn());
 const mockExtractClientIP = vi.hoisted(() => vi.fn());
 const mockGetCachedHandleAvailability = vi.hoisted(() => vi.fn());
 const mockCacheHandleAvailability = vi.hoisted(() => vi.fn());
-
-vi.mock('@/lib/db', () => ({
-  db: {
-    select: mockDbSelect,
-  },
-}));
-
-vi.mock('@/lib/db/schema', () => ({
-  creatorProfiles: {},
-}));
+const mockCheckOnboardingHandleAvailability = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/onboarding/rate-limit', () => ({
   enforceHandleCheckRateLimit: mockEnforceHandleCheckRateLimit,
@@ -27,6 +17,10 @@ vi.mock('@/lib/utils/ip-extraction', () => ({
 vi.mock('@/lib/onboarding/handle-availability-cache', () => ({
   getCachedHandleAvailability: mockGetCachedHandleAvailability,
   cacheHandleAvailability: mockCacheHandleAvailability,
+}));
+
+vi.mock('@/lib/onboarding/reserved-handle', () => ({
+  checkOnboardingHandleAvailability: mockCheckOnboardingHandleAvailability,
 }));
 
 vi.mock('@/lib/error-tracking', () => ({
@@ -46,6 +40,11 @@ describe('GET /api/handle/check', () => {
     mockEnforceHandleCheckRateLimit.mockResolvedValue(undefined);
     mockGetCachedHandleAvailability.mockResolvedValue(null);
     mockCacheHandleAvailability.mockResolvedValue(undefined);
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'available-handle',
+      available: true,
+      reason: 'available',
+    });
   });
 
   it('returns 400 when handle is missing', async () => {
@@ -58,9 +57,17 @@ describe('GET /api/handle/check', () => {
     expect(response.status).toBe(400);
     expect(data.available).toBe(false);
     expect(data.error).toBe('Handle is required');
+    expect(mockCheckOnboardingHandleAvailability).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when handle is too short', async () => {
+  it('returns 400 when handle is too short via canonical helper', async () => {
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'ab',
+      available: false,
+      reason: 'invalid_format',
+      error: 'Username must be at least 3 characters',
+    });
+
     const { GET } = await import('@/app/api/handle/check/route');
     const request = new Request('http://localhost/api/handle/check?handle=ab');
 
@@ -72,10 +79,16 @@ describe('GET /api/handle/check', () => {
     expect(data.error).toContain('at least 3');
   });
 
-  it('returns 400 when handle is too long', async () => {
-    const { GET } = await import('@/app/api/handle/check/route');
-    // USERNAME_MAX_LENGTH is 30 in the canonical validator; 31 is rejected
+  it('returns 400 when handle is too long via canonical helper', async () => {
     const longHandle = 'a'.repeat(31);
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: longHandle,
+      available: false,
+      reason: 'invalid_format',
+      error: 'Username must be no more than 30 characters',
+    });
+
+    const { GET } = await import('@/app/api/handle/check/route');
     const request = new Request(
       `http://localhost/api/handle/check?handle=${longHandle}`
     );
@@ -88,7 +101,15 @@ describe('GET /api/handle/check', () => {
     expect(data.error).toContain('no more than 30');
   });
 
-  it('returns 400 when handle has invalid characters', async () => {
+  it('returns 400 when handle has invalid characters via canonical helper', async () => {
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'test@user',
+      available: false,
+      reason: 'invalid_format',
+      error:
+        'Username can only contain letters, numbers, hyphens, underscores, and dots',
+    });
+
     const { GET } = await import('@/app/api/handle/check/route');
     const request = new Request(
       'http://localhost/api/handle/check?handle=test%40user'
@@ -99,18 +120,14 @@ describe('GET /api/handle/check', () => {
 
     expect(response.status).toBe(400);
     expect(data.available).toBe(false);
-    // Canonical error message now aligns with the onboarding form validator:
-    // letters, numbers, hyphens, underscores, and dots are accepted.
     expect(data.error).toContain('letters, numbers');
   });
 
-  it('accepts dotted handles like real.name and delegates to DB lookup', async () => {
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
-      }),
+  it('accepts dotted handles and returns available true', async () => {
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'real.name',
+      available: true,
+      reason: 'available',
     });
 
     const { GET } = await import('@/app/api/handle/check/route');
@@ -121,20 +138,16 @@ describe('GET /api/handle/check', () => {
     const response = await GET(request);
     const data = await response.json();
 
-    // Pre-fix this returned 400 "letters, numbers, and hyphens" even though the
-    // onboarding form (and completeOnboarding) happily accept real.name.
     expect(response.status).toBe(200);
     expect(data.available).toBe(true);
     expect(mockCacheHandleAvailability).toHaveBeenCalledWith('real.name', true);
   });
 
-  it('accepts underscored handles like real_name and delegates to DB lookup', async () => {
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
-      }),
+  it('accepts underscored handles and returns available true', async () => {
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'real_name',
+      available: true,
+      reason: 'available',
     });
 
     const { GET } = await import('@/app/api/handle/check/route');
@@ -150,7 +163,15 @@ describe('GET /api/handle/check', () => {
     expect(mockCacheHandleAvailability).toHaveBeenCalledWith('real_name', true);
   });
 
-  it('rejects reserved handles before hitting the database', async () => {
+  it('rejects reserved handles before DB via canonical helper', async () => {
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'admin',
+      available: false,
+      reason: 'reserved',
+      error: 'This handle is reserved',
+      suggestedAlternatives: ['admin1', 'admin2', 'admin3'],
+    });
+
     const { GET } = await import('@/app/api/handle/check/route');
     const request = new Request(
       'http://localhost/api/handle/check?handle=admin'
@@ -161,11 +182,11 @@ describe('GET /api/handle/check', () => {
 
     expect(response.status).toBe(400);
     expect(data.available).toBe(false);
-    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(data.suggestedAlternatives).toEqual(['admin1', 'admin2', 'admin3']);
   });
 
-  it('uses cached availability when present', async () => {
-    mockGetCachedHandleAvailability.mockResolvedValue(true);
+  it('uses cached availability when present and still surfaces alternatives when taken', async () => {
+    mockGetCachedHandleAvailability.mockResolvedValue(false);
 
     const { GET } = await import('@/app/api/handle/check/route');
     const request = new Request(
@@ -176,17 +197,16 @@ describe('GET /api/handle/check', () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.available).toBe(true);
-    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(data.available).toBe(false);
+    expect(data.suggestedAlternatives?.[0]).toMatch(/^cachedhandle\d+$/);
+    expect(mockCheckOnboardingHandleAvailability).not.toHaveBeenCalled();
   });
 
   it('returns available true when handle is not taken', async () => {
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
-      }),
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'available-handle',
+      available: true,
+      reason: 'available',
     });
 
     const { GET } = await import('@/app/api/handle/check/route');
@@ -199,19 +219,19 @@ describe('GET /api/handle/check', () => {
 
     expect(response.status).toBe(200);
     expect(data.available).toBe(true);
+    expect(data.suggestedAlternatives).toBeUndefined();
     expect(mockCacheHandleAvailability).toHaveBeenCalledWith(
       'available-handle',
       true
     );
   });
 
-  it('returns available false when handle is taken', async () => {
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ username: 'takenhandle' }]),
-        }),
-      }),
+  it('returns available false with suggestedAlternatives when taken', async () => {
+    mockCheckOnboardingHandleAvailability.mockResolvedValue({
+      handle: 'takenhandle',
+      available: false,
+      reason: 'taken',
+      suggestedAlternatives: ['takenhandle1', 'takenhandle2', 'takenhandle3'],
     });
 
     const { GET } = await import('@/app/api/handle/check/route');
@@ -224,6 +244,16 @@ describe('GET /api/handle/check', () => {
 
     expect(response.status).toBe(200);
     expect(data.available).toBe(false);
+    expect(data.reason).toBe('taken');
+    expect(data.suggestedAlternatives).toEqual([
+      'takenhandle1',
+      'takenhandle2',
+      'takenhandle3',
+    ]);
+    expect(mockCacheHandleAvailability).toHaveBeenCalledWith(
+      'takenhandle',
+      false
+    );
   });
 
   it('returns 429 when rate limited', async () => {

--- a/apps/web/tests/unit/onboarding/OnboardingToolArtifacts.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingToolArtifacts.test.tsx
@@ -304,9 +304,30 @@ describe('onboarding tool artifacts', () => {
     ).toBeDefined();
     expect(screen.queryByText('proposeSocialLink')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Attach Account' }));
+    // Canonical parse normalizes to full Instagram profile URL with path.
     expect(onAttachAccount).toHaveBeenCalledWith(
-      'https://instagram.com/testartist'
+      'https://www.instagram.com/testartist/'
     );
+  });
+
+  it('disables Attach Account for bare instagram.com host without path', () => {
+    const onAttachAccount = vi.fn();
+    fastRender(
+      <OnboardingSocialLinkCard
+        state='output-available'
+        output={{
+          action: 'propose_social_link',
+          url: 'https://instagram.com',
+        }}
+        onAttachAccount={onAttachAccount}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Attach Account' });
+    expect(button).toHaveProperty('disabled', true);
+    fireEvent.click(button);
+    expect(onAttachAccount).not.toHaveBeenCalled();
+    expect(screen.getByText(/Add the account path/i)).toBeDefined();
   });
 
   it('offers None of These when artist results are present', () => {


### PR DESCRIPTION
## Summary
Closes remaining real-path gaps from the onboarding audit verification:

1. **Social attach** — `OnboardingSocialLinkCard` and `handleAttachAccount` require `parseSocialLinkInput` success; bare hosts like `instagram.com` cannot attach; only `parsed.url` is submitted.
2. **Handle check API** — `/api/handle/check` routes through `checkOnboardingHandleAvailability` / canonical contract and returns `suggestedAlternatives` when taken (no silent renames).
3. **Waitlist email copy** — email promises are gated on a known contact via `waitlistReceiptForEmail` + WaitlistOutcomeView body selection.

## Test plan
- [x] `vitest` OnboardingToolArtifacts (attach bare host disabled; full path attaches normalized URL)
- [x] `vitest` `/api/handle/check` (taken → suggestedAlternatives)
- [x] `vitest` waitlist receipt gating
- [x] typecheck via pre-commit