### PR TITLE
fix(ci): exclude public Vercel probe cookies

### DIFF
--- a/apps/web/scripts/lighthouse-vercel-bypass.cjs
+++ b/apps/web/scripts/lighthouse-vercel-bypass.cjs
@@ -18,6 +18,7 @@ const {
   isTrustedVercelProtectedAliasUrl,
   maskSensitiveValues,
   parseProbeUrl,
+  PUBLIC_PROBE_COOKIE_NAMES,
   readVerifiedBuildInfo,
   safeRouteLabel,
   validateBuildInfo,
@@ -57,6 +58,12 @@ function recordSensitiveValues(path, values) {
   } finally {
     closeSync(descriptor);
   }
+}
+
+function sensitiveCookieValues(cookies) {
+  return cookies
+    .filter(cookie => !PUBLIC_PROBE_COOKIE_NAMES.has(cookie.name))
+    .map(cookie => cookie.value);
 }
 
 function parseRequestCookieHeader(header) {
@@ -181,8 +188,11 @@ async function primeLighthouseVercelAliasBypass(
     expectedCommitSha,
     expectedAliasOrigin,
     expectedEnvironment,
-    onSensitiveValues: values =>
-      recordSensitiveValuesImpl(sensitiveValuesPath, values),
+    onSensitiveValues: cookies =>
+      recordSensitiveValuesImpl(
+        sensitiveValuesPath,
+        sensitiveCookieValues(cookies)
+      ),
     onCookies: async (cookies, verifiedTargetUrl) => {
       await browser.defaultBrowserContext().setCookie(...cookies);
       await assertBrowserCookieOriginBoundaryImpl(
@@ -225,8 +235,11 @@ async function primeLighthouseVercelBypass(
     expectedCommitSha,
     expectedDeploymentOrigin,
     expectedEnvironment,
-    onSensitiveValues: values =>
-      recordSensitiveValuesImpl(sensitiveValuesPath, values),
+    onSensitiveValues: cookies =>
+      recordSensitiveValuesImpl(
+        sensitiveValuesPath,
+        sensitiveCookieValues(cookies)
+      ),
     onCookies: async (cookies, verifiedTargetUrl) => {
       await browser.defaultBrowserContext().setCookie(...cookies);
       await assertBrowserCookieOriginBoundaryImpl(
@@ -250,6 +263,7 @@ module.exports.assertBrowserCookieOriginBoundary =
   assertBrowserCookieOriginBoundary;
 module.exports.readVerifiedBuildInfo = readVerifiedBuildInfo;
 module.exports.recordSensitiveValues = recordSensitiveValues;
+module.exports.sensitiveCookieValues = sensitiveCookieValues;
 module.exports.validateCookieOriginBoundaryHeaders =
   validateCookieOriginBoundaryHeaders;
 module.exports.validateBuildInfo = validateBuildInfo;

--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -98,6 +98,7 @@ const {
 const {
   primeLighthouseVercelAliasBypass,
   primeLighthouseVercelBypass,
+  sensitiveCookieValues,
   validateBuildInfo,
   validateCookieOriginBoundaryHeaders,
 } = require('./lighthouse-vercel-bypass.cjs') as {
@@ -153,6 +154,9 @@ const {
     expectedSha: string,
     expectedEnvironment: 'preview' | 'production'
   ) => unknown;
+  readonly sensitiveCookieValues: (
+    cookies: readonly { readonly name: string; readonly value: string }[]
+  ) => readonly string[];
 };
 
 const DEPLOYMENT_URL = 'https://jovie-5sy8pmjja-jovie.vercel.app/';
@@ -236,6 +240,16 @@ function browserFixture({ leakToChild = false } = {}) {
 }
 
 describe('origin-bound Vercel protection bypass', () => {
+  it('records only non-public probe cookie values', () => {
+    expect(
+      sensitiveCookieValues([
+        { name: 'jv_country', value: 'US' },
+        { name: 'jv_cc_required', value: '1' },
+        { name: '__vercel_live_token', value: 'opaque-cookie' },
+      ])
+    ).toEqual(['opaque-cookie']);
+  });
+
   it('never attaches the bypass credential to canonical production', () => {
     const request = buildOriginBoundProbeRequest('https://jov.ie/robots.txt', {
       bypassSecret: 'sentinel-secret',

--- a/apps/web/scripts/vercel-protected-origin.cjs
+++ b/apps/web/scripts/vercel-protected-origin.cjs
@@ -14,6 +14,7 @@ const {
 
 const BYPASS_HEADER = 'x-vercel-protection-bypass';
 const SET_BYPASS_COOKIE_HEADER = 'x-vercel-set-bypass-cookie';
+const PUBLIC_PROBE_COOKIE_NAMES = new Set(['jv_country', 'jv_cc_required']);
 const BUILD_INFO_PATH = '/api/health/build-info';
 const DEFAULT_PROBE_TIMEOUT_MS = 120_000;
 const DEFAULT_VERCEL_API_PAGES = 5;
@@ -741,11 +742,9 @@ async function bootstrapOriginBoundAccess(
     }
 
     const cookies = parseOriginBoundCookies(bootstrapResponse, targetUrl);
-    const sensitiveValues = maskSensitiveValues(
-      cookies.map(cookie => cookie.value)
-    );
+    maskSensitiveValues(cookies.map(cookie => cookie.value));
     if (onSensitiveValues) {
-      await deadline.run(() => onSensitiveValues(sensitiveValues));
+      await deadline.run(() => onSensitiveValues(cookies));
     }
     await deadline.run(() => discardResponseBody(bootstrapResponse));
     if (onCookies) await deadline.run(() => onCookies(cookies, targetUrl));
@@ -842,11 +841,9 @@ async function bootstrapAliasBoundAccess(
     }
 
     const cookies = parseOriginBoundCookies(bootstrapResponse, targetUrl);
-    const sensitiveValues = maskSensitiveValues(
-      cookies.map(cookie => cookie.value)
-    );
+    maskSensitiveValues(cookies.map(cookie => cookie.value));
     if (onSensitiveValues) {
-      await deadline.run(() => onSensitiveValues(sensitiveValues));
+      await deadline.run(() => onSensitiveValues(cookies));
     }
     await deadline.run(() => discardResponseBody(bootstrapResponse));
     if (onCookies) await deadline.run(() => onCookies(cookies, targetUrl));
@@ -1343,6 +1340,7 @@ module.exports = {
   BUILD_INFO_PATH,
   BYPASS_HEADER,
   DEFAULT_PROBE_TIMEOUT_MS,
+  PUBLIC_PROBE_COOKIE_NAMES,
   PUBLIC_HTML_SURFACES,
   SET_BYPASS_COOKIE_HEADER,
   assertAuthorizedDeploymentOrigin,

--- a/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+++ b/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
@@ -2054,6 +2054,26 @@ ${fixtureCheckout}
     ).toBe(true);
   });
 
+  it('fails closed when an unknown dynamic cookie value is shorter than four characters', () => {
+    const workspace = fixture();
+    const runner = fixture();
+    const receipt = join(runner, 'dynamic-cookie-values');
+    const child = `const f=require('node:fs');f.writeFileSync(process.env.PLAYWRIGHT_DYNAMIC_SECRETS_FILE,'xyz\\n',{mode:0o600});f.mkdirSync('out',{recursive:true});f.writeFileSync('out/report.json','{}')`;
+
+    const result = runChild(workspace, runner, child, {
+      PLAYWRIGHT_DYNAMIC_SECRETS_FILE: receipt,
+    });
+
+    expect(result.status).toBe(1);
+    expect(existsSync(receipt)).toBe(false);
+    expect(`${result.stdout}\\n${result.stderr}`).toContain(
+      'categories=inspection-error:1'
+    );
+    expect(
+      existsSync(join(runner, 'safe-playwright-producer', 'blocked'))
+    ).toBe(true);
+  });
+
   it('rejects a dynamic cookie receipt that is not mode 0600', () => {
     const workspace = fixture();
     const runner = fixture();


### PR DESCRIPTION
P0 #14673. OAuth/alias proof passed but artifact guard failed because public jv_country and jv_cc_required metadata cookie values (2/1 chars) entered the dynamic secret receipt. Excludes only those names; unknown short values remain fail-closed, with focused regression coverage. CI authoritative.