### PR TITLE
fix(auth): never let a malformed auth base URL abort the production build

### DIFF
--- a/apps/web/lib/auth/better-auth.ts
+++ b/apps/web/lib/auth/better-auth.ts
@@ -105,7 +105,15 @@ function resolveLocalBetterAuthUrl(): URL | undefined {
     return undefined;
   }
 
-  const configuredUrl = new URL(env.BETTER_AUTH_URL);
+  // A malformed BETTER_AUTH_URL must degrade to the non-local path, never
+  // abort the build while prerendering (page-data collection runs this
+  // module's import graph).
+  let configuredUrl: URL;
+  try {
+    configuredUrl = new URL(env.BETTER_AUTH_URL);
+  } catch {
+    return undefined;
+  }
   return LOOPBACK_HOSTNAMES.has(configuredUrl.hostname)
     ? configuredUrl
     : undefined;

--- a/apps/web/lib/auth/client.ts
+++ b/apps/web/lib/auth/client.ts
@@ -1,6 +1,7 @@
 import { oauthProviderClient } from '@better-auth/oauth-provider/client';
 import { emailOTPClient, oneTapClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
+import { absolutePublicUrl } from '@/lib/env-public';
 
 /**
  * Better Auth browser client.
@@ -14,9 +15,12 @@ import { createAuthClient } from 'better-auth/react';
  * only configuration input is the public Google client id used by the
  * One Tap plugin.
  *
- * No `baseURL` on purpose — the Better Auth handler lives at
+ * Browser calls keep no explicit `baseURL` — the Better Auth handler lives at
  * `/api/auth/[...all]` on the current origin, so the client derives its
- * base URL from `window.location` (same-origin cookies, no CORS).
+ * base URL from `window.location` (same-origin cookies, no CORS). During
+ * SSR/prerender there is no window, so a defensively-normalized base URL is
+ * passed instead (see `absolutePublicUrl`): a host-only or missing
+ * NEXT_PUBLIC_BETTER_AUTH_URL must never abort the production build.
  */
 
 // Read `process.env.NEXT_PUBLIC_*` textually so Next.js can statically
@@ -44,6 +48,15 @@ export function isGoogleOneTapConfigured(): boolean {
  *   load the Google Identity Services script path.
  */
 export const authClient = createAuthClient({
+  // SSR/prerender only: give the client a defensively-normalized base URL so
+  // better-auth's own env chain never raw-parses a host-only or missing
+  // NEXT_PUBLIC_BETTER_AUTH_URL during page-data collection (that aborts the
+  // whole production build on /_not-found). In the browser we keep deriving
+  // from window.location (same-origin cookies, no CORS) as designed.
+  baseURL:
+    typeof window === 'undefined'
+      ? absolutePublicUrl(process.env.NEXT_PUBLIC_BETTER_AUTH_URL)
+      : undefined,
   plugins: [
     emailOTPClient(),
     // Carries the OAuth provider's signed authorization query through the

--- a/apps/web/tests/unit/lib/auth/auth-client-ssr-baseurl.test.ts
+++ b/apps/web/tests/unit/lib/auth/auth-client-ssr-baseurl.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The SSR/prerender baseURL passed to createAuthClient must be a valid
+ * absolute URL even when NEXT_PUBLIC_BETTER_AUTH_URL is host-only, missing,
+ * or malformed — a raw parse failure here aborts the whole production build
+ * during page-data collection (BetterAuthError on /_not-found).
+ */
+describe('auth client SSR baseURL hardening', () => {
+  const original = process.env.NEXT_PUBLIC_BETTER_AUTH_URL;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_BETTER_AUTH_URL;
+    } else {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_URL = original;
+    }
+  });
+
+  async function loadSsrBaseUrl() {
+    // Simulate SSR: page-data collection has no window.
+    vi.stubGlobal('window', undefined);
+    vi.resetModules();
+    // capture the options handed to createAuthClient without loading React
+    vi.doMock('better-auth/react', () => ({
+      createAuthClient: (options: unknown) => options,
+    }));
+    vi.doMock('@better-auth/oauth-provider/client', () => ({
+      oauthProviderClient: () => ({}),
+    }));
+    vi.doMock('better-auth/client/plugins', () => ({
+      emailOTPClient: () => ({}),
+      oneTapClient: () => ({}),
+    }));
+    const mod = await import('@/lib/auth/client');
+    return (mod.authClient as { baseURL?: string }).baseURL;
+  }
+
+  it('passes a valid URL for a host-only env value', async () => {
+    process.env.NEXT_PUBLIC_BETTER_AUTH_URL = 'staging.jov.ie';
+    const baseURL = await loadSsrBaseUrl();
+    expect(() => new URL(baseURL as string)).not.toThrow();
+    expect(baseURL).toBe('https://staging.jov.ie');
+  });
+
+  it('falls back to the canonical origin when the env value is missing', async () => {
+    delete process.env.NEXT_PUBLIC_BETTER_AUTH_URL;
+    const baseURL = await loadSsrBaseUrl();
+    expect(baseURL).toBe('https://jov.ie');
+  });
+
+  it('falls back instead of throwing when the env value is unparseable', async () => {
+    process.env.NEXT_PUBLIC_BETTER_AUTH_URL = 'ht tp://bad url';
+    const baseURL = await loadSsrBaseUrl();
+    expect(baseURL).toBe('https://jov.ie');
+  });
+});


### PR DESCRIPTION
CI production builds (`vercel build` on the runner) failed during page-data collection on `/_not-found` with `BetterAuthError: Invalid base URL` — better-auth's client init raw-parses its env base-URL chain at module evaluation, and a host-only/missing/malformed value aborts the entire build. Blocking the 26.7.0 release train (runs 29882120843, 29884656938).

- `client.ts`: during SSR (no window) pass an explicit baseURL normalized through the existing `absolutePublicUrl` helper (never throws; host-only values get `https://`, unparseable falls back to canonical origin). Browser behavior unchanged: no baseURL, derive from `window.location`.
- `better-auth.ts`: `resolveLocalBetterAuthUrl` degrades to the non-local path on an unparseable `BETTER_AUTH_URL` instead of throwing.
- Unit coverage for host-only, missing, and unparseable env values.

Verified: new tests 3/3, adjacent auth suites 16/16, web typecheck clean, biome clean.