### PR TITLE
fix(release): scan OAuth retry markdown (JOV-4369)

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -554,6 +554,7 @@ jobs:
           EXPECTED_COMMIT_SHA: ${{ inputs.expected_sha }}
           EXPECTED_VERCEL_ALIAS_ORIGIN: https://staging.jov.ie
           EXPECTED_VERCEL_ENVIRONMENT: preview
+          PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'
           PLAYWRIGHT_DYNAMIC_SECRETS_FILE: ${{ runner.temp }}/playwright-dynamic-cookie-values
           PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1933,6 +1933,8 @@ describe('canary health gate workflow', () => {
     expect(oauthStep).toContain(
       'PLAYWRIGHT_DYNAMIC_SECRETS_FILE: ${{ runner.temp }}/playwright-dynamic-cookie-values'
     );
+    expect(oauthStep).toContain("PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'");
+    expect(oauthStep).not.toContain('PLAYWRIGHT_ARTIFACT_ALLOW_IMAGES');
     expect(oauthStep).toContain(
       'attempt_artifact_root="$oauth_retry_root/attempt-${attempt}"'
     );


### PR DESCRIPTION
## Summary
- opt the aliased-staging OAuth proof into the existing fail-closed Markdown scanner
- keep images, opaque containers, unknown binaries, and credential-bearing Markdown blocked
- add a workflow contract preventing accidental image allowance

## Root cause
Production Controller run 29880660795 reached the exact aliased-staging OAuth proof. Google passed on Playwright retry, but the failed attempt emitted `error-context.md`; without the explicit Markdown policy, the artifact guard classified it as `unknown-binary` and poisoned the producer. Production was not mutated.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts tests/unit/ci/playwright-artifact-secrets.test.ts` — 89/89
- `actionlint .github/workflows/production-release.yml`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write .github/workflows/production-release.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- normal pre-commit and pre-push gates, including secret scans, full web lint, affected tests, and CI harness validation

## Bug-to-test
Regression assertion added to `deploy-workflow.test.ts`. Root `test:bug-to-test` classifier reported not applicable because the PR did not yet exist when run; focused regression evidence is above.

## Risk
Security-sensitive CI path. Scope is one producer-step environment flag. The existing scanner still checks credential labels, exact static secrets, and dynamic bypass-cookie receipts; all opaque formats remain fail-closed.

Linear: JOV-4369
