### PR TITLE
fix(ci): exempt merge-queue synthetic heads from version-fanout guard

### DIFF
--- a/scripts/version-fanout-guard.mjs
+++ b/scripts/version-fanout-guard.mjs
@@ -54,6 +54,15 @@ export function isStampAllowedBranch(branch) {
   if (STAMP_ALLOWED_BRANCHES.has(normalized)) {
     return true;
   }
+  // Merge-queue synthetic heads (gh-readonly-queue/<base>/pr-<n>-<sha>) carry
+  // the combined main+PR tree with no source-branch context. The pull_request
+  // lane already enforces the guard on the source branch, so a queued PR's
+  // fan-out writes were validated before enrollment — do not re-classify the
+  // queue branch as a feature branch (GH-14658: version-stamp PRs could never
+  // pass the merge queue).
+  if (normalized.startsWith('gh-readonly-queue/')) {
+    return true;
+  }
   // Integration / train branches roll up already-stamped commits.
   return /^(integration|train|release|hotfix)\//.test(normalized);
 }

--- a/scripts/version-fanout-guard.test.mjs
+++ b/scripts/version-fanout-guard.test.mjs
@@ -40,6 +40,15 @@ test('allows version stamping on main and release/integration branches', () => {
   assert.equal(isStampAllowedBranch('integration/release-train'), true);
 });
 
+test('allows merge-queue synthetic heads (source branch already enforced)', () => {
+  assert.equal(
+    isStampAllowedBranch(
+      'gh-readonly-queue/main/pr-14658-21ed4be61ae4479d8a9bf209ce48f54a153e73b2'
+    ),
+    true
+  );
+});
+
 test('fails when a feature branch edits scalar version files', () => {
   const result = evaluate({ changedFiles: ['VERSION'] });
 


### PR DESCRIPTION
The version-fanout guard classified `gh-readonly-queue/*` group branches as feature branches, so a version-stamp PR (release/*) could never pass the merge queue: ci-fast on the combined head failed with `version 26.6.61 → 26.7.0 on a feature branch` (surfaced by release PR #14658).

The pull_request lane already enforces the guard on the source branch, so the merge_group evaluation is redundant for branch classification — exempt the synthetic head. Includes test coverage.