### PR TITLE
fix(ci): pin sealed Lighthouse uploader cwd via direct Node spawn

### DIFF
--- a/apps/web/scripts/lighthouse-exact-target-guard.test.ts
+++ b/apps/web/scripts/lighthouse-exact-target-guard.test.ts
@@ -20,6 +20,7 @@ import {
   createLighthouseUploadEnvironment,
   readRegularArtifactRecords,
   readSensitiveValues,
+  resolveLighthouseCliPath,
   uploadSealedArtifacts,
   validateExactLighthouseAssertions,
   validateExactLighthouseConfig,
@@ -348,14 +349,13 @@ describe('exact production Lighthouse evidence guard', () => {
       vi.stubEnv('VERCEL_TOKEN', 'sentinel-vercel-token');
       vi.stubEnv('SOME_SECRET', 'sentinel-generic-secret');
       const spawnImpl = vi.fn((command, args, options) => {
-        expect(command).toBe('pnpm');
+        expect(command).toBe(process.execPath);
         const uploadRoot = options.cwd as string;
         const isolatedDirectory = join(uploadRoot, '.lighthouseci');
         const isolatedConfig = join(uploadRoot, 'lighthouserc.json');
         const isolatedArtifact = join(isolatedDirectory, 'lhr-1.json');
         expect(args).toEqual([
-          'exec',
-          'lhci',
+          resolveLighthouseCliPath(),
           'upload',
           `--config=${isolatedConfig}`,
         ]);
@@ -524,6 +524,96 @@ describe('exact production Lighthouse evidence guard', () => {
         uploadSealedArtifacts(configPath, directory, seal, [], spawnImpl)
       ).toThrow('did not publish every exact route');
       expect(() => statSync(join(directory, 'links.json'))).toThrow();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('invokes the LHCI entrypoint directly so project discovery cannot re-anchor the uploader', () => {
+    // Regression for the postdeploy-probes production failure: `pnpm exec`
+    // re-anchors at the nearest package root when the isolated upload root has
+    // no package.json, and LHCI derives .lighthouseci from process.cwd() — so
+    // the uploader wrote links.json into the sealed source tree. The uploader
+    // must be spawned as `node <lhci cli> upload` with cwd pinned to the
+    // isolated root, never through a package-manager exec layer.
+    const cliPath = resolveLighthouseCliPath();
+    expect(cliPath).toMatch(/[\\/]@lhci[\\/]cli[\\/]src[\\/]cli\.js$/);
+
+    const root = mkdtempSync(join(tmpdir(), 'jovie-lhci-direct-spawn-'));
+    const directory = join(root, '.lighthouseci');
+    const configPath = join(root, 'lighthouserc.json');
+    try {
+      mkdirSync(directory);
+      writeFileSync(configPath, JSON.stringify(configFixture()));
+      writeFileSync(
+        join(directory, 'lhr-1.json'),
+        JSON.stringify(reportFixture(HOME_URL))
+      );
+      const seal = createLighthouseArtifactSeal(
+        readRegularArtifactRecords(directory)
+      );
+      const spawnImpl = vi.fn((command, args, options) => {
+        expect(command).toBe(process.execPath);
+        expect(args[0]).toBe(cliPath);
+        expect(args.slice(1)).toEqual([
+          'upload',
+          `--config=${join(options.cwd as string, 'lighthouserc.json')}`,
+        ]);
+        // The uploader's cwd is the isolated root, not a package directory.
+        expect(() =>
+          statSync(join(options.cwd as string, 'package.json'))
+        ).toThrow();
+        writeFileSync(
+          join(options.cwd as string, '.lighthouseci', 'links.json'),
+          JSON.stringify({
+            [HOME_URL]: 'https://storage.example/home',
+            [PROFILE_URL]: 'https://storage.example/profile',
+          })
+        );
+        return { status: 0 };
+      }) as unknown as typeof spawnSync;
+
+      uploadSealedArtifacts(configPath, directory, seal, [], spawnImpl);
+      expect(spawnImpl).toHaveBeenCalledOnce();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('fails closed when a re-anchored uploader writes links into the sealed source tree', () => {
+    // Reproduces the prior production sequence: an uploader whose cwd was
+    // re-anchored at the package root writes links.json next to the sealed
+    // source artifacts instead of inside its isolated copy. The seal must
+    // detect the source-tree mutation and fail closed — never mask it.
+    const root = mkdtempSync(join(tmpdir(), 'jovie-lhci-reanchor-'));
+    const directory = join(root, '.lighthouseci');
+    const configPath = join(root, 'lighthouserc.json');
+    try {
+      mkdirSync(directory);
+      writeFileSync(configPath, JSON.stringify(configFixture()));
+      writeFileSync(
+        join(directory, 'lhr-1.json'),
+        JSON.stringify(reportFixture(HOME_URL))
+      );
+      const seal = createLighthouseArtifactSeal(
+        readRegularArtifactRecords(directory)
+      );
+      const spawnImpl = ((_command, _args, _options) => {
+        // Emulate LHCI resolving `.lighthouseci` from a re-anchored cwd equal
+        // to the package root (the sealed source tree's parent).
+        writeFileSync(
+          join(directory, 'links.json'),
+          JSON.stringify({
+            [HOME_URL]: 'https://storage.example/home',
+            [PROFILE_URL]: 'https://storage.example/profile',
+          })
+        );
+        return { status: 0 };
+      }) as unknown as typeof spawnSync;
+
+      expect(() =>
+        uploadSealedArtifacts(configPath, directory, seal, [], spawnImpl)
+      ).toThrow('Lighthouse artifact set changed after validation.');
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/web/scripts/lighthouse-exact-target-guard.ts
+++ b/apps/web/scripts/lighthouse-exact-target-guard.ts
@@ -20,6 +20,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import { basename, dirname, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
@@ -613,9 +614,16 @@ export function uploadSealedArtifacts(
       ])
     );
 
+    // Invoke the LHCI entrypoint directly with Node. `pnpm exec` performs
+    // project discovery and re-anchors the child at the nearest package root
+    // when its cwd (this isolated upload root) has no package.json — and LHCI
+    // derives its artifact directory from process.cwd(), so a re-anchored
+    // uploader writes links.json into the sealed source tree instead of the
+    // isolated copy ("Lighthouse artifact set changed after validation").
+    // A direct Node spawn pins the uploader's cwd to the isolated root.
     const upload = spawnImpl(
-      'pnpm',
-      ['exec', 'lhci', 'upload', `--config=${uploadConfigPath}`],
+      process.execPath,
+      [resolveLighthouseCliPath(), 'upload', `--config=${uploadConfigPath}`],
       {
         cwd: uploadRoot,
         env: childEnvironment,
@@ -706,6 +714,11 @@ export function uploadSealedArtifacts(
     }
     rmSync(uploadRoot, { force: true, recursive: true });
   }
+}
+
+export function resolveLighthouseCliPath(): string {
+  const requireFromGuard = createRequire(import.meta.url);
+  return requireFromGuard.resolve('@lhci/cli/src/cli.js');
 }
 
 function readOption(argv: readonly string[], name: string): string | undefined {


### PR DESCRIPTION
## Problem
Post-Deploy Probes run [29891421844](https://github.com/JovieInc/Jovie/actions/runs/29891421844) (job [88832576466](https://github.com/JovieInc/Jovie/actions/runs/29891421844/job/88832576466)) failed at "Validate and upload hash-sealed Lighthouse evidence" with `Lighthouse artifact set changed after validation.`, blocking canonical verification of main `b726e7b` (Production Controller [29890285180](https://github.com/JovieInc/Jovie/actions/runs/29890285180) promoted but its in-line post-deploy jobs were skipped).

## Root cause
`uploadSealedArtifacts` spawned `pnpm exec lhci upload` with `cwd` set to the isolated upload root (`.jovie-lhci-upload-*`). That directory has no `package.json`, so pnpm's project discovery re-anchors the child at the nearest package root (`apps/web`). LHCI resolves its artifact directory from `process.cwd()` (`@lhci/utils/src/saved-reports.js`: `path.join(process.cwd(), '.lighthouseci')`), so the uploader wrote `links.json` into the **sealed source tree** instead of the isolated copy. The post-upload source-seal re-validation then (correctly) failed closed with the observed error — before the isolated-copy links check could report anything else. Sandbox check: pnpm 10 can't even resolve bins from a package-less cwd, so the behavior is also package-manager-version dependent — i.e., non-deterministic by construction.

## What changed
- `apps/web/scripts/lighthouse-exact-target-guard.ts`: spawn the uploader as `node <resolved @lhci/cli/src/cli.js> upload --config=<isolated config>` with `cwd` pinned to the isolated upload root (new `resolveLighthouseCliPath()`), removing the package-manager exec layer entirely. **No guard weakened**: exact-origin config validation, sensitive-value scanning, hash-seal checks (source before/after, isolated before/after), inode/stat identity checks, links.json route-coverage/link-safety validation, and the env allowlist are all unchanged.
- `apps/web/scripts/lighthouse-exact-target-guard.test.ts`:
  - updated the sealed-upload contract test to the direct-Node spawn contract (this assertion **fails on the prior `pnpm exec` sequence** and passes with the fix);
  - new test: uploader is invoked via the resolved LHCI entrypoint with a package-less isolated cwd;
  - new test: a re-anchored uploader that writes `links.json` into the sealed source tree still fails closed with `Lighthouse artifact set changed after validation.` (reproduces the production sequence; proves mutation is detected, never masked).

## Before/after artifact behavior
- Before: validated+sealed set uploaded from an isolated copy, but the real uploader ran with cwd=`apps/web` and created `links.json` in the source `.lighthouseci` → source seal mismatch → hard failure.
- After: uploader cwd is deterministically the isolated root; the only post-validation artifact (`links.json`) is created inside the isolated copy, where it is explicitly expected and fully validated (route coverage + https-only links); the sealed source tree stays byte-identical (still re-proven twice).

## Assumptions
- `@lhci/cli` remains a direct dependency of `@jovie/web` (pinned `^0.15.1`; `bin: src/cli.js`, no `exports` map), so `createRequire(import.meta.url).resolve('@lhci/cli/src/cli.js')` is stable.
- No workflow wiring change needed: both `postdeploy-probes.yml` and `production-controller.yml` call this same guard script; the fix covers both call sites. Workflows untouched → actionlint n/a.

## Verification
- `node apps/web/scripts/lighthouse-exact-target-guard.ts` → parses/loads, exits 1 with the expected usage error (module-level smoke).
- Whitespace check on touched files: clean (no trailing whitespace, final newlines present).
- Local `pnpm install` is blocked by sandbox network policy (registry.npmjs.org denied; access request pending) — **verification deferred to CI**: `Unit Tests` lane runs `apps/web/scripts/lighthouse-exact-target-guard.test.ts`, including the new regression coverage. PR stays draft until CI is green.

## Risk & rollback
- Risk: low — single spawn-invocation change inside the guard; identical validation surface. If `@lhci/cli` resolution failed, the guard fails closed (throw), never uploads unvalidated artifacts.
- Rollback: native revert PR through the queue; canonical Production Controller remains promotion authority.

## Receipts
- Source run: Post-Deploy Probes 29891421844 (Lighthouse job 88832576466), main `b726e7b40e1d90346b365f016f970de2ae40e140`.
- Dispatch ID: `gem-production-recovery:b726e7b40e1d90346b365f016f970de2ae40e140:postdeploy-29891421844:lighthouse-artifact-order-v1`
- Fixes #14703 · Linear JOV-4372

<!-- linear-issue-id:JOV-4372 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
