### PR TITLE
[JOV-4370] Keep Doppler production build env authoritative

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -732,6 +732,7 @@ jobs:
           fi
 
           required_runtime_env=(
+            BETTER_AUTH_URL
             NEXT_PUBLIC_BETTER_AUTH_URL
             BETTER_AUTH_SECRET
             DATABASE_URL
@@ -769,8 +770,15 @@ jobs:
             fi
           done
 
+          if ! pnpm --filter=@jovie/web exec tsx \
+            scripts/reconcile-vercel-build-env.ts \
+            --file=.vercel/.env.production.local; then
+            fail_stage "Unable to reconcile the canonical production build environment." production_artifact_failed
+          fi
+
           if ! pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts \
-            --target=prd --source=env; then
+            --target=prd --source=vercel-file \
+            --file=.vercel/.env.production.local; then
             fail_stage "Production signup configuration is incomplete." production_artifact_failed
           fi
 
@@ -867,7 +875,7 @@ jobs:
           }
           export -f production_stage
           doppler run --project jovie-web --config prd \
-            --only-secrets=NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY \
+            --only-secrets=BETTER_AUTH_URL,NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY \
             --no-fallback -- env -u DOPPLER_TOKEN bash -c production_stage
 
       - name: Recheck main immediately before production promotion

--- a/apps/web/lib/readiness/signup-onboarding.ts
+++ b/apps/web/lib/readiness/signup-onboarding.ts
@@ -2,6 +2,7 @@ export type SignupOnboardingReadinessTarget = 'prd' | 'stg' | 'local';
 export type SignupOnboardingReadinessSource = 'env' | 'vercel-file';
 
 export const REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS = [
+  'BETTER_AUTH_URL',
   'NEXT_PUBLIC_BETTER_AUTH_URL',
   'BETTER_AUTH_SECRET',
   'DATABASE_URL',
@@ -21,6 +22,7 @@ export interface SignupOnboardingReadinessResult {
   readonly required: readonly SignupOnboardingEnvKey[];
   readonly present: readonly SignupOnboardingEnvKey[];
   readonly missing: readonly SignupOnboardingEnvKey[];
+  readonly invalid: readonly SignupOnboardingEnvKey[];
 }
 
 interface CheckSignupOnboardingReadinessOptions {
@@ -33,6 +35,39 @@ function hasValue(value: string | undefined): boolean {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+const BETTER_AUTH_URL_KEYS = [
+  'BETTER_AUTH_URL',
+  'NEXT_PUBLIC_BETTER_AUTH_URL',
+] as const satisfies readonly SignupOnboardingEnvKey[];
+
+const ALLOWED_AUTH_ORIGINS = {
+  prd: new Set(['https://jov.ie', 'https://www.jov.ie']),
+  stg: new Set(['https://staging.jov.ie']),
+} as const;
+
+function canonicalAuthOrigin(
+  value: string | undefined,
+  target: Exclude<SignupOnboardingReadinessTarget, 'local'>
+): string | null {
+  if (!hasValue(value)) return null;
+  try {
+    const url = new URL(value!);
+    const isOriginOnly =
+      url.protocol === 'https:' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.port === '' &&
+      url.pathname === '/' &&
+      url.search === '' &&
+      url.hash === '';
+    return isOriginOnly && ALLOWED_AUTH_ORIGINS[target].has(url.origin)
+      ? url.origin
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export function checkSignupOnboardingReadiness({
   env,
   target,
@@ -42,14 +77,32 @@ export function checkSignupOnboardingReadiness({
     target === 'local' ? [] : [...REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS];
   const present = required.filter(key => hasValue(env[key]));
   const missing = required.filter(key => !hasValue(env[key]));
+  const invalidKeys = new Set<SignupOnboardingEnvKey>();
+  if (target !== 'local') {
+    const origins = BETTER_AUTH_URL_KEYS.map(key => ({
+      key,
+      origin: canonicalAuthOrigin(env[key], target),
+    }));
+    for (const { key, origin } of origins) {
+      if (hasValue(env[key]) && !origin) invalidKeys.add(key);
+    }
+    const validOrigins = origins.flatMap(({ origin }) =>
+      origin ? [origin] : []
+    );
+    if (validOrigins.length === 2 && validOrigins[0] !== validOrigins[1]) {
+      for (const key of BETTER_AUTH_URL_KEYS) invalidKeys.add(key);
+    }
+  }
+  const invalid = required.filter(key => invalidKeys.has(key));
 
   return {
-    ok: missing.length === 0,
+    ok: missing.length === 0 && invalid.length === 0,
     target,
     source,
     required,
     present,
     missing,
+    invalid,
   };
 }
 
@@ -69,12 +122,22 @@ export function formatSignupOnboardingReadinessReport(
   }
 
   for (const key of result.required) {
-    lines.push(`${key}: ${result.missing.includes(key) ? 'MISSING' : 'SET'}`);
+    const state = result.missing.includes(key)
+      ? 'MISSING'
+      : result.invalid.includes(key)
+        ? 'INVALID'
+        : 'SET';
+    lines.push(`${key}: ${state}`);
   }
 
   lines.push(`[signup-readiness] status=${result.ok ? 'passed' : 'failed'}`);
   if (!result.ok) {
-    lines.push(`[signup-readiness] missing=${result.missing.join(', ')}`);
+    if (result.missing.length > 0) {
+      lines.push(`[signup-readiness] missing=${result.missing.join(', ')}`);
+    }
+    if (result.invalid.length > 0) {
+      lines.push(`[signup-readiness] invalid=${result.invalid.join(', ')}`);
+    }
   }
 
   return lines.join('\n');

--- a/apps/web/scripts/reconcile-vercel-build-env.test.ts
+++ b/apps/web/scripts/reconcile-vercel-build-env.test.ts
@@ -1,0 +1,196 @@
+import {
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { parse } from 'dotenv';
+import { afterEach, describe, expect, it } from 'vitest';
+import { REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS } from '@/lib/readiness/signup-onboarding';
+import { reconcileVercelBuildEnv } from './reconcile-vercel-build-env';
+
+const roots: string[] = [];
+
+function fixture(): string {
+  const root = resolve(
+    tmpdir(),
+    `jovie-vercel-build-env-${process.pid}-${roots.length}`
+  );
+  rmSync(root, { force: true, recursive: true });
+  mkdirSync(root, { mode: 0o700 });
+  roots.push(root);
+  return root;
+}
+
+function canonicalEnv(): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS.map((key, index) => [
+      key,
+      key === 'BETTER_AUTH_URL' || key === 'NEXT_PUBLIC_BETTER_AUTH_URL'
+        ? 'https://jov.ie'
+        : `value-${index}_with-safe.punctuation:/?@%+=,`,
+    ])
+  );
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('reconcileVercelBuildEnv', () => {
+  it('atomically makes canonical process values authoritative and preserves unrelated values', () => {
+    const root = fixture();
+    const path = resolve(root, 'production.env');
+    writeFileSync(
+      path,
+      'NEXT_PUBLIC_BETTER_AUTH_URL="not a url"\nUNRELATED_VERCEL_VALUE="keep me"\n',
+      { mode: 0o644 }
+    );
+    const env = canonicalEnv();
+
+    expect(reconcileVercelBuildEnv(path, env)).toBe(
+      REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS.length
+    );
+
+    const parsed = parse(readFileSync(path));
+    expect(parsed.UNRELATED_VERCEL_VALUE).toBe('keep me');
+    for (const key of REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS) {
+      expect(parsed[key], key).toBe(env[key]);
+    }
+    expect(Number(lstatSync(path).mode & 0o777)).toBe(0o600);
+    expect(readdirSync(root)).toEqual(['production.env']);
+  });
+
+  it('fails closed without replacing the file when a canonical value is missing', () => {
+    const root = fixture();
+    const path = resolve(root, 'production.env');
+    const original = 'UNRELATED_VERCEL_VALUE="keep me"\n';
+    writeFileSync(path, original);
+    const env = canonicalEnv();
+    delete env.SESSION_SECRET;
+
+    expect(() => reconcileVercelBuildEnv(path, env)).toThrow(
+      'Missing canonical build environment value: SESSION_SECRET'
+    );
+    expect(readFileSync(path, 'utf8')).toBe(original);
+    expect(readdirSync(root)).toEqual(['production.env']);
+  });
+
+  it('fails closed without replacing the file when a value is unsafe to serialize', () => {
+    const root = fixture();
+    const path = resolve(root, 'production.env');
+    const original = 'UNRELATED_VERCEL_VALUE="keep me"\n';
+    writeFileSync(path, original);
+    const env = canonicalEnv();
+    env.SESSION_SECRET = 'unsafe\nvalue';
+
+    expect(() => reconcileVercelBuildEnv(path, env)).toThrow(
+      'Canonical build environment value is not safely serializable: SESSION_SECRET'
+    );
+    expect(readFileSync(path, 'utf8')).toBe(original);
+    expect(readdirSync(root)).toEqual(['production.env']);
+  });
+
+  it('rejects values that Next env loading would expand', () => {
+    const root = fixture();
+    const path = resolve(root, 'production.env');
+    const original = 'UNRELATED_VERCEL_VALUE="keep me"\n';
+    writeFileSync(path, original);
+    const env = canonicalEnv();
+    env.SESSION_SECRET = 'prefix$UNDEFINEDsuffix';
+
+    expect(() => reconcileVercelBuildEnv(path, env)).toThrow(
+      'Canonical build environment value is not safely serializable: SESSION_SECRET'
+    );
+    expect(readFileSync(path, 'utf8')).toBe(original);
+  });
+
+  it('covers the installed Next env dollar-expansion semantics', () => {
+    const rootRequire = createRequire(import.meta.url);
+    const nextRequire = createRequire(rootRequire.resolve('next/package.json'));
+    const { processEnv, resetEnv } = nextRequire('@next/env') as {
+      processEnv: (
+        files: Array<{ path: string; contents: string; env: object }>,
+        directory: string,
+        logger: { info: () => void; error: () => void },
+        forceReload: boolean
+      ) => unknown;
+      resetEnv: () => void;
+    };
+    const probe = 'JOVIE_RECONCILE_EXPANSION_PROBE';
+    delete process.env[probe];
+
+    try {
+      processEnv(
+        [
+          {
+            path: '.env',
+            contents: `${probe}=prefix$UNDEFINEDsuffix\n`,
+            env: {},
+          },
+        ],
+        process.cwd(),
+        { info: () => undefined, error: () => undefined },
+        true
+      );
+      expect(process.env[probe]).toBe('prefix');
+    } finally {
+      resetEnv();
+      delete process.env[probe];
+    }
+  });
+
+  it('does not remove a pre-existing predictable collision sentinel', () => {
+    const root = fixture();
+    const path = resolve(root, 'production.env');
+    const sentinel = `${path}.reconcile-${process.pid}`;
+    writeFileSync(path, 'UNRELATED_VERCEL_VALUE="keep me"\n');
+    writeFileSync(sentinel, 'owned by another process');
+
+    reconcileVercelBuildEnv(path, canonicalEnv());
+
+    expect(readFileSync(sentinel, 'utf8')).toBe('owned by another process');
+    expect(readdirSync(root).sort()).toEqual([
+      'production.env',
+      `production.env.reconcile-${process.pid}`,
+    ]);
+  });
+
+  it('preserves the destination and cleans up owned temp files when rename fails', () => {
+    const root = fixture();
+    const path = resolve(root, 'production.env');
+    const original = 'UNRELATED_VERCEL_VALUE="keep me"\n';
+    writeFileSync(path, original);
+
+    expect(() =>
+      reconcileVercelBuildEnv(path, canonicalEnv(), {
+        rename: () => {
+          throw new Error('simulated rename failure');
+        },
+      })
+    ).toThrow('simulated rename failure');
+    expect(readFileSync(path, 'utf8')).toBe(original);
+    expect(readdirSync(root)).toEqual(['production.env']);
+  });
+
+  it('rejects a symlinked destination', () => {
+    const root = fixture();
+    const target = resolve(root, 'target.env');
+    const link = resolve(root, 'production.env');
+    writeFileSync(target, 'SAFE="1"\n');
+    symlinkSync(target, link);
+
+    expect(() => reconcileVercelBuildEnv(link, canonicalEnv())).toThrow(
+      'Vercel build environment file must be a regular file'
+    );
+    expect(readFileSync(target, 'utf8')).toBe('SAFE="1"\n');
+  });
+});

--- a/apps/web/scripts/reconcile-vercel-build-env.ts
+++ b/apps/web/scripts/reconcile-vercel-build-env.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env tsx
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS } from '@/lib/readiness/signup-onboarding';
+import { resolveEnvFilePath } from './check-signup-readiness';
+
+// @next/env expands `$NAME` references while loading dotenv files. Reject
+// expansion syntax instead of risking a canonical value being silently changed.
+const SAFE_UNQUOTED_ENV_VALUE = /^[^\s"'#$\\\0]+$/u;
+
+interface ReconcileFileOps {
+  readonly rename: typeof renameSync;
+}
+
+const DEFAULT_FILE_OPS: ReconcileFileOps = { rename: renameSync };
+
+function requiredValue(
+  env: NodeJS.ProcessEnv,
+  key: (typeof REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS)[number]
+): string {
+  const value = env[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Missing canonical build environment value: ${key}`);
+  }
+  return value;
+}
+
+function canonicalOverrides(env: NodeJS.ProcessEnv): string {
+  return REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS.map(key => {
+    const value = requiredValue(env, key);
+    if (!SAFE_UNQUOTED_ENV_VALUE.test(value)) {
+      throw new Error(
+        `Canonical build environment value is not safely serializable: ${key}`
+      );
+    }
+    return `${key}=${value}`;
+  }).join('\n');
+}
+
+export function reconcileVercelBuildEnv(
+  path: string,
+  env: NodeJS.ProcessEnv = process.env,
+  fileOps: ReconcileFileOps = DEFAULT_FILE_OPS
+): number {
+  const lexicalPath = resolve(path);
+  const stat = lstatSync(lexicalPath);
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error('Vercel build environment file must be a regular file');
+  }
+  const canonicalPath = realpathSync(lexicalPath);
+
+  const original = readFileSync(canonicalPath, 'utf8');
+  const overrides = canonicalOverrides(env);
+  const separator =
+    original.length === 0 || original.endsWith('\n') ? '' : '\n';
+  const reconciled = `${original}${separator}${overrides}\n`;
+
+  const temporaryDirectory = mkdtempSync(`${canonicalPath}.reconcile-`);
+  const temporaryPath = resolve(temporaryDirectory, 'environment');
+  try {
+    writeFileSync(temporaryPath, reconciled, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fileOps.rename(temporaryPath, canonicalPath);
+    chmodSync(canonicalPath, 0o600);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+    rmdirSync(temporaryDirectory);
+  }
+
+  return REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS.length;
+}
+
+function fileArgument(argv: readonly string[]): string {
+  const argument = argv.find(value => value.startsWith('--file='));
+  return argument?.slice('--file='.length) ?? '.vercel/.env.production.local';
+}
+
+function main() {
+  const path = resolveEnvFilePath(fileArgument(process.argv.slice(2)));
+  const count = reconcileVercelBuildEnv(path);
+  console.log(`[vercel-build-env] reconciled ${count} canonical keys`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `[vercel-build-env] failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    process.exit(1);
+  }
+}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1347,6 +1347,7 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
       '- name: Verify production domains are on canonical Vercel project'
     );
     const runtimeKeys = [
+      'BETTER_AUTH_URL',
       'NEXT_PUBLIC_BETTER_AUTH_URL',
       'BETTER_AUTH_SECRET',
       'DATABASE_URL',
@@ -1375,8 +1376,18 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     expect(stageStep).toContain(
       '--no-fallback -- env -u DOPPLER_TOKEN bash -c production_stage'
     );
-    expect(stageStep).toContain('--target=prd --source=env');
-    expect(stageStep).not.toContain('--target=prd --source=vercel-file');
+    expect(stageStep).toContain('scripts/reconcile-vercel-build-env.ts');
+    expect(stageStep).toContain('--target=prd --source=vercel-file');
+    expect(stageStep).toContain('--file=.vercel/.env.production.local');
+    expect(
+      stageStep.indexOf('vercel pull --yes --environment=production')
+    ).toBeLessThan(stageStep.indexOf('scripts/reconcile-vercel-build-env.ts'));
+    expect(
+      stageStep.indexOf('scripts/reconcile-vercel-build-env.ts')
+    ).toBeLessThan(stageStep.indexOf('--target=prd --source=vercel-file'));
+    expect(stageStep.indexOf('--target=prd --source=vercel-file')).toBeLessThan(
+      stageStep.indexOf('vercel build --prod')
+    );
     expect(stageStep).toContain('required_runtime_env=(');
     expect(stageStep).toContain('Missing production runtime env:');
     expect(stageStep).toContain('runtime_env_args+=(--env "$key")');
@@ -2972,8 +2983,8 @@ describe('production promotion exact-artifact contract', () => {
     expect(deployIndex).toBeGreaterThan(buildIndex);
     expect(inspectIndex).toBeGreaterThan(deployIndex);
     expect(canaryIndex).toBeGreaterThan(inspectIndex);
-    expect(stageStep).toContain('--target=prd --source=env');
-    expect(stageStep).not.toContain('--target=prd --source=vercel-file');
+    expect(stageStep).toContain('scripts/reconcile-vercel-build-env.ts');
+    expect(stageStep).toContain('--target=prd --source=vercel-file');
     expect(stageStep).toContain('VERCEL_GIT_COMMIT_SHA="$EXPECTED_SHA"');
     expect(stageStep).toContain('NEXT_PUBLIC_BUILD_SHA="$expected"');
     expect(stageStep).toContain('--meta "githubCommitSha=${EXPECTED_SHA}"');

--- a/apps/web/tests/unit/lib/readiness/signup-onboarding.test.ts
+++ b/apps/web/tests/unit/lib/readiness/signup-onboarding.test.ts
@@ -6,11 +6,20 @@ import {
   REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS,
 } from '@/lib/readiness/signup-onboarding';
 
+function readyEnv(authOrigin = 'https://jov.ie') {
+  return Object.fromEntries(
+    REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS.map(key => [
+      key,
+      key === 'BETTER_AUTH_URL' || key === 'NEXT_PUBLIC_BETTER_AUTH_URL'
+        ? authOrigin
+        : `${key}-value`,
+    ])
+  );
+}
+
 describe('signup onboarding readiness', () => {
   it('passes only when every required production signup env var is present', () => {
-    const env = Object.fromEntries(
-      REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS.map(key => [key, `${key}-value`])
-    );
+    const env = readyEnv();
 
     const result = checkSignupOnboardingReadiness({
       env,
@@ -20,7 +29,95 @@ describe('signup onboarding readiness', () => {
 
     expect(result.ok).toBe(true);
     expect(result.missing).toEqual([]);
+    expect(result.invalid).toEqual([]);
     expect(result.present).toEqual([...REQUIRED_SIGNUP_ONBOARDING_ENV_KEYS]);
+  });
+
+  it('fails closed on a present but invalid production auth URL without printing it', () => {
+    const env = readyEnv();
+    env.BETTER_AUTH_URL = 'definitely-not-a-url';
+
+    const result = checkSignupOnboardingReadiness({
+      env,
+      target: 'prd',
+      source: 'vercel-file',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual([]);
+    expect(result.invalid).toEqual(['BETTER_AUTH_URL']);
+    const report = formatSignupOnboardingReadinessReport(result);
+    expect(report).toContain('BETTER_AUTH_URL: INVALID');
+    expect(report).toContain('[signup-readiness] invalid=BETTER_AUTH_URL');
+    expect(report).not.toContain('definitely-not-a-url');
+  });
+
+  it.each([
+    ['scheme', 'http://jov.ie'],
+    [
+      'credentials',
+      (() => {
+        const url = new URL('https://jov.ie');
+        url.username = 'user';
+        return url.href;
+      })(),
+    ],
+    ['path', 'https://jov.ie/auth'],
+    ['query', 'https://jov.ie/?from=bad'],
+    ['hash', 'https://jov.ie/#bad'],
+    ['port', 'https://jov.ie:8443'],
+    ['attacker host', 'https://attacker.example'],
+    ['staging host', 'https://staging.jov.ie'],
+  ])('rejects a production auth URL with an invalid %s', (_case, value) => {
+    const env = readyEnv();
+    env.BETTER_AUTH_URL = value;
+
+    const result = checkSignupOnboardingReadiness({
+      env,
+      target: 'prd',
+      source: 'vercel-file',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.invalid).toEqual(['BETTER_AUTH_URL']);
+    expect(formatSignupOnboardingReadinessReport(result)).not.toContain(value);
+  });
+
+  it('requires the server and public Better Auth origins to match', () => {
+    const env = readyEnv();
+    env.NEXT_PUBLIC_BETTER_AUTH_URL = 'https://www.jov.ie';
+
+    const result = checkSignupOnboardingReadiness({
+      env,
+      target: 'prd',
+      source: 'env',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.invalid).toEqual([
+      'BETTER_AUTH_URL',
+      'NEXT_PUBLIC_BETTER_AUTH_URL',
+    ]);
+  });
+
+  it('accepts only the canonical staging origin for staging', () => {
+    const staging = checkSignupOnboardingReadiness({
+      env: readyEnv('https://staging.jov.ie'),
+      target: 'stg',
+      source: 'env',
+    });
+    const productionOrigin = checkSignupOnboardingReadiness({
+      env: readyEnv(),
+      target: 'stg',
+      source: 'env',
+    });
+
+    expect(staging.ok).toBe(true);
+    expect(productionOrigin.ok).toBe(false);
+    expect(productionOrigin.invalid).toEqual([
+      'BETTER_AUTH_URL',
+      'NEXT_PUBLIC_BETTER_AUTH_URL',
+    ]);
   });
 
   it.skip('fails closed with redacted missing-key output (retired Clerk keys)', () => {
@@ -59,6 +156,7 @@ describe('signup onboarding readiness', () => {
 
     expect(result.ok).toBe(true);
     expect(result.missing).toEqual([]);
+    expect(result.invalid).toEqual([]);
   });
 
   it('keeps production canary env extraction complete and deduplicated', () => {


### PR DESCRIPTION
## Incident evidence

- Failed production job `29882120843 / 88806495106` targeted Vercel `jovie/jovie` and failed prerendering with Better Auth `Invalid base URL`; production was not mutated.
- Metadata-only pull of the exact production project found both `BETTER_AUTH_URL` and `NEXT_PUBLIC_BETTER_AUTH_URL` present as keys but empty/unparseable. No values were printed.
- Metadata-only Doppler `jovie-web/prd` verification found both keys present, canonical production origin-only, safe for Next env loading, and matching. No values were printed.
- Better Auth 1.6.23 resolves `BETTER_AUTH_URL` before `NEXT_PUBLIC_BETTER_AUTH_URL`, so both must be canonical.

## Fix

- Include both Better Auth URL keys in the production Doppler allowlist and canonical typed readiness registry.
- Reconcile canonical Doppler values into the pulled Vercel build file atomically before `vercel build`, then validate that final file.
- Fail closed on missing values, Next dotenv expansion syntax including `$`, unsafe serialization, symlink destinations, temp collisions, and rename failures; logs contain key names/status only.
- Require matching canonical origins: production `jov.ie`/`www.jov.ie`, staging `staging.jov.ie`; reject scheme, credentials, path, query, hash, non-default port, attacker host, and cross-environment drift.

## Verification

- Focused Vitest: 112 passed, 1 intentional skip.
- Hook-backed affected verification: 16,886 tests passed across 8 shards; declared skips/todos only.
- Web typecheck: passed.
- Biome/ESLint: passed.
- `actionlint`: passed.
- CI harness validate/check and generated-doc freshness: passed.
- Pre-commit gitleaks and TruffleHog: passed.

## Release posture

Draft only. Do not queue until independent review and source CI are green. Production promotion/proof is owned by the concurrency-recovery task.