### PR TITLE
fix(shell): match app loading skeleton to DESIGN_V1 (JOV-4244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 - **[notifications] Outbound SMS connector (JOV-3626)**: `providers/sms/outbound-sms.ts` gates live Twilio POSTs behind `OUTBOUND_SMS_ENABLED`; `sendNotification()` SMS channel and inbound webhook auto-replies both use it; unit-economics spike documented in `NOTIFICATION_GUIDELINES.md`.
 
 ## [Unreleased]
+- [internal] **App shell loading skeleton** matches `DESIGN_V1` so flag-on users no longer flash the legacy sidebar/header on first `/app` paint.
 
 - **[internal] Staging Better Auth Google OAuth credentials now reach the Vercel build and runtime deploy (#14659):** the release workflow allowlists and forwards both Google client keys, failing closed when either is absent.
 - **Suggested DSP matches no longer flash a skeleton then collapse (JOV-4159):** when the Music drawer loads with no match suggestions (the common case), the section stays empty instead of flashing skeleton rows and shifting sibling content.

--- a/apps/web/app/app/loading.test.tsx
+++ b/apps/web/app/app/loading.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getCachedAuthMock, getAppFlagValueMock } = vi.hoisted(() => ({
+  getCachedAuthMock: vi.fn(),
+  getAppFlagValueMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: getCachedAuthMock,
+}));
+
+vi.mock('@/lib/flags/server', () => ({
+  getAppFlagValue: getAppFlagValueMock,
+}));
+
+vi.mock('@/components/organisms/AppShellSkeleton', () => ({
+  AppShellSkeleton: ({
+    variant,
+  }: {
+    readonly variant?: 'legacy' | 'shellChatV1';
+  }) => (
+    <div data-testid='app-shell-skeleton' data-variant={variant ?? 'legacy'} />
+  ),
+}));
+
+import AppLoading from './loading';
+
+describe('app/app/loading.tsx', () => {
+  beforeEach(() => {
+    getCachedAuthMock.mockReset();
+    getAppFlagValueMock.mockReset();
+    getCachedAuthMock.mockResolvedValue({ userId: 'user_test' });
+  });
+
+  it('renders shellChatV1 skeleton when DESIGN_V1 is enabled', async () => {
+    getAppFlagValueMock.mockResolvedValue(true);
+    const ui = await AppLoading();
+    const { getByTestId } = render(ui);
+
+    expect(getAppFlagValueMock).toHaveBeenCalledWith('DESIGN_V1', {
+      userId: 'user_test',
+    });
+    expect(getByTestId('app-shell-skeleton').getAttribute('data-variant')).toBe(
+      'shellChatV1'
+    );
+  });
+
+  it('renders legacy skeleton when DESIGN_V1 is disabled', async () => {
+    getAppFlagValueMock.mockResolvedValue(false);
+    const ui = await AppLoading();
+    const { getByTestId } = render(ui);
+
+    expect(getByTestId('app-shell-skeleton').getAttribute('data-variant')).toBe(
+      'legacy'
+    );
+  });
+
+  it('passes null userId when unauthenticated', async () => {
+    getCachedAuthMock.mockResolvedValue({ userId: null });
+    getAppFlagValueMock.mockResolvedValue(false);
+    await AppLoading();
+
+    expect(getAppFlagValueMock).toHaveBeenCalledWith('DESIGN_V1', {
+      userId: null,
+    });
+  });
+});

--- a/apps/web/app/app/loading.tsx
+++ b/apps/web/app/app/loading.tsx
@@ -1,10 +1,20 @@
 import { AppShellSkeleton } from '@/components/organisms/AppShellSkeleton';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { getAppFlagValue } from '@/lib/flags/server';
 
 /**
  * App root loading screen
  * Renders a skeleton of the full app shell (sidebar + header + content)
  * to prevent layout shift while the server layout and data resolve.
+ *
+ * Variant must match `(shell)/layout.tsx` so DESIGN_V1 users do not flash
+ * the legacy sidebar/header geometry before the real shell mounts.
  */
-export default function AppLoading() {
-  return <AppShellSkeleton />;
+export default async function AppLoading() {
+  const auth = await getCachedAuth();
+  const shellChatV1 = await getAppFlagValue('DESIGN_V1', {
+    userId: auth.userId,
+  });
+
+  return <AppShellSkeleton variant={shellChatV1 ? 'shellChatV1' : 'legacy'} />;
 }


### PR DESCRIPTION
## Summary
- Resolve `DESIGN_V1` server-side in `app/app/loading.tsx` (same path as `(shell)/layout.tsx`) and pass `shellChatV1` / `legacy` into `AppShellSkeleton`.
- Prevents flag-on users from flashing the legacy sidebar/header geometry on the first `/app` Suspense paint.
- Closes the same root cause as JOV-4256 (duplicate ticket for the same file).

## Linear
- JOV-4244
- JOV-4256

<!-- linear-issue-id:JOV-4244 -->

## Test plan
- [x] `vitest run app/app/loading.test.tsx` (3 tests)
- [ ] CI PR Ready green
- [ ] Visual: with DESIGN_V1 on, hard-nav to `/app` — skeleton sidebar width matches shell

## Bug-to-test
Regression unit tests cover both flag on/off and null userId.

## Risk
Low — loading-only path; no layout structure change beyond matching existing shell variant tokens.