### PR TITLE
fix(dependabot): use valid Electron major update type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
         patterns:
           - 'electron'
         update-types:
-          - 'version-update:semver-major'
+          - 'major'
     ignore:
       # Ignore ALL automated Clerk SDK updates — element-key naming drifts
       # silently between minor versions and breaks the AuthShell SSO-only

--- a/scripts/lib/__tests__/codeql-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/codeql-workflow-contract.test.mjs
@@ -14,6 +14,9 @@ const DEPENDABOT_CONFIG = readFileSync(
 const GITHUB_ACTIONS_DEPENDABOT = DEPENDABOT_CONFIG.match(
   /  - package-ecosystem: 'github-actions'[\s\S]*?(?=\n  - package-ecosystem:|$)/
 )?.[0];
+const NPM_DEPENDABOT = DEPENDABOT_CONFIG.match(
+  /  - package-ecosystem: 'npm'[\s\S]*?(?=\n  - package-ecosystem:|$)/
+)?.[0];
 
 const CODEQL_ACTION_PIN =
   /^\s*uses:\s*github\/codeql-action\/([^@\s]+)@([0-9a-f]{40})\s+#\s+(v\S+)\s*$/gm;
@@ -36,6 +39,12 @@ describe('CodeQL workflow version coherence', () => {
   it('groups CodeQL action updates so Dependabot moves every component together', () => {
     expect(GITHUB_ACTIONS_DEPENDABOT).toMatch(
       /groups:\n(?:\s+#.*\n)*\s+codeql-action:\n\s+patterns:\n\s+- 'github\/codeql-action'/
+    );
+  });
+
+  it('uses Dependabot schema values for Electron major updates', () => {
+    expect(NPM_DEPENDABOT).toMatch(
+      /electron-major:[\s\S]*?update-types:\n\s+- 'major'/
     );
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2569 -->

## Summary
- Replace the invalid Dependabot `version-update:semver-major` value with the schema-valid `major` value for the `electron-major` npm group.
- Add a focused executable contract assertion to the existing Dependabot config test surface.

## Verification
- YAML parse and Electron schema contract: PASS
- Vitest: 1 file, 3 tests passed
- Biome: PASS for changed test file
- `pnpm turbo typecheck`: 10/10 packages passed
- Protected pre-push: proxy guard, Tailwind guard, affected typecheck/lint, CI harness check passed
- Bug-to-test: not applicable (config-only fix)

## Scope
No dependency manifests, lockfiles, queue enrollment, merge, or deploy actions.