### PR TITLE
fix(ci): record zero dynamic-secret probe state (#14678)

### DIFF
--- a/apps/web/scripts/lighthouse-exact-target-guard.test.ts
+++ b/apps/web/scripts/lighthouse-exact-target-guard.test.ts
@@ -27,6 +27,7 @@ import {
   validateLighthouseArtifactSeal,
   validateNoSensitiveArtifactValues,
 } from './lighthouse-exact-target-guard';
+import { ZERO_DYNAMIC_SECRET_RECEIPT } from './vercel-protected-origin.cjs';
 
 const BASE_URL = 'https://jovie-5sy8pmjja-jovie.vercel.app';
 const HOME_URL = `${BASE_URL}/`;
@@ -199,9 +200,14 @@ describe('exact production Lighthouse evidence guard', () => {
   });
 
   it.each([
+    '1',
     'sentinel-bypass-secret',
     'sentinel-cookie-value',
   ])('rejects artifacts containing protected probe state without echoing it', sensitiveValue => {
+    const sensitiveValues =
+      sensitiveValue === '1'
+        ? ['1']
+        : ['sentinel-bypass-secret', 'sentinel-cookie-value'];
     expect(() =>
       validateNoSensitiveArtifactValues(
         [
@@ -210,13 +216,13 @@ describe('exact production Lighthouse evidence guard', () => {
             contents: JSON.stringify({ diagnostic: sensitiveValue }),
           },
         ],
-        ['sentinel-bypass-secret', 'sentinel-cookie-value']
+        sensitiveValues
       )
     ).toThrow('protected probe state');
     try {
       validateNoSensitiveArtifactValues(
         [{ name: 'lhr-1.json', contents: sensitiveValue }],
-        [sensitiveValue]
+        sensitiveValues
       );
     } catch (error) {
       expect(String(error)).not.toContain(sensitiveValue);
@@ -271,6 +277,22 @@ describe('exact production Lighthouse evidence guard', () => {
       expect(() => readSensitiveValues(symlinkReceipt, reports)).toThrow(
         'mode-0600 regular file'
       );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('accepts only the explicit zero dynamic-secret receipt', () => {
+    const root = mkdtempSync(join(tmpdir(), 'jovie-zero-receipt-'));
+    const receipt = join(root, 'sensitive-values');
+    try {
+      writeFileSync(receipt, `${ZERO_DYNAMIC_SECRET_RECEIPT}\n`, {
+        mode: 0o600,
+      });
+      expect(readSensitiveValues(receipt)).toEqual([]);
+
+      writeFileSync(receipt, '');
+      expect(() => readSensitiveValues(receipt)).toThrow('receipt is empty');
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/web/scripts/lighthouse-exact-target-guard.ts
+++ b/apps/web/scripts/lighthouse-exact-target-guard.ts
@@ -25,6 +25,7 @@ import { pathToFileURL } from 'node:url';
 import {
   isExactVercelDeploymentUrl,
   parseProbeUrl,
+  ZERO_DYNAMIC_SECRET_RECEIPT,
 } from './vercel-protected-origin.cjs';
 
 interface ExactLighthouseConfig {
@@ -511,6 +512,12 @@ export function readSensitiveValues(
   const values = contents.split(/\r?\n/).filter(Boolean);
   if (values.length === 0) {
     throw new Error('Lighthouse sensitive-values receipt is empty.');
+  }
+  if (values.includes(ZERO_DYNAMIC_SECRET_RECEIPT)) {
+    if (values.length !== 1) {
+      throw new Error('Lighthouse sensitive-values receipt is malformed.');
+    }
+    return [];
   }
   return values;
 }

--- a/apps/web/scripts/lighthouse-vercel-bypass.cjs
+++ b/apps/web/scripts/lighthouse-vercel-bypass.cjs
@@ -22,12 +22,13 @@ const {
   readVerifiedBuildInfo,
   safeRouteLabel,
   validateBuildInfo,
+  ZERO_DYNAMIC_SECRET_RECEIPT,
 } = require('./vercel-protected-origin.cjs');
 
 const COOKIE_SCOPE_PROBE_PATH = '/__jovie_cookie_scope_probe__';
 
 function recordSensitiveValues(path, values) {
-  const safeValues = maskSensitiveValues(values);
+  const safeValues = values.length === 0 ? [] : maskSensitiveValues(values);
   if (!path) return;
   let expectedIdentity;
   let flags = constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW;
@@ -54,7 +55,11 @@ function recordSensitiveValues(path, values) {
       );
     }
     fchmodSync(descriptor, 0o600);
-    writeSync(descriptor, `${safeValues.join('\n')}\n`, null, 'utf8');
+    const receipt =
+      safeValues.length === 0
+        ? ZERO_DYNAMIC_SECRET_RECEIPT
+        : safeValues.join('\n');
+    writeSync(descriptor, `${receipt}\n`, null, 'utf8');
   } finally {
     closeSync(descriptor);
   }

--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -1,6 +1,7 @@
 import {
   chmodSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -19,6 +20,7 @@ const {
   buildOriginBoundCookieRequest,
   buildOriginBoundProbeRequest,
   maskSensitiveValues,
+  ZERO_DYNAMIC_SECRET_RECEIPT,
   parseExactHostCookieJar,
   readExactHostCookieJar,
   resolveAuthorizedVercelDeployment,
@@ -98,6 +100,7 @@ const {
 const {
   primeLighthouseVercelAliasBypass,
   primeLighthouseVercelBypass,
+  recordSensitiveValues,
   sensitiveCookieValues,
   validateBuildInfo,
   validateCookieOriginBoundaryHeaders,
@@ -157,6 +160,10 @@ const {
   readonly sensitiveCookieValues: (
     cookies: readonly { readonly name: string; readonly value: string }[]
   ) => readonly string[];
+  readonly recordSensitiveValues: (
+    path: string,
+    values: readonly string[]
+  ) => void;
 };
 
 const DEPLOYMENT_URL = 'https://jovie-5sy8pmjja-jovie.vercel.app/';
@@ -240,14 +247,33 @@ function browserFixture({ leakToChild = false } = {}) {
 }
 
 describe('origin-bound Vercel protection bypass', () => {
-  it('records only non-public probe cookie values', () => {
+  it('records an explicit zero-state receipt for public-only probe cookies', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'jovie-zero-receipt-'));
+    const receiptPath = join(directory, 'sensitive-values');
+    try {
+      recordSensitiveValues(
+        receiptPath,
+        sensitiveCookieValues([
+          { name: 'jv_country', value: 'US' },
+          { name: 'jv_cc_required', value: '1' },
+        ])
+      );
+      expect(readFileSync(receiptPath, 'utf8')).toBe(
+        `${ZERO_DYNAMIC_SECRET_RECEIPT}\n`
+      );
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps an unknown short dynamic cookie value in the sensitive receipt', () => {
     expect(
       sensitiveCookieValues([
         { name: 'jv_country', value: 'US' },
         { name: 'jv_cc_required', value: '1' },
-        { name: '__vercel_live_token', value: 'opaque-cookie' },
+        { name: '__unknown_dynamic_cookie', value: '1' },
       ])
-    ).toEqual(['opaque-cookie']);
+    ).toEqual(['1']);
   });
 
   it('never attaches the bypass credential to canonical production', () => {

--- a/apps/web/scripts/vercel-protected-origin.cjs
+++ b/apps/web/scripts/vercel-protected-origin.cjs
@@ -15,6 +15,7 @@ const {
 const BYPASS_HEADER = 'x-vercel-protection-bypass';
 const SET_BYPASS_COOKIE_HEADER = 'x-vercel-set-bypass-cookie';
 const PUBLIC_PROBE_COOKIE_NAMES = new Set(['jv_country', 'jv_cc_required']);
+const ZERO_DYNAMIC_SECRET_RECEIPT = 'jovie-protected-probe:no-dynamic-secrets';
 const BUILD_INFO_PATH = '/api/health/build-info';
 const DEFAULT_PROBE_TIMEOUT_MS = 120_000;
 const DEFAULT_VERCEL_API_PAGES = 5;
@@ -1342,6 +1343,7 @@ module.exports = {
   DEFAULT_PROBE_TIMEOUT_MS,
   PUBLIC_PROBE_COOKIE_NAMES,
   PUBLIC_HTML_SURFACES,
+  ZERO_DYNAMIC_SECRET_RECEIPT,
   SET_BYPASS_COOKIE_HEADER,
   assertAuthorizedDeploymentOrigin,
   assertExactProbeResponse,


### PR DESCRIPTION
## Summary
- add an explicit zero dynamic-secret receipt for public-only Vercel probe cookies
- preserve fail-closed masking, short-value handling, and artifact scanning for all dynamic values
- add targeted regression coverage for public-only, unknown short, real dynamic, and missing/empty receipt cases

## Verification
- `pnpm --filter @jovie/web exec vitest run scripts/lighthouse-vercel-bypass.test.ts scripts/lighthouse-exact-target-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm biome check --write apps/web/scripts/vercel-protected-origin.cjs apps/web/scripts/lighthouse-vercel-bypass.cjs apps/web/scripts/lighthouse-vercel-bypass.test.ts apps/web/scripts/lighthouse-exact-target-guard.ts apps/web/scripts/lighthouse-exact-target-guard.test.ts`

Fixes #14678
