### PR TITLE
fix(release): recover post-deploy build identity

### DIFF
--- a/.github/workflows/postdeploy-probes.yml
+++ b/.github/workflows/postdeploy-probes.yml
@@ -197,7 +197,10 @@ jobs:
         id: target
         if: ${{ steps.trigger.outputs.should_probe == 'true' }}
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           SHOULD_PROBE: ${{ steps.trigger.outputs.should_probe }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -210,7 +213,7 @@ jobs:
             echo "deployment_url_b64="
             echo "commit_sha="
           } >> "$GITHUB_OUTPUT"
-          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for key in GH_TOKEN REPOSITORY VERCEL_AUTOMATION_BYPASS_SECRET VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
             if [ -z "${!key:-}" ]; then
               echo "::error::$key is required to resolve the canonical production deployment."
               exit 1
@@ -235,7 +238,6 @@ jobs:
           deployment_url="$(jq -r '.url' <<<"$canonical_json")"
           deployment_state="$(jq -r '.readyState | ascii_upcase' <<<"$canonical_json")"
           deployment_target="$(jq -r '.target | ascii_downcase' <<<"$canonical_json")"
-          commit_sha="$(jq -r '.meta.githubCommitSha // .gitSource.sha // ""' <<<"$canonical_json")"
           if [[ "$deployment_url" != *://* && "$deployment_url" == *.vercel.app ]]; then
             deployment_url="https://${deployment_url}"
           fi
@@ -243,9 +245,8 @@ jobs:
           if [[ "$deployment_id" != dpl_* ]] ||
             [ "$deployment_state" != "READY" ] ||
             [ "$deployment_target" != "production" ] ||
-            [[ ! "$deployment_url" =~ ^https://jovie-[a-z0-9-]+-jovie\.vercel\.app$ ]] ||
-            [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Canonical production is not an exact READY production deployment with a full commit SHA."
+            [[ ! "$deployment_url" =~ ^https://jovie-[a-z0-9-]+-jovie\.vercel\.app$ ]]; then
+            echo "::error::Canonical production is not an exact READY production deployment."
             exit 1
           fi
 
@@ -254,7 +255,7 @@ jobs:
           exact_json="$(
             VERCEL_CANDIDATE_DEPLOYMENT_URL="$deployment_url" \
             VERCEL_CANDIDATE_DEPLOYMENT_ID="$deployment_id" \
-            EXPECTED_COMMIT_SHA="$commit_sha" \
+            VERCEL_ALLOW_MISSING_COMMIT_SHA=true \
             VERCEL_DEPLOYMENT_MAX_PAGES=5 \
             VERCEL_API_TIMEOUT_MS=120000 \
             VERCEL_DEPLOYMENT_POLL_INTERVAL_MS=3000 \
@@ -264,6 +265,52 @@ jobs:
             echo "::error::Exact landed production deployment identity did not converge."
             exit 1
           }
+          [ "$(jq -r '.url // ""' <<<"$exact_json")" = "$deployment_url" ] || {
+            echo "::error::Exact landed production deployment URL did not converge."
+            exit 1
+          }
+
+          # Vercel source metadata is optional and is absent on some CLI-built
+          # production deployments. Read the deployed build identity from the
+          # exact immutable origin instead, with an origin-bound bypass cookie.
+          build_identity_json="$(
+            VERCEL_PROBE_URL="$deployment_url" \
+            EXPECTED_VERCEL_DEPLOYMENT_ORIGIN="$deployment_url" \
+            EXPECTED_VERCEL_ENVIRONMENT=production \
+            VERCEL_PROBE_TIMEOUT_MS=120000 \
+              node apps/web/scripts/vercel-protected-origin.cjs discover-build-identity
+          )"
+          deployed_sha="$(jq -r '.commitSha // ""' <<<"$build_identity_json")"
+          [[ "$deployed_sha" =~ ^[0-9a-f]{7,40}$ ]] || {
+            echo "::error::Exact production build identity omitted a valid commit SHA."
+            exit 1
+          }
+
+          # Expand the deployed prefix inside this repository, then prove that
+          # exact commit is on main. GitHub rejects ambiguous or foreign SHAs.
+          commit_json="$(gh api "repos/$REPOSITORY/commits/$deployed_sha")"
+          commit_sha="$(jq -r '.sha // ""' <<<"$commit_json")"
+          [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] &&
+            [[ "$commit_sha" == "$deployed_sha"* ]] || {
+            echo "::error::Deployed commit identity did not resolve uniquely in this repository."
+            exit 1
+          }
+          comparison_json="$(gh api "repos/$REPOSITORY/compare/$commit_sha...main")"
+          jq -e --arg sha "$commit_sha" '
+            type == "object" and
+            (.status == "ahead" or .status == "identical") and
+            .base_commit.sha == $sha and
+            .merge_base_commit.sha == $sha
+          ' >/dev/null <<<"$comparison_json" || {
+            echo "::error::Canonical production commit is not an ancestor of main."
+            exit 1
+          }
+
+          observed_vercel_sha="$(jq -r '.commitSha // ""' <<<"$exact_json")"
+          if [ -n "$observed_vercel_sha" ] && [ "$observed_vercel_sha" != "$commit_sha" ]; then
+            echo "::error::Vercel list metadata disagrees with the exact origin build identity."
+            exit 1
+          fi
 
           {
             echo "deployment_id=$deployment_id"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 ## [Unreleased]
 - [internal] **App shell loading skeleton** matches `DESIGN_V1` so flag-on users no longer flash the legacy sidebar/header on first `/app` paint.
 
+- [internal] **Post-deploy probes now identify CLI-built production deployments (JOV-4366):** exact immutable build identity replaces optional Vercel source metadata while preserving project, deployment, origin, environment, and main-ancestry proofs.
 - **[internal] Staging Better Auth Google OAuth credentials now reach the Vercel build and runtime deploy (#14659):** the release workflow allowlists and forwards both Google client keys, failing closed when either is absent.
 - **Suggested DSP matches no longer flash a skeleton then collapse (JOV-4159):** when the Music drawer loads with no match suggestions (the common case), the section stays empty instead of flashing skeleton rows and shifting sibling content.
 - **Update banner shows the real release version (JOV-3459):** "New Version Available" no longer renders a bogus `(v0.0.0)` parenthetical; build-info prefers the stamped release version (and falls back to bundled `version.json`), and both shell/legacy banners omit the version when unavailable.

--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -16,6 +16,7 @@ const {
   assertAuthorizedDeploymentOrigin,
   assertOriginBoundRedirect,
   bootstrapOriginBoundAccess,
+  discoverOriginBoundBuildIdentity,
   buildOriginBoundCookieRequest,
   buildOriginBoundProbeRequest,
   maskSensitiveValues,
@@ -38,12 +39,27 @@ const {
     options: {
       readonly fetchImpl: ReturnType<typeof vi.fn>;
       readonly bypassSecret: string;
-      readonly expectedCommitSha: string;
+      readonly expectedCommitSha?: string;
       readonly expectedDeploymentOrigin: string;
       readonly expectedEnvironment: 'preview' | 'production';
+      readonly maskLineWriter?: (line: string) => void;
       readonly timeoutMs?: number;
     }
   ) => Promise<unknown>;
+  readonly discoverOriginBoundBuildIdentity: (
+    url: string,
+    options: {
+      readonly fetchImpl: ReturnType<typeof vi.fn>;
+      readonly bypassSecret: string;
+      readonly expectedDeploymentOrigin: string;
+      readonly expectedEnvironment: 'preview' | 'production';
+      readonly maskLineWriter?: (line: string) => void;
+    }
+  ) => Promise<{
+    readonly buildId: string;
+    readonly commitSha: string;
+    readonly environment: 'preview' | 'production';
+  }>;
   readonly buildOriginBoundCookieRequest: (
     url: string,
     options: { readonly cookieHeader: string }
@@ -81,11 +97,16 @@ const {
     readonly token: string;
     readonly orgId: string;
     readonly projectId: string;
-    readonly commitSha: string;
+    readonly commitSha?: string;
     readonly candidateUrl?: string;
     readonly candidateId?: string;
+    readonly allowMissingCommitSha?: boolean;
     readonly maxPages?: number;
-  }) => Promise<{ readonly id: string; readonly url: string }>;
+  }) => Promise<{
+    readonly id: string;
+    readonly url: string;
+    readonly commitSha?: string | null;
+  }>;
   readonly verifyPublicDeploymentSurfaces: (
     url: string,
     options: {
@@ -760,6 +781,84 @@ describe('origin-bound Vercel protection bypass', () => {
     ).toThrow('must be explicitly set');
   });
 
+  it('discovers a short commit only from an exact origin-bound production identity', async () => {
+    vi.stubEnv('GITHUB_ACTIONS', 'true');
+    const maskLineWriter = vi.fn();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        responseFixture({
+          status: 307,
+          location: BUILD_INFO_URL,
+          setCookies: [
+            '__vercel_live_token=opaque-cookie; Path=/; Secure; HttpOnly',
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        responseFixture({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            buildId: 'production-build',
+            commitSha: EXPECTED_SHA.slice(0, 7),
+            environment: 'production',
+          }),
+        })
+      );
+
+    await expect(
+      discoverOriginBoundBuildIdentity(DEPLOYMENT_URL, {
+        fetchImpl,
+        bypassSecret: 'sentinel-secret',
+        expectedDeploymentOrigin: DEPLOYMENT_URL,
+        expectedEnvironment: 'production',
+        maskLineWriter,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'production-build',
+      commitSha: EXPECTED_SHA.slice(0, 7),
+      environment: 'production',
+    });
+    expect(maskLineWriter).toHaveBeenCalledWith('::add-mask::opaque-cookie');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects malformed or wrong-environment build identity during discovery', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        responseFixture({
+          status: 307,
+          location: BUILD_INFO_URL,
+          setCookies: [
+            '__vercel_live_token=opaque-cookie; Path=/; Secure; HttpOnly',
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        responseFixture({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            buildId: 'preview-build',
+            commitSha: 'not-a-sha',
+            environment: 'preview',
+          }),
+        })
+      );
+
+    await expect(
+      discoverOriginBoundBuildIdentity(DEPLOYMENT_URL, {
+        fetchImpl,
+        bypassSecret: 'sentinel-secret',
+        expectedDeploymentOrigin: DEPLOYMENT_URL,
+        expectedEnvironment: 'production',
+      })
+    ).rejects.toThrow('wrong-environment build identity');
+  });
+
   it('uses one aborting absolute deadline for a stalled protected bootstrap', async () => {
     vi.useFakeTimers();
     try {
@@ -1022,6 +1121,158 @@ describe('origin-bound Vercel protection bypass', () => {
       })
     ).resolves.toEqual({ id: 'dpl_exact', url: DEPLOYMENT_URL.slice(0, -1) });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts absent Vercel SHA only for an exact READY deployment identity', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          deployments: [
+            {
+              uid: 'dpl_exact',
+              url: DEPLOYMENT_URL,
+              projectId: 'prj_jovie',
+              readyState: 'READY',
+              meta: {},
+            },
+          ],
+          pagination: { next: null },
+        })
+      ),
+    });
+
+    await expect(
+      resolveAuthorizedVercelDeployment({
+        fetchImpl,
+        token: 'sentinel-vercel-token',
+        orgId: 'team_jovie',
+        projectId: 'prj_jovie',
+        candidateUrl: DEPLOYMENT_URL,
+        candidateId: 'dpl_exact',
+        allowMissingCommitSha: true,
+      })
+    ).resolves.toEqual({
+      id: 'dpl_exact',
+      url: DEPLOYMENT_URL.slice(0, -1),
+      commitSha: null,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('rejects missing-SHA mode without both exact deployment coordinates', async () => {
+    await expect(
+      resolveAuthorizedVercelDeployment({
+        fetchImpl: vi.fn(),
+        token: 'sentinel-vercel-token',
+        orgId: 'team_jovie',
+        projectId: 'prj_jovie',
+        candidateUrl: DEPLOYMENT_URL,
+        allowMissingCommitSha: true,
+      })
+    ).rejects.toThrow('requires an exact deployment URL and ID');
+  });
+
+  it('still rejects malformed or conflicting present SHA in missing-SHA mode', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          deployments: [
+            {
+              uid: 'dpl_exact',
+              url: DEPLOYMENT_URL,
+              projectId: 'prj_jovie',
+              readyState: 'READY',
+              meta: { githubCommitSha: 'short-sha' },
+            },
+          ],
+          pagination: { next: null },
+        })
+      ),
+    });
+
+    await expect(
+      resolveAuthorizedVercelDeployment({
+        fetchImpl,
+        token: 'sentinel-vercel-token',
+        orgId: 'team_jovie',
+        projectId: 'prj_jovie',
+        candidateUrl: DEPLOYMENT_URL,
+        candidateId: 'dpl_exact',
+        allowMissingCommitSha: true,
+      })
+    ).rejects.toThrow('malformed commit SHA field');
+  });
+
+  it('rejects contradictory Vercel commit identity fields', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          deployments: [
+            {
+              uid: 'dpl_exact',
+              url: DEPLOYMENT_URL,
+              projectId: 'prj_jovie',
+              readyState: 'READY',
+              meta: { githubCommitSha: EXPECTED_SHA },
+              gitSource: { sha: 'b'.repeat(40) },
+            },
+          ],
+          pagination: { next: null },
+        })
+      ),
+    });
+
+    await expect(
+      resolveAuthorizedVercelDeployment({
+        fetchImpl,
+        token: 'sentinel-vercel-token',
+        orgId: 'team_jovie',
+        projectId: 'prj_jovie',
+        candidateUrl: DEPLOYMENT_URL,
+        candidateId: 'dpl_exact',
+        allowMissingCommitSha: true,
+      })
+    ).rejects.toThrow('conflicting commit SHA fields');
+  });
+
+  it('uses a valid Git-source SHA when metadata contains an empty SHA', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          deployments: [
+            {
+              uid: 'dpl_exact',
+              url: DEPLOYMENT_URL,
+              projectId: 'prj_jovie',
+              readyState: 'READY',
+              meta: { githubCommitSha: '' },
+              gitSource: { sha: EXPECTED_SHA },
+            },
+          ],
+          pagination: { next: null },
+        })
+      ),
+    });
+
+    await expect(
+      resolveAuthorizedVercelDeployment({
+        fetchImpl,
+        token: 'sentinel-vercel-token',
+        orgId: 'team_jovie',
+        projectId: 'prj_jovie',
+        candidateUrl: DEPLOYMENT_URL,
+        candidateId: 'dpl_exact',
+        allowMissingCommitSha: true,
+      })
+    ).resolves.toEqual({
+      id: 'dpl_exact',
+      url: DEPLOYMENT_URL.slice(0, -1),
+      commitSha: EXPECTED_SHA,
+    });
   });
 
   it('retries bounded transport failures and transient Vercel 5xx responses', async () => {

--- a/apps/web/scripts/vercel-protected-origin.cjs
+++ b/apps/web/scripts/vercel-protected-origin.cjs
@@ -625,8 +625,7 @@ async function readResponseText(response, deadline) {
   return deadline ? deadline.run(() => response.text()) : response.text();
 }
 
-function validateBuildInfo(payload, expectedCommitSha, expectedEnvironment) {
-  const expectedSha = requireFullCommitSha(expectedCommitSha);
+function validateBuildIdentity(payload, expectedEnvironment) {
   const environment = requireExpectedEnvironment(expectedEnvironment);
   if (
     !payload ||
@@ -641,18 +640,23 @@ function validateBuildInfo(payload, expectedCommitSha, expectedEnvironment) {
       'Exact Vercel deployment bypass verification returned malformed or wrong-environment build identity.'
     );
   }
-  if (!expectedSha.startsWith(payload.commitSha)) {
+  return payload;
+}
+
+function validateBuildInfo(payload, expectedCommitSha, expectedEnvironment) {
+  const expectedSha = requireFullCommitSha(expectedCommitSha);
+  const identity = validateBuildIdentity(payload, expectedEnvironment);
+  if (!expectedSha.startsWith(identity.commitSha)) {
     throw new Error(
       'Exact Vercel deployment bypass verification returned the wrong commit.'
     );
   }
-  return payload;
+  return identity;
 }
 
-async function readVerifiedBuildInfo(
+async function readBuildIdentity(
   response,
   requestedUrl,
-  expectedCommitSha,
   expectedEnvironment,
   deadline
 ) {
@@ -679,10 +683,26 @@ async function readVerifiedBuildInfo(
       'Exact Vercel deployment bypass verification returned invalid JSON.'
     );
   }
-  return validateBuildInfo(payload, expectedCommitSha, expectedEnvironment);
+  return validateBuildIdentity(payload, expectedEnvironment);
 }
 
-async function bootstrapOriginBoundAccess(
+async function readVerifiedBuildInfo(
+  response,
+  requestedUrl,
+  expectedCommitSha,
+  expectedEnvironment,
+  deadline
+) {
+  const identity = await readBuildIdentity(
+    response,
+    requestedUrl,
+    expectedEnvironment,
+    deadline
+  );
+  return validateBuildInfo(identity, expectedCommitSha, expectedEnvironment);
+}
+
+async function bootstrapOriginBoundAccessInternal(
   rawTargetUrl,
   {
     fetchImpl = globalThis.fetch,
@@ -690,11 +710,13 @@ async function bootstrapOriginBoundAccess(
     expectedCommitSha = process.env.EXPECTED_COMMIT_SHA,
     expectedDeploymentOrigin = process.env.EXPECTED_VERCEL_DEPLOYMENT_ORIGIN,
     expectedEnvironment = process.env.EXPECTED_VERCEL_ENVIRONMENT,
+    maskLineWriter,
     timeoutMs = process.env.VERCEL_PROBE_TIMEOUT_MS ?? DEFAULT_PROBE_TIMEOUT_MS,
     deadline: suppliedDeadline,
     onSensitiveValues,
     onCookies,
-  } = {}
+  } = {},
+  discoverCommitSha
 ) {
   const targetUrl = parseProbeUrl(rawTargetUrl, 'Protected deployment target');
   if (
@@ -708,7 +730,9 @@ async function bootstrapOriginBoundAccess(
   }
   requireExpectedDeploymentOrigin(expectedDeploymentOrigin, targetUrl);
   const environment = requireExpectedEnvironment(expectedEnvironment);
-  const expectedSha = requireFullCommitSha(expectedCommitSha);
+  const expectedSha = discoverCommitSha
+    ? undefined
+    : requireFullCommitSha(expectedCommitSha);
   const deadline =
     suppliedDeadline ??
     createAbsoluteDeadline(timeoutMs, 'Protected deployment bootstrap');
@@ -742,7 +766,10 @@ async function bootstrapOriginBoundAccess(
     }
 
     const cookies = parseOriginBoundCookies(bootstrapResponse, targetUrl);
-    maskSensitiveValues(cookies.map(cookie => cookie.value));
+    maskSensitiveValues(
+      cookies.map(cookie => cookie.value),
+      maskLineWriter
+    );
     if (onSensitiveValues) {
       await deadline.run(() => onSensitiveValues(cookies));
     }
@@ -763,18 +790,38 @@ async function bootstrapOriginBoundAccess(
       verification.url,
       verification.options
     );
-    const buildInfo = await readVerifiedBuildInfo(
-      verificationResponse,
-      verification.url,
-      expectedSha,
-      environment,
-      deadline
-    );
+    const buildInfo = expectedSha
+      ? await readVerifiedBuildInfo(
+          verificationResponse,
+          verification.url,
+          expectedSha,
+          environment,
+          deadline
+        )
+      : await readBuildIdentity(
+          verificationResponse,
+          verification.url,
+          environment,
+          deadline
+        );
 
     return { buildInfo, cookieHeader, cookies, targetUrl };
   } finally {
     if (ownsDeadline) deadline.dispose();
   }
+}
+
+async function bootstrapOriginBoundAccess(rawTargetUrl, options) {
+  return bootstrapOriginBoundAccessInternal(rawTargetUrl, options, false);
+}
+
+async function discoverOriginBoundBuildIdentity(rawTargetUrl, options) {
+  const access = await bootstrapOriginBoundAccessInternal(
+    rawTargetUrl,
+    options,
+    true
+  );
+  return access.buildInfo;
 }
 
 async function bootstrapAliasBoundAccess(
@@ -1035,7 +1082,26 @@ function normalizeDeploymentUrl(rawUrl, label = 'Vercel deployment URL') {
 }
 
 function deploymentCommitSha(deployment) {
-  return deployment?.meta?.githubCommitSha ?? deployment?.gitSource?.sha;
+  const presentShas = [
+    deployment?.meta?.githubCommitSha,
+    deployment?.gitSource?.sha,
+  ].filter(value => value !== undefined && value !== null && value !== '');
+  if (presentShas.length === 0) return undefined;
+  if (
+    presentShas.some(
+      value => typeof value !== 'string' || !FULL_COMMIT_SHA.test(value)
+    )
+  ) {
+    throw new Error(
+      'Exact caller deployment returned a malformed commit SHA field.'
+    );
+  }
+  if (new Set(presentShas).size !== 1) {
+    throw new Error(
+      'Exact caller deployment returned conflicting commit SHA fields.'
+    );
+  }
+  return presentShas[0];
 }
 
 function deploymentState(deployment) {
@@ -1067,6 +1133,8 @@ async function resolveAuthorizedVercelDeployment({
   commitSha = process.env.EXPECTED_COMMIT_SHA ?? process.env.COMMIT_SHA,
   candidateUrl = process.env.VERCEL_CANDIDATE_DEPLOYMENT_URL,
   candidateId = process.env.VERCEL_CANDIDATE_DEPLOYMENT_ID,
+  allowMissingCommitSha = process.env.VERCEL_ALLOW_MISSING_COMMIT_SHA ===
+    'true',
   maxPages = process.env.VERCEL_DEPLOYMENT_MAX_PAGES ??
     DEFAULT_VERCEL_API_PAGES,
   timeoutMs = process.env.VERCEL_API_TIMEOUT_MS ?? 30_000,
@@ -1076,9 +1144,17 @@ async function resolveAuthorizedVercelDeployment({
 } = {}) {
   const credential = token?.trim();
   const project = projectId?.trim();
-  const expectedSha = requireFullCommitSha(commitSha);
   const exactCandidateUrl = normalizeDeploymentUrl(candidateUrl);
   const exactCandidateId = candidateId?.trim() || undefined;
+  if (allowMissingCommitSha && (!exactCandidateId || !exactCandidateUrl)) {
+    throw new Error(
+      'Missing commit SHA mode requires an exact deployment URL and ID.'
+    );
+  }
+  const expectedSha =
+    allowMissingCommitSha && !commitSha
+      ? undefined
+      : requireFullCommitSha(commitSha);
   const pages = Number(maxPages);
   const initialDelay = Number(initialWaitMs);
   const pollInterval = Number(pollIntervalMs);
@@ -1258,6 +1334,9 @@ async function resolveAuthorizedVercelDeployment({
             observedSha === null ||
             observedSha === ''
           ) {
+            if (allowMissingCommitSha && state === 'READY') {
+              return { id, url: urlOrigin, commitSha: null };
+            }
             // READY can precede Git metadata propagation. Missing SHA remains
             // transient, but a present malformed or wrong SHA fails below.
             matchingTransient = true;
@@ -1266,7 +1345,7 @@ async function resolveAuthorizedVercelDeployment({
           if (
             typeof observedSha !== 'string' ||
             !FULL_COMMIT_SHA.test(observedSha) ||
-            observedSha !== expectedSha
+            (expectedSha && observedSha !== expectedSha)
           ) {
             throw new Error(
               'Exact caller deployment does not match the full expected commit SHA.'
@@ -1276,7 +1355,9 @@ async function resolveAuthorizedVercelDeployment({
           if (state === 'READY') {
             matchingReady.set(id, { id, url: urlOrigin });
             if (exactCandidateId || exactCandidateUrl) {
-              return { id, url: urlOrigin };
+              return allowMissingCommitSha
+                ? { id, url: urlOrigin, commitSha: observedSha }
+                : { id, url: urlOrigin };
             }
           } else {
             matchingTransient = true;
@@ -1352,6 +1433,7 @@ module.exports = {
   buildOriginBoundProbeRequest,
   cookiesToRequestHeader,
   createAbsoluteDeadline,
+  discoverOriginBoundBuildIdentity,
   isExactVercelDeploymentUrl,
   isTrustedVercelProtectedAliasUrl,
   maskSensitiveValues,
@@ -1365,6 +1447,7 @@ module.exports = {
   safeRouteLabel,
   stripInlineScripts,
   validateBuildInfo,
+  validateBuildIdentity,
   verifyPublicDeploymentSurfaces,
   writeExactHostCookieJar,
 };
@@ -1380,11 +1463,19 @@ if (require.main === module) {
       process.stdout.write(
         `${JSON.stringify(await resolveAuthorizedVercelDeployment())}\n`
       );
+    } else if (command === 'discover-build-identity') {
+      const buildInfo = await discoverOriginBoundBuildIdentity(
+        process.env.VERCEL_PROBE_URL,
+        {
+          maskLineWriter: line => console.error(line),
+        }
+      );
+      process.stdout.write(`${JSON.stringify(buildInfo)}\n`);
     } else if (command === 'bootstrap-cookie-jar') {
       await bootstrapAndVerifyFromEnvironment();
     } else {
       throw new Error(
-        'Usage: vercel-protected-origin.cjs <assert-authorized-origin|assert-origin-bound-redirect|resolve-deployment|bootstrap-cookie-jar>'
+        'Usage: vercel-protected-origin.cjs <assert-authorized-origin|assert-origin-bound-redirect|resolve-deployment|discover-build-identity|bootstrap-cookie-jar>'
       );
     }
   })().catch(error => {

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -453,13 +453,31 @@ describe('merge_group workflow contract', () => {
     expect(resolve).toContain('.conclusion == "success"');
     // Resolves the landed canonical deployment, never a release candidate.
     expect(resolve).toContain('vercel inspect jov.ie');
-    expect(resolve).toContain('.meta.githubCommitSha // .gitSource.sha');
     expect(resolve).toContain('[ "$deployment_state" != "READY" ]');
     expect(resolve).toContain('[ "$deployment_target" != "production" ]');
     expect(resolve).toContain(
       '^https://jovie-[a-z0-9-]+-jovie\\.vercel\\.app$'
     );
+    expect(resolve).toContain('VERCEL_ALLOW_MISSING_COMMIT_SHA=true');
     expect(resolve).toContain('resolve-deployment');
+    expect(resolve).toContain('discover-build-identity');
+    expect(resolve).toContain(
+      'EXPECTED_VERCEL_DEPLOYMENT_ORIGIN="$deployment_url"'
+    );
+    expect(resolve).toContain('EXPECTED_VERCEL_ENVIRONMENT=production');
+    expect(resolve).toContain(
+      'gh api "repos/$REPOSITORY/commits/$deployed_sha"'
+    );
+    expect(resolve).toContain(
+      'gh api "repos/$REPOSITORY/compare/$commit_sha...main"'
+    );
+    expect(resolve).toContain('.merge_base_commit.sha == $sha');
+    expect(resolve).toContain(
+      'Vercel list metadata disagrees with the exact origin build identity.'
+    );
+    expect(resolve).not.toContain(
+      'commit_sha="$(jq -r \'.meta.githubCommitSha // .gitSource.sha'
+    );
     expect(resolve).toContain('should_probe');
 
     for (const jobId of ['smoke', 'auth-smoke', 'lighthouse']) {


### PR DESCRIPTION
## Summary

- stop treating optional Vercel source metadata as the only production commit identity
- cross-prove the canonical deployment by project, exact ID, immutable URL, READY/production state, and origin-bound build identity
- uniquely expand the deployed SHA inside this GitHub repository and require it to be an ancestor of `main`
- fail closed on malformed, ambiguous, foreign, or contradictory Vercel/GitHub identity evidence

## Evidence

- production failure: Post-Deploy Probes run `29874916691`
- live canonical deployment: `dpl_13TokjqhwBheB8qYfmj2uZwgqwUp` / `jovie-dojdmaf42-jovie.vercel.app`
- live origin-bound build identity: `d170b32`
- GitHub expansion: `d170b32a3cdc54b4be21c4162891618bd4c1fbc5`, proven ancestor of `main`

## Verification

- `pnpm turbo typecheck` — 10/10 packages
- deploy/origin suite — 119/119
- structural workflow suite — 48/48
- `actionlint .github/workflows/postdeploy-probes.yml`
- repo-wide `pnpm biome check --write apps/web`
- focused ESLint, diff check, version fan-out guard, branch guard
- adversarial security review — CLEAN after fixing contradictory dual-SHA handling

## Risk

High-risk production control-plane hotfix. This does not weaken release authorization or mutate production. It repairs the read-only post-deploy observer and keeps all ownership checks fail-closed.

## Tracking

- Linear: JOV-4366
- Graphite submit was attempted after local Graphite branch/commit operations, but the JovieInc Graphite plan is expired; this draft uses the repository GitHub fallback.
