### PR TITLE
fix(release): exclude public geo probe cookies

### DIFF
--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -277,6 +277,8 @@ describe('origin-bound Vercel protection bypass', () => {
         sensitiveCookieValues([
           { name: 'jv_country', value: 'US' },
           { name: 'jv_cc_required', value: '1' },
+          { name: 'jv_city', value: 'Des Moines' },
+          { name: 'jv_region', value: 'Iowa' },
         ])
       );
       expect(readFileSync(receiptPath, 'utf8')).toBe(
@@ -287,14 +289,17 @@ describe('origin-bound Vercel protection bypass', () => {
     }
   });
 
-  it('keeps an unknown short dynamic cookie value in the sensitive receipt', () => {
+  it('filters public geo metadata but keeps audience and unknown short cookies sensitive', () => {
     expect(
       sensitiveCookieValues([
         { name: 'jv_country', value: 'US' },
         { name: 'jv_cc_required', value: '1' },
+        { name: 'jv_city', value: 'Des Moines' },
+        { name: 'jv_region', value: 'Iowa' },
+        { name: 'jv_aid', value: 'audience-cookie-value' },
         { name: '__unknown_dynamic_cookie', value: '1' },
       ])
-    ).toEqual(['1']);
+    ).toEqual(['audience-cookie-value', '1']);
   });
 
   it('never attaches the bypass credential to canonical production', () => {

--- a/apps/web/scripts/vercel-protected-origin.cjs
+++ b/apps/web/scripts/vercel-protected-origin.cjs
@@ -14,7 +14,12 @@ const {
 
 const BYPASS_HEADER = 'x-vercel-protection-bypass';
 const SET_BYPASS_COOKIE_HEADER = 'x-vercel-set-bypass-cookie';
-const PUBLIC_PROBE_COOKIE_NAMES = new Set(['jv_country', 'jv_cc_required']);
+const PUBLIC_PROBE_COOKIE_NAMES = new Set([
+  'jv_cc_required',
+  'jv_city',
+  'jv_country',
+  'jv_region',
+]);
 const ZERO_DYNAMIC_SECRET_RECEIPT = 'jovie-protected-probe:no-dynamic-secrets';
 const BUILD_INFO_PATH = '/api/health/build-info';
 const DEFAULT_PROBE_TIMEOUT_MS = 120_000;


### PR DESCRIPTION
## Summary

- classify `jv_city` and `jv_region` as exact public probe metadata alongside country and consent-region state
- keep `jv_aid` and every unknown cookie in the dynamic-secret receipt
- cover the public-only zero receipt and unknown short-cookie fail-closed path

## Production evidence

Production Controller run 29878049063, job 88795373555, reached the OAuth bootstrap but the artifact guard rejected known public city and region cookie values as dynamic secrets. The canonical cookie registry documents both as profile-personalization metadata.

## Verification

- `pnpm --filter @jovie/web exec vitest run scripts/lighthouse-vercel-bypass.test.ts` (46 passed)
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/playwright-artifact-secrets.test.ts` (12 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/scripts/vercel-protected-origin.cjs apps/web/scripts/lighthouse-vercel-bypass.test.ts`
- `./scripts/security/scan-secrets.sh ci-pr origin/main`
- `git diff --check`

## Risk

Low and fail-closed. The allowlist expands by two exact names only. Audience identity (`jv_aid`) and unknown cookie names remain sensitive.

## Queue

Draft and intentionally not enrolled. Wait for exact source CI to pass before queue admission.