### PR TITLE
fix(release): recover safe OAuth retries

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -563,12 +563,40 @@ jobs:
           cd apps/web
           mkdir -p tests/.auth
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
+          oauth_retry_root="$RUNNER_TEMP/aliased-staging-oauth-retries"
+          mkdir -m 700 "$oauth_retry_root"
+
+          quarantine_oauth_artifacts() {
+            destination="$1"
+            for artifact_path in test-results playwright-report; do
+              if [ -e "$artifact_path" ] || [ -L "$artifact_path" ]; then
+                if [ ! -d "$destination" ]; then
+                  mkdir -m 700 "$destination"
+                fi
+                mv -- "$artifact_path" "$destination/"
+              fi
+            done
+          }
+
           attempt=1
           max_attempts=3
-          until PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \
-            node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run -- \
-              pnpm exec playwright test tests/e2e/oauth-providers.spec.ts \
-                --project=chromium --reporter=line; do
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \
+              node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run -- \
+                pnpm exec playwright test tests/e2e/oauth-providers.spec.ts \
+                  --project=chromium --reporter=line; then
+              break
+            else
+              guard_status=$?
+            fi
+
+            attempt_artifact_root="$oauth_retry_root/attempt-${attempt}"
+            mkdir -m 700 "$attempt_artifact_root"
+            quarantine_oauth_artifacts "$attempt_artifact_root/failed-artifacts"
+            if [ -f "$RUNNER_TEMP/safe-playwright-producer/blocked" ]; then
+              echo "::error::Playwright artifact guard blocked aliased staging OAuth output; refusing an unsafe retry."
+              exit "$guard_status"
+            fi
             if [ "$attempt" -ge "$max_attempts" ]; then
               echo "❌ Aliased staging Better Auth OAuth runtime proof failed after ${max_attempts} attempts."
               exit 1

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -154,6 +154,21 @@ function getShellRunBlocks(workflow: string): string[] {
   return blocks;
 }
 
+function getStepRunScript(step: string): string {
+  const lines = step.split('\n');
+  const run = lines.findIndex(line => /^\s+run:\s*\|\s*$/.test(line));
+
+  expect(run, 'Missing multiline run script').toBeGreaterThanOrEqual(0);
+
+  const body = lines.slice(run + 1);
+  const indentation = Math.min(
+    ...body.filter(line => line.trim()).map(line => line.search(/\S/))
+  );
+  return body
+    .map(line => (line.trim() ? line.slice(indentation) : ''))
+    .join('\n');
+}
+
 describe('source PR path-output reachability contract', () => {
   it('runs fast required gates for workflow-only changes without source unit or build work', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
@@ -871,7 +886,7 @@ describe('deploy workflow Vercel env resolution', () => {
     );
 
     expect(oauthStep).toContain(
-      'until PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \\\n'
+      'if PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \\\n'
     );
     expect(oauthStep).toContain(
       'node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run --'
@@ -1912,9 +1927,206 @@ describe('canary health gate workflow', () => {
     );
     expect(oauthStep).toContain('PLAYWRIGHT_VERCEL_BYPASS_SECRET:');
     expect(oauthStep).toContain('oauth-providers.spec.ts');
+    expect(oauthStep).toContain(
+      'oauth_retry_root="$RUNNER_TEMP/aliased-staging-oauth-retries"'
+    );
+    expect(oauthStep).toContain(
+      'PLAYWRIGHT_DYNAMIC_SECRETS_FILE: ${{ runner.temp }}/playwright-dynamic-cookie-values'
+    );
+    expect(oauthStep).toContain(
+      'attempt_artifact_root="$oauth_retry_root/attempt-${attempt}"'
+    );
+    expect(oauthStep).toContain(
+      'quarantine_oauth_artifacts "$attempt_artifact_root/failed-artifacts"'
+    );
+    expect(oauthStep).toContain(
+      'for artifact_path in test-results playwright-report'
+    );
+    expect(oauthStep).toContain('mv -- "$artifact_path" "$destination/"');
+    expect(oauthStep).toContain(
+      'if [ -f "$RUNNER_TEMP/safe-playwright-producer/blocked" ]'
+    );
+    expect(oauthStep).toContain('refusing an unsafe retry');
+    expect(oauthStep).not.toContain('attempt_runner_temp=');
+    expect(oauthStep).not.toContain('preexisting-artifacts');
+    expect(oauthStep).not.toContain('RUNNER_TEMP="$attempt_runner_temp"');
+    expect(oauthStep).not.toContain('rm -rf test-results');
+    expect(oauthStep.indexOf('guard-playwright-artifacts.mjs')).toBeLessThan(
+      oauthStep.indexOf('failed-artifacts')
+    );
+    expect(oauthStep.indexOf('failed-artifacts')).toBeLessThan(
+      oauthStep.indexOf('safe-playwright-producer/blocked')
+    );
+    expect(oauthStep.indexOf('safe-playwright-producer/blocked')).toBeLessThan(
+      oauthStep.indexOf('if [ "$attempt" -ge "$max_attempts" ]')
+    );
     expect(aliasJob.indexOf('- name: Alias verified deployment')).toBeLessThan(
       aliasJob.indexOf('- name: Verify aliased staging OAuth redirect URIs')
     );
+  });
+
+  it('retries a safe OAuth test failure with clean artifacts and shared guard state', () => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(release, 'alias-staging'),
+      'Verify aliased staging OAuth redirect URIs'
+    );
+    const root = mkdtempSync(resolve(tmpdir(), 'jovie-oauth-retry-'));
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const counter = resolve(root, 'attempt-count');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "$OAUTH_TEST_COUNTER" ]; then
+  attempt="$(cat "$OAUTH_TEST_COUNTER")"
+fi
+attempt=$((attempt + 1))
+printf '%s' "$attempt" > "$OAUTH_TEST_COUNTER"
+if [ -e test-results ] || [ -L test-results ] || [ -e playwright-report ] || [ -L playwright-report ]; then
+  exit 40
+fi
+if [ "$attempt" -eq 1 ]; then
+  mkdir -p test-results
+  printf '{"source":"failed-attempt"}' > test-results/attempt-one.json
+  exit 1
+fi
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\nexit 0\n',
+        {
+          mode: 0o700,
+        }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_TEST_COUNTER: counter,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(counter, 'utf8')).toBe('2');
+      const attemptOne = resolve(
+        runnerTemp,
+        'aliased-staging-oauth-retries/attempt-1'
+      );
+      expect(
+        readFileSync(
+          resolve(attemptOne, 'failed-artifacts/test-results/attempt-one.json'),
+          'utf8'
+        )
+      ).toContain('failed-attempt');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('stops OAuth retries when the artifact guard poisons shared state', () => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(release, 'alias-staging'),
+      'Verify aliased staging OAuth redirect URIs'
+    );
+    const root = mkdtempSync(resolve(tmpdir(), 'jovie-oauth-guard-block-'));
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const counter = resolve(root, 'attempt-count');
+      const sleepMarker = resolve(root, 'sleep-called');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "$OAUTH_TEST_COUNTER" ]; then
+  attempt="$(cat "$OAUTH_TEST_COUNTER")"
+fi
+attempt=$((attempt + 1))
+printf '%s' "$attempt" > "$OAUTH_TEST_COUNTER"
+if [ "$attempt" -gt 1 ]; then
+  exit 42
+fi
+mkdir -p test-results "$RUNNER_TEMP/safe-playwright-producer"
+printf '{"source":"unsafe-attempt"}' > test-results/attempt-one.json
+touch "$RUNNER_TEMP/safe-playwright-producer/blocked"
+exit 23
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\ntouch "$OAUTH_SLEEP_MARKER"\n',
+        { mode: 0o700 }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_SLEEP_MARKER: sleepMarker,
+            OAUTH_TEST_COUNTER: counter,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(23);
+      expect(readFileSync(counter, 'utf8')).toBe('1');
+      expect(result.stdout).toContain('refusing an unsafe retry');
+      expect(() => readFileSync(sleepMarker, 'utf8')).toThrow();
+      expect(
+        readFileSync(
+          resolve(runnerTemp, 'safe-playwright-producer/blocked'),
+          'utf8'
+        )
+      ).toBe('');
+      expect(
+        readFileSync(
+          resolve(
+            runnerTemp,
+            'aliased-staging-oauth-retries/attempt-1/failed-artifacts/test-results/attempt-one.json'
+          ),
+          'utf8'
+        )
+      ).toContain('unsafe-attempt');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary\n\n- preserve one shared Playwright artifact-guard state across aliased staging OAuth retry attempts\n- quarantine test-results and playwright-report from safe failed attempts before retrying\n- stop immediately when the shared guard writes its terminal blocked marker, preserving the poisoned state and evidence\n- retain the landed #14680 dynamic-secret sentinel contract and #14683 PLAYWRIGHT_WORKERS=1 OAuth serialization\n- add executable workflow regressions for safe retry cleanup and terminal poisoned-state behavior\n\n## Scope correction\n\nCurrent main already contains #14680 and #14683, which supersede the earlier protected-origin and Lighthouse cookie-script changes. This PR is intentionally reduced to exactly two files: production-release.yml and its deploy workflow contract. No protected-origin or Lighthouse script remains modified.\n\n## Verification\n\n- deploy workflow contract: 77 tests passed on repo-pinned Node 22\n- actionlint passed for .github/workflows/production-release.yml\n- Biome and git diff --check passed\n- mandatory pre-push gate passed: typecheck, Tailwind guard, focused affected test, Turbo checks, and CI harness validation\n\n## Queue state\n\nThe stale merge group was cancelled and removed. The amended PR remains queue-deferred and outside the native merge queue while fresh source CI and latest production proof are assessed.\n\n## Risk\n\nThe change is limited to retry control and artifact quarantine in the existing aliased staging OAuth proof. A safe nonzero test failure can retry from clean artifact paths; an unsafe or unverifiable guard result remains terminal and cannot be retried.