### PR TITLE
fix(release): isolate production OAuth retries

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1012,13 +1012,30 @@ jobs:
         continue-on-error: true
         env:
           BASE_URL: https://jov.ie
+          PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'
         run: |
           set -euo pipefail
+          : >> "$GITHUB_OUTPUT"
           # The browser must issue the same-origin POST
           # /api/auth/sign-in/social before either provider navigation exists.
           cd apps/web
           mkdir -p tests/.auth
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
+          oauth_retry_root="$RUNNER_TEMP/production-oauth-retries"
+          mkdir -m 700 "$oauth_retry_root"
+
+          quarantine_oauth_artifacts() {
+            destination="$1"
+            for artifact_path in test-results playwright-report; do
+              if [ -e "$artifact_path" ] || [ -L "$artifact_path" ]; then
+                if [ ! -d "$destination" ]; then
+                  mkdir -m 700 "$destination"
+                fi
+                mv -- "$artifact_path" "$destination/"
+              fi
+            done
+          }
+
           attempt=1
           max_attempts=3
           confirmed_attempts=0
@@ -1046,6 +1063,15 @@ jobs:
               exit 0
             fi
 
+            attempt_artifact_root="$oauth_retry_root/attempt-${attempt}"
+            mkdir -m 700 "$attempt_artifact_root"
+            if [ -f "$report" ]; then
+              mkdir -m 700 "$attempt_artifact_root/failed-artifacts"
+              mv -- "$report" "$attempt_artifact_root/failed-artifacts/oauth-provider-report.json"
+              report="$attempt_artifact_root/failed-artifacts/oauth-provider-report.json"
+            fi
+            quarantine_oauth_artifacts "$attempt_artifact_root/failed-artifacts"
+
             # Only explicit runtime-contract assertions in a valid Playwright
             # report confirm a regression. Browser/tool/network/report failures
             # remain uncertainty and can never request rollback.
@@ -1066,6 +1092,10 @@ jobs:
             else
               uncertain=true
               echo "OAuth attempt ${attempt}/${max_attempts} lacked exact structured runtime-contract evidence."
+            fi
+            if [ -f "$RUNNER_TEMP/safe-playwright-producer/blocked" ]; then
+              echo "::error::Playwright artifact guard blocked production OAuth output; refusing an unsafe retry."
+              exit 1
             fi
             if [ "$attempt" -lt "$max_attempts" ]; then
               sleep_seconds=$((attempt * 15))

--- a/apps/web/tests/lib/hud/shipper-state.test.ts
+++ b/apps/web/tests/lib/hud/shipper-state.test.ts
@@ -1,14 +1,43 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
-const hermesDir = join(homedir(), '.hermes');
-const stateDir = join(hermesDir, 'state');
-const logsDir = join(hermesDir, 'logs');
-const jobsLogPath = join(logsDir, 'jobs.jsonl');
-const inflightPath = join(stateDir, 'inflight-ship-jobs.json');
-const whatShippedPath = join(stateDir, 'what_shipped.json');
+const mockedOs = vi.hoisted(() => ({ home: '' }));
+
+vi.mock('node:os', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  const mocked = { ...actual, homedir: () => mockedOs.home };
+  return { ...mocked, default: mocked };
+});
+
+let hermesDir = '';
+let stateDir = '';
+let logsDir = '';
+let jobsLogPath = '';
+let inflightPath = '';
+let whatShippedPath = '';
+
+beforeAll(() => {
+  mockedOs.home = mkdtempSync(join('/tmp', 'jovie-shipper-state-test-'));
+  hermesDir = join(mockedOs.home, '.hermes');
+  stateDir = join(hermesDir, 'state');
+  logsDir = join(hermesDir, 'logs');
+  jobsLogPath = join(logsDir, 'jobs.jsonl');
+  inflightPath = join(stateDir, 'inflight-ship-jobs.json');
+  whatShippedPath = join(stateDir, 'what_shipped.json');
+});
+
+afterAll(() => {
+  rmSync(mockedOs.home, { force: true, recursive: true });
+});
 
 function writeJsonl(path: string, rows: readonly object[]): void {
   writeFileSync(path, rows.map(row => JSON.stringify(row)).join('\n'));
@@ -20,7 +49,7 @@ describe('getHudShipperStatus', () => {
     mkdirSync(logsDir, { recursive: true });
   });
 
-  it('parses in-flight jobs and recent shipper events', async () => {
+  it('reports idle from hermetic state without the operator pause sentinel', async () => {
     writeJsonl(jobsLogPath, [
       {
         job: 'codex-issue-shipper',

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -884,6 +884,7 @@ describe('deploy workflow Vercel env resolution', () => {
       getJobBlock(workflow, 'alias-staging'),
       'Verify aliased staging OAuth redirect URIs'
     );
+    const productionOauthJob = getJobBlock(workflow, 'production-oauth-gate');
 
     expect(oauthStep).toContain(
       'if PLAYWRIGHT_WORKERS=1 CI=true SMOKE_ONLY=1 \\\n'
@@ -892,9 +893,12 @@ describe('deploy workflow Vercel env resolution', () => {
       'node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" --run --'
     );
     expect(oauthStep).toContain("PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'");
+    expect(productionOauthJob).toContain(
+      "PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'"
+    );
     expect(
       workflow.match(/PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'/g)
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     expect(oauthStep).toContain(
       'pnpm exec playwright test tests/e2e/oauth-providers.spec.ts'
     );
@@ -2145,6 +2149,196 @@ exit 23
           'utf8'
         )
       ).toContain('unsafe-attempt');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('retries production OAuth with quarantined artifacts and a clean producer workspace', () => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthJob = getJobBlock(release, 'production-oauth-gate');
+    const oauthStep = getStepBlock(
+      oauthJob,
+      'Probe production Better Auth Google + Apple runtime'
+    );
+    const root = mkdtempSync(
+      resolve(tmpdir(), 'jovie-production-oauth-retry-')
+    );
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const counter = resolve(root, 'attempt-count');
+      const githubOutput = resolve(root, 'github-output');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+[ "\${PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN:-}" = "true" ] || exit 43
+attempt=0
+if [ -f "$OAUTH_TEST_COUNTER" ]; then
+  attempt="$(cat "$OAUTH_TEST_COUNTER")"
+fi
+attempt=$((attempt + 1))
+printf '%s' "$attempt" > "$OAUTH_TEST_COUNTER"
+if [ -e test-results ] || [ -L test-results ] || [ -e playwright-report ] || [ -L playwright-report ]; then
+  exit 40
+fi
+mkdir -p test-results
+printf '# Error context\n\nSafe production retry diagnostics.\n' > test-results/error-context.md
+if [ "$attempt" -eq 1 ]; then
+  printf '%s' '{"suites":[{"results":[{"status":"passed"},{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: apple navigation timed out"}]}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
+  exit 1
+fi
+printf '%s' '{"suites":[{"results":[{"status":"passed"},{"status":"passed"}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\nexit 0\n',
+        { mode: 0o700 }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_TEST_COUNTER: counter,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(counter, 'utf8')).toBe('2');
+      expect(readFileSync(githubOutput, 'utf8')).toContain(
+        'oauth_status=passed'
+      );
+      expect(
+        readFileSync(
+          resolve(
+            runnerTemp,
+            'production-oauth-retries/attempt-1/failed-artifacts/test-results/error-context.md'
+          ),
+          'utf8'
+        )
+      ).toContain('Safe production retry diagnostics.');
+      expect(
+        readFileSync(
+          resolve(
+            runnerTemp,
+            'production-oauth-retries/attempt-1/failed-artifacts/oauth-provider-report.json'
+          ),
+          'utf8'
+        )
+      ).toContain('CONFIRMED_OAUTH_RUNTIME_CONTRACT');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('stops production OAuth retries when the artifact guard poisons shared state', () => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(release, 'production-oauth-gate'),
+      'Probe production Better Auth Google + Apple runtime'
+    );
+    const root = mkdtempSync(
+      resolve(tmpdir(), 'jovie-production-oauth-poison-')
+    );
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const counter = resolve(root, 'attempt-count');
+      const githubOutput = resolve(root, 'github-output');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "$OAUTH_TEST_COUNTER" ]; then
+  attempt="$(cat "$OAUTH_TEST_COUNTER")"
+fi
+attempt=$((attempt + 1))
+printf '%s' "$attempt" > "$OAUTH_TEST_COUNTER"
+mkdir -p test-results "$RUNNER_TEMP/safe-playwright-producer"
+printf '%s' '{"source":"unsafe-attempt"}' > test-results/attempt-one.json
+touch "$RUNNER_TEMP/safe-playwright-producer/blocked"
+printf '%s' '{"suites":[{"results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: untrusted"}]}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
+exit 23
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\nexit 42\n',
+        { mode: 0o700 }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_TEST_COUNTER: counter,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status).toBe(1);
+      expect(readFileSync(counter, 'utf8')).toBe('1');
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'refusing an unsafe retry'
+      );
+      expect(readFileSync(githubOutput, 'utf8')).not.toContain(
+        'oauth_status=failed'
+      );
+      expect(
+        readFileSync(
+          resolve(
+            runnerTemp,
+            'production-oauth-retries/attempt-1/failed-artifacts/test-results/attempt-one.json'
+          ),
+          'utf8'
+        )
+      ).toContain('unsafe-attempt');
+      expect(
+        readFileSync(
+          resolve(
+            runnerTemp,
+            'production-oauth-retries/attempt-1/failed-artifacts/oauth-provider-report.json'
+          ),
+          'utf8'
+        )
+      ).toContain('CONFIRMED_OAUTH_RUNTIME_CONTRACT');
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+++ b/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
@@ -1139,6 +1139,10 @@ ${fixtureCheckout}
       'utf8'
     );
     const aliasJob = jobBlock(productionRelease, 'alias-staging');
+    const productionOauthJob = jobBlock(
+      productionRelease,
+      'production-oauth-gate'
+    );
     const oauthProbe = stepBlock(
       aliasJob,
       'Verify aliased staging OAuth redirect URIs'
@@ -1179,9 +1183,12 @@ ${fixtureCheckout}
       'PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}'
     );
     expect(oauthProbe).toContain("PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'");
+    expect(productionOauthJob).toContain(
+      "PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'"
+    );
     expect(
       productionRelease.match(/PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'/g)
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     const action = readFileSync(
       join(githubRoot, 'actions/upload-safe-playwright-artifact/action.yml'),
       'utf8'


### PR DESCRIPTION
OAuth attempts now isolate/quarantine artifacts, and terminal poison stops retries.

Regression: OAuth 91/91.
The fourth test-only HUD file makes homedir state hermetic because the mandatory hook otherwise read the live operator pause sentinel.

Full hook passed. Sol review: no findings. Bug-to-test: satisfied.