### PR TITLE
fix(release): allow safe OAuth markdown artifacts

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -554,6 +554,7 @@ jobs:
           EXPECTED_COMMIT_SHA: ${{ inputs.expected_sha }}
           EXPECTED_VERCEL_ALIAS_ORIGIN: https://staging.jov.ie
           EXPECTED_VERCEL_ENVIRONMENT: preview
+          PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'
           PLAYWRIGHT_DYNAMIC_SECRETS_FILE: ${{ runner.temp }}/playwright-dynamic-cookie-values
           PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -891,6 +891,10 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(oauthStep).toContain(
       'node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run --'
     );
+    expect(oauthStep).toContain("PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'");
+    expect(
+      workflow.match(/PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'/g)
+    ).toHaveLength(1);
     expect(oauthStep).toContain(
       'pnpm exec playwright test tests/e2e/oauth-providers.spec.ts'
     );
@@ -1986,6 +1990,7 @@ describe('canary health gate workflow', () => {
         resolve(fakeBin, 'node'),
         `#!/usr/bin/env bash
 set -euo pipefail
+[ "\${PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN:-}" = "true" ] || exit 43
 attempt=0
 if [ -f "$OAUTH_TEST_COUNTER" ]; then
   attempt="$(cat "$OAUTH_TEST_COUNTER")"
@@ -1997,7 +2002,7 @@ if [ -e test-results ] || [ -L test-results ] || [ -e playwright-report ] || [ -
 fi
 if [ "$attempt" -eq 1 ]; then
   mkdir -p test-results
-  printf '{"source":"failed-attempt"}' > test-results/attempt-one.json
+  printf '# Error context\n\nSafe retry diagnostics.\n' > test-results/error-context.md
   exit 1
 fi
 `,
@@ -2021,6 +2026,7 @@ fi
             GITHUB_WORKSPACE: workspace,
             OAUTH_TEST_COUNTER: counter,
             PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
             RUNNER_TEMP: runnerTemp,
           },
           encoding: 'utf8',
@@ -2035,10 +2041,10 @@ fi
       );
       expect(
         readFileSync(
-          resolve(attemptOne, 'failed-artifacts/test-results/attempt-one.json'),
+          resolve(attemptOne, 'failed-artifacts/test-results/error-context.md'),
           'utf8'
         )
-      ).toContain('failed-attempt');
+      ).toContain('Safe retry diagnostics.');
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+++ b/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
@@ -1178,6 +1178,10 @@ ${fixtureCheckout}
     expect(oauthProbe).toContain(
       'PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}'
     );
+    expect(oauthProbe).toContain("PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'");
+    expect(
+      productionRelease.match(/PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'/g)
+    ).toHaveLength(1);
     const action = readFileSync(
       join(githubRoot, 'actions/upload-safe-playwright-artifact/action.yml'),
       'utf8'


### PR DESCRIPTION
## Incident

Production Controller run 29880660795, job 88801959542, passed alias identity and canary checks but failed after a flaky Google OAuth retry emitted error-context.md. The Playwright artifact guard rejected that Markdown as unknown-binary.

## Fix

- allow Markdown only for the aliased staging OAuth guarded step
- retain UTF-8 parsing and credential scanning for Markdown
- keep trace, zip, HTML, and unknown binary blocking unchanged
- extend executable retry and workflow-scope contracts

## Verification

- 89 targeted workflow/artifact guard tests passed
- Biome passed on all changed files
- git diff --check passed
- gitleaks scanned the commit with no findings