### PR TITLE
fix(test): select production OAuth repair contracts

### DIFF
--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -81,6 +81,53 @@ const AFFECTED_TEST_SELECTOR_MANIFEST = [
   'scripts/run-affected-tests.mjs',
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const PRODUCTION_OAUTH_REPAIR_CORE = [
+  '.github/workflows/production-release.yml',
+  'apps/web/scripts/lighthouse-vercel-bypass.test.ts',
+  'apps/web/scripts/vercel-protected-origin.cjs',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts',
+];
+const PRODUCTION_OAUTH_REPAIR_TESTS = [
+  'apps/web/scripts/lighthouse-vercel-bypass.test.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts',
+];
+const PRODUCTION_OAUTH_REPAIR_WITH_SELECTOR = [
+  ...PRODUCTION_OAUTH_REPAIR_CORE,
+  ...AFFECTED_TEST_SELECTOR_MANIFEST,
+];
+const PRODUCTION_OAUTH_WEB_COMMAND = [
+  'pnpm',
+  [
+    '--filter',
+    '@jovie/web',
+    'exec',
+    'vitest',
+    'run',
+    'scripts/lighthouse-vercel-bypass.test.ts',
+    'tests/unit/ci/deploy-workflow.test.ts',
+    'tests/unit/ci/playwright-artifact-secrets.test.ts',
+    '--passWithNoTests',
+    '--maxWorkers',
+    '2',
+  ],
+];
+const SELECTOR_REGRESSION_COMMAND = [
+  'pnpm',
+  [
+    'exec',
+    'vitest',
+    '--root',
+    'scripts',
+    '--config',
+    'vitest.config.mts',
+    'run',
+    'lib/__tests__/automation-verify.test.mjs',
+    '--maxWorkers',
+    '2',
+  ],
+];
 const PR_SIZE_GUARD_MANIFEST = [
   '.github/workflows/pr-size-guard.yml',
   'scripts/lib/pr-size-guard-policy.mjs',
@@ -277,38 +324,93 @@ const NEON_ATTEMPT_ARTIFACT_MANIFEST = [
 ];
 
 describe('automation-verify affected scope', () => {
-  it('keeps a production workflow contract-only diff on focused coverage', () => {
-    const plan = buildAffectedTestPlan([
-      '.github/workflows/production-release.yml',
-      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
-    ]);
+  it('keeps the exact production OAuth repair on focused web contracts', () => {
+    const plan = buildAffectedTestPlan(PRODUCTION_OAUTH_REPAIR_CORE);
 
     expect(plan.mode).toBe('selected');
-    expect(plan.selectedTests).toEqual([
-      'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+    expect(plan.selectedTests).toEqual(PRODUCTION_OAUTH_REPAIR_TESTS);
+    expect(plan.scriptVitestTests).toEqual([]);
+    expect(buildSelectedTestCommands(plan, '2')).toEqual([
+      PRODUCTION_OAUTH_WEB_COMMAND,
     ]);
   });
 
-  it('fails closed when the production workflow contract includes unknown source', () => {
+  it('keeps the self-modifying production OAuth repair on focused contracts', () => {
+    const plan = buildAffectedTestPlan(PRODUCTION_OAUTH_REPAIR_WITH_SELECTOR);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual(PRODUCTION_OAUTH_REPAIR_TESTS);
+    expect(plan.scriptVitestTests).toEqual([
+      'scripts/lib/__tests__/automation-verify.test.mjs',
+    ]);
+    expect(buildSelectedTestCommands(plan, '2')).toEqual([
+      SELECTOR_REGRESSION_COMMAND,
+      PRODUCTION_OAUTH_WEB_COMMAND,
+    ]);
+  });
+
+  it.each(
+    PRODUCTION_OAUTH_REPAIR_CORE
+  )('fails closed when the production OAuth repair is missing core input %s', missingInput => {
+    expect(
+      buildAffectedTestPlan(
+        PRODUCTION_OAUTH_REPAIR_CORE.filter(file => file !== missingInput)
+      ).mode
+    ).toBe('full');
+    expect(
+      buildAffectedTestPlan(
+        PRODUCTION_OAUTH_REPAIR_WITH_SELECTOR.filter(
+          file => file !== missingInput
+        )
+      ).mode
+    ).toBe('full');
+  });
+
+  it.each(
+    AFFECTED_TEST_SELECTOR_MANIFEST
+  )('fails closed when the production OAuth repair includes only selector input %s', selectorInput => {
+    expect(
+      buildAffectedTestPlan([...PRODUCTION_OAUTH_REPAIR_CORE, selectorInput])
+        .mode
+    ).toBe('full');
+  });
+
+  it.each([
+    'apps/web/lib/unknown-production-release.ts',
+    '.github/workflows/unknown-production-release.yml',
+    'scripts/unknown-production-release.mjs',
+  ])('fails closed when the production OAuth repair includes unknown peer %s', unknownPeer => {
+    for (const manifest of [
+      PRODUCTION_OAUTH_REPAIR_CORE,
+      PRODUCTION_OAUTH_REPAIR_WITH_SELECTOR,
+    ]) {
+      expect(buildAffectedTestPlan([...manifest, unknownPeer]).mode).toBe(
+        'full'
+      );
+    }
+  });
+
+  it('fails closed for the legacy partial production workflow pair', () => {
     expect(
       buildAffectedTestPlan([
         '.github/workflows/production-release.yml',
-        'apps/web/lib/unknown-production-release.ts',
         'apps/web/tests/unit/ci/deploy-workflow.test.ts',
       ]).mode
     ).toBe('full');
   });
 
-  it.each([
-    '.github/workflows/unknown-production-release.yml',
-    'scripts/unknown-production-release.mjs',
-  ])('fails closed when the production workflow contract includes unknown automation %s', unknownAutomation => {
+  it.each(
+    PRODUCTION_OAUTH_REPAIR_CORE
+  )('fails closed when production OAuth repair input %s was deleted', deletedInput => {
     expect(
-      buildAffectedTestPlan([
-        '.github/workflows/production-release.yml',
-        'apps/web/tests/unit/ci/deploy-workflow.test.ts',
-        unknownAutomation,
-      ]).mode
+      buildAffectedTestPlan(PRODUCTION_OAUTH_REPAIR_CORE, {
+        isFileAvailable: file => file !== deletedInput,
+      }).mode
+    ).toBe('full');
+    expect(
+      buildAffectedTestPlan(PRODUCTION_OAUTH_REPAIR_WITH_SELECTOR, {
+        isFileAvailable: file => file !== deletedInput,
+      }).mode
     ).toBe('full');
   });
 

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -101,6 +101,18 @@ const AFFECTED_TEST_SELECTOR_MANIFEST = new Set([
 const AFFECTED_TEST_SELECTOR_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const PRODUCTION_OAUTH_REPAIR_CORE = new Set([
+  '.github/workflows/production-release.yml',
+  'apps/web/scripts/lighthouse-vercel-bypass.test.ts',
+  'apps/web/scripts/vercel-protected-origin.cjs',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts',
+]);
+const PRODUCTION_OAUTH_REPAIR_TESTS = [
+  'apps/web/scripts/lighthouse-vercel-bypass.test.ts',
+  'apps/web/tests/unit/ci/deploy-workflow.test.ts',
+  'apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts',
+];
 const AUTHENTICATED_A11Y_REPAIR_CORE = new Set([
   'apps/web/app/app/(shell)/chat/loading.tsx',
   'apps/web/app/exp/shell-v1/page.tsx',
@@ -409,6 +421,27 @@ export function buildAffectedTestPlan(
   const isExactAffectedTestSelector =
     affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
     files.length === AFFECTED_TEST_SELECTOR_MANIFEST.size;
+  const productionOauthRepairInputCount = files.filter(file =>
+    PRODUCTION_OAUTH_REPAIR_CORE.has(file)
+  ).length;
+  const hasAvailableProductionOauthRepairInputs = [
+    ...PRODUCTION_OAUTH_REPAIR_CORE,
+    ...AFFECTED_TEST_SELECTOR_MANIFEST,
+  ].every(file => !files.includes(file) || isFileAvailable(file));
+  const isExactProductionOauthRepairCore =
+    productionOauthRepairInputCount === PRODUCTION_OAUTH_REPAIR_CORE.size &&
+    files.length === PRODUCTION_OAUTH_REPAIR_CORE.size &&
+    hasAvailableProductionOauthRepairInputs;
+  const isExactProductionOauthRepairWithSelector =
+    productionOauthRepairInputCount === PRODUCTION_OAUTH_REPAIR_CORE.size &&
+    affectedTestSelectorInputCount === AFFECTED_TEST_SELECTOR_MANIFEST.size &&
+    files.length ===
+      PRODUCTION_OAUTH_REPAIR_CORE.size +
+        AFFECTED_TEST_SELECTOR_MANIFEST.size &&
+    hasAvailableProductionOauthRepairInputs;
+  const isExactProductionOauthRepair =
+    isExactProductionOauthRepairCore ||
+    isExactProductionOauthRepairWithSelector;
   const authenticatedA11yRepairInputCount = files.filter(file =>
     AUTHENTICATED_A11Y_REPAIR_CORE.has(file)
   ).length;
@@ -567,21 +600,20 @@ export function buildAffectedTestPlan(
         !file.startsWith('apps/web/tests/performance/')
     )
   );
-  const isExactProductionReleaseContract =
-    files.length === 2 &&
-    files.includes('.github/workflows/production-release.yml') &&
-    directlyRunnableTestFiles.has(
-      'apps/web/tests/unit/ci/deploy-workflow.test.ts'
-    );
   const hasUnsupportedAutomationPeer =
     files.some(
       file => file.startsWith('.github/') || file.startsWith('scripts/')
-    ) && !isExactProductionReleaseContract;
+    ) && !isExactProductionOauthRepair;
   const hasManifestInputBeyondDirectTests = manifest =>
     files.some(
       file =>
         manifest.has(file) &&
-        (hasUnsupportedAutomationPeer || !directlyRunnableTestFiles.has(file))
+        (hasUnsupportedAutomationPeer ||
+          (!directlyRunnableTestFiles.has(file) &&
+            !(
+              isExactProductionOauthRepairWithSelector &&
+              AFFECTED_TEST_SELECTOR_MANIFEST.has(file)
+            )))
     );
   const mandatoryTests = [];
   const hasSeedConfirmationChange = files.some(
@@ -657,6 +689,9 @@ export function buildAffectedTestPlan(
   if (isExactNeonAttemptArtifactRepair) {
     mandatoryTests.push(...NEON_ATTEMPT_ARTIFACT_TESTS);
   }
+  if (isExactProductionOauthRepair) {
+    mandatoryTests.push(...PRODUCTION_OAUTH_REPAIR_TESTS);
+  }
   if (
     isExactPerformanceProfilerRepairPrimary ||
     isExactPerformanceProfilerRepairWithSelectorLegacy
@@ -694,6 +729,7 @@ export function buildAffectedTestPlan(
       ? SCANNER_LOAD_REPAIR_SCRIPT_TESTS
       : []),
     ...(isExactAffectedTestSelector ||
+    isExactProductionOauthRepairWithSelector ||
     (isExactAuthenticatedA11yRepair && affectedTestSelectorInputCount > 0) ||
     isExactPrSizeGuardWithSelector ||
     isExactGoldenPathSmokeContractRepair ||
@@ -738,6 +774,8 @@ export function buildAffectedTestPlan(
     if (file.startsWith('apps/web/tests/eval/promptfoo/')) return true;
     if (isInvestorNoteIngestionInput(file)) return true;
     if (isCiCancellationHealerInput(file)) return true;
+    if (isExactProductionOauthRepair && PRODUCTION_OAUTH_REPAIR_CORE.has(file))
+      return true;
     if (
       isExactAuthenticatedA11yRepair &&
       AUTHENTICATED_A11Y_REPAIR_CORE.has(file)
@@ -990,6 +1028,7 @@ export function buildAffectedTestPlan(
             isExactPrerequisiteTrain ||
             isExactVercelCongestionControl ||
             isExactAffectedTestSelector ||
+            isExactProductionOauthRepair ||
             isExactAuthenticatedA11yRepair ||
             isExactPrSizeGuard ||
             isExactPrSizeGuardWithSelector ||


### PR DESCRIPTION
## Summary
- recognize only the exact five-file production OAuth repair as a focused selector contract
- allow the exact self-modifying seven-file shape only when both selector files are present
- keep missing, deleted, partial-selector, legacy-pair, and unknown-peer shapes fail-closed to the full suite

## Verification
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/automation-verify.test.mjs --maxWorkers 2` — 199 passed
- exact selected web contracts — 122 passed across 3 files
- `pnpm turbo typecheck` — 10/10 packages passed
- focused Biome and `git diff --check` — clean
- exact fixture dry-run — 3 web tests; self-modifying fixture also adds selector regression
- committed CLI dry-run — selected selector regression
- pre-push affected bundle and CI harness — passed

## Risk
Selector behavior only. Ambiguous shapes remain full-suite; no CI gates or workflow files are changed.

Automerge intentionally disabled.