### PR TITLE
fix(auth): retain secondary storage method contract

### DIFF
--- a/apps/web/lib/auth/secondary-storage.ts
+++ b/apps/web/lib/auth/secondary-storage.ts
@@ -130,7 +130,7 @@ export function resetSecondaryStorageMemoryForTests(): void {
 // Storage implementation
 // ---------------------------------------------------------------------------
 
-export const secondaryStorage: SecondaryStorage = {
+export const secondaryStorage = {
   async get(key) {
     const redis = getRedis();
     if (!redis) {
@@ -274,4 +274,4 @@ export const secondaryStorage: SecondaryStorage = {
       });
     }
   },
-};
+} satisfies SecondaryStorage;


### PR DESCRIPTION
## Summary
- preserve the concrete required `getAndDelete` method type while validating the object against Better Auth `SecondaryStorage`
- restore the canonical source/pre-push typecheck on exact current `main`
- keep the existing fail-closed Redis behavior unchanged

## Root cause
`secondaryStorage: SecondaryStorage` widened `getAndDelete` to the upstream optional member type. The implementation always provides the method, but its own regression tests could no longer invoke it under the dependency versions now on `main`. Exact `origin/main` SHA `f776c7ff9af47bae2e04992a6a3210962463af00` reproduced TS2722 at all four calls.

## Verification
- `pnpm --filter @jovie/web exec vitest run lib/auth/secondary-storage.test.ts` (4/4)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- full enabled pre-push hook: typecheck, lint, eight web shards, CI harness

Linear: [JOV-4389](https://linear.app/jovie/issue/JOV-4389/restore-main-typecheck-for-better-auth-secondary-storage-getdel-tests)

This is a standalone prerequisite for audio PR #14730; no audio code is included.