### PR TITLE
fix(audio): don't swallow first timeupdate under uptime-clocked throttle

### DIFF
--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -333,7 +333,11 @@ async function advanceQueueToIndex(index: number): Promise<void> {
 }
 
 function bindAudioEvents(el: HTMLAudioElement): void {
-  let lastNotifiedAt = 0;
+  // -Infinity (not 0): with performance.now() clocked from process start, a
+  // timeupdate fired within the first PROGRESS_NOTIFY_MS of uptime would be
+  // swallowed by the throttle when initialized to 0, dropping the first
+  // progress update (surfaced as a shard-order-dependent unit test flake).
+  let lastNotifiedAt = -Infinity;
   el.addEventListener('timeupdate', () => {
     // ~4 Hz keeps cross-surface scrub bars smooth without rAF thrash.
     const now =
@@ -380,7 +384,7 @@ function bindAudioEvents(el: HTMLAudioElement): void {
     });
   });
   el.addEventListener('seeked', () => {
-    lastNotifiedAt = 0; // invalidate throttle so next timeupdate fires
+    lastNotifiedAt = -Infinity; // invalidate throttle so next timeupdate fires
     setState({
       currentTime: el.currentTime,
       duration: Number.isFinite(el.duration) ? el.duration : 0,


### PR DESCRIPTION
## Summary

One-line-class bug in `useTrackAudioPlayer`: `lastNotifiedAt` initialized to `0` lets the ~4Hz timeupdate throttle swallow any `timeupdate` fired within the first `PROGRESS_NOTIFY_MS` of process uptime (`performance.now()` is process-relative). This surfaced as a deterministic shard-order-dependent failure in `useTrackAudioPlayer.test.ts` (`currentTime` stuck at 0 in full-shard runs, passes in isolation) — currently breaking the local pre-push gate for any branch synced with main.

Fix: initialize (and invalidate on `seeked`) with `-Infinity` — semantically 'never notified'.

## Checks

- Full shard 1/8 (272 files, 2030 tests — the exact repro that failed twice on plain origin/main): **passes** with the fix
- Failing test file alone: passes

No Linear issue — ad-hoc hotfix; discovered while landing #14652.