### PR TITLE
fix(desktop): pass publish version as equals option

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1002,7 +1002,7 @@ jobs:
           }
           pnpm --filter @jovie/desktop exec electron-builder publish \
             --config electron-builder.yml \
-            --version "$release_version" \
+            --version="$release_version" \
             --files "${publish_files[@]}"
 
       - name: Capture production publisher identity

--- a/scripts/desktop-release-guard.test.mjs
+++ b/scripts/desktop-release-guard.test.mjs
@@ -339,3 +339,13 @@ test('desktop staging is a bounded artifact and production is separately proven'
   assert.doesNotMatch(marker, /contents: write|electron-builder publish/);
   assert.doesNotMatch(desktopWorkflow, /--publish always/);
 });
+
+test('desktop publisher passes the release version as an equals-form option', () => {
+  const publish = step(
+    job(desktopWorkflow, 'build'),
+    'Publish production desktop release'
+  );
+
+  assert.match(publish, /--version="\$release_version"/);
+  assert.doesNotMatch(publish, /--version\s+"\$release_version"/);
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4401 -->

## Summary

Fixes the electron-builder publish parser regression by changing the workflow token from separated `--version "$release_version"` to equals-form `--version="$release_version"`.

Adds executable workflow-contract coverage requiring equals form and rejecting the separated form.

## Verification

- Regression test: `scripts/desktop-release-guard.test.mjs`
- `node --test scripts/desktop-release-guard.test.mjs` (15/15)
- `pnpm biome check --write scripts/desktop-release-guard.test.mjs`
- `pnpm turbo typecheck`
- `pnpm run ci:harness:check`
- `pnpm run ci:branching-guard validate`
- `pnpm --filter @jovie/web run test:bug-to-test` with this regression reference
- actionlint and Ruby YAML parse
- pinned electron-builder 25.1.8 parser probe accepted `--version=26.7.0` before expected config validation failure
- `git diff --check`

bug-to-test: satisfied

This PR does not publish artifacts, rerun the desktop release, enqueue the PR, merge, deploy, or mutate the issue-dispatch pause.