### PR TITLE
fix(release): inject staging auth URL into readiness

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -174,7 +174,7 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_STG }}
         run: >-
           doppler run --project jovie-web --config stg
-          --only-secrets=NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY,NEXT_PUBLIC_APP_URL,NEXT_PUBLIC_PROFILE_URL,NEXT_PUBLIC_PROFILE_HOSTNAME
+          --only-secrets=BETTER_AUTH_URL,NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY,NEXT_PUBLIC_APP_URL,NEXT_PUBLIC_PROFILE_URL,NEXT_PUBLIC_PROFILE_HOSTNAME
           --no-fallback -- env -u DOPPLER_TOKEN pnpm --filter=@jovie/web exec
           tsx scripts/check-signup-readiness.ts --target=stg --source=env
       - name: Build (preview target for staging verification)

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1324,12 +1324,16 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     const buildIndex = workflow.indexOf(
       '- name: Build (preview target for staging verification)'
     );
+    const readinessAllowlist =
+      readinessStep.match(/--only-secrets=([^\s]+)/)?.[1]?.split(',') ?? [];
 
     expect(readinessIndex).toBeGreaterThanOrEqual(0);
     expect(buildIndex).toBeGreaterThan(readinessIndex);
     expect(readinessStep).toContain('--target=stg');
     expect(readinessStep).toContain('--source=env');
     expect(readinessStep).not.toContain('--source=vercel-file');
+    expect(readinessAllowlist).toContain('BETTER_AUTH_URL');
+    expect(readinessAllowlist).toContain('NEXT_PUBLIC_BETTER_AUTH_URL');
     expect(buildStep).toContain('vercel build');
   });
 


### PR DESCRIPTION
## Summary
- Inject `BETTER_AUTH_URL` into the staging signup-readiness Doppler allowlist so the fail-closed preflight sees the same server/public auth URL pair already used by staging build and deploy.
- Parse the readiness allowlist in the deploy workflow contract and require exact membership for both `BETTER_AUTH_URL` and `NEXT_PUBLIC_BETTER_AUTH_URL`.

## Bug-to-Test
bug-to-test: satisfied — `apps/web/tests/unit/ci/deploy-workflow.test.ts`

## Test Coverage
The staging readiness allowlist regression is covered by the existing production workflow contract suite. The production wrapper remains unchanged and its exact allowlist contract already requires both auth URL keys.

## Pre-Landing Review
No issues found. Independent adversarial review found no FIXABLE or INVESTIGATE findings.

## Design Review
No frontend files changed — design review skipped.

## Eval Results
No prompt-related files changed — evals skipped.

## Plan Completion
No plan file detected.

## Linear follow-ups
Linear follow-ups: none.

## Verification Results
- `actionlint .github/workflows/production-release.yml`
- `pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts tests/unit/ci/deploy-workflow.test.ts` — 77/77 passed locally and again in the pre-push affected bundle
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Hook-backed pre-push gate: typecheck, lint, affected tests, and CI harness docs all passed

## Test plan
- [x] Staging readiness requests the server and public Better Auth URLs
- [x] Production readiness continues to request the server and public Better Auth URLs
- [x] Production release workflow passes actionlint
