### PR TITLE
fix(ci): serialize aliased staging OAuth proof

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -565,7 +565,7 @@ jobs:
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
           attempt=1
           max_attempts=3
-          until CI=true SMOKE_ONLY=1 \
+          until PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \
             node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run -- \
               pnpm exec playwright test tests/e2e/oauth-providers.spec.ts \
                 --project=chromium --reporter=line; do

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -863,6 +863,28 @@ describe('deploy workflow Vercel env resolution', () => {
     );
   });
 
+  it('serializes only the aliased staging OAuth proof', () => {
+    const workflow = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(workflow, 'alias-staging'),
+      'Verify aliased staging OAuth redirect URIs'
+    );
+
+    expect(oauthStep).toContain(
+      'until PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \\\n'
+    );
+    expect(oauthStep).toContain(
+      'node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run --'
+    );
+    expect(oauthStep).toContain(
+      'pnpm exec playwright test tests/e2e/oauth-providers.spec.ts'
+    );
+    expect(oauthStep).toContain('--project=chromium --reporter=line');
+    expect(oauthStep).toContain('max_attempts=3');
+    expect(oauthStep).toContain('sleep "$sleep_seconds"');
+    expect(workflow).not.toMatch(/^\s+PLAYWRIGHT_WORKERS:/m);
+  });
+
   it('cross-proves one-shot CI evidence under one dedicated FIFO production lease', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const controller = readFileSync(productionControllerWorkflowPath, 'utf8');


### PR DESCRIPTION
<!-- linear-issue-id:14681 -->

## Summary
- Set `PLAYWRIGHT_WORKERS=1` only on the production-release aliased staging OAuth proof command.
- Preserve `CI=true SMOKE_ONLY=1`, the artifact guard, Chromium OAuth spec, and existing three-attempt retry loop.
- Add focused workflow contract coverage proving the override is scoped to this proof step.

## Evidence
- Controller 29876229314 staging build/canary passed; alias OAuth was `1 flaky, 2 passed` with Apple passing on retry.
- `git diff --check` passed.
- Focused Vitest and Biome could not run locally because this workspace has no installed `vitest` or `biome` binaries.

Closes #14681