### PR TITLE
fix(release): count only production Sentry errors

### DIFF
--- a/.github/actions/sentry-error-gate/action.yml
+++ b/.github/actions/sentry-error-gate/action.yml
@@ -100,11 +100,18 @@ runs:
 
         echo "Baseline window: $START_ISO to $END_ISO ($WINDOW_MINUTES min)"
 
-        # Count total events across all issues in the window
-        # Use the stats endpoint for more accurate event counts
-        STATS_RESPONSE=$(curl --fail --silent --show-error \
+        # Count only production error events. Sentry's Discover dataset also
+        # contains transactions and preview traffic; without this filter normal
+        # request volume or preview failures can trigger a false rollback.
+        STATS_RESPONSE=$(curl --fail --silent --show-error --get \
           -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-          "https://sentry.io/api/0/organizations/$SENTRY_ORG/events-stats/?project=$SENTRY_PROJECT_ID&field=count()&start=$START_ISO&end=$END_ISO&interval=1m")
+          --data-urlencode "project=$SENTRY_PROJECT_ID" \
+          --data-urlencode "field=count()" \
+          --data-urlencode "query=event.type:error environment:vercel-production" \
+          --data-urlencode "start=$START_ISO" \
+          --data-urlencode "end=$END_ISO" \
+          --data-urlencode "interval=1m" \
+          "https://sentry.io/api/0/organizations/$SENTRY_ORG/events-stats/")
 
         jq -e '
           type == "object" and
@@ -151,9 +158,15 @@ runs:
 
         echo "Post-deploy window: $START_ISO to $END_ISO ($SOAK_MINUTES min)"
 
-        STATS_RESPONSE=$(curl --fail --silent --show-error \
+        STATS_RESPONSE=$(curl --fail --silent --show-error --get \
           -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-          "https://sentry.io/api/0/organizations/$SENTRY_ORG/events-stats/?project=$SENTRY_PROJECT_ID&field=count()&start=$START_ISO&end=$END_ISO&interval=1m")
+          --data-urlencode "project=$SENTRY_PROJECT_ID" \
+          --data-urlencode "field=count()" \
+          --data-urlencode "query=event.type:error environment:vercel-production" \
+          --data-urlencode "start=$START_ISO" \
+          --data-urlencode "end=$END_ISO" \
+          --data-urlencode "interval=1m" \
+          "https://sentry.io/api/0/organizations/$SENTRY_ORG/events-stats/")
 
         jq -e '
           type == "object" and

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -115,6 +115,14 @@ function getStepBlock(workflow: string, stepName: string): string {
   return block.join('\n');
 }
 
+function getSentryStatsRequests(action: string): string[] {
+  return (
+    action.match(
+      /STATS_RESPONSE=\$\(curl[\s\S]*?"https:\/\/sentry\.io\/api\/0\/organizations\/\$SENTRY_ORG\/events-stats\/"\)/g
+    ) ?? []
+  );
+}
+
 function getJobBlock(workflow: string, jobKey: string): string {
   const lines = workflow.split('\n');
   const start = lines.findIndex(line => line === `  ${jobKey}:`);
@@ -3869,7 +3877,47 @@ describe('production promotion exact-artifact contract', () => {
     expect(sentryAction).toContain(
       'BASELINE_RATE_LIMIT_SCALED=$((BASELINE * THRESHOLD * POST_MINUTES))'
     );
+    const statsRequests = getSentryStatsRequests(sentryAction);
+    expect(statsRequests).toHaveLength(2);
+    const exactProductionErrorQuery =
+      '--data-urlencode "query=event.type:error environment:vercel-production"';
+    for (const request of statsRequests) {
+      expect(request).toContain('curl --fail --silent --show-error --get');
+      expect(request.match(/--data-urlencode "query=[^"]+"/g)).toEqual([
+        exactProductionErrorQuery,
+      ]);
+    }
+    expect(sentryAction).not.toContain('events-stats/?project=');
     expect(sentryAction).not.toContain('SENTRY_ORG:\n        required: true');
+  });
+
+  it('excludes transaction and preview volume while preserving real production error spikes', () => {
+    const sentryAction = readFileSync(sentryGateActionPath, 'utf8');
+    const isRateSpike = (
+      baseline: number,
+      postDeploy: number,
+      baselineMinutes = 30,
+      postMinutes = 5,
+      threshold = 3
+    ) => postDeploy * baselineMinutes > baseline * threshold * postMinutes;
+
+    // Exact 2026-07-22 incident: raw Discover traffic falsely spiked at 26/21.
+    // Error-only evidence was 1/0, but that sole baseline error came from
+    // vercel-preview; exact vercel-production errors were 0/0.
+    expect(isRateSpike(26, 21)).toBe(true);
+    expect(isRateSpike(1, 0)).toBe(false);
+    expect(isRateSpike(0, 0)).toBe(false);
+
+    // A genuine error-rate increase remains blocking after filtering.
+    expect(isRateSpike(6, 4)).toBe(true);
+    const statsRequests = getSentryStatsRequests(sentryAction);
+    expect(statsRequests).toHaveLength(2);
+    for (const request of statsRequests) {
+      expect(request).toContain(
+        '--data-urlencode "query=event.type:error environment:vercel-production"'
+      );
+    }
+    expect(sentryAction).toContain('echo "gate_status=failed"');
   });
 
   it('keeps cost and main-health observers strict, deduplicated, and bounded', () => {


### PR DESCRIPTION
## Summary
Fixes the reviewed production Sentry recovery for controller `29937877237`.

The prior unfiltered production sample counted `26/21` and caused a false rollback. The release logic now applies the exact error-only production Sentry filter. Thresholds and fail-closed semantics are unchanged.

## Verification
- Node 22 focused tests: `93/93`
- Typecheck, actionlint, YAML, Biome, and diff checks passed
- Independent Sol review: no findings

## Scope
- Draft only, targeting `main`
- No production mutation
- Queue handling intentionally deferred