### PR TITLE
perf(ci): unit tests 10 shards @ max-parallel 120

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2890,10 +2890,11 @@ jobs:
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      # Hosted capacity runs all five logical shards without consuming Gem.
-      max-parallel: 5
+      # Org hosted capacity ceiling ~120 concurrent jobs. Do not artificially
+      # serialize unit shards — wall-clock merge latency is the bottleneck.
+      max-parallel: 120
       matrix:
-        shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
+        shard: ['1/10', '2/10', '3/10', '4/10', '5/10', '6/10', '7/10', '8/10', '9/10', '10/10']
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1612,9 +1612,9 @@ describe('unit-test runner capacity', () => {
     expect(unitJob).not.toContain('runs-on: jovie-runner');
     expect(unitJob).not.toContain('ci-unit-runner-route');
     expect(unitJob).not.toContain('vars.CI_UNIT_RUNNER');
-    expect(unitJob).toContain('max-parallel: 5');
+    expect(unitJob).toContain('max-parallel: 120');
     expect(unitJob).toContain(
-      'Hosted capacity runs all five logical shards without consuming Gem'
+      'Do not artificially\n      # serialize unit shards'
     );
     expect(unitJob).toContain('all five named');
     expect(unitJob).toContain('warm-canary receipts');

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -136,7 +136,7 @@ describe('merge_group workflow contract', () => {
     expect(units).toContain('runs-on: ubuntu-latest');
     expect(units).not.toContain('runs-on: jovie-runner');
     expect(units).not.toContain('vars.CI_UNIT_RUNNER');
-    expect(units).toContain('max-parallel: 5');
+    expect(units).toContain('max-parallel: 120');
     expect(units).toContain('all five named');
   });
 
@@ -272,8 +272,8 @@ describe('merge_group workflow contract', () => {
     expect(buildLayout).toContain('Run deterministic layout behavior guard');
     expect(buildLayout).not.toContain('actions/upload-artifact');
     expect(buildLayout).not.toContain('actions/download-artifact');
-    expect(unitTests).toContain("shard: ['1/5', '2/5', '3/5', '4/5', '5/5']");
-    expect(unitTests).toContain('max-parallel: 5');
+    expect(unitTests).toContain("shard: ['1/10', '2/10', '3/10', '4/10', '5/10', '6/10', '7/10', '8/10', '9/10', '10/10']");
+    expect(unitTests).toContain('max-parallel: 120');
     expect(getJobBlock(CI_WORKFLOW, 'ci-a11y')).not.toContain(
       "github.event_name == 'merge_group'"
     );

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -272,7 +272,9 @@ describe('merge_group workflow contract', () => {
     expect(buildLayout).toContain('Run deterministic layout behavior guard');
     expect(buildLayout).not.toContain('actions/upload-artifact');
     expect(buildLayout).not.toContain('actions/download-artifact');
-    expect(unitTests).toContain("shard: ['1/10', '2/10', '3/10', '4/10', '5/10', '6/10', '7/10', '8/10', '9/10', '10/10']");
+    expect(unitTests).toContain(
+      "shard: ['1/10', '2/10', '3/10', '4/10', '5/10', '6/10', '7/10', '8/10', '9/10', '10/10']"
+    );
     expect(unitTests).toContain('max-parallel: 120');
     expect(getJobBlock(CI_WORKFLOW, 'ci-a11y')).not.toContain(
       "github.event_name == 'merge_group'"

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -638,7 +638,7 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert "runs-on: ubuntu-latest" in units
     assert "runs-on: jovie-runner" not in units
     assert "vars.CI_UNIT_RUNNER" not in units
-    assert "max-parallel: 5" in units
+    assert "max-parallel: 120" in units
     assert "all five named" in units
 
 


### PR DESCRIPTION
## Summary
Biggest CI throughput bottleneck: Unit Tests strategy was \`max-parallel: 5\` with only a 5-way matrix (after previously running 10 shards). That caps wall-clock merge latency regardless of org capacity (~120 jobs).

## Change
- Matrix: \`1/10\` … \`10/10\`
- \`max-parallel: 120\` (effectively uncapped for this matrix; org capacity is the real ceiling)
- Update workflow contract tests

## Test plan
- [ ] CI green on this PR
- [ ] Merge-group unit job shows 10 parallel shards
- [ ] Observe lower unit-stage wall time / merge p50