### PR TITLE
fix(hermes): validate launchd artifacts before install

### DIFF
--- a/scripts/hermes/bootstrap-air.sh
+++ b/scripts/hermes/bootstrap-air.sh
@@ -32,6 +32,10 @@ HERMES_HOME="${HOME}/.hermes"
 LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
 DOPPLER_PROJECT="jovie-web"
 DOPPLER_CONFIG="dev"
+INSTALL_HELPER="${REPO_ROOT}/scripts/hermes/lib/install-launchd-artifacts.sh"
+
+# shellcheck source=scripts/hermes/lib/install-launchd-artifacts.sh
+source "$INSTALL_HELPER"
 
 REQUIRED_SECRETS=(
   HERMES_TELEGRAM_BOT_TOKEN
@@ -137,6 +141,9 @@ require_cmd jq
 require_cmd sqlite3
 require_cmd curl
 require_cmd node
+require_cmd python3
+require_cmd plutil
+require_cmd shasum
 
 NODE_VERSION="$(node --version)"
 if [[ ! "$NODE_VERSION" =~ ^v22\.([0-9]+)\.([0-9]+) ]]; then
@@ -263,10 +270,8 @@ mkdir -p \
   "$HERMES_HOME/logs/launchd" \
   "$HERMES_HOME/state"
 chmod 700 "$HERMES_HOME"
-install -m 755 "${REPO_ROOT}/scripts/hermes/shipper-gated-entrypoint.py" \
-  "${HERMES_HOME}/scripts/shipper-gated-entrypoint.py"
 ln -sf "$TSX_BIN" "${HERMES_HOME}/bin/tsx"
-ok "Hermes home: $HERMES_HOME (shipper-gated-entrypoint installed)"
+ok "Hermes home: $HERMES_HOME"
 
 # 10. Render ~/.hermes/.env from Doppler
 log "Rendering ~/.hermes/.env"
@@ -322,20 +327,27 @@ PYEOF
 chmod 600 "${HERMES_HOME}/config.yaml"
 ok "Hermes config rendered (secrets stay as env refs)"
 
-# 12. Install shipper entrypoint to ~/.hermes/scripts (launchd ProgramArguments)
-log "Installing shipper-gated-entrypoint.py"
-mkdir -p "${HERMES_HOME}/scripts"
-install -m 755 "${REPO_ROOT}/scripts/hermes/shipper-gated-entrypoint.py" \
-  "${HERMES_HOME}/scripts/shipper-gated-entrypoint.py"
-ok "shipper-gated-entrypoint.py installed"
-
-# 13. Render launchd plists
-log "Rendering launchd plists"
+# 12. Stage and validate launchd artifacts before replacing installed copies.
+log "Staging launchd artifacts"
 mkdir -p "$LAUNCH_AGENTS"
+LAUNCHD_STAGE="$(hermes_create_launchd_stage)"
+trap 'hermes_remove_launchd_stage "$LAUNCHD_STAGE"' EXIT
+INSTALL_ARGS=()
+hermes_stage_artifact \
+  "${REPO_ROOT}/scripts/hermes/shipper-gated-entrypoint.py" \
+  "${LAUNCHD_STAGE}/shipper-gated-entrypoint.py" \
+  755
+INSTALL_ARGS+=(
+  "${LAUNCHD_STAGE}/shipper-gated-entrypoint.py"
+  "${HERMES_HOME}/scripts/shipper-gated-entrypoint.py"
+  755
+)
+
+# 13. Render launchd plists into the same validated stage.
 for tmpl in "${REPO_ROOT}/scripts/hermes/launchd/"*.plist.template; do
   [[ -f "$tmpl" ]] || continue
   label="$(basename "$tmpl" .plist.template)"
-  out="${LAUNCH_AGENTS}/${label}.plist"
+  out="${LAUNCHD_STAGE}/${label}.plist"
   # Python substitution is safer than sed for paths that may contain |, &, /, etc.
   HOME_V="$HOME" REPO_V="$REPO_ROOT" HERMES_V="$HERMES_BIN" \
   GBRAIN_V="$GBRAIN_BIN" TSX_V="$TSX_BIN" NODE_BIN_V="$NODE_BIN_DIR" TS_IP_V="$TAILSCALE_IP" \
@@ -358,8 +370,12 @@ for k, v in mapping.items():
 with open(dst, "w") as f:
     f.write(content)
 PYEOF
-  ok "rendered $label"
+  INSTALL_ARGS+=("$out" "${LAUNCH_AGENTS}/${label}.plist" 644)
+  ok "staged $label"
 done
+
+hermes_install_validated_launchd_artifacts "$LAUNCHD_STAGE" "${INSTALL_ARGS[@]}"
+ok "validated and installed launchd artifacts"
 
 if [[ "$MODE" == "reconfigure" ]]; then
   log "Reconfigure complete. Restart services with:"

--- a/scripts/hermes/bootstrap-pro-launchd.sh
+++ b/scripts/hermes/bootstrap-pro-launchd.sh
@@ -28,6 +28,10 @@ LAUNCHD_TEMPLATE_DIR="${REPO_ROOT}/scripts/hermes/launchd"
 SHIPPER_ENTRYPOINT_SRC="${REPO_ROOT}/scripts/hermes/shipper-gated-entrypoint.py"
 SHIPPER_ENTRYPOINT_DST="${HERMES_SCRIPTS}/shipper-gated-entrypoint.py"
 CODEX_SHIPPER_PLIST_TEMPLATE="${LAUNCHD_TEMPLATE_DIR}/co.jovie.hermes.cron-codex-issue-shipper.plist.template"
+INSTALL_HELPER="${REPO_ROOT}/scripts/hermes/lib/install-launchd-artifacts.sh"
+
+# shellcheck source=scripts/hermes/lib/install-launchd-artifacts.sh
+source "$INSTALL_HELPER"
 
 log() { printf "\033[1;34m▶\033[0m %s\n" "$*"; }
 ok() { printf "\033[1;32m✓\033[0m %s\n" "$*"; }
@@ -81,33 +85,45 @@ fi
 require_cmd node
 require_cmd python3
 require_cmd launchctl
+require_cmd plutil
+require_cmd shasum
 chmod +x "${REPO_ROOT}/scripts/hermes/ship-loop.sh"
 [[ -f "$SHIPPER_ENTRYPOINT_SRC" ]] || die "Missing shipper entrypoint: $SHIPPER_ENTRYPOINT_SRC"
 [[ -f "$CODEX_SHIPPER_PLIST_TEMPLATE" ]] || die "Missing codex shipper plist: $CODEX_SHIPPER_PLIST_TEMPLATE"
 
 mkdir -p "$HERMES_HOME/logs/launchd" "$HERMES_SCRIPTS" "$LAUNCH_AGENTS"
-cp "$SHIPPER_ENTRYPOINT_SRC" "$SHIPPER_ENTRYPOINT_DST"
-chmod +x "$SHIPPER_ENTRYPOINT_DST"
-ok "installed shipper-gated-entrypoint.py"
+LAUNCHD_STAGE="$(hermes_create_launchd_stage)"
+trap 'hermes_remove_launchd_stage "$LAUNCHD_STAGE"' EXIT
+INSTALL_ARGS=()
+hermes_stage_artifact "$SHIPPER_ENTRYPOINT_SRC" \
+  "${LAUNCHD_STAGE}/shipper-gated-entrypoint.py" 755
+INSTALL_ARGS+=(
+  "${LAUNCHD_STAGE}/shipper-gated-entrypoint.py"
+  "$SHIPPER_ENTRYPOINT_DST"
+  755
+)
 
 log "Rendering Houston launchd plists (mode=$MODE)"
 while IFS= read -r label; do
   [[ -n "$label" ]] || continue
   tmpl="${PRO_TEMPLATE_DIR}/${label}.plist.template"
-  out="${LAUNCH_AGENTS}/${label}.plist"
+  out="${LAUNCHD_STAGE}/${label}.plist"
   render_plist "$tmpl" "$out"
-  ok "rendered $label"
+  INSTALL_ARGS+=("$out" "${LAUNCH_AGENTS}/${label}.plist" 644)
+  ok "staged $label"
 done < <(pro_labels)
 
-render_plist "$CODEX_SHIPPER_PLIST_TEMPLATE" "${LAUNCH_AGENTS}/co.jovie.hermes.cron-codex-issue-shipper.plist"
-ok "rendered co.jovie.hermes.cron-codex-issue-shipper"
+CODEX_SHIPPER_PLIST_STAGE="${LAUNCHD_STAGE}/co.jovie.hermes.cron-codex-issue-shipper.plist"
+render_plist "$CODEX_SHIPPER_PLIST_TEMPLATE" "$CODEX_SHIPPER_PLIST_STAGE"
+INSTALL_ARGS+=(
+  "$CODEX_SHIPPER_PLIST_STAGE"
+  "${LAUNCH_AGENTS}/co.jovie.hermes.cron-codex-issue-shipper.plist"
+  644
+)
+ok "staged co.jovie.hermes.cron-codex-issue-shipper"
 
-AGENTCOOKIE_SENDER_TEMPLATE="${PRO_TEMPLATE_DIR}/co.jovie.hermes.agentcookie-sender.plist.template"
-if [[ -f "$AGENTCOOKIE_SENDER_TEMPLATE" ]]; then
-  render_plist "$AGENTCOOKIE_SENDER_TEMPLATE" \
-    "${LAUNCH_AGENTS}/co.jovie.hermes.agentcookie-sender.plist"
-  ok "rendered co.jovie.hermes.agentcookie-sender"
-fi
+hermes_install_validated_launchd_artifacts "$LAUNCHD_STAGE" "${INSTALL_ARGS[@]}"
+ok "validated and installed launchd artifacts"
 
 if [[ "$MODE" == "reconfigure" ]]; then
   log "Reconfigure complete. Restart with:"

--- a/scripts/hermes/lib/install-launchd-artifacts.sh
+++ b/scripts/hermes/lib/install-launchd-artifacts.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Shared fail-closed installer for Hermes launchd Python and plist artifacts.
+# Callers render/copy every artifact into one stage, then pass install triplets:
+#   <staged path> <destination path> <mode>
+
+hermes_sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+hermes_create_launchd_stage() {
+  mktemp -d "${TMPDIR:-/tmp}/jovie-hermes-launchd.XXXXXX"
+}
+
+hermes_remove_launchd_stage() {
+  local stage_dir="$1"
+
+  if [[ -d "$stage_dir" && "$(basename "$stage_dir")" == jovie-hermes-launchd.* ]]; then
+    rm -rf -- "$stage_dir"
+    return
+  fi
+
+  printf 'Refusing to remove unexpected launchd stage: %s\n' "$stage_dir" >&2
+  return 1
+}
+
+hermes_stage_artifact() {
+  local source_path="$1"
+  local staged_path="$2"
+  local mode="$3"
+
+  mkdir -p "$(dirname "$staged_path")"
+  install -m "$mode" "$source_path" "$staged_path"
+}
+
+hermes_validate_launchd_stage() {
+  local stage_dir="$1"
+  local python_bin="${HERMES_PYTHON_BIN:-python3}"
+  local plutil_bin="${HERMES_PLUTIL_BIN:-plutil}"
+  local python_count=0
+  local plist_count=0
+  local artifact
+
+  command -v "$python_bin" >/dev/null 2>&1 || {
+    printf 'Missing Python validator: %s\n' "$python_bin" >&2
+    return 1
+  }
+  command -v "$plutil_bin" >/dev/null 2>&1 || {
+    printf 'Missing plist validator: %s\n' "$plutil_bin" >&2
+    return 1
+  }
+
+  while IFS= read -r -d '' artifact; do
+    if ! PYTHONPYCACHEPREFIX="${stage_dir}/.pycache" \
+      "$python_bin" -m py_compile "$artifact"; then
+      printf 'Invalid Python launchd entrypoint: %s\n' "$artifact" >&2
+      return 1
+    fi
+    python_count=$((python_count + 1))
+  done < <(find "$stage_dir" -type f -name '*.py' -print0)
+
+  while IFS= read -r -d '' artifact; do
+    if ! "$plutil_bin" -lint "$artifact" >/dev/null; then
+      printf 'Invalid launchd plist: %s\n' "$artifact" >&2
+      return 1
+    fi
+    plist_count=$((plist_count + 1))
+  done < <(find "$stage_dir" -type f -name '*.plist' -print0)
+
+  if (( python_count == 0 )); then
+    printf 'Launchd stage contains no Python entrypoint: %s\n' "$stage_dir" >&2
+    return 1
+  fi
+  if (( plist_count == 0 )); then
+    printf 'Launchd stage contains no plist: %s\n' "$stage_dir" >&2
+    return 1
+  fi
+}
+
+hermes_atomic_install_artifact() {
+  local staged_path="$1"
+  local destination_path="$2"
+  local mode="$3"
+  local destination_dir
+  local install_tmp
+  local staged_sha
+  local installed_sha
+
+  destination_dir="$(dirname "$destination_path")"
+  mkdir -p "$destination_dir"
+  install_tmp="$(mktemp "${destination_dir}/.jovie-install.$(basename "$destination_path").XXXXXX")"
+
+  if ! install -m "$mode" "$staged_path" "$install_tmp"; then
+    rm -f "$install_tmp"
+    return 1
+  fi
+
+  staged_sha="$(hermes_sha256 "$staged_path")" || return 1
+  installed_sha="$(hermes_sha256 "$install_tmp")" || return 1
+  if [[ "$staged_sha" != "$installed_sha" ]]; then
+    printf 'Staged artifact checksum mismatch before install: %s\n' "$destination_path" >&2
+    rm -f "$install_tmp"
+    return 1
+  fi
+
+  if ! mv -f "$install_tmp" "$destination_path"; then
+    rm -f "$install_tmp"
+    return 1
+  fi
+  installed_sha="$(hermes_sha256 "$destination_path")" || return 1
+  if [[ "$staged_sha" != "$installed_sha" ]]; then
+    printf 'Installed artifact checksum mismatch: %s\n' "$destination_path" >&2
+    return 1
+  fi
+}
+
+hermes_install_validated_launchd_artifacts() {
+  local stage_dir="$1"
+  shift
+
+  if (( $# == 0 || $# % 3 != 0 )); then
+    printf 'Expected one or more <staged> <destination> <mode> triplets\n' >&2
+    return 2
+  fi
+
+  # This must complete before the first destination is touched.
+  hermes_validate_launchd_stage "$stage_dir"
+
+  while (( $# > 0 )); do
+    hermes_atomic_install_artifact "$1" "$2" "$3"
+    shift 3
+  done
+}

--- a/scripts/hermes/shipper-gated-entrypoint.py
+++ b/scripts/hermes/shipper-gated-entrypoint.py
@@ -144,7 +144,6 @@ def gbrain_alive(hermes_home: Path) -> bool:
             text=True,
             timeout=30,
             check=False,
-            timeout=30,
         )
         if proc.returncode != 0 or not proc.stdout.strip():
             return False

--- a/scripts/lib/__tests__/hermes-launchd.test.mjs
+++ b/scripts/lib/__tests__/hermes-launchd.test.mjs
@@ -1,8 +1,83 @@
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+const INSTALL_HELPER = join(
+  REPO_ROOT,
+  'scripts/hermes/lib/install-launchd-artifacts.sh'
+);
+
+function installLaunchdFixtures({ pythonSource, plistSource }) {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'hermes-launchd-install-'));
+  const sourceDir = join(fixtureRoot, 'source');
+  const installedDir = join(fixtureRoot, 'installed');
+  const binDir = join(fixtureRoot, 'bin');
+  mkdirSync(sourceDir);
+  mkdirSync(installedDir);
+  mkdirSync(binDir);
+
+  const pythonPath = join(sourceDir, 'entrypoint.py');
+  const plistPath = join(sourceDir, 'job.plist');
+  const installedPython = join(installedDir, 'entrypoint.py');
+  const installedPlist = join(installedDir, 'job.plist');
+  writeFileSync(pythonPath, pythonSource);
+  writeFileSync(plistPath, plistSource);
+  writeFileSync(installedPython, 'ORIGINAL_PYTHON\n');
+  writeFileSync(installedPlist, 'ORIGINAL_PLIST\n');
+
+  const plutilPath = join(binDir, 'plutil');
+  writeFileSync(
+    plutilPath,
+    `#!/usr/bin/env python3
+import plistlib
+import sys
+
+with open(sys.argv[-1], 'rb') as handle:
+    plistlib.load(handle)
+`
+  );
+  chmodSync(plutilPath, 0o755);
+
+  const result = spawnSync(
+    'bash',
+    [
+      '-c',
+      `set -euo pipefail
+source "$INSTALL_HELPER"
+stage="$(hermes_create_launchd_stage)"
+trap 'hermes_remove_launchd_stage "$stage"' EXIT
+hermes_stage_artifact "$FIXTURE_PYTHON" "$stage/entrypoint.py" 755
+hermes_stage_artifact "$FIXTURE_PLIST" "$stage/job.plist" 644
+hermes_install_validated_launchd_artifacts "$stage" \
+  "$stage/entrypoint.py" "$INSTALLED_PYTHON" 755 \
+  "$stage/job.plist" "$INSTALLED_PLIST" 644`,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FIXTURE_PLIST: plistPath,
+        FIXTURE_PYTHON: pythonPath,
+        HERMES_PLUTIL_BIN: plutilPath,
+        INSTALLED_PLIST: installedPlist,
+        INSTALLED_PYTHON: installedPython,
+        INSTALL_HELPER,
+      },
+    }
+  );
+
+  return { installedPlist, installedPython, result };
+}
 
 function renderTemplate(templatePath, mapping) {
   let content = readFileSync(templatePath, 'utf8');
@@ -81,6 +156,28 @@ describe('hermes gh monitor launchd templates', () => {
 });
 
 describe('shipper-gated entrypoint', () => {
+  it('compiles every Python launchd entrypoint', () => {
+    const entrypoints = readdirSync(join(REPO_ROOT, 'scripts/hermes')).filter(
+      entry => entry.endsWith('.py')
+    );
+    const pycache = mkdtempSync(join(tmpdir(), 'hermes-pycache-'));
+
+    expect(entrypoints.length).toBeGreaterThan(0);
+
+    for (const entrypoint of entrypoints) {
+      const result = spawnSync(
+        'python3',
+        ['-m', 'py_compile', join(REPO_ROOT, 'scripts/hermes', entrypoint)],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, PYTHONPYCACHEPREFIX: pycache },
+        }
+      );
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+    }
+  });
+
   it('documents gbrain and grok preflight gates', () => {
     const script = readFileSync(
       join(REPO_ROOT, 'scripts/hermes/shipper-gated-entrypoint.py'),
@@ -133,6 +230,60 @@ describe('shipper-gated entrypoint', () => {
       '<key>HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS</key>'
     );
     expect(rendered).toContain('<string>2</string>');
+  });
+});
+
+describe('hermes launchd artifact installation', () => {
+  const validPython = 'print("ready")\n';
+  const validPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>Label</key><string>test</string></dict></plist>
+`;
+
+  it('installs only validated artifacts with source-identical bytes', () => {
+    const { installedPlist, installedPython, result } = installLaunchdFixtures({
+      plistSource: validPlist,
+      pythonSource: validPython,
+    });
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(readFileSync(installedPython, 'utf8')).toBe(validPython);
+    expect(readFileSync(installedPlist, 'utf8')).toBe(validPlist);
+  });
+
+  it.each([
+    {
+      name: 'invalid Python',
+      plistSource: validPlist,
+      pythonSource: 'def broken(:\n',
+    },
+    {
+      name: 'invalid plist',
+      plistSource: '<plist><dict>',
+      pythonSource: validPython,
+    },
+  ])('rejects $name before replacing installed artifacts', fixtures => {
+    const { installedPlist, installedPython, result } =
+      installLaunchdFixtures(fixtures);
+
+    expect(result.status).not.toBe(0);
+    expect(readFileSync(installedPython, 'utf8')).toBe('ORIGINAL_PYTHON\n');
+    expect(readFileSync(installedPlist, 'utf8')).toBe('ORIGINAL_PLIST\n');
+  });
+
+  it.each([
+    'bootstrap-air.sh',
+    'bootstrap-pro-launchd.sh',
+  ])('%s installs launchd artifacts through the validated stage', bootstrapName => {
+    const bootstrap = readFileSync(
+      join(REPO_ROOT, 'scripts/hermes', bootstrapName),
+      'utf8'
+    );
+
+    expect(bootstrap).toContain('source "$INSTALL_HELPER"');
+    expect(bootstrap).toContain('hermes_create_launchd_stage');
+    expect(bootstrap).toContain('hermes_install_validated_launchd_artifacts');
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the duplicate `timeout` keyword that makes the committed launchd shipper entrypoint fail Python compilation
- stage the full Python/plist artifact set for both Air and Pro bootstraps, validate with `py_compile` and `plutil -lint`, then atomically install only validated bytes
- verify SHA-256 equality before and after installation
- compile every top-level Hermes Python entrypoint and prove invalid Python/plist fixtures cannot replace existing installed files

## Root cause
The bootstrap paths copied/rendered launchd artifacts directly into their installed locations. Repository tests asserted text fragments but never compiled the Python entrypoint or validated rendered plists, so a repeated `timeout` keyword reached `origin/main` while the installed MBP copy happened to remain parseable through drift.

## Bug-to-Test
bug-to-test: satisfied — `scripts/lib/__tests__/hermes-launchd.test.mjs`

## Test Coverage
- valid staged Python + plist install with byte-identical results
- invalid Python rejected before installed artifacts change
- invalid plist rejected before installed artifacts change
- every top-level `scripts/hermes/*.py` entrypoint compiles
- both bootstrap paths are wired through the validated staging installer

## Verification
- `bash -n scripts/hermes/lib/install-launchd-artifacts.sh scripts/hermes/bootstrap-pro-launchd.sh scripts/hermes/bootstrap-air.sh`
- `shellcheck scripts/hermes/lib/install-launchd-artifacts.sh`
- `PYTHONPYCACHEPREFIX=<temp> python3 -m py_compile scripts/hermes/*.py`
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/hermes-launchd.test.mjs` — 13/13 passed
- `pnpm --filter @jovie/web run test:bug-to-test` — satisfied
- temporary-home Pro `--reconfigure` — 4 plists passed `plutil -lint`; installed entrypoint SHA-256 matched repository source
- pre-push affected verification — typecheck/lint/CI harness passed

## Scope
P0-1 only. No watchdog, provider, pause, lease, or cooldown changes.

## Release hold
Keep this PR draft. Production is red and #14714 is the controller recovery fix. Do not mark ready, add `merge-queue`, enroll, or merge until Summer confirms the production controller is green.

## Linear follow-ups
Linear follow-ups: none.
