### PR TITLE
fix(test): keep direct contract tests focused

### DIFF
--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -299,6 +299,35 @@ describe('automation-verify affected scope', () => {
     ).toBe('full');
   });
 
+  it.each([
+    '.github/workflows/unknown-production-release.yml',
+    'scripts/unknown-production-release.mjs',
+  ])('fails closed when the production workflow contract includes unknown automation %s', unknownAutomation => {
+    expect(
+      buildAffectedTestPlan([
+        '.github/workflows/production-release.yml',
+        'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+        unknownAutomation,
+      ]).mode
+    ).toBe('full');
+  });
+
+  it('keeps directly changed Playwright specs out of the Vitest exemption', () => {
+    expect(
+      buildAffectedTestPlan(['apps/web/tests/e2e/mobile-overflow.spec.ts']).mode
+    ).toBe('full');
+  });
+
+  it('fails closed when a manifest-linked direct test was deleted', () => {
+    const deletedTest = 'apps/web/scripts/test-performance-profiler.test.ts';
+
+    expect(
+      buildAffectedTestPlan([deletedTest], {
+        isFileAvailable: file => file !== deletedTest,
+      }).mode
+    ).toBe('full');
+  });
+
   it('keeps runner I/O admission on focused controller regressions', () => {
     const plan = buildAffectedTestPlan(RUNNER_IO_PRESSURE_MANIFEST);
 

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -277,6 +277,28 @@ const NEON_ATTEMPT_ARTIFACT_MANIFEST = [
 ];
 
 describe('automation-verify affected scope', () => {
+  it('keeps a production workflow contract-only diff on focused coverage', () => {
+    const plan = buildAffectedTestPlan([
+      '.github/workflows/production-release.yml',
+      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+    ]);
+  });
+
+  it('fails closed when the production workflow contract includes unknown source', () => {
+    expect(
+      buildAffectedTestPlan([
+        '.github/workflows/production-release.yml',
+        'apps/web/lib/unknown-production-release.ts',
+        'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+      ]).mode
+    ).toBe('full');
+  });
+
   it('keeps runner I/O admission on focused controller regressions', () => {
     const plan = buildAffectedTestPlan(RUNNER_IO_PRESSURE_MANIFEST);
 
@@ -1124,8 +1146,21 @@ describe('automation-verify affected scope', () => {
     ).toBe('full');
   });
 
+  it('runs a directly changed profiler test without requiring its repair manifest', () => {
+    const plan = buildAffectedTestPlan([
+      'apps/web/scripts/test-performance-profiler.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual([
+      'apps/web/scripts/test-performance-profiler.test.ts',
+    ]);
+  });
+
   it.each(
-    PERFORMANCE_PROFILER_REPAIR_ANCHORS
+    PERFORMANCE_PROFILER_REPAIR_ANCHORS.filter(
+      input => input !== 'apps/web/scripts/test-performance-profiler.test.ts'
+    )
   )('fails closed when the profiler repair input %s is standalone', input => {
     expect(buildAffectedTestPlan([input]).mode).toBe('full');
   });

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -378,7 +379,10 @@ function unique(values) {
   return [...new Set(values)];
 }
 
-export function buildAffectedTestPlan(changedFiles) {
+export function buildAffectedTestPlan(
+  changedFiles,
+  { isFileAvailable = file => existsSync(resolve(REPO_ROOT, file)) } = {}
+) {
   const files = unique(changedFiles.filter(Boolean)).sort();
   if (files.some(file => GLOBAL_TEST_INPUTS.has(file))) {
     return { mode: 'full', relatedFiles: [], mandatoryTests: [] };
@@ -555,9 +559,30 @@ export function buildAffectedTestPlan(changedFiles) {
       // Per docs/PR_FLOW.md, Playwright remains in hosted manual/deep lanes.
       !(isExactMobileOverflowNavigationRace && file.endsWith('.spec.ts'))
   );
-  const directTestFiles = new Set(directTests);
+  const directlyRunnableTestFiles = new Set(
+    directTests.filter(
+      file =>
+        isFileAvailable(file) &&
+        !file.startsWith('apps/web/tests/e2e/') &&
+        !file.startsWith('apps/web/tests/performance/')
+    )
+  );
+  const isExactProductionReleaseContract =
+    files.length === 2 &&
+    files.includes('.github/workflows/production-release.yml') &&
+    directlyRunnableTestFiles.has(
+      'apps/web/tests/unit/ci/deploy-workflow.test.ts'
+    );
+  const hasUnsupportedAutomationPeer =
+    files.some(
+      file => file.startsWith('.github/') || file.startsWith('scripts/')
+    ) && !isExactProductionReleaseContract;
   const hasManifestInputBeyondDirectTests = manifest =>
-    files.some(file => manifest.has(file) && !directTestFiles.has(file));
+    files.some(
+      file =>
+        manifest.has(file) &&
+        (hasUnsupportedAutomationPeer || !directlyRunnableTestFiles.has(file))
+    );
   const mandatoryTests = [];
   const hasSeedConfirmationChange = files.some(
     file =>

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -446,9 +446,6 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactNeonAttemptArtifactRepair =
     neonAttemptArtifactInputCount === NEON_ATTEMPT_ARTIFACT_MANIFEST.size &&
     files.length === NEON_ATTEMPT_ARTIFACT_MANIFEST.size;
-  const performanceProfilerRepairInputCount = files.filter(file =>
-    PERFORMANCE_PROFILER_REPAIR_ANCHORS.has(file)
-  ).length;
   const isExactPerformanceProfilerRepairPrimary =
     files.length === PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST.size &&
     files.every(file => PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST.has(file));
@@ -461,9 +458,6 @@ export function buildAffectedTestPlan(changedFiles) {
   const isExactScannerLoadRepairWithSelector =
     files.length === SCANNER_LOAD_REPAIR_MANIFEST.size &&
     files.every(file => SCANNER_LOAD_REPAIR_MANIFEST.has(file));
-  const scannerLoadRepairInputCount = files.filter(file =>
-    SCANNER_LOAD_REPAIR_MANIFEST.has(file)
-  ).length;
   const isExactPerformanceProfilerRepairWithSelector =
     isExactPerformanceProfilerRepairWithSelectorLegacy ||
     isExactScannerLoadRepairWithSelector;
@@ -561,6 +555,9 @@ export function buildAffectedTestPlan(changedFiles) {
       // Per docs/PR_FLOW.md, Playwright remains in hosted manual/deep lanes.
       !(isExactMobileOverflowNavigationRace && file.endsWith('.spec.ts'))
   );
+  const directTestFiles = new Set(directTests);
+  const hasManifestInputBeyondDirectTests = manifest =>
+    files.some(file => manifest.has(file) && !directTestFiles.has(file));
   const mandatoryTests = [];
   const hasSeedConfirmationChange = files.some(
     file =>
@@ -790,9 +787,10 @@ export function buildAffectedTestPlan(changedFiles) {
   const hasUnknownPrerequisiteTrainPeer =
     hasPrerequisiteTrainCorners && !isExactPrerequisiteTrain;
   const hasIncompleteVercelCongestionControl =
-    vercelCongestionControlInputCount > 0 && !isExactVercelCongestionControl;
+    hasManifestInputBeyondDirectTests(VERCEL_CONGESTION_CONTROL_MANIFEST) &&
+    !isExactVercelCongestionControl;
   const hasIncompleteAffectedTestSelector =
-    affectedTestSelectorInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(AFFECTED_TEST_SELECTOR_MANIFEST) &&
     !isExactAffectedTestSelector &&
     !isExactAuthenticatedA11yRepair &&
     !isExactGoldenPathSmokeContractRepair &&
@@ -807,11 +805,11 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactLayoutGuardContract &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompletePrSizeGuard =
-    prSizeGuardInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(PR_SIZE_GUARD_MANIFEST) &&
     !isExactPrSizeGuard &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompletePerformanceProfilerRepair =
-    performanceProfilerRepairInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(PERFORMANCE_PROFILER_REPAIR_ANCHORS) &&
     !isExactPerformanceProfilerRepair &&
     !isExactGoldenPathSmokeContractRepair &&
     !isExactNeonAttemptArtifactRepair &&
@@ -821,7 +819,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract;
   const hasIncompleteScannerLoadRepair =
-    scannerLoadRepairInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(SCANNER_LOAD_REPAIR_MANIFEST) &&
     !isExactScannerLoadRepairPrimary &&
     !isExactScannerLoadRepairWithSelector &&
     !isExactAffectedTestSelector &&
@@ -839,7 +837,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactLayoutGuardContract &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteGtmqSourceGateReaper =
-    gtmqSourceGateReaperInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(GTMQ_SOURCE_GATE_REAPER_MANIFEST) &&
     !isExactGtmqSourceGateReaper &&
     !isExactAuthenticatedA11yRepair &&
     !isExactGoldenPathSmokeContractRepair &&
@@ -855,7 +853,9 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactLayoutGuardContract &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteMobileOverflowNavigationRace =
-    mobileOverflowNavigationRaceInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(
+      MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST
+    ) &&
     !isExactMobileOverflowNavigationRace &&
     !isExactAuthenticatedA11yRepair &&
     !isExactAffectedTestSelector &&
@@ -870,7 +870,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactLayoutGuardContract &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteRunnerIoPressure =
-    runnerIoPressureInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(RUNNER_IO_PRESSURE_MANIFEST) &&
     !isExactRunnerIoPressure &&
     !isExactAuthenticatedA11yRepair &&
     !isExactGoldenPathSmokeContractRepair &&
@@ -885,7 +885,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactLayoutGuardContract &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteRunnerPrerequisiteContract =
-    runnerPrerequisiteContractInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(RUNNER_PREREQUISITE_CONTRACT_MANIFEST) &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactAuthenticatedA11yRepair &&
     !isExactAffectedTestSelector &&
@@ -901,7 +901,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactRunnerIoPressure &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteLayoutGuardContract =
-    layoutGuardContractInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(LAYOUT_GUARD_CONTRACT_MANIFEST) &&
     !isExactLayoutGuardContract &&
     !isExactAuthenticatedA11yRepair &&
     !isExactPrerequisiteTrain &&
@@ -917,7 +917,7 @@ export function buildAffectedTestPlan(changedFiles) {
     !isExactRunnerIoPressure &&
     !isExactPrSizeGuardWithSelector;
   const hasIncompleteNeonAttemptArtifactRepair =
-    neonAttemptArtifactInputCount > 0 &&
+    hasManifestInputBeyondDirectTests(NEON_ATTEMPT_ARTIFACT_MANIFEST) &&
     !isExactNeonAttemptArtifactRepair &&
     !isExactAuthenticatedA11yRepair &&
     !isExactPrerequisiteTrain &&


### PR DESCRIPTION
## Summary
- Keep directly changed runnable Vitest contract tests on focused coverage even when the same test appears in several exact repair manifests.
- Preserve fail-closed full-suite selection for unknown application or automation source, genuinely partial repair manifests, Playwright/performance specs, and deleted manifest-linked tests.
- Production workflow fixture now changes from `full` to `selected`, selecting only `apps/web/tests/unit/ci/deploy-workflow.test.ts` instead of eight sequential full-suite shards.
- Expected impact: avoid roughly 40 minutes of unnecessary full-suite work for this observed production-release hotfix shape.

## Bug-to-Test
bug-to-test: satisfied

Regression tests: `scripts/lib/__tests__/automation-verify.test.mjs` covers the exact production workflow fixture, standalone runnable direct tests, unknown app/script/workflow peers, non-Vitest Playwright specs, and deleted test paths.

## Test Coverage
Changed selector branches have positive and fail-closed negative regressions. Existing exact and partial-manifest cases remain covered by the selector suite.

## Pre-Landing Review
No issues found after an independent adversarial re-review of the final diff.

## Design Review
No frontend files changed.

## Eval Results
No prompt-related files changed; evals skipped.

## Scope Drift
Scope Check: CLEAN

## Plan Completion
No plan file detected.

## Linear follow-ups
Linear follow-ups: none.

## Verification Results
- [x] Selector regression suite: 185 passed, 0 failed
- [x] Exact production workflow fixture: `full` → `selected`
- [x] Unknown application, script, and workflow source remain `full`
- [x] Playwright specs and deleted manifest tests remain fail-closed
- [x] Bug-to-test gate satisfied
- [x] Biome check passed
- [x] `git diff --check` passed

## Test plan
- [x] Run `scripts/lib/__tests__/automation-verify.test.mjs`
- [x] Dry-run exact production workflow fixture
- [x] Verify unknown-source, non-Vitest, deleted-test, and partial-manifest negatives remain fail-closed
