### PR TITLE
refactor(design-system): delete retired .linear-marketing CSS (system A teardown)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -123,7 +123,6 @@ html[data-desktop-runtime="electron"] [data-shell-design="shellChatV1"]
 /* Marketing pages use document scrolling rather than app-shell scroll panes.
    Only override html — setting overflow-y:auto on body promotes overflow-x:clip
    to overflow-x:hidden, which creates a scroll container that breaks sticky. */
-html:has(.linear-marketing),
 html:has(.system-b-marketing),
 html:has(.home-viewport) {
   height: auto;
@@ -131,7 +130,6 @@ html:has(.home-viewport) {
   overflow-y: auto;
   overscroll-behavior: auto;
 }
-body:has(.linear-marketing),
 body:has(.system-b-marketing),
 body:has(.home-viewport) {
   height: auto;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1830,16 +1830,15 @@ html[data-profile-initial-mode]
    ============================================
 
    Activate Linear styling on marketing pages by adding
-   [data-theme="linear"] to a parent element or using
-   the legacy .linear-marketing class or the semantic .system-b-marketing
-   wrapper while the remaining legacy surfaces migrate separately.
+   [data-theme="linear"] to a parent element or the semantic
+   .system-b-marketing wrapper. The legacy .linear-marketing class is
+   retired (System A teardown, 2026-07-21).
 
    This maps Linear tokens to the existing design system
    variables for seamless integration.
 */
 
 [data-theme="linear"],
-.linear-marketing,
 .system-b-marketing {
   /* Unified type (one system, two languages): Inter body + UI; Satoshi reserved
      for display/headings (approved exception). DM Sans retired 2026-06-18. */
@@ -1878,7 +1877,6 @@ html[data-profile-initial-mode]
   --color-border-focus: var(--linear-border-focus);
 }
 
-.linear-marketing.dark,
 .system-b-marketing.dark,
 .home-viewport.dark,
 .system-b-root-not-found-page.dark {
@@ -1966,7 +1964,6 @@ html:not(.dark) [data-testid^="profile-mode-drawer"] :where(a, button, span) {
   transition: none !important;
 }
 
-html:not(.dark) .linear-marketing :where(a, button, span),
 html:not(.dark) .system-b-marketing :where(a, button, span),
 html:not(.dark) [data-testid="header-nav"] a[href="/signin"],
 html:not(.dark) [data-testid="not-found"] :where(a, button, span),
@@ -1979,24 +1976,12 @@ html:not(.dark) .smart-link-powered-by {
 }
 
 /* Marketing typography: headings use Satoshi (display font). Product controls
-   on semantic System B surfaces use Inter; the legacy wrapper keeps its
-   existing display treatment until System A is fully retired. */
-.linear-marketing h1,
-.linear-marketing h2,
-.linear-marketing h3,
-.linear-marketing h4,
+   on semantic System B surfaces use Inter. */
 .system-b-marketing h1,
 .system-b-marketing h2,
 .system-b-marketing h3,
 .system-b-marketing h4 {
   font-family: var(--marketing-font-display);
-}
-
-.linear-marketing button,
-.linear-marketing [role="button"],
-.linear-marketing a[class*="btn"] {
-  font-family: var(--marketing-font-display);
-  letter-spacing: -0.01em;
 }
 
 .system-b-marketing button,
@@ -12395,7 +12380,7 @@ body:has(.system-b-brand-page) .marketing-glass-header__cta:focus-visible {
    stops: -bg (subtle fill / atmosphere), -solid (text/icon/halo), -fg (legible
    text on -solid). Used to rotate accents across feature surfaces (Bento,
    Profile hero, Loop diagram). Never use as primary CTA color — primary CTA
-   stays white-on-black per .linear-marketing contract above.
+   stays white-on-black per the neutral-CTA rule (DESIGN.md, 2026-04-11).
 
    Source: home-page-hero handoff bundle (Claude Design 2026-04).
 */

--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -381,7 +381,6 @@
 
 :root.dark,
 .system-b-marketing.dark,
-.linear-marketing.dark,
 [data-theme="linear"].dark {
   /* Text — extracted directly from linear.app computed styles (2026-03-10):
      --color-text-primary: #f7f8f8  (rgb 247,248,248)


### PR DESCRIPTION
## What

Final System A teardown. The ratchet allowlist went empty in #14630 (all holdouts reskinned); this deletes the retired `.linear-marketing` selectors:

- `design-system.css`: removed from the shared token block selector groups, the marketing h1-h4 display-font group, the System A button-font rule, and the transition-none group; comments updated
- `linear-tokens.css`: removed from the `:root.dark` group
- `globals.css`: removed from the document-scroll unlock rules

The underlying `--linear-*` token *values* stay — they are consumed app-wide; `.system-b-marketing` is the semantic marketing wrapper going forward.

## Verification

- 54 files / 195 tests green (design-system + marketing suites, incl. the singular-system-b ratchet and all reskin guards)
- Zero remaining `.linear-marketing` references outside absence-assertions in guard tests and comments