### PR TITLE
fix(ci): isolate native queue from legacy label

### DIFF
--- a/scripts/ci-merge-queue-check.mjs
+++ b/scripts/ci-merge-queue-check.mjs
@@ -8,6 +8,7 @@ import {
   validateLiveMergeQueueRuleset,
   validateMergeQueueEnrollHotPath,
   validateMergeQueueRepoConfig,
+  validateNativeDrainQueueLabelIsolation,
 } from './lib/merge-queue-guard.mjs';
 import { DEFAULT_MERGE_QUEUE_BACKEND } from './merge-queue-backend.mjs';
 
@@ -68,12 +69,15 @@ function runValidate({ checkLive = false } = {}) {
   const autoenrollWorkflowYaml = readRepoFile(
     MERGE_QUEUE_REPO_PATHS.autoenrollWorkflow
   );
+  const drainScript = readRepoFile(MERGE_QUEUE_REPO_PATHS.drainScript);
   const repoValidation = validateMergeQueueRepoConfig({
     backend,
     branchProtectionYaml,
     ciWorkflowYaml,
   });
   const enrollHotPath = validateMergeQueueEnrollHotPath(autoenrollWorkflowYaml);
+  const drainLabelIsolation =
+    validateNativeDrainQueueLabelIsolation(drainScript);
 
   if (repoValidation.warnings.length > 0) {
     console.warn('Merge queue repo-config warnings:');
@@ -82,7 +86,7 @@ function runValidate({ checkLive = false } = {}) {
     }
   }
 
-  if (!repoValidation.ok || !enrollHotPath.ok) {
+  if (!repoValidation.ok || !enrollHotPath.ok || !drainLabelIsolation.ok) {
     if (!repoValidation.ok) {
       console.error('Merge queue repo-config validation failed:');
       for (const error of repoValidation.errors) {
@@ -95,6 +99,12 @@ function runValidate({ checkLive = false } = {}) {
         console.error(`- ${error}`);
       }
     }
+    if (!drainLabelIsolation.ok) {
+      console.error('Native drain label-isolation validation failed:');
+      for (const error of drainLabelIsolation.errors) {
+        console.error(`- ${error}`);
+      }
+    }
     process.exitCode = 1;
     return;
   }
@@ -103,6 +113,7 @@ function runValidate({ checkLive = false } = {}) {
     `Repo config OK — required aggregates: ${repoValidation.contexts.join(', ')}`
   );
   console.log('Enroll hot path OK — no test-only dependency bootstrap');
+  console.log('Native drain OK — no legacy merge-queue label dependency');
 
   if (!checkLive) {
     return;

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Backend-routed PR queue drain. Graphite uses the merge-queue label as its
 # transport; GitHub native uses exact-head enrollment and authoritative queue
-# state while retaining the label only as intent/audit evidence.
+# state without reading, writing, or requiring that legacy transport label.
 # Autonomous shipping (2026-07-06): taste gates are advisory — only hold/gated/needs-human block.
 #
 # It deliberately does NOT:
@@ -117,6 +117,7 @@ enroll_if_still_eligible() {  # enroll_if_still_eligible <num>
     fi
     return 0
   fi
+  # native-queue-transport:enrollment:start
   if [[ "$MERGE_QUEUE_BACKEND" == "native" ]]; then
     head_oid="$(jq -r '.headRefOid // empty' <<<"$current")"
     if [[ ! "$head_oid" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -136,7 +137,7 @@ enroll_if_still_eligible() {  # enroll_if_still_eligible <num>
     if ! current="$(gh_retry pr view "$n" -R "$REPO" \
       --json state,isDraft,mergeable,labels,headRefOid 2>/dev/null)"; then
       echo "    !! could not refresh #$n after native enrollment; compensating" >&2
-      if ! remove_held_queue_label_strict "$n"; then
+      if ! dequeue_strict "$n"; then
         echo "    !! CRITICAL: could not compensate uncertain native enrollment for #$n" >&2
         return 1
       fi
@@ -154,49 +155,17 @@ enroll_if_still_eligible() {  # enroll_if_still_eligible <num>
       ) | not)
     ' <<<"$current" >/dev/null; then
       echo "    ⏸ eligibility changed during native enrollment for #$n; compensating"
-      if ! remove_held_queue_label_strict "$n"; then
+      if ! dequeue_strict "$n"; then
         echo "    !! CRITICAL: could not compensate held native enrollment for #$n" >&2
         return 1
       fi
       return 2
     fi
 
-    # Audit label is best-effort evidence only: external watchers (e.g.
-    # Graphite's account-less unlabel hook) can strip it within seconds, and a
-    # missing audit label must never unwind a proven native enrollment
-    # (GH-14694: drain repeatedly dequeued freshly-enrolled PRs when the label
-    # vanished between the write and the final proof).
-    if ! gh_retry pr edit "$n" -R "$REPO" --add-label merge-queue >/dev/null; then
-      echo "    note: could not record native intent label for #$n (non-fatal)"
-    fi
-
-    # Final proof re-verifies eligibility and native queue membership — never
-    # the audit label, which external watchers may legitimately strip. The
-    # labeled event remains a later safety net; this controller does not rely
-    # on that event to repair its own mutation.
-    if ! current="$(gh_retry pr view "$n" -R "$REPO" \
-      --json state,isDraft,mergeable,labels,headRefOid 2>/dev/null)" \
-      || ! jq -e --arg expected_head "$expected_head" '
-        .state == "OPEN"
-        and (.isDraft | not)
-        and .mergeable == "MERGEABLE"
-        and ((.headRefOid // "") | ascii_downcase) == $expected_head
-        and ([.labels[].name] | any(
-          . == "needs-human" or . == "hold" or . == "gated"
-          or . == "queue-deferred" or . == "needs-conflict-resolution"
-          or . == "fast"
-        ) | not)
-      ' <<<"$current" >/dev/null; then
-      echo "    ⏸ eligibility changed while recording native enrollment for #$n; compensating"
-      if ! remove_held_queue_label_strict "$n"; then
-        echo "    !! CRITICAL: could not compensate final native eligibility failure for #$n" >&2
-        return 1
-      fi
-      return 2
-    fi
     echo "    +native-queue on #$n at $head_oid"
     return 0
   fi
+  # native-queue-transport:enrollment:end
   if ! gh_retry pr edit "$n" -R "$REPO" --add-label merge-queue >/dev/null; then
     echo "    !! failed to add merge-queue on #$n" >&2
     return 1
@@ -204,7 +173,7 @@ enroll_if_still_eligible() {  # enroll_if_still_eligible <num>
   if ! current="$(gh_retry pr view "$n" -R "$REPO" \
     --json state,isDraft,mergeable,labels 2>/dev/null)"; then
     echo "    !! could not verify #$n after enrollment" >&2
-    if ! remove_held_queue_label_strict "$n"; then
+    if ! dequeue_strict "$n"; then
       echo "    !! CRITICAL: could not prove failed enrollment was compensated for #$n" >&2
     fi
     return 1
@@ -224,13 +193,13 @@ enroll_if_still_eligible() {  # enroll_if_still_eligible <num>
     return 0
   fi
   echo "    !! enrollment verification failed for #$n" >&2
-  if ! remove_held_queue_label_strict "$n"; then
+  if ! dequeue_strict "$n"; then
     echo "    !! CRITICAL: could not prove failed enrollment was compensated for #$n" >&2
   fi
   return 1
 }
 
-remove_held_queue_label_strict() {  # remove_held_queue_label_strict <num>
+dequeue_strict() {  # dequeue_strict <num>
   local n="$1" current
   if [[ "$DRY_RUN" == "1" ]]; then
     if [[ "$MERGE_QUEUE_BACKEND" == "native" ]]; then
@@ -240,24 +209,16 @@ remove_held_queue_label_strict() {  # remove_held_queue_label_strict <num>
     fi
     return 0
   fi
+  # native-queue-transport:dequeue:start
   if [[ "$MERGE_QUEUE_BACKEND" == "native" ]]; then
     if ! node scripts/merge-queue-backend.mjs dequeue "$n" >/dev/null; then
       echo "    !! failed to prove native dequeue for held PR #$n" >&2
       return 1
     fi
-    if ! current="$(gh_retry pr view "$n" -R "$REPO" --json labels 2>/dev/null)"; then
-      echo "    !! could not read intent label after native dequeue for #$n" >&2
-      return 1
-    fi
-    if jq -e '([.labels[].name] | index("merge-queue")) != null' <<<"$current" >/dev/null; then
-      if ! gh_retry pr edit "$n" -R "$REPO" --remove-label merge-queue >/dev/null; then
-        echo "    !! failed to remove native intent label from #$n" >&2
-        return 1
-      fi
-    fi
     echo "    -native-queue on #$n"
     return 0
   fi
+  # native-queue-transport:dequeue:end
   if ! gh_retry pr edit "$n" -R "$REPO" --remove-label merge-queue >/dev/null; then
     echo "    !! failed to remove merge-queue hold violation from #$n" >&2
     return 1
@@ -414,11 +375,11 @@ echo "$SNAP" | jq -r '
   ] | .[]'
 
 # --- DEQUEUE: hard-gated PRs must not occupy queue slots ---
-echo "=== DEQUEUE (hard gates → -merge-queue) ==="
+echo "=== DEQUEUE (hard gates → queue removal) ==="
 while read -r pr; do
     n=$(jq -r '.n' <<<"$pr"); t=$(jq -r '.t' <<<"$pr")
     echo "  #$n  $t"
-    if ! remove_held_queue_label_strict "$n"; then
+    if ! dequeue_strict "$n"; then
       echo "::error::Failed to prove held PR #$n is outside merge queue" >&2
       exit 1
     fi
@@ -439,7 +400,7 @@ while read -r pr; do
 # PRs (13741/13746/13779) through synchronized dequeue/re-enroll cycles.
 # Dequeue only on: needs-conflict-resolution, a CONFIRMED merge conflict
 # (m == CONFLICTING, never UNKNOWN), or actually-failing checks (.fail).
-echo "=== DEQUEUE (conflict / failing → -merge-queue) ==="
+echo "=== DEQUEUE (conflict / failing → queue removal) ==="
 echo "$SNAP" | jq -c '.[]
   | select(.q == true)
   | select((.head|startswith("gtmq_"))|not)
@@ -460,7 +421,7 @@ echo "$SNAP" | jq -c '.[]
     ' <<<"$pr")
     echo "  #$n  $t  ✗ $reason"
     if [[ "$MERGE_QUEUE_BACKEND" == "native" ]]; then
-      if ! remove_held_queue_label_strict "$n"; then
+      if ! dequeue_strict "$n"; then
         echo "::error::Failed to prove PR #$n is outside native merge queue" >&2
         exit 1
       fi
@@ -474,9 +435,9 @@ echo "$SNAP" | jq -c '.[]
 # mergeStateStatus==CLEAN: zombie cancelled/queued required-check runs (from
 # cancel-in-progress) pin otherwise-green PRs at BLOCKED, and gating enrollment on
 # CLEAN meant those PRs never entered the queue. Enrolling a not-yet-green PR is
-# safe — Graphite re-validates and the dequeue step above removes any that truly
+# safe — the backend re-validates and the dequeue step above removes any that truly
 # fail. `.fail` only counts terminal failing checks, not pending/queued ones.
-echo "=== ENROLL (mergeable + not failing → +merge-queue) ==="
+echo "=== ENROLL (mergeable + not failing → queue admission) ==="
 # Honor the checked-in queue policy's maxQueueDepth. Use process substitution rather
 # than a pipe so ENROLLED_THIS_RUN remains in the parent shell and the cap is
 # actually enforced.

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -31,6 +31,7 @@ import {
   validateLiveMergeQueueRuleset,
   validateMergeQueueEnrollHotPath,
   validateMergeQueueRepoConfig,
+  validateNativeDrainQueueLabelIsolation,
 } from '../merge-queue-guard.mjs';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
@@ -478,6 +479,29 @@ describe('aggregate required checks', () => {
     const result = validateMergeQueueEnrollHotPath(autoenrollYaml);
     expect(result.ok).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+
+  it('isolates the legacy label from native drain enrollment and dequeue', () => {
+    const drainScript = readFileSync(
+      resolve(REPO_ROOT, MERGE_QUEUE_REPO_PATHS.drainScript),
+      'utf8'
+    );
+
+    expect(validateNativeDrainQueueLabelIsolation(drainScript)).toEqual({
+      ok: true,
+      errors: [],
+    });
+
+    const regressed = drainScript.replace(
+      '# native-queue-transport:enrollment:end',
+      'gh_retry pr edit "$n" --add-label merge-queue\n  # native-queue-transport:enrollment:end'
+    );
+    expect(validateNativeDrainQueueLabelIsolation(regressed)).toEqual({
+      ok: false,
+      errors: [
+        'native drain enrollment must not read, write, or require the legacy merge-queue label',
+      ],
+    });
   });
 
   it('validates the legacy Graphite ruleset shape only when explicitly selected', () => {

--- a/scripts/lib/merge-queue-guard.mjs
+++ b/scripts/lib/merge-queue-guard.mjs
@@ -1205,6 +1205,7 @@ export const MERGE_QUEUE_REPO_PATHS = Object.freeze({
   branchProtection: BRANCH_PROTECTION_RULESET_PATH,
   ciWorkflow: CI_WORKFLOW_PATH,
   autoenrollWorkflow: MERGE_QUEUE_AUTOENROLL_WORKFLOW_PATH,
+  drainScript: 'scripts/drain-pr-queue.sh',
 });
 
 /**
@@ -1275,6 +1276,76 @@ export function validateMergeQueueEnrollHotPath(workflowYaml = '') {
   ) {
     errors.push(
       'enroll hot path must authorize only the native queue controller'
+    );
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+const NATIVE_DRAIN_TRANSPORT_AREAS = Object.freeze(['enrollment', 'dequeue']);
+
+function extractNativeDrainTransportArea(script, area) {
+  const startMarker = `# native-queue-transport:${area}:start`;
+  const endMarker = `# native-queue-transport:${area}:end`;
+  const start = script.indexOf(startMarker);
+  const end = script.indexOf(endMarker, start + startMarker.length);
+  if (start < 0 || end < 0) return '';
+  return script.slice(start, end + endMarker.length);
+}
+
+/**
+ * Native queue mutations must never use the legacy Graphite transport label.
+ * Marked transport regions make this invariant deterministic without trying to
+ * parse arbitrary Bash control flow.
+ *
+ * @param {string} drainScript
+ */
+export function validateNativeDrainQueueLabelIsolation(drainScript = '') {
+  const errors = [];
+  const areas = new Map();
+  const legacyLabelPatterns = [
+    /--(?:add|remove)-label\s+["']?merge-queue["']?/,
+    /index\(["']merge-queue["']\)/,
+    /(?:^|[\s"'=])merge-queue(?:[\s"']|$)/m,
+  ];
+
+  for (const area of NATIVE_DRAIN_TRANSPORT_AREAS) {
+    const block = extractNativeDrainTransportArea(drainScript, area);
+    areas.set(area, block);
+    if (!block) {
+      errors.push(`native drain ${area} transport markers are required`);
+      continue;
+    }
+    if (legacyLabelPatterns.some(pattern => pattern.test(block))) {
+      errors.push(
+        `native drain ${area} must not read, write, or require the legacy merge-queue label`
+      );
+    }
+  }
+
+  const enrollment = areas.get('enrollment') ?? '';
+  if (!/merge-queue-backend\.mjs enroll "\$n" "\$head_oid"/.test(enrollment)) {
+    errors.push(
+      'native drain enrollment must bind the exact head to backend enrollment'
+    );
+  }
+  if (
+    !/--arg expected_head "\$expected_head"/.test(enrollment) ||
+    !/\.headRefOid/.test(enrollment)
+  ) {
+    errors.push(
+      'native drain enrollment must retain its exact-head postcondition'
+    );
+  }
+
+  const dequeue = areas.get('dequeue') ?? '';
+  if (!/merge-queue-backend\.mjs dequeue "\$n"/.test(dequeue)) {
+    errors.push('native drain dequeue must prove the backend postcondition');
+  }
+
+  if (!/\$backend == "graphite" and \. == "merge-queue"/.test(drainScript)) {
+    errors.push(
+      'legacy merge-queue eligibility may exist only behind the explicit Graphite backend'
     );
   }
 


### PR DESCRIPTION
## Summary
- make GitHub native merge queue enrollment/dequeue use only the authoritative backend, never the legacy `merge-queue` Graphite transport label
- preserve exact-head enrollment and post-mutation eligibility compensation for drafts, hard gates, and `queue-deferred`
- add a checked-in structural invariant so native label reads/writes cannot regress silently

## Recovery evidence
Repeated auto-enroll passes were repopulating deferred PRs and superseding production proof. In native mode, queue membership now comes from `merge-queue-backend.mjs list-state`; `queue-deferred` is rejected both in the candidate selector and in the fresh pre/post-enrollment reads. The legacy label remains reachable only behind the explicit Graphite backend.

## Bug-to-Test
bug-to-test: satisfied

Regression evidence:
- `scripts/tests/test_gh_retry.py::TestDrainPrQueueWiring::test_enroll_refuses_draft_or_deferred_state_from_fresh_read`
- `scripts/tests/test_gh_retry.py::TestDrainPrQueueWiring::test_native_enrollment_compensates_when_gated_label_races_mutation`
- `scripts/lib/__tests__/merge-queue-guard.test.mjs` rejects native enrollment/dequeue blocks that reference `merge-queue`
- `node scripts/ci-merge-queue-check.mjs validate` wires the invariant into CI policy validation

## Pre-Landing Review
No issues found. Scope is limited to native queue transport isolation and its regression guard.

## Design Review
No frontend files changed; design review skipped.

## Eval Results
No prompt-related files changed; evals skipped.

## Plan Completion
No standalone plan file; this is a bounded production-recovery fix within the active CI concurrency audit.

## Linear follow-ups
Linear follow-ups: none. Ad-hoc recovery work coordinated through gbrain.

## Verification Results
- [x] `python3 -m pytest -q scripts/tests/test_gh_retry.py` — 60 passed
- [x] guard/backend Vitest suites — 95 passed
- [x] `node scripts/ci-merge-queue-check.mjs validate`
- [x] `bash -n` and `shellcheck -x scripts/drain-pr-queue.sh`
- [x] changed-file Biome — no fixes
- [x] scripts typecheck — no new errors above the shrink-only baseline
- [x] web Turbo typecheck — 3/3 tasks passed
- [x] normal pre-push hook — typecheck, lint, 8 sequential full Vitest shards, CI harness validation all passed
- [x] `actionlint` not applicable; no workflow YAML changed

## Test plan
- [x] Deferred/draft PRs cannot enroll from a stale snapshot
- [x] A hard gate racing native enrollment triggers authoritative dequeue compensation
- [x] Native queue transport cannot read/write/require the legacy label
- [x] Graphite remains the only backend allowed to use the legacy label
