### PR TITLE
fix(audio): dedupe sidebar mini-player vs persistent bar, dock the now-playing surface (JOV-3511)

### DIFF
--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -36,8 +36,11 @@ const SHELL_AUDIO_BAR_TRANSITION =
   'max-height var(--ds-motion-cinematic-duration) var(--ds-motion-cinematic-easing), opacity var(--ds-motion-cinematic-duration) var(--ds-motion-cinematic-easing), transform var(--ds-motion-cinematic-duration) var(--ds-motion-cinematic-easing)';
 const SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME =
   'transition-[max-height,opacity,transform,border-color,background-color] duration-cinematic ease-cinematic';
+// Docked flat into the expanded bar surface (JOV-3511): no card border,
+// surface fill, or drop shadow — the track row sits directly on the docked
+// bar instead of floating elevated above it.
 const SHELL_NOW_PLAYING_CARD_CLASSNAME =
-  'max-w-56 rounded-lg border border-(--app-shell-border)/75 bg-(--app-shell-content-surface) px-2 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform] duration-cinematic ease-cinematic';
+  'max-w-56 px-2 py-2 transition-[opacity,transform] duration-cinematic ease-cinematic';
 const SHELL_NOW_PLAYING_ROW_CLASSNAME =
   'max-w-64 border border-(--app-shell-border)/75 bg-(--app-shell-content-surface) shadow-[0_10px_24px_rgba(0,0,0,0.12)] transition-[opacity,transform,border-color,background-color] duration-cinematic ease-cinematic';
 
@@ -245,15 +248,28 @@ export function PersistentAudioBar({
   ]);
 
   useEffect(() => {
-    if (!isShellAudioBar || !activeTrackId) {
+    if (!activeTrackId) {
       resetAudioChromeSnapshot();
       return;
     }
 
+    if (isShellAudioBar) {
+      setAudioChromeSnapshot({
+        activeTrackId,
+        compactPlayerVisible,
+        fullPlayerVisible: !compactPlayerVisible,
+      });
+      return;
+    }
+
+    // Legacy variant: the docked legacy bar is the only persistent surface
+    // and it renders whenever a track is active — publish full-player
+    // ownership so the sidebar mini-player reserves instead of doubling
+    // (JOV-3511).
     setAudioChromeSnapshot({
       activeTrackId,
-      compactPlayerVisible,
-      fullPlayerVisible: !compactPlayerVisible,
+      compactPlayerVisible: false,
+      fullPlayerVisible: true,
     });
   }, [activeTrackId, compactPlayerVisible, isShellAudioBar]);
 

--- a/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
+++ b/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
@@ -9,8 +9,16 @@ import { useAudioChromeSnapshot } from './audio-chrome-state';
 /**
  * SidebarBottomNowPlayingBridge — production audio adapter for the shell
  * `SidebarBottomNowPlaying` atom inside `UnifiedSidebar`. Renders only when
- * there's an active track and the persistent compact player does not already
- * own the same now-playing surface.
+ * there's an active track and no persistent audio surface (compact OR
+ * full/expanded bar, in either shell variant) already owns the same
+ * now-playing track (JOV-3511: never both at once).
+ *
+ * Ownership semantics: `PersistentAudioBar` publishes an audio-chrome
+ * snapshot whenever it has an active track. An empty snapshot therefore
+ * means no persistent bar is mounted, and the sidebar mini-player is the
+ * canonical now-playing surface and stays visible. When a persistent
+ * surface owns the track, the slot stays mounted at its fixed height in a
+ * reserved state (opacity-0 + inert) so hiding never shifts layout.
  *
  * Adapter: production `useTrackAudioPlayer().playbackState` →
  * `NowPlayingTrack` (trackTitle / artistName / artworkUrl). Tap-to-play
@@ -34,19 +42,21 @@ export function SidebarBottomNowPlayingBridge() {
   );
   if (!hasActiveTrack) return null;
 
-  const compactPlayerOwnsTrack =
-    audioChrome.compactPlayerVisible &&
-    audioChrome.activeTrackId === playbackState.activeTrackId;
+  const persistentSurfaceOwnsTrack =
+    audioChrome.activeTrackId === playbackState.activeTrackId &&
+    (audioChrome.compactPlayerVisible || audioChrome.fullPlayerVisible);
 
   return (
     <div
       data-shell-audio-surface='sidebar-compact'
-      data-state={compactPlayerOwnsTrack ? 'reserved' : 'visible'}
-      aria-hidden={compactPlayerOwnsTrack}
-      inert={compactPlayerOwnsTrack ? true : undefined}
+      data-state={persistentSurfaceOwnsTrack ? 'reserved' : 'visible'}
+      aria-hidden={persistentSurfaceOwnsTrack}
+      inert={persistentSurfaceOwnsTrack ? true : undefined}
       className={cn(
         'h-(--app-shell-audio-compact-height) overflow-hidden px-2 pb-2 pt-1 transition-[opacity,transform] duration-cinematic ease-cinematic',
-        compactPlayerOwnsTrack ? 'pointer-events-none opacity-0' : 'opacity-100'
+        persistentSurfaceOwnsTrack
+          ? 'pointer-events-none opacity-0'
+          : 'opacity-100'
       )}
     >
       <SidebarBottomNowPlaying

--- a/apps/web/components/shell/SidebarNowPlaying.tsx
+++ b/apps/web/components/shell/SidebarNowPlaying.tsx
@@ -17,9 +17,11 @@ export interface NowPlayingTrack {
 }
 
 /**
- * SidebarNowPlaying — floating now-playing card pinned to the canvas
- * left-edge, just above the audio bar. Collapsed mode renders just the
- * artwork (10×10) — used when the sidebar itself is collapsed to icons.
+ * SidebarNowPlaying — now-playing track row rendered inside the docked
+ * audio bar surface (JOV-3511: flat, not a floating/elevated card — the
+ * caller supplies surface styling via `className`). Collapsed mode renders
+ * just the artwork (10×10) — used when the sidebar itself is collapsed to
+ * icons.
  *
  * Pure presentational. Caller controls `isPlaying` + `onPlay`. Pass
  * `playOverlayVisible={true}` when the audio bar is hidden so the artwork

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -539,6 +539,53 @@ describe('PersistentAudioBar', () => {
     });
   });
 
+  it('publishes full-player chrome ownership in the legacy variant and clears on unmount (JOV-3511)', () => {
+    setPlaying({ artistName: 'DJ Cool' });
+
+    const { unmount } = render(<PersistentAudioBar variant='legacy' />);
+
+    // The legacy docked bar is the only persistent surface and renders
+    // whenever a track is active — it must claim full-player ownership so
+    // the sidebar mini-player reserves instead of doubling.
+    expect(getAudioChromeSnapshot()).toEqual({
+      activeTrackId: 'track-1',
+      compactPlayerVisible: false,
+      fullPlayerVisible: true,
+    });
+
+    unmount();
+
+    expect(getAudioChromeSnapshot()).toEqual({
+      activeTrackId: null,
+      compactPlayerVisible: false,
+      fullPlayerVisible: false,
+    });
+  });
+
+  it('docks the shell V1 now-playing card flat into the bar surface (JOV-3511)', () => {
+    setPlaying({ artistName: 'DJ Cool' });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    const expandedSurface = screen.getByTestId('audio-surface-expanded-shell');
+    // The bar itself stays docked below content with its top seam.
+    expect(expandedSurface).toHaveClass('border-t');
+
+    const card = expandedSurface.querySelector('.max-w-56');
+    expect(card).not.toBeNull();
+    // Flattened: the now-playing row carries no floating-card treatment
+    // (drop shadow, rounded card chrome, border, elevated surface fill).
+    expect(card?.className).not.toMatch(/shadow-/);
+    expect(card?.className).not.toMatch(/rounded-/);
+    expect(card?.className).not.toMatch(/border/);
+    expect(card?.className).not.toContain('bg-(--app-shell-content-surface)');
+    // Content is unchanged: artwork, title, and artist still render.
+    expect(
+      within(expandedSurface).getByText('Midnight Drive')
+    ).toBeInTheDocument();
+    expect(within(expandedSurface).getByText('DJ Cool')).toBeInTheDocument();
+  });
+
   it('handles shell V1 active-track keyboard shortcuts', () => {
     setPlaying({ artistName: 'DJ Cool', hasLyrics: true });
     pathname = APP_ROUTES.CHAT;

--- a/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
+++ b/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
@@ -103,6 +103,63 @@ describe('SidebarBottomNowPlayingBridge', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('reserves the slot when the full/expanded persistent player owns the active track (JOV-3511)', () => {
+    _state = {
+      ..._state,
+      activeTrackId: 'track-1',
+      trackTitle: 'Lost in the Light',
+      artistName: 'Bahamas',
+      isPlaying: false,
+    };
+    // Default expanded-bar state (and what the legacy variant publishes):
+    // the full player is visible, the compact player is not.
+    setAudioChromeSnapshot({
+      activeTrackId: 'track-1',
+      compactPlayerVisible: false,
+      fullPlayerVisible: true,
+    });
+
+    render(<SidebarBottomNowPlayingBridge />);
+
+    const slot = document.querySelector(
+      '[data-shell-audio-surface="sidebar-compact"]'
+    );
+    expect(slot).toHaveAttribute('data-state', 'reserved');
+    expect(slot).toHaveAttribute('aria-hidden', 'true');
+    expect(slot).toHaveAttribute('inert');
+    expect(
+      screen.queryByRole('button', { name: 'Play' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the reserved slot height fixed so hiding never shifts layout', () => {
+    _state = {
+      ..._state,
+      activeTrackId: 'track-1',
+      trackTitle: 'Lost in the Light',
+      artistName: 'Bahamas',
+      isPlaying: false,
+    };
+    setAudioChromeSnapshot({
+      activeTrackId: 'track-1',
+      compactPlayerVisible: false,
+      fullPlayerVisible: true,
+    });
+
+    render(<SidebarBottomNowPlayingBridge />);
+
+    const slot = document.querySelector(
+      '[data-shell-audio-surface="sidebar-compact"]'
+    );
+    // Height-preserving hide: the fixed compact-height slot stays mounted
+    // (no h-0 / hidden / collapse), only opacity + interactivity change.
+    expect(slot).toHaveClass('h-(--app-shell-audio-compact-height)');
+    expect(slot).toHaveClass('opacity-0');
+    expect(slot).not.toHaveClass('h-0');
+    expect(slot).not.toHaveClass('hidden');
+    expect(slot).not.toHaveClass('invisible');
+  });
+
   it('still renders when compact state belongs to a different track', () => {
     _state = {
       ..._state,


### PR DESCRIPTION
## Workstream

Chat audio player duplication + elevation — [JOV-3511](https://linear.app/jovie/issue/JOV-3511) (P1). **Scope: AC#1 + AC#2 only** (the core defects). AC#3–5 (right-rail cleanup, oversized audio thumbnail, square action-button hover states) are bundled P2 polish on the same component, deliberately deferred to a follow-up pass so the P1 defects land in a minimal, reviewable diff.

## Root cause + fix

**AC#1 — duplicate player.** `SidebarBottomNowPlayingBridge` (sidebar mini-player in `UnifiedSidebar`) reserved its slot only when the persistent **compact** player owned the track (`compactPlayerVisible`). The default state is the **expanded** full bar (`barCollapsed=false` → `compactPlayerVisible=false`), so the sidebar mini and the full-width bar rendered simultaneously. In the `legacy` variant the chrome snapshot was never published at all, duplicating there too.

Fix:
- Bridge ownership rule is now: reserve whenever the snapshot's `activeTrackId` matches AND (`compactPlayerVisible` OR `fullPlayerVisible`) — using the existing `fullPlayerVisible` snapshot field.
- Legacy variant now publishes `{ activeTrackId, compactPlayerVisible: false, fullPlayerVisible: true }` from `PersistentAudioBar` — truthful, since the legacy bar renders iff a track is active. The bridge stays variant-agnostic.
- **Absent-snapshot semantics (documented in the component):** an empty snapshot means no persistent bar is mounted, so the sidebar mini-player is the canonical now-playing surface and stays visible. Never double-renders, because every mounted persistent bar with an active track publishes ownership.
- No layout shift (per `.claude/rules/ui.md`): the reserved slot keeps its fixed `h-(--app-shell-audio-compact-height)`; only opacity/interactivity change (opacity-0 + `aria-hidden` + `inert`), no height/reflow.

**AC#2 — elevation.** The expanded shell surface floated an elevated now-playing card (`rounded-lg border bg-(--app-shell-content-surface) shadow-[0_10px_24px_rgba(0,0,0,0.12)]`) above the bar that is docked below content. Flattened: the card class is now `max-w-56 px-2 py-2` + transitions — the track row sits directly on the docked `border-t` bar surface. Card content (artwork, title, artist, play overlay) unchanged. Checked for screenshot/visual baselines pinning the elevated look — none exist (grep over e2e/stories). The minimized compact row keeps its existing treatment (out of AC#2 scope).

## Changed files

- `apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx` — ownership rule + documented semantics
- `apps/web/components/organisms/PersistentAudioBar.tsx` — legacy snapshot publish; flattened card class
- `apps/web/components/shell/SidebarNowPlaying.tsx` — docstring updated to match docked usage
- `apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx` — full-player ownership regression + fixed-height no-layout-shift guard
- `apps/web/tests/components/organisms/PersistentAudioBar.test.tsx` — legacy ownership publish/clear + docked-flat guard

## Validation

- `vitest run` bridge + PersistentAudioBar: **35/35 pass** (incl. 5 new)
- Adjacent suites (UnifiedSidebar ×2, SidebarNowPlaying, SidebarBottomNowPlaying, shell-variant-parity, AppShellFrame, AuthShell.flag): **33/33 pass**
- `pnpm biome check --write` on changed files: clean, no fixes
- `pnpm --filter @jovie/web run typecheck -- --pretty false`: clean

## Risk

Low. Presentational/ownership-logic only; no API, routing, or data changes. The one behavioral flip: the sidebar mini-player now hides in states where it previously duplicated (the intended AC). A surface that mounts `UnifiedSidebar` without `PersistentAudioBar` keeps the mini-player (empty snapshot ⇒ canonical).

## Rollback

Revert this single commit; no migrations, flags, or shared state.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20`
- Written: `engineering/chat-audio-player-dedup-elevation` (ownership semantics, legacy handling, flattening, AC#3–5 deferral, tests)
