### PR TITLE
ci: fix Canary Health Gate false positive on profile flight payload

### DIFF
--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -1251,9 +1251,9 @@ describe('origin-bound Vercel protection bypass', () => {
       fetchImpl,
       attempts: 1,
     });
-    expect(fetchImpl.mock.calls.some(([url]) => new URL(url).pathname === '/tim')).toBe(
-      true
-    );
+    expect(
+      fetchImpl.mock.calls.some(([url]) => new URL(url).pathname === '/tim')
+    ).toBe(true);
   });
 
   it('still rejects rendered error content outside inline scripts', async () => {

--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -1208,6 +1208,96 @@ describe('origin-bound Vercel protection bypass', () => {
     ).rejects.toThrow(error);
   });
 
+  it('accepts a healthy profile whose inline flight payload serializes the not-found boundary', async () => {
+    // Next.js embeds the route's not-found template inside the RSC flight
+    // payload of every HEALTHY page render. The error-content scan must not
+    // treat that serialized script text as rendered error content.
+    const healthyProfile =
+      '<html><body><h1>Tim White</h1>' +
+      'healthy'.repeat(200) +
+      '<script>self.__next_f.push([1,"{\\"className\\":\\"system-b-public-profile-not-found-title\\",\\"children\\":\\"Profile not found\\"}"])</script>' +
+      '<script type="application/json">{"message":"Something went wrong"}</script>' +
+      '</body></html>';
+    const html = '<html><body>' + 'healthy'.repeat(200) + '</body></html>';
+    const fetchImpl = vi.fn(async (rawUrl: URL, _options: unknown) => {
+      const url = new URL(rawUrl);
+      const isHealth = url.pathname === '/api/health';
+      const isProfile = url.pathname === '/tim';
+      return {
+        status: 200,
+        url: url.href,
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === 'content-type'
+              ? isHealth
+                ? 'application/json'
+                : 'text/html; charset=utf-8'
+              : null,
+        },
+        text: vi
+          .fn()
+          .mockResolvedValue(
+            isHealth
+              ? JSON.stringify({ status: 'ok', database: 'ok' })
+              : isProfile
+                ? healthyProfile
+                : html
+          ),
+      };
+    });
+
+    await verifyPublicDeploymentSurfaces(DEPLOYMENT_URL, {
+      cookieHeader: '__vercel_live_token=opaque-cookie',
+      fetchImpl,
+      attempts: 1,
+    });
+    expect(fetchImpl.mock.calls.some(([url]) => new URL(url).pathname === '/tim')).toBe(
+      true
+    );
+  });
+
+  it('still rejects rendered error content outside inline scripts', async () => {
+    const renderedError =
+      '<html><body><script>self.__next_f.push([1,"ok"])</script>' +
+      '<h1>Profile not found</h1>' +
+      'x'.repeat(600) +
+      '</body></html>';
+    const html = '<html><body>' + 'healthy'.repeat(200) + '</body></html>';
+    const fetchImpl = vi.fn(async (rawUrl: URL, _options: unknown) => {
+      const url = new URL(rawUrl);
+      const isHealth = url.pathname === '/api/health';
+      return {
+        status: 200,
+        url: url.href,
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === 'content-type'
+              ? isHealth
+                ? 'application/json'
+                : 'text/html; charset=utf-8'
+              : null,
+        },
+        text: vi
+          .fn()
+          .mockResolvedValue(
+            isHealth
+              ? JSON.stringify({ status: 'ok', database: 'ok' })
+              : url.pathname === '/tim'
+                ? renderedError
+                : html
+          ),
+      };
+    });
+
+    await expect(
+      verifyPublicDeploymentSurfaces(DEPLOYMENT_URL, {
+        cookieHeader: '__vercel_live_token=opaque-cookie',
+        fetchImpl,
+        attempts: 1,
+      })
+    ).rejects.toThrow('Public profile returned error or not-found content.');
+  });
+
   it('checks the complete public-surface set with cookie-only exact-route requests', async () => {
     const html = '<html><body>' + 'healthy'.repeat(200) + '</body></html>';
     const fetchImpl = vi.fn(async (rawUrl: URL, _options: unknown) => {

--- a/apps/web/scripts/vercel-protected-origin.cjs
+++ b/apps/web/scripts/vercel-protected-origin.cjs
@@ -40,6 +40,16 @@ const TRANSIENT_VERCEL_API_STATUSES = new Set([
 ]);
 const PUBLIC_ERROR_CONTENT =
   /application error|internal server error|something went wrong|error occurred|this page could not be found|page could not be found|profile not found|temporarily unavailable|auth unavailable|turnstile is not configured/i;
+// Next.js serializes error/not-found boundary templates into the RSC flight
+// payload (<script>self.__next_f.push(...)</script>) of every healthy page, so
+// error phrases like "Profile not found" legitimately appear inside inline
+// scripts without ever rendering. Strip script blocks before the error-content
+// scan; a genuinely rendered error page carries the phrase in visible markup.
+const INLINE_SCRIPT_BLOCK = /<script\b[^>]*>[\s\S]*?<\/script\s*>/gi;
+
+function stripInlineScripts(html) {
+  return html.replace(INLINE_SCRIPT_BLOCK, '');
+}
 const PUBLIC_HTML_SURFACES = Object.freeze([
   { label: 'Homepage', path: '/', minimumBytes: 1_000 },
   { label: 'Public profile', path: '/tim', minimumBytes: 500 },
@@ -946,7 +956,7 @@ async function verifyPublicSurfaceOnce(
   ) {
     throw new Error(`${surface.label} returned an incomplete document.`);
   }
-  if (PUBLIC_ERROR_CONTENT.test(body)) {
+  if (PUBLIC_ERROR_CONTENT.test(stripInlineScripts(body))) {
     throw new Error(`${surface.label} returned error or not-found content.`);
   }
 }
@@ -1355,6 +1365,7 @@ module.exports = {
   requireExpectedEnvironment,
   resolveAuthorizedVercelDeployment,
   safeRouteLabel,
+  stripInlineScripts,
   validateBuildInfo,
   verifyPublicDeploymentSurfaces,
   writeExactHostCookieJar,


### PR DESCRIPTION
## Problem
Production Controller on main is blocked: Canary Health Gate fails with `Public profile returned error or not-found content.` on a healthy staging deployment (run [29861582456](https://github.com/JovieInc/Jovie/actions/runs/29861582456), main SHA `919c9b36`).

## Root cause (exact)
`verifyPublicSurfaceOnce` in `apps/web/scripts/vercel-protected-origin.cjs` runs `PUBLIC_ERROR_CONTENT` against the **raw** HTML body. Next.js serializes the `[username]` route's not-found boundary — including the literal copy `"Profile not found"` (`system-b-public-profile-not-found-title`) — into the RSC flight payload (`<script>self.__next_f.push(...)</script>`) of **every healthy profile render**. Verified live: `https://jov.ie/tim` returns 200 with the real profile and matches the regex only at offset ~141989, inside an inline `<script>` block. The over-broad scan shipped in #14500 (2026-07-20); the next controller run tripped it. The application route/data are healthy — the canary assertion is the defect.

## What changed
- `vercel-protected-origin.cjs`: strip inline `<script>...</script>` blocks (`stripInlineScripts`, exported) before the `PUBLIC_ERROR_CONTENT` scan. Structural checks (HTTP 200, content-type, minimum bytes, `<html>`/`<body>`) still run on the full body. A genuinely rendered error/not-found page still fails: its copy appears in visible markup outside scripts (regression-tested).
- `lighthouse-vercel-bypass.test.ts`: two new tests — (1) healthy profile with the not-found boundary serialized in the flight payload passes; (2) rendered `Profile not found` outside scripts still rejects with the exact CI error message. Existing rendered-error rejection test unchanged and still valid.

## Assumptions
- Real user-facing error pages always render their error copy in visible (non-script) markup — true for Next error/not-found boundaries and the existing test fixtures.
- Escaped `\u003c/script` inside flight JSON cannot prematurely close a script block (Next escapes it), so the strip regex is safe.

## Verification
Sandbox has no npm registry access (requested, not yet granted), so `pnpm turbo lint typecheck test:fast` + `build:web` could not run locally — **draft stays until CI proves the gate**. The changed module is dependency-free CJS with injectable fetch, so the exact test scenarios were executed standalone in Node v24:

```
$ node --check vercel-protected-origin.cjs
SYNTAX-OK
$ node harness (verifyPublicDeploymentSurfaces with mocked fetch):
1 strip removes scripts: true
2 healthy-with-flight-payload: PASS
3 rendered-error rejected as expected: Public profile returned error or not-found content.
4 real prod /tim HTML: PASS   <- the exact body that fails on main today
```
Pre-fix, the same real `/tim` HTML matches the regex (`"Profile not found" @141989`, inside `<script>`), reproducing the CI failure.

## Rollback
Single self-contained commit; revert restores the previous raw-body scan. No runtime/app code touched — CI-script-only blast radius.

## Dispatch
State 0 production recovery — Production Controller blocker (run 29861582456). Recovery-only; no unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)