### PR TITLE
fix(auth): return handled 401 for OTT user mismatch instead of untyped 500 (JOV-4278)

### DIFF
--- a/apps/web/app/api/auth/native/exchange/route.ts
+++ b/apps/web/app/api/auth/native/exchange/route.ts
@@ -199,11 +199,36 @@ export async function POST(request: Request) {
 
     let exchangePayload: NativeExchangePayload;
     if (client === 'ios') {
-      exchangePayload = await createIosNativeExchangePayload(
+      const iosExchange = await createIosNativeExchangePayload(
         result.ott,
         result.userId,
         request
       );
+
+      // OTT resolved to a different user than the exchange record. This is an
+      // auth rejection, not a server fault: the guard stays (the exchange is
+      // refused) but the client gets a handled 401 so it can restart
+      // finalization instead of surfacing a bare 500 (JOV-4278). The OTT is
+      // single-use and already consumed by `verifyOneTimeToken`, so it cannot
+      // be replayed after this rejection.
+      if (!iosExchange.ok) {
+        void trackAuthEvent('auth_exchange_failed', {
+          client,
+          intent: 'sign_in',
+          result: 'failed',
+          reason: iosExchange.reason,
+        });
+
+        return NextResponse.json(
+          {
+            error: 'Native auth exchange user mismatch',
+            reason: iosExchange.reason,
+          },
+          { status: 401, headers: NO_STORE_HEADERS }
+        );
+      }
+
+      exchangePayload = iosExchange.payload;
     } else {
       // Electron: return the OTT. The native-complete page POSTs it to
       // `/api/auth/one-time-token/verify` which sets the session cookie.
@@ -253,12 +278,21 @@ export async function POST(request: Request) {
  * `session.expiresIn` (7 days). The iOS client never needs to refresh —
  * the bearer plugin's `set-auth-token` response header refreshes the
  * stored token + expiry on each API call (eng row 31).
+ *
+ * A user mismatch is returned as a handled failure (`ott_user_mismatch`)
+ * rather than thrown: the binding is correct-by-construction, so a
+ * mismatch means identity mutated inside the OTT window — an expected
+ * auth rejection (401), not an unhandled server error (JOV-4278).
  */
+type IosNativeExchangeResult =
+  | { readonly ok: true; readonly payload: NativeExchangePayload }
+  | { readonly ok: false; readonly reason: 'ott_user_mismatch' };
+
 async function createIosNativeExchangePayload(
   ott: string,
   expectedUserId: string,
   request: Request
-): Promise<NativeExchangePayload> {
+): Promise<IosNativeExchangeResult> {
   const verification = await auth.api.verifyOneTimeToken({
     body: { token: ott },
     request,
@@ -269,7 +303,7 @@ async function createIosNativeExchangePayload(
 
   const verifiedUserId = verification?.user?.id ?? null;
   if (!verifiedUserId || verifiedUserId !== expectedUserId) {
-    throw new Error('OTT user mismatch');
+    return { ok: false, reason: 'ott_user_mismatch' };
   }
 
   const ctx = await auth.$context;
@@ -280,9 +314,12 @@ async function createIosNativeExchangePayload(
   }
 
   return {
-    sessionToken: session.token,
-    sessionId: session.id,
-    userId: verifiedUserId,
-    expiresInSeconds: NATIVE_SESSION_EXPIRES_IN_SECONDS,
+    ok: true,
+    payload: {
+      sessionToken: session.token,
+      sessionId: session.id,
+      userId: verifiedUserId,
+      expiresInSeconds: NATIVE_SESSION_EXPIRES_IN_SECONDS,
+    },
   };
 }

--- a/apps/web/tests/unit/api/auth/native-exchange.test.ts
+++ b/apps/web/tests/unit/api/auth/native-exchange.test.ts
@@ -189,6 +189,67 @@ describe('native auth exchange route (Better Auth)', () => {
     expect(data.reason).toBe('ott_missing');
   });
 
+  it('returns 401 ott_user_mismatch when the OTT resolves to a different user', async () => {
+    setupSuccessfulExchange('ott_123', 'user_ba_123');
+    setupIosSessionCreation();
+    mockVerifyOneTimeToken.mockResolvedValue({
+      user: { id: 'user_other_999' },
+      session: { userId: 'user_other_999' },
+    });
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest('ios'));
+    const data = await response.json();
+
+    // Handled auth rejection — never a 500
+    expect(response.status).toBe(401);
+    expect(data.reason).toBe('ott_user_mismatch');
+    // Guard preserved: the exchange is rejected, no fresh session is minted
+    expect(mockInternalAdapterCreateSession).not.toHaveBeenCalled();
+    // Handled failures are not reported as unhandled server errors
+    expect(mockCaptureError).not.toHaveBeenCalled();
+    // Telemetry mirrors the ott_missing event shape
+    expect(mockCreateAuthAnalyticsEvent).toHaveBeenCalledWith(
+      'auth_exchange_failed',
+      {
+        client: 'ios',
+        intent: 'sign_in',
+        result: 'failed',
+        reason: 'ott_user_mismatch',
+      }
+    );
+  });
+
+  it('returns 401 ott_user_mismatch when the OTT resolves without a user', async () => {
+    setupSuccessfulExchange('ott_123', 'user_ba_123');
+    setupIosSessionCreation();
+    mockVerifyOneTimeToken.mockResolvedValue(null);
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest('ios'));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.reason).toBe('ott_user_mismatch');
+    expect(mockInternalAdapterCreateSession).not.toHaveBeenCalled();
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('keeps a genuine session-creation failure as a captured 500', async () => {
+    setupSuccessfulExchange();
+    setupIosSessionCreation();
+    mockInternalAdapterCreateSession.mockResolvedValue(null);
+    mockCaptureError.mockResolvedValue(undefined);
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest('ios'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Native auth exchange failed');
+    expect(mockCaptureError).toHaveBeenCalled();
+  });
+
   it('returns 401 with reason for invalid exchange (wrong_code)', async () => {
     mockConsumeStoredNativeExchangeCode.mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Workstream summary

OTT user mismatch error hygiene for the native auth exchange (`POST /api/auth/native/exchange`). The iOS OTT→user guard threw an untyped `Error('OTT user mismatch')`, which the route catch-all turned into a 500 + Sentry group (JOVIE-WEB-QZ); the iOS client surfaced it as `NativeAuthExchangeError.requestFailed(statusCode: 500)` (JOV-4279). This PR converts that throw into a handled 401 response, mirroring the existing `ott_missing` pattern ~20 lines up in the same handler.

## Issue

Linear JOV-4278 (P1, MVP Stability) — `Error: OTT user mismatch` at `apps/web/app/api/auth/native/exchange/route.ts:272`. Triage on record: the binding is correct-by-construction (exchange record `userId` from `getSession` at callback; OTT minted from the same session; `verifyOneTimeToken` resolves via `consumeVerificationValue`; nothing updates `ba_sessions.userId`; FK onDelete cascade), so a mismatch means identity mutated inside the ≤5-min OTT window. Root cause of that mutation needs Sentry event data and is **out of scope** for this PR.

## Guard-preserved contract

No behavior change except status/shape/telemetry:

- The exchange is still **rejected** on mismatch — no `ba_sessions` row is minted (`internalAdapter.createSession` is never reached).
- The OTT is single-use and already consumed by `verifyOneTimeToken` before the guard runs, so it cannot be replayed after rejection.
- Response: `401 { error: 'Native auth exchange user mismatch', reason: 'ott_user_mismatch' }` (was: 500 `{ error: 'Native auth exchange failed' }`).
- Telemetry: `trackAuthEvent('auth_exchange_failed', { client, intent: 'sign_in', result: 'failed', reason: 'ott_user_mismatch' })` — same shape as `ott_missing`; no user IDs. No `captureError`, so the Sentry group stops receiving expected-rejection events (acceptance: JOVIE-WEB-QZ/QY at 0 new events over 7 days); recurrence is now measured via the analytics event.

## Scope

- `apps/web/app/api/auth/native/exchange/route.ts` — `createIosNativeExchangePayload` now returns a discriminated result (`{ ok: true, payload } | { ok: false, reason: 'ott_user_mismatch' }`); the route handles it like `ott_missing`.
- `apps/web/tests/unit/api/auth/native-exchange.test.ts` — regression coverage.
- Adjacent-bug sweep (same file): the only other untyped throw is `Native session creation failed` — deliberately **unchanged**: a session-row creation failure is a genuine internal fault where 500 + Sentry capture is the correct contract; a regression test pins that. No other files touched.

## Validation

- `pnpm --filter web exec vitest run tests/unit/api/auth/native-exchange.test.ts` — 10/10 pass (7 existing + 3 new: mismatch→401 with reason + no session minted + no captureError + event tracked; null-user→401; session-creation failure stays captured 500).
- `pnpm biome check --write` on both changed files — clean, no fixes.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — pass.

## Risk

Low. Single route, iOS exchange path only; success path payload unchanged (Swift `NativeAuthExchangeResponse` decodes unchanged); Electron path untouched. iOS already maps non-2xx exchange responses to a restartable finalization error, and 401 is strictly more actionable than 500.

## Rollback

Revert this single commit; the route returns to the previous throw→500 behavior with no data or schema implications.

## GBrain

- Read: `engineering/backlog-triage-2026-07-20`
- Written: `engineering/ott-user-mismatch-error-hygiene` (handled-vs-thrown contract, preserved guard, event shape, data-blocked root cause)