### PR TITLE
fix(ci): keep CodeQL action bundle coherent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,11 @@ updates:
       - 'dependencies'
       - 'github-actions'
       - 'automated'
+    groups:
+      # init/analyze load one shared bundle and must move in the same PR.
+      codeql-action:
+        patterns:
+          - 'github/codeql-action'
 
   # Enable version updates for Docker (if needed)
   - package-ecosystem: 'docker'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3.28.15
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -60,6 +60,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3.28.15
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: '/language:${{matrix.language}}'

--- a/scripts/lib/__tests__/codeql-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/codeql-workflow-contract.test.mjs
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const CODEQL_WORKFLOW = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/codeql.yml'),
+  'utf8'
+);
+const DEPENDABOT_CONFIG = readFileSync(
+  resolve(REPO_ROOT, '.github/dependabot.yml'),
+  'utf8'
+);
+const GITHUB_ACTIONS_DEPENDABOT = DEPENDABOT_CONFIG.match(
+  /  - package-ecosystem: 'github-actions'[\s\S]*?(?=\n  - package-ecosystem:|$)/
+)?.[0];
+
+const CODEQL_ACTION_PIN =
+  /^\s*uses:\s*github\/codeql-action\/([^@\s]+)@([0-9a-f]{40})\s+#\s+(v\S+)\s*$/gm;
+
+describe('CodeQL workflow version coherence', () => {
+  it('pins every CodeQL component in the job to one action release', () => {
+    const pins = [...CODEQL_WORKFLOW.matchAll(CODEQL_ACTION_PIN)].map(
+      match => ({
+        component: match[1],
+        revision: match[2],
+        version: match[3],
+      })
+    );
+
+    expect(pins.map(pin => pin.component).sort()).toEqual(['analyze', 'init']);
+    expect([...new Set(pins.map(pin => pin.revision))]).toHaveLength(1);
+    expect([...new Set(pins.map(pin => pin.version))]).toHaveLength(1);
+  });
+
+  it('groups CodeQL action updates so Dependabot moves every component together', () => {
+    expect(GITHUB_ACTIONS_DEPENDABOT).toMatch(
+      /groups:\n(?:\s+#.*\n)*\s+codeql-action:\n\s+patterns:\n\s+- 'github\/codeql-action'/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Pin CodeQL `init` and `analyze` to the same immutable v4.37.1 bundle commit.
- Group `github/codeql-action` Dependabot updates so every component moves together.
- Add a contract test that fails when component revisions or version comments diverge.

## Bug-to-Test

`bug-to-test: satisfied` via `scripts/lib/__tests__/codeql-workflow-contract.test.mjs`.

## Test Coverage

All changed CodeQL configuration paths have contract coverage: component discovery, shared immutable revision, shared release comment, and Dependabot grouping.

## Pre-Landing Review

No actionable issues found.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. The diff is limited to CodeQL bundle coherence and its regression guard.

## Plan Completion

No plan file detected.

## Linear follow-ups

None.

## Test plan

- [x] `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codeql-workflow-contract.test.mjs` (2/2)
- [x] `actionlint .github/workflows/codeql.yml`
- [x] YAML parse for `.github/dependabot.yml` and `.github/workflows/codeql.yml`
- [x] `pnpm biome check scripts/lib/__tests__/codeql-workflow-contract.test.mjs`
- [x] `pnpm --filter @jovie/web run test:bug-to-test`
- [x] `pnpm ci:harness:check`
- [x] Normal pre-push hook under Node 22 (typecheck, lint, affected verification, harness)

Draft only. Do not enqueue or merge until orchestrator verification.