### PR TITLE
fix(agents): finalize GitHub issue claims

### DIFF
--- a/.github/workflows/github-ai-orchestrator.yml
+++ b/.github/workflows/github-ai-orchestrator.yml
@@ -257,6 +257,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ needs.guard.outputs.issue_number }}
           BRANCH_NAME: ${{ needs.guard.outputs.branch_name }}
+          TRACKER_CLAIM_OWNER: github-ai:${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}
         run: |
           node scripts/github-claim-issue.mjs "$ISSUE_NUMBER" \
             "GitHub AI Orchestrator claimed issue #${ISSUE_NUMBER}. Working branch: ${BRANCH_NAME}."
@@ -384,10 +385,10 @@ jobs:
             --title "$PR_TITLE" \
             --body-file "$PR_BODY_FILE"
 
-  sync_in_review:
-    name: Sync issue to In Review
-    needs: [guard, implement_and_open_pr]
-    if: needs.guard.outputs.should_run == 'true'
+  finalize_claim:
+    name: Finalize GitHub issue claim
+    needs: [guard, claim_issue, implement_and_open_pr]
+    if: ${{ always() && needs.guard.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -399,29 +400,23 @@ jobs:
         with:
           sparse-checkout: |
             scripts/lib/tracker.mjs
+            scripts/github-finalize-issue-claim.mjs
           sparse-checkout-cone-mode: false
 
-      - name: Transition issue to in-review
+      - name: Finalize exact owned claim
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ needs.guard.outputs.issue_number }}
           BRANCH_NAME: ${{ needs.guard.outputs.branch_name }}
+          IMPLEMENT_RESULT: ${{ needs.implement_and_open_pr.result }}
+          TRACKER_CLAIM_OWNER: github-ai:${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}
         run: |
           PR_URL=$(gh pr list --head "$BRANCH_NAME" --state open --json url --jq '.[0].url // empty')
-          NOTE="Automated PR opened for #${ISSUE_NUMBER}"
+          OUTCOME="retryable"
+          NOTE="Implementation result: ${IMPLEMENT_RESULT}. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           if [[ -n "$PR_URL" ]]; then
-            NOTE="${NOTE}: ${PR_URL}"
+            OUTCOME="in-review"
+            NOTE="Automated PR opened for #${ISSUE_NUMBER}: ${PR_URL}. ${NOTE}"
           fi
-          export NOTE
-          node --input-type=module -e "
-            import { transitionIssue } from './scripts/lib/tracker.mjs';
-            const result = transitionIssue({
-              number: Number(process.env.ISSUE_NUMBER),
-              status: 'in-review',
-              note: process.env.NOTE,
-            });
-            if (!result.success) {
-              console.error(result.error ?? 'transition failed');
-              process.exit(1);
-            }
-          "
+          node scripts/github-finalize-issue-claim.mjs \
+            "$ISSUE_NUMBER" "$OUTCOME" "$NOTE"

--- a/scripts/github-claim-issue.mjs
+++ b/scripts/github-claim-issue.mjs
@@ -5,6 +5,7 @@ const issueRef = process.argv[2];
 const note = process.argv[3] ?? 'Loop orchestrator dispatch';
 const assignee = process.env.TRACKER_ASSIGNEE;
 const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY;
+const ownerToken = process.env.TRACKER_CLAIM_OWNER;
 
 if (!issueRef) {
   console.error('Usage: github-claim-issue.mjs <issue-number|#N> [note]');
@@ -22,6 +23,7 @@ const result = claimIssue({
   assignee,
   note,
   repo,
+  ownerToken,
 });
 
 if (!result.success) {

--- a/scripts/github-finalize-issue-claim.mjs
+++ b/scripts/github-finalize-issue-claim.mjs
@@ -14,6 +14,11 @@ if (!issueRef || !outcome) {
   process.exit(1);
 }
 
+if (outcome !== 'retryable' && outcome !== 'in-review') {
+  console.error(`Invalid claim finalizer outcome: ${outcome}`);
+  process.exit(1);
+}
+
 const number = Number.parseInt(String(issueRef).replace(/^#/, ''), 10);
 if (!Number.isFinite(number)) {
   console.error(`Invalid issue number: ${issueRef}`);

--- a/scripts/github-finalize-issue-claim.mjs
+++ b/scripts/github-finalize-issue-claim.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { finalizeIssueClaim } from './lib/tracker.mjs';
+
+const issueRef = process.argv[2];
+const outcome = process.argv[3];
+const note = process.argv[4] ?? '';
+const ownerToken = process.env.TRACKER_CLAIM_OWNER;
+const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY;
+
+if (!issueRef || !outcome) {
+  console.error(
+    'Usage: github-finalize-issue-claim.mjs <issue-number|#N> <retryable|in-review> [note]'
+  );
+  process.exit(1);
+}
+
+const number = Number.parseInt(String(issueRef).replace(/^#/, ''), 10);
+if (!Number.isFinite(number)) {
+  console.error(`Invalid issue number: ${issueRef}`);
+  process.exit(1);
+}
+
+const result = finalizeIssueClaim({
+  number,
+  ownerToken,
+  outcome,
+  note,
+  repo,
+});
+
+if (!result.success) {
+  console.error(result.error ?? 'claim finalizer failed');
+  process.exit(1);
+}
+
+console.log(
+  result.changed
+    ? `Finalized #${number} as ${outcome}`
+    : `No claim change for #${number}: ${result.reason}`
+);

--- a/scripts/lib/__tests__/tracker.test.mjs
+++ b/scripts/lib/__tests__/tracker.test.mjs
@@ -6,6 +6,7 @@ import {
   buildIssueCreateArgs,
   claimIssue,
   fileGithubIssue,
+  finalizeIssueClaim,
   parseIssueNumber,
   queryTodoIssues,
   STATUS_IN_PROGRESS,
@@ -125,6 +126,46 @@ describe('claimIssue', () => {
     expect(calls[2].join(' ')).toContain('test claim');
   });
 
+  it('persists the exact owner before publishing an in-progress claim', () => {
+    const calls = [];
+    const exec = args => {
+      calls.push(args);
+      return '';
+    };
+    const result = claimIssue(
+      {
+        number: 42,
+        note: 'owned claim',
+        ownerToken: 'github-ai:JovieInc/Jovie:123:1',
+      },
+      exec
+    );
+    expect(result.success).toBe(true);
+    expect(calls[0]).toContain('comment');
+    expect(calls[0].join(' ')).toContain(
+      '<!-- github-ai-claim-owner:github-ai:JovieInc/Jovie:123:1 -->'
+    );
+    expect(calls[1]).toContain(STATUS_IN_PROGRESS);
+  });
+
+  it('does not publish an unowned status when the owner receipt fails', () => {
+    const calls = [];
+    const exec = args => {
+      calls.push(args);
+      throw new Error('comment unavailable');
+    };
+    const result = claimIssue(
+      {
+        number: 42,
+        ownerToken: 'github-ai:JovieInc/Jovie:123:1',
+      },
+      exec
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('comment');
+  });
+
   it('keeps the status claim when assignee assignment fails', () => {
     const calls = [];
     const exec = args => {
@@ -139,6 +180,151 @@ describe('claimIssue', () => {
     expect(result.success).toBe(true);
     expect(calls[0]).toContain(STATUS_IN_PROGRESS);
     expect(calls.at(-1)).toContain('comment');
+  });
+});
+
+describe('finalizeIssueClaim', () => {
+  const ownerToken = 'github-ai:JovieInc/Jovie:123:1';
+  const ownerMarker = `<!-- github-ai-claim-owner:${ownerToken} -->`;
+
+  function createExec({ labels, comments }) {
+    const calls = [];
+    const exec = args => {
+      calls.push(args);
+      const endpoint = args.at(-1);
+      if (String(endpoint).includes('/comments?')) {
+        return JSON.stringify([comments]);
+      }
+      if (String(endpoint).endsWith('/issues/42')) {
+        return JSON.stringify({
+          state: 'open',
+          labels: labels.map(name => ({ name })),
+        });
+      }
+      return '';
+    };
+    return { calls, exec };
+  }
+
+  it('releases an owned failed claim while retaining agent-ready', () => {
+    const { calls, exec } = createExec({
+      labels: [AGENT_READY_LABEL, STATUS_IN_PROGRESS],
+      comments: [{ user: { login: 'github-actions[bot]' }, body: ownerMarker }],
+    });
+    const result = finalizeIssueClaim(
+      {
+        number: 42,
+        ownerToken,
+        outcome: 'retryable',
+        note: 'Implementation result: failure',
+        repo: 'JovieInc/Jovie',
+      },
+      exec
+    );
+    expect(result).toMatchObject({ success: true, changed: true });
+    const edit = calls.find(call => call[0] === 'issue' && call[1] === 'edit');
+    expect(edit).toContain(STATUS_IN_PROGRESS);
+    expect(edit).not.toContain(AGENT_READY_LABEL);
+    expect(edit).not.toContain('--add-label');
+    expect(calls.some(call => call.join(' ').includes('result: failure'))).toBe(
+      true
+    );
+  });
+
+  it('transitions an owned claim to in-review when a PR exists', () => {
+    const { calls, exec } = createExec({
+      labels: [AGENT_READY_LABEL, STATUS_IN_PROGRESS],
+      comments: [{ user: { login: 'github-actions[bot]' }, body: ownerMarker }],
+    });
+    const result = finalizeIssueClaim(
+      {
+        number: 42,
+        ownerToken,
+        outcome: 'in-review',
+        note: 'PR opened',
+        repo: 'JovieInc/Jovie',
+      },
+      exec
+    );
+    expect(result).toMatchObject({ success: true, changed: true });
+    const edit = calls.find(call => call[0] === 'issue' && call[1] === 'edit');
+    expect(edit).toContain(STATUS_IN_PROGRESS);
+    expect(edit).toContain(STATUS_IN_REVIEW);
+  });
+
+  it('cannot release a newer run claim', () => {
+    const { calls, exec } = createExec({
+      labels: [AGENT_READY_LABEL, STATUS_IN_PROGRESS],
+      comments: [
+        { user: { login: 'github-actions[bot]' }, body: ownerMarker },
+        {
+          user: { login: 'github-actions[bot]' },
+          body: '<!-- github-ai-claim-owner:github-ai:JovieInc/Jovie:456:1 -->',
+        },
+      ],
+    });
+    const result = finalizeIssueClaim(
+      {
+        number: 42,
+        ownerToken,
+        outcome: 'retryable',
+        repo: 'JovieInc/Jovie',
+      },
+      exec
+    );
+    expect(result).toMatchObject({
+      success: true,
+      changed: false,
+      reason: 'not-owner',
+    });
+    expect(calls.some(call => call[0] === 'issue')).toBe(false);
+  });
+
+  it('is idempotent after a claim is already finalized', () => {
+    const { calls, exec } = createExec({
+      labels: [AGENT_READY_LABEL],
+      comments: [{ user: { login: 'github-actions[bot]' }, body: ownerMarker }],
+    });
+    const result = finalizeIssueClaim(
+      {
+        number: 42,
+        ownerToken,
+        outcome: 'retryable',
+        repo: 'JovieInc/Jovie',
+      },
+      exec
+    );
+    expect(result).toMatchObject({
+      success: true,
+      changed: false,
+      reason: 'already-finalized',
+    });
+    expect(calls.some(call => call[0] === 'issue')).toBe(false);
+  });
+
+  it('retries label cleanup without duplicating persisted metadata', () => {
+    const { calls, exec } = createExec({
+      labels: [AGENT_READY_LABEL, STATUS_IN_PROGRESS],
+      comments: [
+        { user: { login: 'github-actions[bot]' }, body: ownerMarker },
+        {
+          user: { login: 'github-actions[bot]' },
+          body: `<!-- github-ai-claim-finalized:${ownerToken}:retryable -->`,
+        },
+      ],
+    });
+    const result = finalizeIssueClaim(
+      {
+        number: 42,
+        ownerToken,
+        outcome: 'retryable',
+        repo: 'JovieInc/Jovie',
+      },
+      exec
+    );
+    expect(result).toMatchObject({ success: true, changed: true });
+    expect(calls.filter(call => call[0] === 'issue')).toHaveLength(1);
+    expect(calls.find(call => call[0] === 'issue')).toContain('edit');
   });
 });
 

--- a/scripts/lib/tracker.mjs
+++ b/scripts/lib/tracker.mjs
@@ -19,6 +19,8 @@ import { execFileSync } from 'node:child_process';
 export const STATUS_IN_PROGRESS = 'status:in-progress';
 export const STATUS_IN_REVIEW = 'status:in-review';
 export const AGENT_READY_LABEL = 'agent-ready';
+export const CLAIM_OWNER_MARKER = 'github-ai-claim-owner';
+export const CLAIM_FINALIZED_MARKER = 'github-ai-claim-finalized';
 
 /** @type {ReadonlySet<string>} */
 export const STATUS_LABELS = new Set([STATUS_IN_PROGRESS, STATUS_IN_REVIEW]);
@@ -44,6 +46,28 @@ function defaultExec(args, input) {
 
 function repoArgs(repo) {
   return repo ? ['--repo', repo] : [];
+}
+
+function isValidClaimOwner(ownerToken) {
+  return /^[A-Za-z0-9._:/-]+$/.test(ownerToken ?? '');
+}
+
+function claimOwnerMarker(ownerToken) {
+  return `<!-- ${CLAIM_OWNER_MARKER}:${ownerToken} -->`;
+}
+
+function claimFinalizedMarker(ownerToken, outcome) {
+  return `<!-- ${CLAIM_FINALIZED_MARKER}:${ownerToken}:${outcome} -->`;
+}
+
+function commentAuthor(comment) {
+  return comment?.user?.login ?? comment?.author?.login ?? '';
+}
+
+function flattenComments(raw) {
+  const parsed = JSON.parse(raw);
+  const pages = Array.isArray(parsed) ? parsed : [];
+  return pages.flatMap(page => (Array.isArray(page) ? page : [page]));
 }
 
 /**
@@ -112,12 +136,33 @@ export function shouldMirrorLinear(env = process.env) {
  * Claim a GitHub issue for agent work: assignee + status:in-progress label.
  * Never throws.
  *
- * @param {{ number: number, assignee?: string, note?: string, repo?: string }} input
+ * @param {{ number: number, assignee?: string, note?: string, repo?: string, ownerToken?: string }} input
  * @param {(args: string[]) => string} [exec]
  */
 export function claimIssue(input, exec = args => defaultExec(args)) {
-  const { number, assignee, note = 'Agent dispatch', repo } = input;
+  const { number, assignee, note = 'Agent dispatch', repo, ownerToken } = input;
   try {
+    if (ownerToken && !isValidClaimOwner(ownerToken)) {
+      throw new Error('Invalid claim owner token');
+    }
+
+    const commentArgs = [
+      'issue',
+      'comment',
+      String(number),
+      ...repoArgs(repo),
+      '--body',
+      `**Agent claim** ${note}${
+        ownerToken ? `\n\n${claimOwnerMarker(ownerToken)}` : ''
+      }`,
+    ];
+
+    // Persist the exact owner before publishing the status label. If the
+    // receipt write fails, there is no unowned in-progress claim to strand.
+    if (ownerToken) {
+      exec(commentArgs);
+    }
+
     const editArgs = [
       'issue',
       'edit',
@@ -145,14 +190,9 @@ export function claimIssue(input, exec = args => defaultExec(args)) {
       }
     }
 
-    exec([
-      'issue',
-      'comment',
-      String(number),
-      ...repoArgs(repo),
-      '--body',
-      `**Agent claim** ${note}`,
-    ]);
+    if (!ownerToken) {
+      exec(commentArgs);
+    }
 
     return {
       success: true,
@@ -162,6 +202,118 @@ export function claimIssue(input, exec = args => defaultExec(args)) {
   } catch (error) {
     return {
       success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Finalize an orchestrator-owned issue claim. The latest trusted claim receipt
+ * must match ownerToken, so an old workflow run cannot release a newer run's
+ * claim. Retryable finalization removes only status:in-progress and preserves
+ * agent-ready. PR finalization transitions the owned claim to in-review.
+ *
+ * @param {{ number: number, ownerToken: string, outcome: 'retryable' | 'in-review', note?: string, repo: string, expectedActor?: string }} input
+ * @param {(args: string[]) => string} [exec]
+ */
+export function finalizeIssueClaim(input, exec = args => defaultExec(args)) {
+  const {
+    number,
+    ownerToken,
+    outcome,
+    note = '',
+    repo,
+    expectedActor = 'github-actions[bot]',
+  } = input;
+
+  try {
+    if (!repo) throw new Error('repo is required to finalize a claim');
+    if (!isValidClaimOwner(ownerToken)) {
+      throw new Error('Invalid claim owner token');
+    }
+    if (outcome !== 'retryable' && outcome !== 'in-review') {
+      throw new Error(`Invalid claim finalizer outcome: ${outcome}`);
+    }
+
+    const comments = flattenComments(
+      exec([
+        'api',
+        '--paginate',
+        '--slurp',
+        `repos/${repo}/issues/${number}/comments?per_page=100`,
+      ])
+    ).filter(comment => commentAuthor(comment) === expectedActor);
+    const latestClaim = comments
+      .map(comment => String(comment?.body ?? ''))
+      .filter(body => body.includes(`<!-- ${CLAIM_OWNER_MARKER}:`))
+      .at(-1);
+
+    if (!latestClaim?.includes(claimOwnerMarker(ownerToken))) {
+      return {
+        success: true,
+        changed: false,
+        number,
+        outcome,
+        reason: 'not-owner',
+      };
+    }
+
+    const issue = JSON.parse(exec(['api', `repos/${repo}/issues/${number}`]));
+    const labels = new Set(
+      (issue.labels ?? []).map(label =>
+        typeof label === 'string' ? label : label.name
+      )
+    );
+    const alreadyFinalized =
+      outcome === 'in-review'
+        ? labels.has(STATUS_IN_REVIEW) && !labels.has(STATUS_IN_PROGRESS)
+        : !labels.has(STATUS_IN_PROGRESS);
+    if (alreadyFinalized) {
+      return {
+        success: true,
+        changed: false,
+        number,
+        outcome,
+        reason: 'already-finalized',
+      };
+    }
+
+    if (!labels.has(STATUS_IN_PROGRESS)) {
+      return {
+        success: true,
+        changed: false,
+        number,
+        outcome,
+        reason: 'no-active-claim',
+      };
+    }
+
+    const finalizedMarker = claimFinalizedMarker(ownerToken, outcome);
+    const hasFinalizedReceipt = comments.some(comment =>
+      String(comment?.body ?? '').includes(finalizedMarker)
+    );
+    if (!hasFinalizedReceipt) {
+      exec([
+        'issue',
+        'comment',
+        String(number),
+        ...repoArgs(repo),
+        '--body',
+        `**Agent claim finalizer** ${note}\n\n${finalizedMarker}`,
+      ]);
+    }
+
+    if (outcome === 'in-review') {
+      swapLabels(number, [STATUS_IN_PROGRESS], [STATUS_IN_REVIEW], exec, repo);
+    } else {
+      swapLabels(number, [STATUS_IN_PROGRESS], [], exec, repo);
+    }
+
+    return { success: true, changed: true, number, outcome };
+  } catch (error) {
+    return {
+      success: false,
+      changed: false,
       error: error instanceof Error ? error.message : String(error),
     };
   }

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -96,7 +96,7 @@ HOSTED_BACKGROUND_CONTROLLER_JOBS = (
     ("github-ai-dispatcher.yml", "dispatch"),
     ("github-ai-orchestrator.yml", "guard"),
     ("github-ai-orchestrator.yml", "claim_issue"),
-    ("github-ai-orchestrator.yml", "sync_in_review"),
+    ("github-ai-orchestrator.yml", "finalize_claim"),
     ("neon-scheduled-cleanup.yml", "scheduled-cleanup"),
     ("observability-issue.yml", "sync-issue"),
     ("reusable-ci-lint.yml", "lint"),
@@ -586,6 +586,25 @@ def test_scheduled_synthetic_alerts_before_preserving_failure() -> None:
     assert workflow.index("Send Slack Alert on Failure") < workflow.index(
         "Fail job if tests failed"
     )
+
+
+def test_github_ai_orchestrator_always_finalizes_exact_owned_claim() -> None:
+    """Every claimed run must release for retry or transition its PR to review."""
+    block = _job_block("github-ai-orchestrator.yml", "finalize_claim")
+    claim = _job_block("github-ai-orchestrator.yml", "claim_issue")
+
+    assert "needs: [guard, claim_issue, implement_and_open_pr]" in block
+    assert "if: ${{ always() && needs.guard.outputs.should_run == 'true' }}" in block
+    assert "IMPLEMENT_RESULT: ${{ needs.implement_and_open_pr.result }}" in block
+    assert 'OUTCOME="retryable"' in block
+    assert 'OUTCOME="in-review"' in block
+    assert "github-finalize-issue-claim.mjs" in block
+    owner_token = (
+        "github-ai:${{ github.repository }}:${{ github.run_id }}:"
+        "${{ github.run_attempt }}"
+    )
+    assert owner_token in block
+    assert owner_token in claim
 
 
 def test_live_model_work_never_fans_out_from_pull_requests() -> None:


### PR DESCRIPTION
## Summary

- records an exact GitHub Actions run owner before publishing `status:in-progress`
- adds one `always()` finalizer for success, provider/action failure, cancellation, and timeout
- transitions owned claims with an open branch PR to `status:in-review`
- releases only `status:in-progress` on retryable outcomes, preserving `agent-ready`
- persists finalizer outcome/run metadata and prevents stale runs from releasing newer claims

## Bug-to-Test

bug-to-test: satisfied

Regression tests cover retryable release, PR transition, exact-owner rejection, receipt-before-status ordering, and idempotent recovery after partial cleanup.

## Verification

- `pnpm exec vitest run scripts/lib/__tests__/tracker.test.mjs` — 24 passed
- `python3 -m pytest scripts/tests/test_agent_workflow_hygiene.py -q` — 31 passed
- `actionlint .github/workflows/github-ai-orchestrator.yml` — passed
- `pnpm run typecheck:scripts` — passed; 197 pre-existing errors match the unchanged baseline, zero new errors
- `node scripts/ci-fast-lanes.mjs` — all lanes passed, including scripts-typecheck and structural
- `git diff --check` — passed
- pre-commit secret and repo-hygiene hooks — passed
- pre-push typecheck, affected verify, lint, CI harness validation — passed

## Risk

High-risk agent control-plane workflow. The PR remains draft and must not be promoted or merge-queued until the coordinator confirms production remains green.

## Linear follow-ups

Linear follow-ups: none.
