### PR TITLE
fix(build): include Sharp libvips in Vercel traces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4306,6 +4306,7 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
+          SKIP_SKILLS_CATALOG_SYNC: '1'
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.vercelignore
+++ b/.vercelignore
@@ -60,6 +60,8 @@ cleanup_old_branches*.sh
 # Build-critical web postbuild script
 !apps/web/scripts/
 !apps/web/scripts/sync-standalone-assets.mjs
+!apps/web/scripts/ensure-sharp-runtime-traces.mjs
+!apps/web/scripts/resolve-package-json.mjs
 
 # Source-deploy fallback still needs these runtime directories from apps/web.
 !apps/web/scripts/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -139,7 +139,7 @@
     "biome:ci": "biome ci .",
     "biome:check": "biome check .",
     "clean": "rm -rf .next out dist coverage .nyc_output",
-    "postbuild": "next-sitemap && if [ \"${VERCEL_ENV:-}\" = \"preview\" ] || [ \"${VERCEL_SKIP_STANDALONE_ASSET_SYNC:-false}\" = \"true\" ]; then echo 'Skipping standalone asset sync for Vercel preview build'; else node ./scripts/sync-standalone-assets.mjs; fi && if [ -f scripts/sync-skills-catalog.ts ]; then tsx scripts/sync-skills-catalog.ts; else echo 'Skipping skills catalog sync - file not found (resilient)'; fi",
+    "postbuild": "next-sitemap && node ./scripts/ensure-sharp-runtime-traces.mjs && if [ \"${VERCEL_ENV:-}\" = \"preview\" ] || [ \"${VERCEL_SKIP_STANDALONE_ASSET_SYNC:-false}\" = \"true\" ]; then echo 'Skipping standalone asset sync for Vercel preview build'; else node ./scripts/sync-standalone-assets.mjs; fi && if [ -f scripts/sync-skills-catalog.ts ]; then tsx scripts/sync-skills-catalog.ts; else echo 'Skipping skills catalog sync - file not found (resilient)'; fi",
     "verify-artist-images": "node scripts/verify-artist-images.js",
     "update-artist-images": "node scripts/update-artist-images.js",
     "ensure-valid-artist-images": "node scripts/ensure-valid-artist-images.js",

--- a/apps/web/scripts/ensure-sharp-runtime-traces.mjs
+++ b/apps/web/scripts/ensure-sharp-runtime-traces.mjs
@@ -1,0 +1,294 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolvePackageJson } from './resolve-package-json.mjs';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(scriptDir, '..');
+const require = createRequire(import.meta.url);
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function walkFiles(rootDir, predicate) {
+  const matches = [];
+  if (!existsSync(rootDir)) return matches;
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      matches.push(...walkFiles(entryPath, predicate));
+    } else if (entry.isFile() && predicate(entryPath)) {
+      matches.push(entryPath);
+    }
+  }
+
+  return matches;
+}
+
+function isSharpTrace(files) {
+  return files.some(
+    file =>
+      /(?:^|\/)sharp-[0-9a-f]{12,40}(?:\/|$)/i.test(file) ||
+      /(?:^|\/)node_modules\/sharp(?:\/|$)/i.test(file)
+  );
+}
+
+function isLibvipsSharedLibrary(filePath) {
+  return /libvips-cpp(?:\.so(?:\.[0-9.]+)?|\.[0-9.]+\.dylib)$/i.test(filePath);
+}
+
+function getPackageNameFromPath(filePath) {
+  const segments = path.resolve(filePath).split(path.sep);
+  const nodeModulesIndex = segments.lastIndexOf('node_modules');
+  if (nodeModulesIndex === -1) return null;
+
+  const firstPackageSegment = segments[nodeModulesIndex + 1];
+  if (!firstPackageSegment) return null;
+  if (firstPackageSegment.startsWith('@')) {
+    const packageSegment = segments[nodeModulesIndex + 2];
+    return packageSegment ? `${firstPackageSegment}/${packageSegment}` : null;
+  }
+
+  return firstPackageSegment;
+}
+
+function isSharpNativePackage(packageName) {
+  return packageName?.startsWith('@img/sharp-') ?? false;
+}
+
+function isSharpNativeAddonEntry(filePath, packageName) {
+  return (
+    /\.node$/i.test(filePath) &&
+    (isSharpNativePackage(packageName) ||
+      /(?:^|[+/])sharp-(?!libvips)[^/]*\/.*\.node$/i.test(filePath))
+  );
+}
+
+function assertExistingLibvipsFiles(filePaths) {
+  if (filePaths.length === 0) {
+    throw new Error(
+      'Sharp runtime trace repair found no libvips shared libraries'
+    );
+  }
+
+  for (const filePath of filePaths) {
+    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+      throw new Error(`Sharp libvips shared library is missing: ${filePath}`);
+    }
+  }
+}
+
+export function findSharpSharedLibraries({
+  packageRoot = appRoot,
+  platform = process.platform,
+  arch = process.arch,
+  libc = detectRuntimeLibc(platform),
+  requireFromScript = require,
+  resolvePackageJsonFn = resolvePackageJson,
+} = {}) {
+  const workspaceRoot = path.resolve(packageRoot, '..', '..');
+  const resolutionPaths = [
+    packageRoot,
+    path.join(packageRoot, 'node_modules', '.pnpm'),
+    workspaceRoot,
+    path.join(workspaceRoot, 'node_modules', '.pnpm'),
+  ];
+  const sharpPackageJsonPath = resolvePackageJsonFn(
+    requireFromScript,
+    'sharp',
+    resolutionPaths
+  );
+  const sharpPackageJson = JSON.parse(
+    readFileSync(sharpPackageJsonPath, 'utf8')
+  );
+  const packageName = getSharpLibvipsPackageName({ platform, arch, libc });
+  const optionalDependencies = sharpPackageJson.optionalDependencies ?? {};
+  if (!(packageName in optionalDependencies)) {
+    throw new Error(
+      `Sharp does not declare the expected runtime package ${packageName}`
+    );
+  }
+
+  try {
+    const packageJsonPath = resolvePackageJsonFn(
+      requireFromScript,
+      packageName,
+      resolutionPaths
+    );
+    const libraries = walkFiles(
+      path.join(path.dirname(packageJsonPath), 'lib'),
+      isLibvipsSharedLibrary
+    );
+    if (libraries.length > 0) return libraries;
+  } catch (error) {
+    if (
+      error?.code !== 'MODULE_NOT_FOUND' &&
+      !String(error).includes('Unable to find package.json')
+    ) {
+      throw error;
+    }
+  }
+
+  throw new Error(
+    `Sharp runtime trace repair could not resolve a libvips shared library for ${platform}-${arch}-${libc ?? 'default'}. Checked: ${packageName}`
+  );
+}
+
+export function detectRuntimeLibc(platform = process.platform) {
+  if (platform !== 'linux') return null;
+  const report = process.report?.getReport();
+  return report?.header?.glibcVersionRuntime ? 'glibc' : 'musl';
+}
+
+export function getSharpLibvipsPackageName({
+  platform,
+  arch,
+  libc = detectRuntimeLibc(platform),
+}) {
+  return `@img/sharp-libvips-${getSharpPlatformRuntime({ platform, libc })}-${arch}`;
+}
+
+export function getSharpNativePackageName({
+  platform,
+  arch,
+  libc = detectRuntimeLibc(platform),
+}) {
+  return `@img/sharp-${getSharpPlatformRuntime({ platform, libc })}-${arch}`;
+}
+
+function getSharpPlatformRuntime({ platform, libc }) {
+  if (platform === 'linux') {
+    if (libc !== 'glibc' && libc !== 'musl') {
+      throw new Error(`Unsupported Linux libc for Sharp: ${libc}`);
+    }
+    return libc === 'musl' ? 'linuxmusl' : 'linux';
+  }
+
+  return platform;
+}
+
+export function repairSharpRuntimeTraces({
+  traceRoot,
+  sharedLibraries,
+  platform = process.platform,
+  arch = process.arch,
+  libc = detectRuntimeLibc(platform),
+}) {
+  const tracePaths = walkFiles(traceRoot, filePath =>
+    filePath.endsWith('.nft.json')
+  );
+  const expectedNativePackageName = getSharpNativePackageName({
+    platform,
+    arch,
+    libc,
+  });
+  assertExistingLibvipsFiles(sharedLibraries);
+  let sharpTraceCount = 0;
+  let repairedTraceCount = 0;
+
+  for (const tracePath of tracePaths) {
+    const trace = JSON.parse(readFileSync(tracePath, 'utf8'));
+    if (!Array.isArray(trace.files) || !isSharpTrace(trace.files)) continue;
+
+    sharpTraceCount += 1;
+    const nativeAddonEntries = trace.files
+      .filter(file => /\.node$/i.test(file))
+      .map(file => ({
+        file,
+        resolvedPath: path.resolve(path.dirname(tracePath), file),
+        packageName: getPackageNameFromPath(
+          path.resolve(path.dirname(tracePath), file)
+        ),
+      }))
+      .filter(({ file, packageName }) =>
+        isSharpNativeAddonEntry(file, packageName)
+      );
+    const mismatchedAddon = nativeAddonEntries.find(
+      ({ packageName }) => packageName !== expectedNativePackageName
+    );
+    if (mismatchedAddon) {
+      throw new Error(
+        `Sharp runtime trace native addon must belong to ${expectedNativePackageName}, found ${mismatchedAddon.packageName ?? 'an unknown package'}: ${tracePath}`
+      );
+    }
+
+    const expectedAddon = nativeAddonEntries.find(
+      ({ packageName }) => packageName === expectedNativePackageName
+    );
+    if (!expectedAddon) {
+      throw new Error(
+        `Sharp runtime trace is missing a native addon from ${expectedNativePackageName}: ${tracePath}`
+      );
+    }
+    if (
+      !existsSync(expectedAddon.resolvedPath) ||
+      !statSync(expectedAddon.resolvedPath).isFile()
+    ) {
+      throw new Error(
+        `Sharp runtime trace native addon is missing on disk relative to its NFT: ${expectedAddon.file} (${tracePath})`
+      );
+    }
+
+    const additions = sharedLibraries.map(libraryPath =>
+      toPosixPath(path.relative(path.dirname(tracePath), libraryPath))
+    );
+    const nextFiles = [...new Set([...trace.files, ...additions])].sort();
+    if (nextFiles.length !== trace.files.length) {
+      writeFileSync(
+        tracePath,
+        `${JSON.stringify({ ...trace, files: nextFiles })}\n`
+      );
+      repairedTraceCount += 1;
+    }
+
+    if (!nextFiles.some(isLibvipsSharedLibrary)) {
+      throw new Error(
+        `Sharp runtime trace is missing the libvips shared library: ${tracePath}`
+      );
+    }
+  }
+
+  if (sharpTraceCount === 0) {
+    throw new Error(
+      `Sharp runtime trace repair found no Sharp-backed traces under ${traceRoot}`
+    );
+  }
+
+  return { repairedTraceCount, sharpTraceCount };
+}
+
+export function ensureSharpRuntimeTraces({
+  traceRoot = path.join(appRoot, '.next', 'server'),
+  sharedLibraries = findSharpSharedLibraries(),
+  platform = process.platform,
+  arch = process.arch,
+  libc = detectRuntimeLibc(platform),
+} = {}) {
+  return repairSharpRuntimeTraces({
+    traceRoot,
+    sharedLibraries,
+    platform,
+    arch,
+    libc,
+  });
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isMain) {
+  const result = ensureSharpRuntimeTraces();
+  console.log(
+    `Verified Sharp native runtime contract across ${result.sharpTraceCount} trace(s); repaired ${result.repairedTraceCount}.`
+  );
+}

--- a/apps/web/scripts/ensure-sharp-runtime-traces.mjs
+++ b/apps/web/scripts/ensure-sharp-runtime-traces.mjs
@@ -212,19 +212,16 @@ export function repairSharpRuntimeTraces({
       .filter(({ file, packageName }) =>
         isSharpNativeAddonEntry(file, packageName)
       );
-    const mismatchedAddon = nativeAddonEntries.find(
-      ({ packageName }) => packageName !== expectedNativePackageName
-    );
-    if (mismatchedAddon) {
-      throw new Error(
-        `Sharp runtime trace native addon must belong to ${expectedNativePackageName}, found ${mismatchedAddon.packageName ?? 'an unknown package'}: ${tracePath}`
-      );
-    }
-
     const expectedAddon = nativeAddonEntries.find(
       ({ packageName }) => packageName === expectedNativePackageName
     );
     if (!expectedAddon) {
+      const mismatchedAddon = nativeAddonEntries[0];
+      if (mismatchedAddon) {
+        throw new Error(
+          `Sharp runtime trace native addon must belong to ${expectedNativePackageName}, found ${mismatchedAddon.packageName ?? 'an unknown package'}: ${tracePath}`
+        );
+      }
       throw new Error(
         `Sharp runtime trace is missing a native addon from ${expectedNativePackageName}: ${tracePath}`
       );

--- a/apps/web/scripts/ensure-sharp-runtime-traces.test.mjs
+++ b/apps/web/scripts/ensure-sharp-runtime-traces.test.mjs
@@ -321,6 +321,46 @@ describe('repairSharpRuntimeTraces', () => {
     expect(plainTraceAfter).toBe(plainTraceBefore);
   });
 
+  it('accepts the expected native addon alongside an optional libc addon', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+    const traceRoot = path.join(root, '.next', 'server');
+    const libraryPath = path.join(root, 'libvips-cpp.so.8.18.3');
+    writeFileSync(libraryPath, 'fixture');
+    const expectedNativeAddonPath = createSharpNativeAddon(
+      root,
+      getSharpNativePackageName(glibcX64)
+    );
+    const optionalNativeAddonPath = createSharpNativeAddon(
+      root,
+      '@img/sharp-linuxmusl-x64'
+    );
+    const sharpTracePath = writeTrace(
+      traceRoot,
+      'app/api/chat/route.js.nft.json',
+      [
+        '../../../../node_modules/sharp-76070f79591ce98c',
+        toTraceRelativePath(traceRoot, optionalNativeAddonPath),
+        toTraceRelativePath(traceRoot, expectedNativeAddonPath),
+      ]
+    );
+
+    expect(
+      repairSharpRuntimeTraces({
+        traceRoot,
+        sharedLibraries: [libraryPath],
+        ...glibcX64,
+      })
+    ).toEqual({ repairedTraceCount: 1, sharpTraceCount: 1 });
+
+    expect(JSON.parse(readFileSync(sharpTracePath, 'utf8')).files).toContain(
+      path
+        .relative(path.dirname(sharpTracePath), libraryPath)
+        .split(path.sep)
+        .join('/')
+    );
+  });
+
   it('fails closed when a syntactically matching native addon is missing', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
     temporaryRoots.push(root);

--- a/apps/web/scripts/ensure-sharp-runtime-traces.test.mjs
+++ b/apps/web/scripts/ensure-sharp-runtime-traces.test.mjs
@@ -1,0 +1,493 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ensureSharpRuntimeTraces,
+  findSharpSharedLibraries,
+  getSharpLibvipsPackageName,
+  getSharpNativePackageName,
+  repairSharpRuntimeTraces,
+} from './ensure-sharp-runtime-traces.mjs';
+
+const temporaryRoots = [];
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(appRoot, '..', '..');
+const localSourceExtensions = [
+  '.mjs',
+  '.js',
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+  '.jsx',
+];
+const gitProbeEnv = (() => {
+  const localEnvVars = spawnSync('git', ['rev-parse', '--local-env-vars'], {
+    encoding: 'utf8',
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_'))
+    ),
+  });
+  expect(localEnvVars.status, localEnvVars.stderr).toBe(0);
+  const localEnvVarNames = new Set(localEnvVars.stdout.trim().split(/\s+/));
+
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !localEnvVarNames.has(name))
+  );
+})();
+
+function buildAndPostbuildScriptPaths() {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(appRoot, 'package.json'), 'utf8')
+  );
+  const commands = ['build', 'postbuild'].map(scriptName => {
+    const command = packageJson.scripts?.[scriptName];
+    expect(command, `Missing package.json ${scriptName} script`).toEqual(
+      expect.any(String)
+    );
+    return command;
+  });
+  const scriptPaths = new Set();
+  const entryPattern =
+    /\b(?:node|tsx)\s+(?:(?:--[^\s;&|()]+)\s+)*((?:\.\/)?scripts\/[^\s;&|()]+\.(?:mjs|cjs|js|mts|cts|ts|tsx|jsx))(?=$|[\s;&|()])/g;
+
+  for (const command of commands) {
+    for (const match of command.matchAll(entryPattern)) {
+      scriptPaths.add(match[1].replace(/^\.\//, ''));
+    }
+  }
+
+  expect(scriptPaths.size).toBeGreaterThan(0);
+  return [...scriptPaths].sort();
+}
+
+function createVercelIgnoreProbe(vercelIgnore) {
+  const root = mkdtempSync(path.join(tmpdir(), 'jovie-vercelignore-'));
+  temporaryRoots.push(root);
+  writeFileSync(path.join(root, '.gitignore'), vercelIgnore);
+  const init = spawnSync('git', ['-C', root, 'init', '--quiet'], {
+    encoding: 'utf8',
+    env: gitProbeEnv,
+  });
+  expect(init.status, init.stderr).toBe(0);
+  return root;
+}
+
+function isIgnoredByVercelIgnore(relativePath, probeRoot) {
+  const absolutePath = path.join(probeRoot, relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, 'fixture');
+  const result = spawnSync(
+    'git',
+    [
+      '-C',
+      probeRoot,
+      'check-ignore',
+      '--no-index',
+      '--quiet',
+      '--',
+      relativePath,
+    ],
+    { encoding: 'utf8', env: gitProbeEnv }
+  );
+  expect(result.status, result.stderr).not.toBe(128);
+  return result.status === 0;
+}
+
+function resolveLocalSourceFile(sourcePath, specifier) {
+  const candidate = path.resolve(path.dirname(sourcePath), specifier);
+  const candidates = path.extname(candidate)
+    ? [candidate]
+    : [
+        candidate,
+        ...localSourceExtensions.map(extension => `${candidate}${extension}`),
+      ];
+  const resolved = candidates.find(candidatePath => existsSync(candidatePath));
+
+  expect(
+    resolved,
+    `Unable to resolve local static import ${specifier} from ${sourcePath}`
+  ).toBeDefined();
+  return resolved;
+}
+
+function collectLocalStaticImportClosure(entryPaths) {
+  const requiredFiles = new Set();
+  const pending = entryPaths.map(entryPath => path.resolve(appRoot, entryPath));
+
+  while (pending.length > 0) {
+    const sourcePath = pending.pop();
+    if (requiredFiles.has(sourcePath)) continue;
+
+    const relativePath = path.relative(repoRoot, sourcePath);
+    expect(
+      relativePath.startsWith('..') || path.isAbsolute(relativePath),
+      `Local static import escaped the repository: ${sourcePath}`
+    ).toBe(false);
+    expect(
+      existsSync(sourcePath),
+      `Missing required source file: ${sourcePath}`
+    ).toBe(true);
+    requiredFiles.add(sourcePath);
+
+    const source = readFileSync(sourcePath, 'utf8');
+    const staticImportPattern =
+      /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
+    for (const match of source.matchAll(staticImportPattern)) {
+      pending.push(resolveLocalSourceFile(sourcePath, match[1]));
+    }
+  }
+
+  return [...requiredFiles].sort();
+}
+
+function toRepoRelativePath(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+function writeTrace(root, relativePath, files) {
+  const tracePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(tracePath), { recursive: true });
+  writeFileSync(tracePath, JSON.stringify({ version: 1, files }));
+  return tracePath;
+}
+
+function createSharpPackage(root, packageName, packageJson = {}) {
+  const version = packageJson.version ?? '0.35.3';
+  const packageRoot = path.join(
+    root,
+    'node_modules',
+    '.pnpm',
+    `${packageName.replace('/', '+')}@${version}`,
+    'node_modules',
+    ...packageName.split('/')
+  );
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(
+    path.join(packageRoot, 'package.json'),
+    JSON.stringify({ name: packageName, ...packageJson, version })
+  );
+
+  const packageLink = path.join(
+    root,
+    'node_modules',
+    ...packageName.split('/')
+  );
+  mkdirSync(path.dirname(packageLink), { recursive: true });
+  symlinkSync(packageRoot, packageLink, 'dir');
+  return packageRoot;
+}
+
+function createSharpNativeAddon(
+  root,
+  packageName,
+  { createAddon = true } = {}
+) {
+  const packageRoot = createSharpPackage(root, packageName);
+
+  const addonPath = path.join(
+    packageRoot,
+    'lib',
+    `${packageName.slice('@img/'.length)}-0.35.3.node`
+  );
+  if (createAddon) {
+    mkdirSync(path.dirname(addonPath), { recursive: true });
+    writeFileSync(addonPath, 'native addon fixture');
+  }
+
+  return addonPath;
+}
+
+function createSharpRuntimeResolutionFixture(root) {
+  const packageNames = [
+    '@img/sharp-libvips-linux-x64',
+    '@img/sharp-libvips-linuxmusl-x64',
+  ];
+  createSharpPackage(root, 'sharp', {
+    optionalDependencies: Object.fromEntries(
+      packageNames.map(packageName => [packageName, '1.3.2'])
+    ),
+  });
+
+  return Object.fromEntries(
+    packageNames.map(packageName => {
+      const packageRoot = createSharpPackage(root, packageName, {
+        version: '1.3.2',
+      });
+      const libraryPath = path.join(
+        packageRoot,
+        'lib',
+        'libvips-cpp.so.8.18.3'
+      );
+      mkdirSync(path.dirname(libraryPath), { recursive: true });
+      writeFileSync(libraryPath, `libvips fixture for ${packageName}`);
+      return [packageName, libraryPath];
+    })
+  );
+}
+
+const glibcX64 = { platform: 'linux', arch: 'x64', libc: 'glibc' };
+
+describe('repairSharpRuntimeTraces', () => {
+  it('ships every build and postbuild entry and its local static imports', () => {
+    const vercelIgnore = readFileSync(
+      path.resolve(appRoot, '..', '..', '.vercelignore'),
+      'utf8'
+    );
+    const entryPaths = buildAndPostbuildScriptPaths();
+    const requiredFiles = collectLocalStaticImportClosure(entryPaths);
+    const probeRoot = createVercelIgnoreProbe(vercelIgnore);
+
+    expect(entryPaths).toContain('scripts/ensure-sharp-runtime-traces.mjs');
+    expect(requiredFiles.length).toBeGreaterThanOrEqual(entryPaths.length);
+    for (const requiredFile of requiredFiles) {
+      const relativePath = toRepoRelativePath(requiredFile);
+      expect(
+        isIgnoredByVercelIgnore(relativePath, probeRoot),
+        `Required build source is ignored by .vercelignore: ${relativePath}`
+      ).toBe(false);
+    }
+  });
+
+  it('adds libvips only to traces that load the Sharp native addon', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+    const traceRoot = path.join(root, '.next', 'server');
+    const libraryPath = path.join(
+      root,
+      'node_modules',
+      '@img',
+      'sharp-libvips-linux-x64',
+      'lib',
+      'libvips-cpp.so.8.18.3'
+    );
+    mkdirSync(path.dirname(libraryPath), { recursive: true });
+    writeFileSync(libraryPath, 'fixture');
+
+    const nativeAddonPath = createSharpNativeAddon(
+      root,
+      getSharpNativePackageName(glibcX64)
+    );
+    const sharpTracePath = writeTrace(
+      traceRoot,
+      'app/api/chat/route.js.nft.json',
+      [
+        '../../../../node_modules/sharp-76070f79591ce98c',
+        toTraceRelativePath(traceRoot, nativeAddonPath),
+      ]
+    );
+    const plainTracePath = writeTrace(
+      traceRoot,
+      'app/api/health/route.js.nft.json',
+      ['../../../../server/chunks/health.js']
+    );
+    const plainTraceBefore = readFileSync(plainTracePath, 'utf8');
+
+    expect(
+      repairSharpRuntimeTraces({
+        traceRoot,
+        sharedLibraries: [libraryPath],
+        ...glibcX64,
+      })
+    ).toEqual({ repairedTraceCount: 1, sharpTraceCount: 1 });
+
+    const sharpTrace = JSON.parse(readFileSync(sharpTracePath, 'utf8'));
+    const plainTraceAfter = readFileSync(plainTracePath, 'utf8');
+    expect(sharpTrace.files).toContain(
+      path
+        .relative(path.dirname(sharpTracePath), libraryPath)
+        .split(path.sep)
+        .join('/')
+    );
+    expect(plainTraceAfter).toBe(plainTraceBefore);
+  });
+
+  it('fails closed when a syntactically matching native addon is missing', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+    const traceRoot = path.join(root, '.next', 'server');
+    const libraryPath = path.join(root, 'libvips-cpp.so.8.18.3');
+    writeFileSync(libraryPath, 'fixture');
+    const nativeAddonPath = createSharpNativeAddon(
+      root,
+      getSharpNativePackageName(glibcX64),
+      { createAddon: false }
+    );
+    writeTrace(traceRoot, 'app/api/chat/route.js.nft.json', [
+      '../../../../node_modules/sharp-76070f79591ce98c',
+      toTraceRelativePath(traceRoot, nativeAddonPath),
+    ]);
+
+    expect(() =>
+      repairSharpRuntimeTraces({
+        traceRoot,
+        sharedLibraries: [libraryPath],
+        ...glibcX64,
+      })
+    ).toThrow('missing on disk relative to its NFT');
+  });
+
+  it.each([
+    ['platform', '@img/sharp-darwin-arm64'],
+    ['architecture', '@img/sharp-linux-arm64'],
+    ['Linux libc', '@img/sharp-linuxmusl-x64'],
+  ])('fails closed when the present native addon has the wrong %s', (_label, packageName) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+    const traceRoot = path.join(root, '.next', 'server');
+    const libraryPath = path.join(root, 'libvips-cpp.so.8.18.3');
+    writeFileSync(libraryPath, 'fixture');
+    const nativeAddonPath = createSharpNativeAddon(root, packageName);
+    writeTrace(traceRoot, 'app/api/chat/route.js.nft.json', [
+      '../../../../node_modules/sharp-76070f79591ce98c',
+      toTraceRelativePath(traceRoot, nativeAddonPath),
+    ]);
+
+    expect(() =>
+      repairSharpRuntimeTraces({
+        traceRoot,
+        sharedLibraries: [libraryPath],
+        ...glibcX64,
+      })
+    ).toThrow('must belong to @img/sharp-linux-x64');
+  });
+
+  it('fails closed when no Sharp-backed traces exist', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+    const traceRoot = path.join(root, '.next', 'server');
+    const libraryPath = path.join(root, 'libvips-cpp.so.8.18.3');
+    writeFileSync(libraryPath, 'fixture');
+    writeTrace(traceRoot, 'app/api/health/route.js.nft.json', [
+      '../../../../server/chunks/health.js',
+    ]);
+
+    expect(() =>
+      repairSharpRuntimeTraces({
+        traceRoot,
+        sharedLibraries: [libraryPath],
+      })
+    ).toThrow('found no Sharp-backed traces');
+  });
+
+  it('fails closed when the resolved shared library is missing', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+
+    expect(() =>
+      ensureSharpRuntimeTraces({
+        traceRoot: root,
+        sharedLibraries: [path.join(root, 'libvips-cpp.so.8.18.3')],
+      })
+    ).toThrow('shared library is missing');
+  });
+
+  it('fails closed when the exact platform package cannot be resolved', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-trace-'));
+    temporaryRoots.push(root);
+    const sharpPackageJsonPath = path.join(root, 'sharp-package.json');
+    writeFileSync(
+      sharpPackageJsonPath,
+      JSON.stringify({
+        optionalDependencies: {
+          '@img/sharp-libvips-linux-x64': '1.3.2',
+        },
+      })
+    );
+    const unresolved = Object.assign(new Error('not found'), {
+      code: 'MODULE_NOT_FOUND',
+    });
+
+    expect(() =>
+      findSharpSharedLibraries({
+        packageRoot: root,
+        platform: 'linux',
+        arch: 'x64',
+        libc: 'glibc',
+        resolvePackageJsonFn: (_require, packageName) => {
+          if (packageName === 'sharp') return sharpPackageJsonPath;
+          throw unresolved;
+        },
+      })
+    ).toThrow('could not resolve a libvips shared library');
+  });
+
+  it.each([
+    [
+      'glibc',
+      glibcX64,
+      '@img/sharp-libvips-linux-x64',
+      '@img/sharp-libvips-linuxmusl-x64',
+    ],
+    [
+      'musl',
+      { platform: 'linux', arch: 'x64', libc: 'musl' },
+      '@img/sharp-libvips-linuxmusl-x64',
+      '@img/sharp-libvips-linux-x64',
+    ],
+  ])('finds the exact on-disk libvips package for Linux %s through production resolution', (_libc, runtime, expectedPackageName, wrongPackageName) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'jovie-sharp-runtime-'));
+    temporaryRoots.push(root);
+    const libraries = createSharpRuntimeResolutionFixture(root);
+    const expectedLibraryPath = realpathSync(libraries[expectedPackageName]);
+    const wrongLibraryPath = realpathSync(libraries[wrongPackageName]);
+
+    expect(getSharpLibvipsPackageName(runtime)).toBe(expectedPackageName);
+    expect(existsSync(expectedLibraryPath)).toBe(true);
+    expect(findSharpSharedLibraries({ packageRoot: root, ...runtime })).toEqual(
+      [expectedLibraryPath]
+    );
+    expect(expectedLibraryPath).not.toBe(wrongLibraryPath);
+  });
+
+  it('selects exactly one glibc or musl runtime package', () => {
+    expect(getSharpNativePackageName(glibcX64)).toBe('@img/sharp-linux-x64');
+    expect(
+      getSharpNativePackageName({
+        platform: 'linux',
+        arch: 'x64',
+        libc: 'musl',
+      })
+    ).toBe('@img/sharp-linuxmusl-x64');
+    expect(
+      getSharpLibvipsPackageName({
+        platform: 'linux',
+        arch: 'x64',
+        libc: 'glibc',
+      })
+    ).toBe('@img/sharp-libvips-linux-x64');
+    expect(
+      getSharpLibvipsPackageName({
+        platform: 'linux',
+        arch: 'x64',
+        libc: 'musl',
+      })
+    ).toBe('@img/sharp-libvips-linuxmusl-x64');
+  });
+});
+
+function toTraceRelativePath(traceRoot, filePath) {
+  return path
+    .relative(path.join(traceRoot, 'app/api/chat'), filePath)
+    .split(path.sep)
+    .join('/');
+}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -991,6 +991,31 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(deployScript).not.toContain('--token');
   });
 
+  it('skips catalog mutation only for the manual PR preview build', () => {
+    const previewWorkflow = readFileSync(workflowPath, 'utf8');
+    const productionWorkflow = readFileSync(
+      productionReleaseWorkflowPath,
+      'utf8'
+    );
+    const previewBuild = getStepBlock(
+      getJobBlock(previewWorkflow, 'ci-pr-vercel-preview'),
+      'Build (PR preview)'
+    );
+    const productionBuild = getStepBlock(
+      getJobBlock(productionWorkflow, 'promote-production'),
+      'Build and stage production deployment'
+    );
+    const webPackage = JSON.parse(
+      readFileSync(resolve(repoRoot, 'apps/web/package.json'), 'utf8')
+    ) as { scripts: Record<string, string> };
+
+    expect(previewBuild).toContain("SKIP_SKILLS_CATALOG_SYNC: '1'");
+    expect(productionBuild).not.toContain('SKIP_SKILLS_CATALOG_SYNC');
+    expect(webPackage.scripts.postbuild).toContain(
+      'scripts/sync-skills-catalog.ts'
+    );
+  });
+
   it('keeps Vercel secrets and runtime values out of every preview and production process argument', () => {
     const previewWorkflow = readFileSync(workflowPath, 'utf8');
     const productionWorkflow = readFileSync(


### PR DESCRIPTION
## Production RCA

Vercel Linux function NFTs could retain Sharp's native addon without the matching libvips shared libraries, causing the production Sharp runtime failure. The postbuild repair resolves the exact Linux libc/architecture libvips package, adds libraries only to Sharp-backed NFT traces, and fails closed on missing or mismatched runtime artifacts.

## Preview build RCA and fix

The corrected Sharp contract was proven in manual workflow run 29969442935, job 89088069704: the public build succeeded and all three preview build attempts repaired 79/79 traces. Each preview attempt then reached the postbuild skills-catalog database mutation with an invalid Vercel preview DATABASE_URL. The PR preview build now sets SKIP_SKILLS_CATALOG_SYNC=1; production builds remain unsuppressed.

## Exact verification evidence

- Focused workflow regression: 94/94
- Skills catalog sync unit tests: 12/12
- Current-head bug-to-test proof before the fix: failed on the missing preview skip contract
- Web typecheck under Node 22: passed
- Biome on touched test: passed
- Actionlint: passed; only pre-existing ShellCheck advisories in unrelated workflow lines
- git diff --check: passed
- Normal commit hooks: passed, including secret scans, hygiene, governance, ESLint, and typecheck
- Normal pre-push hook: passed, including the exhaustive affected web test bundle
- Exact commit: 314db5675a9627f1cb011c410640d288b4e9c1aa

This PR remains ready and explicitly queue-deferred while production recovery is red.