### PR TITLE
fix(release): forward Apple OAuth credentials to staging

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -245,6 +245,10 @@ jobs:
               BETTER_AUTH_URL
               AUTH_GOOGLE_CLIENT_ID
               AUTH_GOOGLE_CLIENT_SECRET
+              AUTH_APPLE_CLIENT_ID
+              AUTH_APPLE_TEAM_ID
+              AUTH_APPLE_KEY_ID
+              AUTH_APPLE_PRIVATE_KEY
               DATABASE_URL
               SESSION_SECRET
               AI_GATEWAY_API_KEY
@@ -272,6 +276,10 @@ jobs:
                 --env BETTER_AUTH_URL \
                 --env AUTH_GOOGLE_CLIENT_ID \
                 --env AUTH_GOOGLE_CLIENT_SECRET \
+                --env AUTH_APPLE_CLIENT_ID \
+                --env AUTH_APPLE_TEAM_ID \
+                --env AUTH_APPLE_KEY_ID \
+                --env AUTH_APPLE_PRIVATE_KEY \
                 --env DATABASE_URL \
                 --env SESSION_SECRET \
                 --env AI_GATEWAY_API_KEY \

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1214,6 +1214,10 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
       'BETTER_AUTH_URL',
       'AUTH_GOOGLE_CLIENT_ID',
       'AUTH_GOOGLE_CLIENT_SECRET',
+      'AUTH_APPLE_CLIENT_ID',
+      'AUTH_APPLE_TEAM_ID',
+      'AUTH_APPLE_KEY_ID',
+      'AUTH_APPLE_PRIVATE_KEY',
       'DATABASE_URL',
       'SESSION_SECRET',
       'AI_GATEWAY_API_KEY',
@@ -1233,7 +1237,14 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     const deployAllowlist = deployStep
       .split('\n')
       .find(line => line.includes('--only-secrets='));
-    for (const key of ['AUTH_GOOGLE_CLIENT_ID', 'AUTH_GOOGLE_CLIENT_SECRET']) {
+    for (const key of [
+      'AUTH_GOOGLE_CLIENT_ID',
+      'AUTH_GOOGLE_CLIENT_SECRET',
+      'AUTH_APPLE_CLIENT_ID',
+      'AUTH_APPLE_TEAM_ID',
+      'AUTH_APPLE_KEY_ID',
+      'AUTH_APPLE_PRIVATE_KEY',
+    ]) {
       expect(deployAllowlist).toContain(key);
     }
 
@@ -1241,7 +1252,14 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
       workflow,
       'Build (preview target for staging verification)'
     );
-    for (const key of ['AUTH_GOOGLE_CLIENT_ID', 'AUTH_GOOGLE_CLIENT_SECRET']) {
+    for (const key of [
+      'AUTH_GOOGLE_CLIENT_ID',
+      'AUTH_GOOGLE_CLIENT_SECRET',
+      'AUTH_APPLE_CLIENT_ID',
+      'AUTH_APPLE_TEAM_ID',
+      'AUTH_APPLE_KEY_ID',
+      'AUTH_APPLE_PRIVATE_KEY',
+    ]) {
       const buildAllowlist = buildStep
         .split('\n')
         .find(line => line.includes('--only-secrets='));


### PR DESCRIPTION
P0 #14667. Adds existing AUTH_APPLE runtime keys to staging Vercel prebuilt deployment plus workflow contract coverage. Root-cause receipt: controller 29868090605; deploy-staging/public canary passed; Better Auth dynamically requires all four Apple values. CI is authoritative.