### PR TITLE
fix(audio): preserve waveform playback while trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 - [internal] **App shell loading skeleton** matches `DESIGN_V1` so flag-on users no longer flash the legacy sidebar/header on first `/app` paint.
 
 - [internal] **Post-deploy probes now identify CLI-built production deployments (JOV-4366):** exact immutable build identity replaces optional Vercel source metadata while preserving project, deployment, origin, environment, and main-ancestry proofs.
+- **Waveform trimming no longer interrupts preview audio (JOV-2929):** trim updates keep one media element alive, playhead and trim handles work from the keyboard, decode failures can be retried without collapsing the editor, and local play/seek latency is measured.
 - **[internal] Staging Better Auth Google OAuth credentials now reach the Vercel build and runtime deploy (#14659):** the release workflow allowlists and forwards both Google client keys, failing closed when either is absent.
 
 ## [26.7.0] - 2026-07-21

--- a/apps/web/components/features/release/AudioWaveformEditor.stories.tsx
+++ b/apps/web/components/features/release/AudioWaveformEditor.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useEffect, useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+import { AudioWaveformEditor } from './AudioWaveformEditor';
+
+const SAMPLE_RATE = 44_100;
+const DURATION_SECONDS = 4;
+
+function createToneWavBlob(): Blob {
+  const sampleCount = SAMPLE_RATE * DURATION_SECONDS;
+  const bytesPerSample = 2;
+  const dataSize = sampleCount * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  const writeAscii = (offset: number, value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index));
+    }
+  };
+
+  writeAscii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, SAMPLE_RATE * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, 'data');
+  view.setUint32(40, dataSize, true);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const envelope = Math.sin((Math.PI * index) / sampleCount);
+    const sample = Math.sin((2 * Math.PI * 220 * index) / SAMPLE_RATE);
+    view.setInt16(
+      44 + index * bytesPerSample,
+      sample * envelope * 12_000,
+      true
+    );
+  }
+
+  return new Blob([buffer], { type: 'audio/wav' });
+}
+
+function RealAudioWaveformFixture() {
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = URL.createObjectURL(createToneWavBlob());
+    setAudioUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, []);
+
+  if (!audioUrl) {
+    return <div className='h-40 w-96' data-testid='audio-fixture-loading' />;
+  }
+
+  return (
+    <AudioWaveformEditor
+      audioUrl={audioUrl}
+      initialSnippet={{ startMs: 0, endMs: 4_000 }}
+    />
+  );
+}
+
+const meta: Meta<typeof RealAudioWaveformFixture> = {
+  title: 'Features/Release/AudioWaveformEditor',
+  component: RealAudioWaveformFixture,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className='w-96 rounded-lg bg-surface-1 p-4'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Decodes generated PCM WAV bytes and drives real browser sliders in Chromium. */
+export const RealPcmDecodeAndTrim: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const position = await canvas.findByRole(
+      'slider',
+      {
+        name: 'Waveform Position',
+      },
+      { timeout: 10_000 }
+    );
+    await expect(position).toHaveAttribute('max', '4000');
+
+    const startHandle = canvas.getByRole('slider', {
+      name: 'Adjust Snippet Start',
+    });
+    await userEvent.click(startHandle);
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(startHandle).toHaveAttribute('aria-valuenow', '1000');
+    await expect(canvas.getByText('Snippet: 0:01 – 0:04')).toBeInTheDocument();
+  },
+};

--- a/apps/web/components/features/release/AudioWaveformEditor.tsx
+++ b/apps/web/components/features/release/AudioWaveformEditor.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Loader2, Pause, Play } from 'lucide-react';
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
@@ -20,17 +22,40 @@ import {
   type AudioSnippet,
   createDefaultSnippet,
   formatSnippetRange,
+  MIN_SNIPPET_DURATION_MS,
   normalizeSnippet,
 } from '@/lib/audio/snippet';
 import { formatTime } from '@/lib/format-time';
+import {
+  type InteractionLatencyMarkHandle,
+  markInteractionStart,
+  measureInteractionPoint,
+} from '@/lib/monitoring/interaction-latency';
 import { cn } from '@/lib/utils';
 
 type TrimHandle = 'start' | 'end';
 
 const WAVEFORM_WIDTH = 1000;
 const WAVEFORM_HEIGHT = 56;
+const TRIM_KEY_STEP_MS = 1_000;
+
+function finishLatencyMark(
+  mark: InteractionLatencyMarkHandle | null,
+  point: string
+): null {
+  const measureName = measureInteractionPoint(mark, point);
+  if (mark && typeof performance !== 'undefined') {
+    performance.clearMarks?.(mark.startMark);
+    performance.clearMarks?.(`${mark.id}:${point}`);
+  }
+  if (measureName && typeof performance !== 'undefined') {
+    performance.clearMeasures?.(measureName);
+  }
+  return null;
+}
 
 function peaksToPath(peaks: readonly number[]): string {
+  if (peaks.length === 0) return '';
   const stride = WAVEFORM_WIDTH / peaks.length;
   const centerY = WAVEFORM_HEIGHT / 2;
   const amplitude = WAVEFORM_HEIGHT / 2 - 2;
@@ -81,8 +106,14 @@ export function AudioWaveformEditor({
   const uid = useId().replace(/:/g, '-');
   const waveformRef = useRef<HTMLDivElement>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const snippetRef = useRef<AudioSnippet | null>(initialSnippet ?? null);
+  const initialSnippetRef = useRef<AudioSnippet | null>(initialSnippet ?? null);
+  const durationMsRef = useRef<number | null>(durationMs ?? null);
   const dragRef = useRef<TrimHandle | null>(null);
   const holdsGlobalFocusRef = useRef(false);
+  const playGenerationRef = useRef(0);
+  const playLatencyMarkRef = useRef<InteractionLatencyMarkHandle | null>(null);
+  const seekLatencyMarkRef = useRef<InteractionLatencyMarkHandle | null>(null);
   const { playbackState: globalPlayback } = useTrackAudioPlayer();
 
   const [peaks, setPeaks] = useState<readonly number[]>([]);
@@ -95,6 +126,7 @@ export function AudioWaveformEditor({
     initialSnippet ?? null
   );
   const [isSaving, setIsSaving] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   const activeDurationMs = resolvedDurationMs > 0 ? resolvedDurationMs : 0;
   const waveformPath = useMemo(() => peaksToPath(peaks), [peaks]);
@@ -105,10 +137,27 @@ export function AudioWaveformEditor({
   const snippetEndPercent = snippet
     ? percentFromMs(snippet.endMs, activeDurationMs)
     : 100;
+  snippetRef.current = snippet;
+  initialSnippetRef.current = initialSnippet ?? null;
+  durationMsRef.current = durationMs ?? null;
 
   useEffect(() => {
     setSnippet(initialSnippet ?? null);
   }, [initialSnippet]);
+
+  useEffect(() => {
+    setPeaks([]);
+    setResolvedDurationMs(durationMsRef.current ?? 0);
+    setCurrentTimeMs(0);
+    setIsPlaying(false);
+    setSnippet(initialSnippetRef.current);
+  }, [audioUrl]);
+
+  useEffect(() => {
+    if (durationMs !== null && durationMs !== undefined && durationMs > 0) {
+      setResolvedDurationMs(durationMs);
+    }
+  }, [durationMs]);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,10 +168,11 @@ export function AudioWaveformEditor({
       .then(result => {
         if (cancelled) return;
         setPeaks(result.peaks);
-        setResolvedDurationMs(durationMs ?? result.durationMs);
+        const resolvedDuration = durationMsRef.current ?? result.durationMs;
+        setResolvedDurationMs(resolvedDuration);
         setSnippet(current => {
           if (current) return current;
-          return createDefaultSnippet(durationMs ?? result.durationMs);
+          return createDefaultSnippet(resolvedDuration);
         });
       })
       .catch(error => {
@@ -140,7 +190,7 @@ export function AudioWaveformEditor({
     return () => {
       cancelled = true;
     };
-  }, [audioUrl, durationMs]);
+  }, [audioUrl, loadAttempt]);
 
   useEffect(() => {
     const audio = new Audio(audioUrl);
@@ -152,50 +202,98 @@ export function AudioWaveformEditor({
       holdsGlobalFocusRef.current = false;
       resumePlaybackAfterInterruption();
     };
+    const isCurrentSource = () => audioRef.current === audio;
 
     const handleTimeUpdate = () => {
+      if (!isCurrentSource()) return;
       setCurrentTimeMs(Math.round(audio.currentTime * 1000));
-      if (!snippet) return;
-      if (audio.currentTime * 1000 >= snippet.endMs) {
+      const activeSnippet = snippetRef.current;
+      if (!activeSnippet) return;
+      if (audio.currentTime * 1000 >= activeSnippet.endMs) {
         audio.pause();
-        audio.currentTime = snippet.startMs / 1000;
+        audio.currentTime = activeSnippet.startMs / 1000;
         setIsPlaying(false);
         releaseGlobalFocus();
       }
     };
     const handleEnded = () => {
+      if (!isCurrentSource()) return;
       setIsPlaying(false);
       releaseGlobalFocus();
     };
-    const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
+    const handlePlaying = () => {
+      if (!isCurrentSource()) return;
+      playLatencyMarkRef.current = finishLatencyMark(
+        playLatencyMarkRef.current,
+        'audible'
+      );
+      setIsPlaying(true);
+    };
+    const handlePause = () => {
+      if (!isCurrentSource()) return;
+      setIsPlaying(false);
+    };
+    const handleSeeking = () => {
+      if (!isCurrentSource()) return;
+      seekLatencyMarkRef.current ??= markInteractionStart('audio-snippet-seek');
+    };
+    const handleSeeked = () => {
+      if (!isCurrentSource()) return;
+      seekLatencyMarkRef.current = finishLatencyMark(
+        seekLatencyMarkRef.current,
+        'settled'
+      );
+      setCurrentTimeMs(Math.round(audio.currentTime * 1000));
+    };
 
     audio.addEventListener('timeupdate', handleTimeUpdate);
     audio.addEventListener('ended', handleEnded);
-    audio.addEventListener('play', handlePlay);
+    audio.addEventListener('playing', handlePlaying);
     audio.addEventListener('pause', handlePause);
+    audio.addEventListener('seeking', handleSeeking);
+    audio.addEventListener('seeked', handleSeeked);
 
     return () => {
+      playGenerationRef.current += 1;
       try {
-        audio.pause();
+        if (!audio.paused) audio.pause();
       } catch {
         // jsdom throws Not implemented for HTMLMediaElement.pause
       }
       audio.src = '';
       audio.removeEventListener('timeupdate', handleTimeUpdate);
       audio.removeEventListener('ended', handleEnded);
-      audio.removeEventListener('play', handlePlay);
+      audio.removeEventListener('playing', handlePlaying);
       audio.removeEventListener('pause', handlePause);
-      audioRef.current = null;
+      audio.removeEventListener('seeking', handleSeeking);
+      audio.removeEventListener('seeked', handleSeeked);
+      if (audioRef.current === audio) audioRef.current = null;
+      playLatencyMarkRef.current = finishLatencyMark(
+        playLatencyMarkRef.current,
+        'unmounted'
+      );
+      seekLatencyMarkRef.current = finishLatencyMark(
+        seekLatencyMarkRef.current,
+        'unmounted'
+      );
       releaseGlobalFocus();
     };
-  }, [audioUrl, snippet]);
+  }, [audioUrl]);
 
   useEffect(() => {
     if (!globalPlayback.isPlaying) return;
     const audio = audioRef.current;
-    if (!audio || audio.paused) return;
-    audio.pause();
+    if (!audio) return;
+    playGenerationRef.current += 1;
+    playLatencyMarkRef.current = finishLatencyMark(
+      playLatencyMarkRef.current,
+      'interrupted'
+    );
+    seekLatencyMarkRef.current = finishLatencyMark(
+      seekLatencyMarkRef.current,
+      'interrupted'
+    );
+    if (!audio.paused) audio.pause();
     setIsPlaying(false);
     if (holdsGlobalFocusRef.current) {
       holdsGlobalFocusRef.current = false;
@@ -208,6 +306,11 @@ export function AudioWaveformEditor({
       const audio = audioRef.current;
       if (!audio || activeDurationMs <= 0) return;
       const clamped = Math.max(0, Math.min(nextMs, activeDurationMs));
+      seekLatencyMarkRef.current = finishLatencyMark(
+        seekLatencyMarkRef.current,
+        'superseded'
+      );
+      seekLatencyMarkRef.current = markInteractionStart('audio-snippet-seek');
       audio.currentTime = clamped / 1000;
       setCurrentTimeMs(clamped);
     },
@@ -219,6 +322,11 @@ export function AudioWaveformEditor({
     if (!audio) return;
 
     if (isPlaying) {
+      playGenerationRef.current += 1;
+      playLatencyMarkRef.current = finishLatencyMark(
+        playLatencyMarkRef.current,
+        'paused'
+      );
       audio.pause();
       if (holdsGlobalFocusRef.current) {
         holdsGlobalFocusRef.current = false;
@@ -241,9 +349,31 @@ export function AudioWaveformEditor({
       holdsGlobalFocusRef.current = true;
     }
 
+    playLatencyMarkRef.current = finishLatencyMark(
+      playLatencyMarkRef.current,
+      'superseded'
+    );
+    playLatencyMarkRef.current = markInteractionStart('audio-snippet-play');
+    const generation = ++playGenerationRef.current;
     try {
       await audio.play();
+      if (
+        audioRef.current === audio &&
+        playGenerationRef.current === generation
+      ) {
+        setIsPlaying(true);
+      }
     } catch {
+      if (
+        audioRef.current !== audio ||
+        playGenerationRef.current !== generation
+      ) {
+        return;
+      }
+      playLatencyMarkRef.current = finishLatencyMark(
+        playLatencyMarkRef.current,
+        'failed'
+      );
       setIsPlaying(false);
       if (holdsGlobalFocusRef.current) {
         holdsGlobalFocusRef.current = false;
@@ -265,15 +395,6 @@ export function AudioWaveformEditor({
       if (normalized) setSnippet(normalized);
     },
     [activeDurationMs, snippet]
-  );
-
-  const handleWaveformPointerDown = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (disabled || activeDurationMs <= 0) return;
-      const rect = event.currentTarget.getBoundingClientRect();
-      seekTo(msFromClientX(event.clientX, rect, activeDurationMs));
-    },
-    [activeDurationMs, disabled, seekTo]
   );
 
   const handleHandlePointerDown = useCallback(
@@ -305,6 +426,37 @@ export function AudioWaveformEditor({
     dragRef.current = null;
   }, []);
 
+  const handleHandleKeyDown = useCallback(
+    (handle: TrimHandle) => (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (disabled || !snippet || activeDurationMs <= 0) return;
+
+      const currentValue = handle === 'start' ? snippet.startMs : snippet.endMs;
+      let nextValue: number | null = null;
+      switch (event.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          nextValue = currentValue - TRIM_KEY_STEP_MS;
+          break;
+        case 'ArrowRight':
+        case 'ArrowUp':
+          nextValue = currentValue + TRIM_KEY_STEP_MS;
+          break;
+        case 'Home':
+          nextValue = 0;
+          break;
+        case 'End':
+          nextValue = activeDurationMs;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      updateSnippetHandle(handle, nextValue);
+    },
+    [activeDurationMs, disabled, snippet, updateSnippetHandle]
+  );
+
   const handleSaveSnippet = useCallback(async () => {
     if (!snippet || !onSaveSnippet) return;
     const normalized = normalizeSnippet(snippet, activeDurationMs);
@@ -319,37 +471,28 @@ export function AudioWaveformEditor({
     }
   }, [activeDurationMs, onSaveSnippet, snippet]);
 
-  if (loadError) {
-    return (
-      <p className='text-xs text-error' data-testid='audio-waveform-error'>
-        {loadError}
-      </p>
-    );
-  }
-
   return (
     <div className='space-y-3' data-testid='audio-waveform-editor'>
       <div className='flex items-center justify-between gap-2'>
-        <button
-          type='button'
+        <Button
+          variant='secondary'
+          size='icon'
           onClick={() => {
             handleTogglePlayback().catch(() => {});
           }}
-          disabled={disabled || isLoading || activeDurationMs <= 0}
+          disabled={
+            disabled || isLoading || Boolean(loadError) || activeDurationMs <= 0
+          }
           aria-label={
             isPlaying ? 'Pause waveform preview' : 'Play waveform preview'
           }
-          className={cn(
-            'inline-flex h-8 w-8 items-center justify-center rounded-md border border-subtle bg-surface-1 text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-2',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
-          )}
         >
           {isPlaying ? (
             <Pause className='h-3.5 w-3.5' strokeWidth={2.5} />
           ) : (
             <Play className='h-3.5 w-3.5 translate-x-px' strokeWidth={2.5} />
           )}
-        </button>
+        </Button>
         <div className='min-w-0 text-right text-2xs text-tertiary-token tabular-nums'>
           <span>{formatTime(currentTimeMs / 1000)}</span>
           <span className='mx-1 text-quaternary-token'>/</span>
@@ -360,10 +503,9 @@ export function AudioWaveformEditor({
       <div
         ref={waveformRef}
         className={cn(
-          'relative h-14 overflow-hidden rounded-lg border border-subtle bg-surface-0',
+          'relative h-14 overflow-hidden rounded-lg border border-subtle bg-surface-0 focus-within:ring-2 focus-within:ring-(--linear-border-focus)/55 focus-within:ring-offset-2 focus-within:ring-offset-(--linear-app-content-surface)',
           disabled ? 'pointer-events-none opacity-60' : 'cursor-pointer'
         )}
-        onPointerDown={handleWaveformPointerDown}
         data-testid='audio-waveform-surface'
       >
         {isLoading ? (
@@ -372,6 +514,20 @@ export function AudioWaveformEditor({
               className='h-4 w-4 animate-spin text-tertiary-token motion-reduce:animate-none'
               aria-hidden='true'
             />
+          </div>
+        ) : loadError ? (
+          <div
+            className='flex h-full items-center justify-center gap-2 px-3 text-2xs text-secondary-token'
+            data-testid='audio-waveform-error'
+          >
+            <span>Waveform unavailable.</span>
+            <Button
+              variant='tertiary'
+              size='sm'
+              onClick={() => setLoadAttempt(attempt => attempt + 1)}
+            >
+              Retry
+            </Button>
           </div>
         ) : (
           <>
@@ -382,17 +538,6 @@ export function AudioWaveformEditor({
               aria-hidden='true'
             >
               <defs>
-                <linearGradient
-                  id={`wave-fill-${uid}`}
-                  x1='0%'
-                  y1='0%'
-                  x2='100%'
-                  y2='0%'
-                >
-                  <stop offset='0%' stopColor='rgb(168 85 247 / 0.85)' />
-                  <stop offset='55%' stopColor='rgb(236 72 153 / 0.85)' />
-                  <stop offset='100%' stopColor='rgb(59 130 246 / 0.85)' />
-                </linearGradient>
                 <clipPath id={`wave-played-${uid}`}>
                   <rect
                     x='0'
@@ -402,18 +547,35 @@ export function AudioWaveformEditor({
                   />
                 </clipPath>
               </defs>
-              <path d={waveformPath} fill='rgb(148 163 184 / 0.28)' />
               <path
                 d={waveformPath}
-                fill={`url(#wave-fill-${uid})`}
+                className='fill-current text-quaternary-token opacity-30'
+              />
+              <path
+                d={waveformPath}
+                fill='var(--color-accent)'
+                fillOpacity='0.8'
                 clipPath={`url(#wave-played-${uid})`}
               />
             </svg>
 
+            <input
+              type='range'
+              min={0}
+              max={activeDurationMs}
+              step={100}
+              value={Math.min(currentTimeMs, activeDurationMs)}
+              onChange={event => seekTo(Number(event.currentTarget.value))}
+              disabled={disabled || activeDurationMs <= 0}
+              aria-label='Waveform Position'
+              aria-valuetext={formatTime(currentTimeMs / 1000)}
+              className='absolute inset-0 h-full w-full cursor-pointer opacity-0 disabled:cursor-default'
+            />
+
             {snippet ? (
               <>
                 <div
-                  className='pointer-events-none absolute inset-y-0 bg-cyan-400/10'
+                  className='pointer-events-none absolute inset-y-0 bg-accent/10'
                   style={{
                     left: `${snippetStartPercent}%`,
                     right: `${100 - snippetEndPercent}%`,
@@ -421,22 +583,48 @@ export function AudioWaveformEditor({
                 />
                 <button
                   type='button'
-                  aria-label='Adjust snippet start'
+                  role='slider'
+                  aria-label='Adjust Snippet Start'
+                  aria-valuemin={0}
+                  aria-valuemax={Math.max(
+                    0,
+                    snippet.endMs - MIN_SNIPPET_DURATION_MS
+                  )}
+                  aria-valuenow={snippet.startMs}
+                  aria-valuetext={formatTime(snippet.startMs / 1000)}
                   onPointerDown={handleHandlePointerDown('start')}
                   onPointerMove={handleHandlePointerMove}
                   onPointerUp={handleHandlePointerUp}
-                  className='absolute top-1 bottom-1 z-10 w-2 -translate-x-1/2 rounded-full border border-cyan-300/80 bg-cyan-400 shadow-[0_0_0_1px_rgba(15,23,42,0.35)]'
+                  onPointerCancel={handleHandlePointerUp}
+                  onKeyDown={handleHandleKeyDown('start')}
+                  disabled={disabled || activeDurationMs <= 0}
+                  className='focus-ring-themed absolute inset-y-0 z-10 w-11 -translate-x-1/2 rounded-md'
                   style={{ left: `${snippetStartPercent}%` }}
-                />
+                >
+                  <span className='pointer-events-none absolute top-1 bottom-1 left-1/2 w-1.5 -translate-x-1/2 rounded-full border border-accent/70 bg-accent shadow-sm' />
+                </button>
                 <button
                   type='button'
-                  aria-label='Adjust snippet end'
+                  role='slider'
+                  aria-label='Adjust Snippet End'
+                  aria-valuemin={Math.min(
+                    activeDurationMs,
+                    snippet.startMs + MIN_SNIPPET_DURATION_MS
+                  )}
+                  aria-valuemax={activeDurationMs}
+                  aria-valuenow={snippet.endMs}
+                  aria-valuetext={formatTime(snippet.endMs / 1000)}
                   onPointerDown={handleHandlePointerDown('end')}
                   onPointerMove={handleHandlePointerMove}
                   onPointerUp={handleHandlePointerUp}
-                  className='absolute top-1 bottom-1 z-10 w-2 -translate-x-1/2 rounded-full border border-cyan-300/80 bg-cyan-400 shadow-[0_0_0_1px_rgba(15,23,42,0.35)]'
+                  onPointerCancel={handleHandlePointerUp}
+                  onKeyDown={handleHandleKeyDown('end')}
+                  disabled={disabled || activeDurationMs <= 0}
+                  className='focus-ring-themed absolute inset-y-0 z-10 w-11 -translate-x-1/2 rounded-md'
                   style={{ left: `${snippetEndPercent}%` }}
-                />
+                >
+                  <span className='pointer-events-none absolute top-1 bottom-1 left-1/2 w-1.5 -translate-x-1/2 rounded-full border border-accent/70 bg-accent shadow-sm' />
+                </button>
               </>
             ) : null}
 
@@ -448,26 +636,30 @@ export function AudioWaveformEditor({
         )}
       </div>
 
-      {snippet ? (
-        <div className='flex items-center justify-between gap-2'>
-          <p className='text-2xs text-secondary-token'>
-            Snippet: {formatSnippetRange(snippet.startMs, snippet.endMs)}
-          </p>
-          {onSaveSnippet ? (
-            <button
-              type='button'
-              onClick={() => {
-                handleSaveSnippet().catch(() => {});
-              }}
-              disabled={disabled || isSaving}
-              className='inline-flex h-7 items-center rounded-md border border-subtle bg-surface-1 px-2.5 text-2xs font-medium text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-2 disabled:opacity-60'
-              data-testid='audio-snippet-save'
-            >
-              {isSaving ? 'Saving…' : 'Save snippet'}
-            </button>
-          ) : null}
-        </div>
-      ) : null}
+      <div className='flex min-h-9 items-center justify-between gap-2'>
+        {snippet && !isLoading && !loadError ? (
+          <>
+            <p className='text-2xs text-secondary-token'>
+              Snippet: {formatSnippetRange(snippet.startMs, snippet.endMs)}
+            </p>
+            {onSaveSnippet ? (
+              <Button
+                variant='secondary'
+                size='sm'
+                onClick={() => {
+                  handleSaveSnippet().catch(() => {});
+                }}
+                disabled={disabled || isSaving}
+                data-testid='audio-snippet-save'
+              >
+                {isSaving ? 'Saving…' : 'Save Snippet'}
+              </Button>
+            ) : null}
+          </>
+        ) : (
+          <span aria-hidden='true' />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/tests/components/features/release/AudioWaveformEditor.test.tsx
+++ b/apps/web/tests/components/features/release/AudioWaveformEditor.test.tsx
@@ -1,0 +1,630 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AudioWaveformEditor } from '@/components/features/release/AudioWaveformEditor';
+
+const decodeWaveformPeaksMock = vi.fn();
+const pauseGlobalPlaybackMock = vi.fn();
+const resumeGlobalPlaybackMock = vi.fn();
+let globalPlaybackState = {
+  activeTrackId: null as string | null,
+  isPlaying: false,
+};
+
+vi.mock('@/lib/audio/decode-waveform-peaks', () => ({
+  decodeWaveformPeaks: (...args: unknown[]) => decodeWaveformPeaksMock(...args),
+}));
+
+vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
+  pausePlaybackForInterruption: () => pauseGlobalPlaybackMock(),
+  resumePlaybackAfterInterruption: () => resumeGlobalPlaybackMock(),
+  useTrackAudioPlayer: () => ({
+    playbackState: globalPlaybackState,
+  }),
+}));
+
+interface MockAudioElement {
+  readonly play: ReturnType<typeof vi.fn>;
+  readonly pause: ReturnType<typeof vi.fn>;
+  readonly addEventListener: ReturnType<typeof vi.fn>;
+  readonly removeEventListener: ReturnType<typeof vi.fn>;
+  readonly listeners: Record<string, Array<() => void>>;
+  currentTime: number;
+  duration: number;
+  paused: boolean;
+  preload: string;
+  src: string;
+}
+
+let audioInstances: MockAudioElement[] = [];
+
+function createMockAudio(src = ''): MockAudioElement {
+  const listeners: Record<string, Array<() => void>> = {};
+  const audio: MockAudioElement = {
+    play: vi.fn().mockImplementation(() => {
+      audio.paused = false;
+      return Promise.resolve();
+    }),
+    pause: vi.fn().mockImplementation(() => {
+      audio.paused = true;
+    }),
+    addEventListener: vi.fn((event: string, listener: () => void) => {
+      listeners[event] ??= [];
+      listeners[event].push(listener);
+    }),
+    removeEventListener: vi.fn((event: string, listener: () => void) => {
+      listeners[event] = (listeners[event] ?? []).filter(
+        current => current !== listener
+      );
+    }),
+    listeners,
+    currentTime: 0,
+    duration: 120,
+    paused: true,
+    preload: '',
+    src,
+  };
+  audioInstances.push(audio);
+  return audio;
+}
+
+function fireAudioEvent(audio: MockAudioElement, event: string): void {
+  for (const listener of audio.listeners[event] ?? []) listener();
+}
+
+vi.stubGlobal('Audio', function MockAudio(src?: string) {
+  return createMockAudio(src);
+});
+vi.stubGlobal('PointerEvent', MouseEvent);
+
+describe('AudioWaveformEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    audioInstances = [];
+    globalPlaybackState = { activeTrackId: null, isPlaying: false };
+    decodeWaveformPeaksMock.mockResolvedValue({
+      peaks: [0.2, 0.8, 0.5],
+      durationMs: 120_000,
+    });
+  });
+
+  it('keeps one media element while trim handles update by keyboard', async () => {
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+        initialSnippet={{ startMs: 10_000, endMs: 40_000 }}
+      />
+    );
+
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const startHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet Start',
+    });
+    const endHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet End',
+    });
+
+    fireEvent.keyDown(startHandle, { key: 'ArrowRight' });
+    fireEvent.keyDown(endHandle, { key: 'ArrowLeft' });
+
+    expect(startHandle).toHaveAttribute('aria-valuenow', '11000');
+    expect(endHandle).toHaveAttribute('aria-valuenow', '39000');
+    expect(screen.getByText('Snippet: 0:11 – 0:39')).toBeInTheDocument();
+    expect(audioInstances).toHaveLength(1);
+  });
+
+  it('supports pointer trimming and stops updates after pointer cancellation', async () => {
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={100_000}
+        initialSnippet={{ startMs: 10_000, endMs: 80_000 }}
+      />
+    );
+
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const surface = screen.getByTestId('audio-waveform-surface');
+    const startHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet Start',
+    });
+    surface.getBoundingClientRect = () =>
+      ({
+        left: 100,
+        width: 200,
+      }) as DOMRect;
+    startHandle.setPointerCapture = vi.fn();
+
+    fireEvent.pointerDown(startHandle, { pointerId: 7 });
+    fireEvent.pointerMove(startHandle, { clientX: 200 });
+    expect(startHandle).toHaveAttribute('aria-valuenow', '50000');
+    expect(startHandle.setPointerCapture).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerCancel(startHandle);
+    fireEvent.pointerMove(startHandle, { clientX: 120 });
+    expect(startHandle).toHaveAttribute('aria-valuenow', '50000');
+  });
+
+  it('supports Home and End trim commands while preserving minimum duration', async () => {
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={10_000}
+        initialSnippet={{ startMs: 2_000, endMs: 8_000 }}
+      />
+    );
+
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const startHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet Start',
+    });
+    const endHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet End',
+    });
+    fireEvent.keyDown(startHandle, { key: 'End' });
+    expect(startHandle).toHaveAttribute('aria-valuenow', '9000');
+    fireEvent.keyDown(endHandle, { key: 'Home' });
+    expect(endHandle).toHaveAttribute('aria-valuenow', '10000');
+    fireEvent.keyDown(startHandle, { key: 'Home' });
+    fireEvent.keyDown(endHandle, { key: 'End' });
+    expect(startHandle).toHaveAttribute('aria-valuenow', '0');
+    expect(endHandle).toHaveAttribute('aria-valuenow', '10000');
+  });
+
+  it('removes disabled trim handles from keyboard operation', async () => {
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+        initialSnippet={{ startMs: 10_000, endMs: 40_000 }}
+        disabled
+      />
+    );
+
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const startHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet Start',
+    });
+    const endHandle = screen.getByRole('slider', {
+      name: 'Adjust Snippet End',
+    });
+
+    expect(startHandle).toBeDisabled();
+    expect(endHandle).toBeDisabled();
+    fireEvent.keyDown(startHandle, { key: 'ArrowRight' });
+    fireEvent.keyDown(endHandle, { key: 'ArrowLeft' });
+    expect(startHandle).toHaveAttribute('aria-valuenow', '10000');
+    expect(endHandle).toHaveAttribute('aria-valuenow', '40000');
+  });
+
+  it('uses the latest trim boundary without recreating or interrupting audio', async () => {
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+        initialSnippet={{ startMs: 10_000, endMs: 40_000 }}
+      />
+    );
+
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    fireEvent.keyDown(
+      screen.getByRole('slider', { name: 'Adjust Snippet Start' }),
+      { key: 'ArrowRight' }
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider', { name: 'Adjust Snippet End' }),
+      { key: 'ArrowLeft' }
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+    const audio = audioInstances[0];
+    expect(audio).toBeDefined();
+    expect(audio?.play).toHaveBeenCalledTimes(1);
+    expect(pauseGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      if (!audio) return;
+      audio.currentTime = 39;
+      fireAudioEvent(audio, 'timeupdate');
+    });
+
+    expect(audio?.pause).toHaveBeenCalledTimes(1);
+    expect(audio?.currentTime).toBe(11);
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+    expect(audioInstances).toHaveLength(1);
+  });
+
+  it('retires media only when the source changes and resets source-local state', async () => {
+    const { rerender } = render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/first.mp3'
+        durationMs={120_000}
+        initialSnippet={{ startMs: 10_000, endMs: 40_000 }}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const firstAudio = audioInstances[0];
+
+    rerender(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/second.mp3'
+        durationMs={90_000}
+        initialSnippet={{ startMs: 5_000, endMs: 35_000 }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Snippet: 0:05 – 0:35')).toBeInTheDocument();
+    });
+    expect(firstAudio?.src).toBe('');
+    expect(audioInstances).toHaveLength(2);
+    expect(audioInstances[1]?.src).toBe('https://cdn.example.com/second.mp3');
+  });
+
+  it('keeps live playback state when duration metadata changes', async () => {
+    const { rerender } = render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const audio = audioInstances[0];
+    act(() => {
+      if (!audio) return;
+      audio.currentTime = 20;
+      fireAudioEvent(audio, 'playing');
+      fireAudioEvent(audio, 'timeupdate');
+    });
+
+    rerender(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={121_000}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Pause waveform preview' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('0:20')).toBeInTheDocument();
+    expect(screen.getByText('2:01')).toBeInTheDocument();
+    expect(audioInstances).toHaveLength(1);
+    expect(decodeWaveformPeaksMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('measures play-to-audible and releases focus on explicit pause', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
+    const clearMarksSpy = vi.spyOn(performance, 'clearMarks');
+    const clearMeasuresSpy = vi.spyOn(performance, 'clearMeasures');
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const audio = audioInstances[0];
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+    act(() => {
+      if (audio) fireAudioEvent(audio, 'playing');
+    });
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-snippet-play:event-to-audible',
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(clearMarksSpy).toHaveBeenCalled();
+    expect(clearMeasuresSpy).toHaveBeenCalledWith(
+      'audio-snippet-play:event-to-audible'
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Pause waveform preview' })
+    );
+    act(() => {
+      if (audio) fireAudioEvent(audio, 'pause');
+    });
+    expect(audio?.pause).toHaveBeenCalledTimes(1);
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    ).toBeInTheDocument();
+    measureSpy.mockRestore();
+    clearMarksSpy.mockRestore();
+    clearMeasuresSpy.mockRestore();
+  });
+
+  it('releases focus when the media element ends', async () => {
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+    const audio = audioInstances[0];
+    act(() => {
+      if (!audio) return;
+      fireAudioEvent(audio, 'playing');
+      fireAudioEvent(audio, 'ended');
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    ).toBeInTheDocument();
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers focus and reports latency when playback fails', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    audioInstances[0]?.play.mockRejectedValueOnce(new Error('Not allowed'));
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+    await waitFor(() =>
+      expect(measureSpy).toHaveBeenCalledWith(
+        'audio-snippet-play:event-to-failed',
+        expect.any(String),
+        expect.any(String)
+      )
+    );
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    ).toBeInTheDocument();
+    measureSpy.mockRestore();
+  });
+
+  it('ignores a retired source play rejection after replacement playback starts', async () => {
+    let rejectFirstPlay: ((error: Error) => void) | undefined;
+    const { rerender } = render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/first.mp3'
+        durationMs={120_000}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    const firstAudio = audioInstances[0];
+    firstAudio?.play.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirstPlay = reject;
+        })
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+
+    rerender(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/second.mp3'
+        durationMs={90_000}
+      />
+    );
+    await waitFor(() => expect(audioInstances).toHaveLength(2));
+    const secondAudio = audioInstances[1];
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+    act(() => {
+      if (!secondAudio) return;
+      fireAudioEvent(secondAudio, 'playing');
+    });
+
+    await act(async () => {
+      rejectFirstPlay?.(new Error('Retired source rejection'));
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Pause waveform preview' })
+    ).toBeInTheDocument();
+    expect(pauseGlobalPlaybackMock).toHaveBeenCalledTimes(2);
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps stable editor geometry and retries a waveform decode failure', async () => {
+    decodeWaveformPeaksMock
+      .mockRejectedValueOnce(new Error('Decoder exploded'))
+      .mockResolvedValueOnce({ peaks: [0.4, 0.9], durationMs: 90_000 });
+
+    render(
+      <AudioWaveformEditor audioUrl='https://cdn.example.com/preview.mp3' />
+    );
+
+    expect(await screen.findByTestId('audio-waveform-error')).toHaveTextContent(
+      'Waveform unavailable.'
+    );
+    expect(screen.getByTestId('audio-waveform-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('audio-waveform-surface')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('slider', { name: 'Waveform Position' })
+      ).toBeInTheDocument();
+    });
+    expect(decodeWaveformPeaksMock).toHaveBeenCalledTimes(2);
+    expect(audioInstances).toHaveLength(1);
+  });
+
+  it('derives duration and a default snippet from decoded audio', async () => {
+    decodeWaveformPeaksMock.mockResolvedValueOnce({
+      peaks: [],
+      durationMs: 90_000,
+    });
+    render(
+      <AudioWaveformEditor audioUrl='https://cdn.example.com/preview.wav' />
+    );
+
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    expect(screen.getByText('1:30')).toBeInTheDocument();
+    expect(screen.getByText('Snippet: 0:30 – 1:00')).toBeInTheDocument();
+    expect(screen.getByTestId('audio-waveform-surface')).toBeInTheDocument();
+  });
+
+  it('persists normalized trim state and restores the save control', async () => {
+    let resolveSave: (() => void) | undefined;
+    const onSaveSnippet = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveSave = resolve;
+        })
+    );
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+        initialSnippet={{ startMs: 10_000, endMs: 40_000 }}
+        onSaveSnippet={onSaveSnippet}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+
+    fireEvent.click(screen.getByTestId('audio-snippet-save'));
+    expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled();
+    expect(onSaveSnippet).toHaveBeenCalledWith({
+      startMs: 10_000,
+      endMs: 40_000,
+    });
+    await act(async () => {
+      resolveSave?.();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: 'Save Snippet' })).toBeEnabled();
+  });
+
+  it('measures waveform seek settlement and updates the media position', async () => {
+    const markSpy = vi.spyOn(performance, 'mark');
+    const measureSpy = vi.spyOn(performance, 'measure');
+    render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+
+    const position = await screen.findByRole('slider', {
+      name: 'Waveform Position',
+    });
+    fireEvent.change(position, { target: { value: '42000' } });
+    const audio = audioInstances[0];
+    expect(audio?.currentTime).toBe(42);
+
+    act(() => {
+      if (!audio) return;
+      fireAudioEvent(audio, 'seeking');
+      fireAudioEvent(audio, 'seeked');
+    });
+
+    expect(markSpy).toHaveBeenCalledWith(
+      expect.stringContaining('audio-snippet-seek')
+    );
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-snippet-seek:event-to-settled',
+      expect.any(String),
+      expect.any(String)
+    );
+    markSpy.mockRestore();
+    measureSpy.mockRestore();
+  });
+
+  it('closes pending local interaction marks when global playback takes ownership', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
+    let resolvePlay: (() => void) | undefined;
+    const { rerender } = render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+    const position = await screen.findByRole('slider', {
+      name: 'Waveform Position',
+    });
+    const audio = audioInstances[0];
+    audio?.play.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          if (audio) audio.paused = false;
+          resolvePlay = resolve;
+        })
+    );
+
+    fireEvent.change(position, { target: { value: '42000' } });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+    globalPlaybackState = { activeTrackId: 'global-track', isPlaying: true };
+    rerender(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-snippet-play:event-to-interrupted',
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-snippet-seek:event-to-interrupted',
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(audio?.pause).toHaveBeenCalledTimes(1);
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvePlay?.();
+      await Promise.resolve();
+    });
+    expect(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    ).toBeInTheDocument();
+    measureSpy.mockRestore();
+  });
+
+  it('releases global audio focus and retires the local source on unmount', async () => {
+    const { unmount } = render(
+      <AudioWaveformEditor
+        audioUrl='https://cdn.example.com/preview.mp3'
+        durationMs={120_000}
+      />
+    );
+    await screen.findByRole('slider', { name: 'Waveform Position' });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Play waveform preview' })
+    );
+
+    const audio = audioInstances[0];
+    unmount();
+
+    expect(audio?.pause).toHaveBeenCalled();
+    expect(audio?.src).toBe('');
+    expect(resumeGlobalPlaybackMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- keep one media element alive while trim bounds change
- add keyboard-accessible playhead and trim handles
- expose retryable decode failures and local play/seek latency instrumentation

Linear: JOV-2929

## Verification
- 17/17 waveform continuity and keyboard tests
- focused audio web lane: 53/53
- web typecheck and production build
- hook: all 8 web shards plus CI harness validation