### PR TITLE
fix(release): classify production OAuth reports by final outcomes

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1047,30 +1047,45 @@ jobs:
               PLAYWRIGHT_JSON_OUTPUT_NAME="$report" \
               node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs" \
               --run -- pnpm exec playwright test tests/e2e/oauth-providers.spec.ts \
-              --project=chromium --reporter=json || probe_status=$?
+              --project=chromium --no-deps --reporter=json || probe_status=$?
             if [ "$probe_status" -eq 0 ] && jq -e '
-              def specs:
-                .suites[0].suites[0].specs;
+              def oauth_suites:
+                [.suites[]? | select(
+                  type == "object" and
+                  .title == "oauth-providers.spec.ts" and
+                  .file == "oauth-providers.spec.ts"
+                )];
+              def oauth_specs:
+                oauth_suites[0].suites[0].specs;
               type == "object" and (.suites | type == "array") and
               (.suites | length) == 1 and
-              .suites[0].title == "oauth-providers.spec.ts" and
-              .suites[0].file == "tests/e2e/oauth-providers.spec.ts" and
-              (.suites[0].suites | type == "array") and
-              (.suites[0].suites | length) == 1 and
-              .suites[0].suites[0].title == "candidate-bound Better Auth OAuth runtime @production-smoke" and
-              (specs | type == "array") and
-              (specs | map(.title)) == [
+              (oauth_suites | length) == 1 and
+              (oauth_suites[0].specs | type == "array") and
+              (oauth_suites[0].specs | length) == 0 and
+              (oauth_suites[0].suites | type == "array") and
+              (oauth_suites[0].suites | length) == 1 and
+              oauth_suites[0].suites[0].title == "candidate-bound Better Auth OAuth runtime @production-smoke" and
+              (oauth_specs | type == "array") and
+              (oauth_specs | map(.title)) == [
                 "google UI starts the exact Better Auth provider redirect",
                 "apple UI starts the exact Better Auth provider redirect"
               ] and
-              all(specs[];
+              all(oauth_specs[];
                 (.tests | type == "array") and
                 (.tests | length) == 1 and
+                (.tests[0].status == "expected" or .tests[0].status == "flaky") and
+                .tests[0].expectedStatus == "passed" and
                 .tests[0].projectName == "chromium" and
                 (.tests[0].results | type == "array") and
                 (.tests[0].results | length) > 0 and
                 .tests[0].results[-1].status == "passed"
-              )
+              ) and
+              (.errors | type == "array") and
+              (.errors | length) == 0 and
+              (.stats | type == "object") and
+              (.stats.unexpected // 0) == 0 and
+              (.stats.skipped // 0) == 0 and
+              ((.stats.expected // 0) + (.stats.flaky // 0) == 2)
             ' >/dev/null "$report"; then
               {
                 echo "ba_health=passed"
@@ -1092,16 +1107,56 @@ jobs:
             # Only explicit runtime-contract assertions in a valid Playwright
             # report confirm a regression. Browser/tool/network/report failures
             # remain uncertainty and can never request rollback.
-            if [ -s "$report" ] && jq -e '
-              def results:
-                [ .suites[]? | .. | objects | select(has("results")) | .results[]? ];
+            if [ "$probe_status" -ne 0 ] && [ -s "$report" ] && jq -e '
+              def oauth_suites:
+                [.suites[]? | select(
+                  type == "object" and
+                  .title == "oauth-providers.spec.ts" and
+                  .file == "oauth-providers.spec.ts"
+                )];
+              def oauth_specs:
+                oauth_suites[0].suites[0].specs;
+              def oauth_tests:
+                [oauth_specs[]?.tests[]?];
+              def final_results:
+                [oauth_tests[]?.results[-1]];
               type == "object" and (.suites | type == "array") and
-              (results | map(select(.status == "failed")) | length) > 0 and
-              all(results[] | select(.status != "passed" and .status != "skipped");
-                .status == "failed" and
-                ([.errors[]?.message // ""] | any(
-                  contains("CONFIRMED_OAUTH_RUNTIME_CONTRACT")
-                ))
+              (.suites | length) == 1 and
+              (oauth_suites | length) == 1 and
+              (oauth_suites[0].specs | type == "array") and
+              (oauth_suites[0].specs | length) == 0 and
+              (oauth_suites[0].suites | type == "array") and
+              (oauth_suites[0].suites | length) == 1 and
+              oauth_suites[0].suites[0].title == "candidate-bound Better Auth OAuth runtime @production-smoke" and
+              (oauth_specs | type == "array") and
+              (oauth_specs | map(.title)) == [
+                "google UI starts the exact Better Auth provider redirect",
+                "apple UI starts the exact Better Auth provider redirect"
+              ] and
+              (oauth_tests | length) == 2 and
+              all(oauth_specs[];
+                (.tests | type == "array") and
+                (.tests | length) == 1 and
+                (
+                  (.tests[0].status == "unexpected" and
+                    .tests[0].results[-1].status == "failed") or
+                  (.tests[0].status == "expected" and
+                    .tests[0].results[-1].status == "passed")
+                ) and
+                .tests[0].projectName == "chromium" and
+                .tests[0].expectedStatus == "passed" and
+                (.tests[0].results | type == "array") and
+                (.tests[0].results | length) > 0
+              ) and
+              (final_results | map(select(.status == "failed")) | length) > 0 and
+              all(final_results[];
+                .status == "passed" or
+                (
+                  .status == "failed" and
+                  ([.errors[]?.message // ""] | any(
+                    contains("CONFIRMED_OAUTH_RUNTIME_CONTRACT")
+                  ))
+                )
               )
             ' >/dev/null "$report"; then
               confirmed_attempts=$((confirmed_attempts + 1))

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1049,11 +1049,28 @@ jobs:
               --run -- pnpm exec playwright test tests/e2e/oauth-providers.spec.ts \
               --project=chromium --reporter=json || probe_status=$?
             if [ "$probe_status" -eq 0 ] && jq -e '
-              def results:
-                [ .suites[]? | .. | objects | select(has("results")) | .results[]? ];
+              def specs:
+                .suites[0].suites[0].specs;
               type == "object" and (.suites | type == "array") and
-              (results | map(select(.status == "passed")) | length) == 2 and
-              (results | map(select(.status == "skipped")) | length) == 0
+              (.suites | length) == 1 and
+              .suites[0].title == "oauth-providers.spec.ts" and
+              .suites[0].file == "tests/e2e/oauth-providers.spec.ts" and
+              (.suites[0].suites | type == "array") and
+              (.suites[0].suites | length) == 1 and
+              .suites[0].suites[0].title == "candidate-bound Better Auth OAuth runtime @production-smoke" and
+              (specs | type == "array") and
+              (specs | map(.title)) == [
+                "google UI starts the exact Better Auth provider redirect",
+                "apple UI starts the exact Better Auth provider redirect"
+              ] and
+              all(specs[];
+                (.tests | type == "array") and
+                (.tests | length) == 1 and
+                .tests[0].projectName == "chromium" and
+                (.tests[0].results | type == "array") and
+                (.tests[0].results | length) > 0 and
+                .tests[0].results[-1].status == "passed"
+              )
             ' >/dev/null "$report"; then
               {
                 echo "ba_health=passed"

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -2161,6 +2161,7 @@ exit 23
       oauthJob,
       'Probe production Better Auth Google + Apple runtime'
     );
+    expect(oauthStep).toContain('--no-deps');
     const root = mkdtempSync(
       resolve(tmpdir(), 'jovie-production-oauth-retry-')
     );
@@ -2195,7 +2196,7 @@ if [ "$attempt" -eq 1 ]; then
   printf '%s' '{"suites":[{"results":[{"status":"passed"},{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: apple navigation timed out"}]}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
   exit 1
 fi
-printf '%s' '{"suites":[{"title":"oauth-providers.spec.ts","file":"tests/e2e/oauth-providers.spec.ts","suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"}]}]}]}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
+printf '%s' '{"config":{"workers":1},"stats":{"startTime":"2026-07-22T00:00:00.000Z","duration":1,"expected":2,"skipped":0,"unexpected":0,"flaky":0},"suites":[{"title":"oauth-providers.spec.ts","file":"oauth-providers.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","file":"oauth-providers.spec.ts","line":42,"column":1,"specs":[{"title":"google UI starts the exact Better Auth provider redirect","ok":true,"tags":[],"tests":[{"timeout":60000,"annotations":[],"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"workerIndex":0,"status":"passed","duration":1,"errors":[],"stdout":[],"stderr":[],"retry":0}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","ok":true,"tags":[],"tests":[{"timeout":60000,"annotations":[],"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"workerIndex":0,"status":"passed","duration":1,"errors":[],"stdout":[],"stderr":[],"retry":0}]}]}]}]}],"errors":[]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
 `,
         { mode: 0o700 }
       );
@@ -2276,7 +2277,7 @@ printf '%s' '{"suites":[{"title":"oauth-providers.spec.ts","file":"tests/e2e/oau
         `#!/usr/bin/env bash
 set -euo pipefail
 cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
-{"suites":[{"title":"oauth-providers.spec.ts","file":"tests/e2e/oauth-providers.spec.ts","suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"},{"status":"passed"}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"}]}]}]}]}]}
+{"config":{"workers":1},"stats":{"startTime":"2026-07-22T00:00:00.000Z","duration":1,"expected":1,"skipped":0,"unexpected":0,"flaky":1},"suites":[{"title":"oauth-providers.spec.ts","file":"oauth-providers.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","file":"oauth-providers.spec.ts","line":42,"column":1,"specs":[{"title":"google UI starts the exact Better Auth provider redirect","ok":true,"tests":[{"timeout":60000,"annotations":[],"expectedStatus":"passed","status":"flaky","projectName":"chromium","results":[{"workerIndex":0,"status":"failed","duration":1,"errors":[{"message":"transient"}],"stdout":[],"stderr":[],"retry":0},{"workerIndex":1,"status":"passed","duration":1,"errors":[],"stdout":[],"stderr":[],"retry":1}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","ok":true,"tests":[{"timeout":60000,"annotations":[],"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"workerIndex":0,"status":"passed","duration":1,"errors":[],"stdout":[],"stderr":[],"retry":0}]}]}]}]}],"errors":[]}
 JSON
 `,
         { mode: 0o700 }
@@ -2302,6 +2303,257 @@ JSON
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       expect(readFileSync(githubOutput, 'utf8')).toContain(
         'oauth_status=passed'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    ['duplicate OAuth file suite', 'duplicate-suite'],
+    ['missing expected spec', 'missing-spec'],
+    ['wrong expected spec title', 'wrong-spec'],
+    ['wrong project', 'wrong-project'],
+    ['empty result history', 'empty-results'],
+    ['missing final result status', 'missing-final-status'],
+    ['nonpassed final result', 'nonpassed-final'],
+  ])('rejects a fail-closed OAuth report with %s', (_label, reportCase) => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(release, 'production-oauth-gate'),
+      'Probe production Better Auth Google + Apple runtime'
+    );
+    const root = mkdtempSync(
+      resolve(tmpdir(), 'jovie-production-oauth-invalid-report-')
+    );
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const githubOutput = resolve(root, 'github-output');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
+{"config":{"workers":1},"stats":{"startTime":"2026-07-22T00:00:00.000Z","duration":1,"expected":2,"skipped":0,"unexpected":0,"flaky":0},"suites":[{"title":"oauth-providers.spec.ts","file":"oauth-providers.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","file":"oauth-providers.spec.ts","specs":[{"title":"google UI starts the exact Better Auth provider redirect","ok":true,"tests":[{"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"status":"passed"}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","ok":true,"tests":[{"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"status":"passed"}]}]}]}]}],"errors":[]}
+JSON
+case "$OAUTH_REPORT_CASE" in
+  duplicate-suite) jq '.suites += [.suites[0]]' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+  missing-spec) jq 'del(.suites[0].suites[0].specs[1])' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+  wrong-spec) jq '.suites[0].suites[0].specs[1].title = "unexpected provider redirect"' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+  wrong-project) jq '.suites[0].suites[0].specs[0].tests[0].projectName = "firefox"' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+  empty-results) jq '.suites[0].suites[0].specs[0].tests[0].results = []' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+  missing-final-status) jq '.suites[0].suites[0].specs[0].tests[0].results = [{}]' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+  nonpassed-final) jq '.suites[0].suites[0].specs[0].tests[0].results = [{"status":"failed"}]' "$PLAYWRIGHT_JSON_OUTPUT_NAME" > "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" ;;
+esac
+mv "$PLAYWRIGHT_JSON_OUTPUT_NAME.tmp" "$PLAYWRIGHT_JSON_OUTPUT_NAME"
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\nexit 0\n',
+        {
+          mode: 0o700,
+        }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_REPORT_CASE: reportCase,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(readFileSync(githubOutput, 'utf8')).not.toContain(
+        'oauth_status=passed'
+      );
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'OAuth probe was inconclusive'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    ['recovered flaky retry history', 'recovered-flaky'],
+    ['wrong OAuth suite marker', 'wrong-suite-marker'],
+    ['malformed suite marker', 'malformed-suite-marker'],
+    ['mixed marked and unmarked final failures', 'mixed-final-failures'],
+  ])('does not classify %s as a confirmed regression', (_label, reportCase) => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(release, 'production-oauth-gate'),
+      'Probe production Better Auth Google + Apple runtime'
+    );
+    const root = mkdtempSync(
+      resolve(tmpdir(), 'jovie-production-oauth-fallback-')
+    );
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const githubOutput = resolve(root, 'github-output');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+case "$OAUTH_REPORT_CASE" in
+  recovered-flaky)
+    cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
+{"config":{"workers":1},"stats":{"expected":1,"skipped":0,"unexpected":0,"flaky":1},"errors":[],"suites":[{"title":"oauth-providers.spec.ts","file":"oauth-providers.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"flaky","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: transient"}]},{"status":"passed"}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"status":"passed"}]}]}]}]}]}
+JSON
+    ;;
+  wrong-suite-marker)
+    cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
+{"config":{"workers":1},"stats":{"expected":0,"skipped":0,"unexpected":2,"flaky":0},"errors":[],"suites":[{"title":"unrelated.spec.ts","file":"unrelated.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: wrong suite"}]}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"expected","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: wrong suite"}]}]}]}]}]}]}
+JSON
+    ;;
+  malformed-suite-marker)
+    cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
+{"suites":[{"title":"unrelated.spec.ts","file":"unrelated.spec.ts","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: malformed suite"}]}]}]}
+JSON
+    ;;
+  mixed-final-failures)
+    cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
+{"config":{"workers":1},"stats":{"expected":0,"skipped":0,"unexpected":2,"flaky":0},"errors":[],"suites":[{"title":"oauth-providers.spec.ts","file":"oauth-providers.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"unexpected","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: marked"}]}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"unexpected","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"infrastructure failure without runtime-contract evidence"}]}]}]}]}]}]}
+JSON
+    ;;
+esac
+exit 23
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\nexit 0\n',
+        {
+          mode: 0o700,
+        }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_REPORT_CASE: reportCase,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(readFileSync(githubOutput, 'utf8')).not.toContain(
+        'oauth_status=failed'
+      );
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'OAuth probe was inconclusive'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('classifies three exact aggregate OAuth failures as a confirmed regression', () => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthStep = getStepBlock(
+      getJobBlock(release, 'production-oauth-gate'),
+      'Probe production Better Auth Google + Apple runtime'
+    );
+    const root = mkdtempSync(
+      resolve(tmpdir(), 'jovie-production-oauth-confirmed-failure-')
+    );
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const counter = resolve(root, 'attempt-count');
+      const githubOutput = resolve(root, 'github-output');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "\${OAUTH_TEST_COUNTER}" ]; then
+  attempt="$(cat "\${OAUTH_TEST_COUNTER}")"
+fi
+attempt=$((attempt + 1))
+printf '%s' "\${attempt}" > "\${OAUTH_TEST_COUNTER}"
+cat > "\${PLAYWRIGHT_JSON_OUTPUT_NAME}" <<'JSON'
+{"config":{"workers":1},"stats":{"expected":0,"skipped":0,"unexpected":2,"flaky":0},"errors":[],"suites":[{"title":"oauth-providers.spec.ts","file":"oauth-providers.spec.ts","specs":[],"suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"unexpected","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: google redirect contract failed"}]}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"expectedStatus":"passed","status":"unexpected","projectName":"chromium","results":[{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: apple redirect contract failed"}]}]}]}]}]}]}
+JSON
+exit 23
+`,
+        { mode: 0o700 }
+      );
+      writeFileSync(
+        resolve(fakeBin, 'sleep'),
+        '#!/usr/bin/env bash\nexit 0\n',
+        { mode: 0o700 }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_WORKSPACE: workspace,
+            OAUTH_TEST_COUNTER: counter,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(readFileSync(counter, 'utf8')).toBe('3');
+      expect(readFileSync(githubOutput, 'utf8')).toContain(
+        'oauth_status=failed'
+      );
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'Confirmed Better Auth OAuth runtime-contract failure 3/3.'
       );
     } finally {
       rmSync(root, { force: true, recursive: true });

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -2195,7 +2195,7 @@ if [ "$attempt" -eq 1 ]; then
   printf '%s' '{"suites":[{"results":[{"status":"passed"},{"status":"failed","errors":[{"message":"CONFIRMED_OAUTH_RUNTIME_CONTRACT: apple navigation timed out"}]}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
   exit 1
 fi
-printf '%s' '{"suites":[{"results":[{"status":"passed"},{"status":"passed"}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
+printf '%s' '{"suites":[{"title":"oauth-providers.spec.ts","file":"tests/e2e/oauth-providers.spec.ts","suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"}]}]}]}]}]}' > "$PLAYWRIGHT_JSON_OUTPUT_NAME"
 `,
         { mode: 0o700 }
       );
@@ -2246,6 +2246,63 @@ printf '%s' '{"suites":[{"results":[{"status":"passed"},{"status":"passed"}]}]}'
           'utf8'
         )
       ).toContain('CONFIRMED_OAUTH_RUNTIME_CONTRACT');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('accepts a clean report when retry history contains three passed results', () => {
+    const release = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const oauthJob = getJobBlock(release, 'production-oauth-gate');
+    const oauthStep = getStepBlock(
+      oauthJob,
+      'Probe production Better Auth Google + Apple runtime'
+    );
+    const root = mkdtempSync(
+      resolve(tmpdir(), 'jovie-production-oauth-three-pass-')
+    );
+
+    try {
+      const workspace = resolve(root, 'workspace');
+      const web = resolve(workspace, 'apps/web');
+      const fakeBin = resolve(root, 'bin');
+      const runnerTemp = resolve(root, 'runner-temp');
+      const githubOutput = resolve(root, 'github-output');
+      mkdirSync(web, { recursive: true });
+      mkdirSync(fakeBin);
+      mkdirSync(runnerTemp);
+      writeFileSync(
+        resolve(fakeBin, 'node'),
+        `#!/usr/bin/env bash
+set -euo pipefail
+cat > "$PLAYWRIGHT_JSON_OUTPUT_NAME" <<'JSON'
+{"suites":[{"title":"oauth-providers.spec.ts","file":"tests/e2e/oauth-providers.spec.ts","suites":[{"title":"candidate-bound Better Auth OAuth runtime @production-smoke","specs":[{"title":"google UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"},{"status":"passed"}]}]},{"title":"apple UI starts the exact Better Auth provider redirect","tests":[{"projectName":"chromium","results":[{"status":"passed"}]}]}]}]}]}
+JSON
+`,
+        { mode: 0o700 }
+      );
+
+      const result = spawnSync(
+        'bash',
+        ['-c', `set -euo pipefail\n${getStepRunScript(oauthStep)}`],
+        {
+          cwd: workspace,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: githubOutput,
+            GITHUB_WORKSPACE: workspace,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+            PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true',
+            RUNNER_TEMP: runnerTemp,
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(githubOutput, 'utf8')).toContain(
+        'oauth_status=passed'
+      );
     } finally {
       rmSync(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary
- classify production OAuth Playwright reports by exact suite/spec identity and logical test final outcomes
- accept clean reports with retry-history duplicates when every expected test finishes passed
- preserve artifact quarantine, poison terminal behavior, fail-closed uncertainty, and confirmed-regression semantics

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts --reporter=dot` — 80 passed
- `pnpm --filter @jovie/web run test:bug-to-test` — satisfied
- `actionlint -config-file .github/actionlint.yaml .github/workflows/production-release.yml` — passed
- `bash -n .github/scripts/verify-production-alias.sh` — passed
- `git diff --check` — passed
- protected commit and push hooks — passed

Ad hoc production bug fix; no Linear issue was supplied. Queue enrollment is intentionally deferred.
