### PR TITLE
fix(ci): poll heartbeat job evidence to settlement

### DIFF
--- a/.github/scripts/query-runner-heartbeat.sh
+++ b/.github/scripts/query-runner-heartbeat.sh
@@ -5,6 +5,8 @@ set -uo pipefail
 HEARTBEAT_WORKFLOW="${HEARTBEAT_WORKFLOW:-runner-heartbeat.yml}"
 HEARTBEAT_MAX_AGE_SECONDS="${HEARTBEAT_MAX_AGE_SECONDS:-1500}"
 HEARTBEAT_API_TIMEOUT_SECONDS="${HEARTBEAT_API_TIMEOUT_SECONDS:-20}"
+HEARTBEAT_JOB_POLL_ATTEMPTS="${HEARTBEAT_JOB_POLL_ATTEMPTS:-3}"
+HEARTBEAT_JOB_POLL_INTERVAL_SECONDS="${HEARTBEAT_JOB_POLL_INTERVAL_SECONDS:-2}"
 HEARTBEAT_EXPECTED_SHA="${HEARTBEAT_EXPECTED_SHA:-}"
 HEARTBEAT_EXPECTED_EVENT="${HEARTBEAT_EXPECTED_EVENT:-}"
 HEARTBEAT_GH_TEST_HELPER="${HEARTBEAT_GH_TEST_HELPER:-}"
@@ -58,6 +60,12 @@ if ! [[ "$HEARTBEAT_MAX_AGE_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if ! [[ "$HEARTBEAT_API_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
   degrade uncertain "heartbeat API timeout is malformed"
+fi
+if ! [[ "$HEARTBEAT_JOB_POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  degrade uncertain "heartbeat job poll bound is malformed"
+fi
+if ! [[ "$HEARTBEAT_JOB_POLL_INTERVAL_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  degrade uncertain "heartbeat job poll interval is malformed"
 fi
 
 STRICT_EXPECTATION=false
@@ -180,36 +188,86 @@ case "$status" in
     ;;
 esac
 
-if ! jobs_json="$(heartbeat_gh_api \
-  --paginate --slurp \
-  "repos/$GH_REPO/actions/runs/$run_id/attempts/$run_attempt/jobs?per_page=100" \
-  2>/dev/null)"; then
-  degrade uncertain "exact heartbeat job API is unavailable"
-fi
-if ! jq -e '
-  type == "array" and length > 0 and
-  all(.[]; type == "object" and (.jobs | type == "array"))
-' >/dev/null <<<"$jobs_json"; then
-  degrade uncertain "exact heartbeat job evidence is malformed"
-fi
-heartbeat_jobs="$(jq -c '
-  [
-    .[] | .jobs[]? |
-    select(.name == "Self-hosted runner heartbeat")
-  ] | unique_by(.id)
-' <<<"$jobs_json")"
-if ! jq -e --argjson run_id "$run_id" --arg head_sha "$head_sha" '
-  length == 1 and
-  (.[0].id | type == "number" and . > 0) and
-  .[0].run_id == $run_id and
-  .[0].head_sha == $head_sha and
-  .[0].status == "completed" and
-  .[0].conclusion == "success" and
-  (.[0].runner_id | type == "number" and . > 0) and
-  (.[0].runner_name | type == "string" and length > 0) and
-  (.[0].labels | type == "array" and index("jovie-runner") != null)
-' >/dev/null <<<"$heartbeat_jobs"; then
-  degrade uncertain "exact heartbeat job did not complete successfully"
-fi
+jobs_endpoint="repos/$GH_REPO/actions/runs/$run_id/attempts/$run_attempt/jobs?per_page=100"
+heartbeat_job_id=""
+for ((job_poll_attempt = 1; job_poll_attempt <= HEARTBEAT_JOB_POLL_ATTEMPTS; job_poll_attempt++)); do
+  if ! jobs_json="$(heartbeat_gh_api \
+    --paginate --slurp \
+    "$jobs_endpoint" \
+    2>/dev/null)"; then
+    degrade uncertain "exact heartbeat job API is unavailable"
+  fi
+  if ! jq -e '
+    type == "array" and length > 0 and
+    all(.[]; type == "object" and (.jobs | type == "array"))
+  ' >/dev/null <<<"$jobs_json"; then
+    degrade uncertain "exact heartbeat job evidence is malformed"
+  fi
+  if ! heartbeat_jobs="$(jq -c '
+    [
+      .[] | .jobs[]? |
+      select(.name == "Self-hosted runner heartbeat")
+    ] | unique_by(.id)
+  ' <<<"$jobs_json")"; then
+    degrade uncertain "exact heartbeat job evidence is malformed"
+  fi
+  if ! jq -e \
+    --argjson run_id "$run_id" \
+    --argjson run_attempt "$run_attempt" \
+    --arg head_sha "$head_sha" '
+    length == 1 and
+    (.[0].id | type == "number" and . > 0) and
+    (.[0].run_id | type == "number") and
+    .[0].run_id == $run_id and
+    (.[0].run_attempt | type == "number") and
+    .[0].run_attempt == $run_attempt and
+    (.[0].head_sha | type == "string") and
+    .[0].head_sha == $head_sha and
+    (.[0].status | type == "string") and
+    ((.[0].conclusion // "") | type == "string")
+  ' >/dev/null <<<"$heartbeat_jobs"; then
+    degrade uncertain "exact heartbeat job identity is malformed or changed"
+  fi
 
-emit_health up healthy "exact heartbeat run $run_id attempt $run_attempt succeeded ${age_seconds}s ago ($run_url)"
+  current_job_id="$(jq -r '.[0].id' <<<"$heartbeat_jobs")"
+  if [[ -n "$heartbeat_job_id" && "$current_job_id" != "$heartbeat_job_id" ]]; then
+    degrade uncertain "exact heartbeat job identity changed while polling"
+  fi
+  heartbeat_job_id="$current_job_id"
+  job_status="$(jq -r '.[0].status' <<<"$heartbeat_jobs")"
+  job_conclusion="$(jq -r '.[0].conclusion // ""' <<<"$heartbeat_jobs")"
+
+  case "$job_status" in
+    completed)
+      if [[ "$job_conclusion" != "success" ]]; then
+        if [[ -n "$job_conclusion" ]]; then
+          degrade unhealthy "exact heartbeat job completed with conclusion=$job_conclusion"
+        fi
+        degrade uncertain "exact heartbeat job conclusion is malformed"
+      fi
+      if ! jq -e '
+        (.[0].runner_id | type == "number" and . > 0) and
+        (.[0].runner_name | type == "string" and length > 0) and
+        (.[0].labels | type == "array" and index("jovie-runner") != null)
+      ' >/dev/null <<<"$heartbeat_jobs"; then
+        degrade uncertain "exact heartbeat runner identity is malformed or missing"
+      fi
+      emit_health up healthy "exact heartbeat run $run_id attempt $run_attempt succeeded ${age_seconds}s ago ($run_url)"
+      exit 0
+      ;;
+    queued|in_progress|waiting|requested|pending)
+      if [[ -n "$job_conclusion" ]]; then
+        degrade unhealthy "exact heartbeat job is status=$job_status conclusion=$job_conclusion"
+      fi
+      if (( job_poll_attempt == HEARTBEAT_JOB_POLL_ATTEMPTS )); then
+        degrade unhealthy "exact heartbeat job remained unsettled after ${HEARTBEAT_JOB_POLL_ATTEMPTS} observations"
+      fi
+      sleep "$HEARTBEAT_JOB_POLL_INTERVAL_SECONDS"
+      ;;
+    *)
+      degrade uncertain "exact heartbeat job status is not recognized"
+      ;;
+  esac
+done
+
+degrade unhealthy "exact heartbeat job polling exhausted its bound"

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -421,6 +421,8 @@ jobs:
     env:
       HEARTBEAT_MAX_AGE_SECONDS: '1500'
       HEARTBEAT_API_TIMEOUT_SECONDS: '20'
+      HEARTBEAT_JOB_POLL_ATTEMPTS: '3'
+      HEARTBEAT_JOB_POLL_INTERVAL_SECONDS: '2'
 
     steps:
       - name: Checkout main policy code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
           HEARTBEAT_MAX_AGE_SECONDS: '900'
           HEARTBEAT_API_TIMEOUT_SECONDS: '5'
+          HEARTBEAT_JOB_POLL_ATTEMPTS: '3'
+          HEARTBEAT_JOB_POLL_INTERVAL_SECONDS: '2'
           HEARTBEAT_EXPECTED_EVENT: ''
           HEARTBEAT_EXPECTED_SHA: ''
           HEARTBEAT_POLL_ATTEMPTS: '10'

--- a/.github/workflows/runner-health-monitor.yml
+++ b/.github/workflows/runner-health-monitor.yml
@@ -36,6 +36,8 @@ jobs:
     env:
       HEARTBEAT_MAX_AGE_SECONDS: '1500'
       HEARTBEAT_API_TIMEOUT_SECONDS: '20'
+      HEARTBEAT_JOB_POLL_ATTEMPTS: '3'
+      HEARTBEAT_JOB_POLL_INTERVAL_SECONDS: '2'
     steps:
       - name: Checkout main policy code
         continue-on-error: true

--- a/scripts/tests/fixtures/runner-heartbeat-gh/gh
+++ b/scripts/tests/fixtures/runner-heartbeat-gh/gh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${HEARTBEAT_FIXTURE_SCENARIO:?HEARTBEAT_FIXTURE_SCENARIO is required}"
+: "${HEARTBEAT_FIXTURE_STATE_DIR:?HEARTBEAT_FIXTURE_STATE_DIR is required}"
+
+mkdir -p "$HEARTBEAT_FIXTURE_STATE_DIR"
+endpoint=""
+for argument in "$@"; do
+  if [[ "$argument" == repos/* ]]; then
+    endpoint="$argument"
+  fi
+done
+
+run_id=29989764821
+run_attempt=1
+head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+if [[ "$endpoint" == *'/jobs?per_page=100' ]]; then
+  expected_endpoint="repos/JovieInc/Jovie/actions/runs/$run_id/attempts/$run_attempt/jobs?per_page=100"
+  if [[ "$endpoint" != "$expected_endpoint" ]]; then
+    echo "unexpected jobs endpoint" >&2
+    exit 1
+  fi
+  jobs_count_file="$HEARTBEAT_FIXTURE_STATE_DIR/jobs-count"
+  jobs_count=0
+  if [[ -f "$jobs_count_file" ]]; then
+    jobs_count="$(<"$jobs_count_file")"
+  fi
+  jobs_count=$((jobs_count + 1))
+  echo "$jobs_count" > "$jobs_count_file"
+
+  job_status='completed'
+  job_conclusion='"success"'
+  job_run_id="$run_id"
+  job_run_attempt="$run_attempt"
+  job_head_sha="$head_sha"
+  runner_id='55'
+  runner_name='"gem-linux-2"'
+  labels='["jovie-runner"]'
+
+  case "$HEARTBEAT_FIXTURE_SCENARIO" in
+    lagging-then-settled)
+      if (( jobs_count == 1 )); then
+        job_status='in_progress'
+        job_conclusion='null'
+      fi
+      ;;
+    persistent-lag)
+      job_status='in_progress'
+      job_conclusion='null'
+      ;;
+    changed-evidence)
+      if (( jobs_count == 1 )); then
+        job_status='in_progress'
+        job_conclusion='null'
+      else
+        job_head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      fi
+      ;;
+    wrong-identity)
+      job_run_id=42
+      ;;
+    missing-label)
+      labels='["ubuntu-latest"]'
+      ;;
+    failed)
+      job_status='completed'
+      job_conclusion='"failure"'
+      ;;
+    *)
+      echo "unknown fixture scenario" >&2
+      exit 2
+      ;;
+  esac
+
+  cat <<JSON
+[{"jobs":[{"id":89149681067,"run_id":$job_run_id,"run_attempt":$job_run_attempt,"head_sha":"$job_head_sha","name":"Self-hosted runner heartbeat","status":"$job_status","conclusion":$job_conclusion,"runner_id":$runner_id,"runner_name":$runner_name,"labels":$labels}]}]
+JSON
+  exit 0
+fi
+
+updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat <<JSON
+{"workflow_runs":[{"id":$run_id,"run_attempt":$run_attempt,"name":"Runner Heartbeat","path":".github/workflows/runner-heartbeat.yml","head_branch":"main","head_sha":"$head_sha","head_repository":{"full_name":"JovieInc/Jovie"},"event":"schedule","status":"completed","conclusion":"success","updated_at":"$updated_at","html_url":"https://github.com/JovieInc/Jovie/actions/runs/$run_id"}]}
+JSON

--- a/scripts/tests/test_runner_routing.py
+++ b/scripts/tests/test_runner_routing.py
@@ -15,6 +15,9 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
 _QUERY_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "query-runner-heartbeat.sh"
 _AWAIT_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "await-runner-heartbeat.sh"
+_FIXTURE_GH = (
+    _REPO_ROOT / "scripts" / "tests" / "fixtures" / "runner-heartbeat-gh" / "gh"
+)
 
 
 def _job_block(workflow: str, job_name: str) -> str:
@@ -115,6 +118,7 @@ def _exact_evidence(
     job: dict[str, Any] = {
         "id": 843137,
         "run_id": run["id"],
+        "run_attempt": run["run_attempt"],
         "head_sha": run.get("head_sha", head_sha),
         "name": "Self-hosted runner heartbeat",
         "status": "completed",
@@ -189,6 +193,53 @@ def _run_query(
             key, value = line.split("=", 1)
             outputs[key] = value
     return result, outputs
+
+
+def _run_fixture_query(
+    tmp_path: Path,
+    scenario: str,
+    *,
+    attempts: int = 3,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str], int]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    state_dir = tmp_path / "fixture-state"
+    output = tmp_path / "github-output"
+    fake_sleep = tmp_path / "sleep"
+    fake_sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_sleep.chmod(fake_sleep.stat().st_mode | stat.S_IXUSR)
+    env = os.environ.copy()
+    env.pop("GITHUB_ACTIONS", None)
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "GH_REPO": "JovieInc/Jovie",
+            "GITHUB_OUTPUT": str(output),
+            "HEARTBEAT_GH_TEST_HELPER": str(_FIXTURE_GH),
+            "HEARTBEAT_GH_TEST_MODE": "1",
+            "HEARTBEAT_MAX_AGE_SECONDS": "900",
+            "HEARTBEAT_API_TIMEOUT_SECONDS": "5",
+            "HEARTBEAT_JOB_POLL_ATTEMPTS": str(attempts),
+            "HEARTBEAT_JOB_POLL_INTERVAL_SECONDS": "1",
+            "HEARTBEAT_FIXTURE_SCENARIO": scenario,
+            "HEARTBEAT_FIXTURE_STATE_DIR": str(state_dir),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(_QUERY_SCRIPT)],
+        cwd=_REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    outputs: dict[str, str] = {}
+    if output.exists():
+        for line in output.read_text(encoding="utf-8").splitlines():
+            key, value = line.split("=", 1)
+            outputs[key] = value
+    jobs_count_file = state_dir / "jobs-count"
+    jobs_count = int(jobs_count_file.read_text(encoding="utf-8"))
+    return result, outputs, jobs_count
 
 
 def _run_await(
@@ -268,6 +319,52 @@ def test_exact_fresh_run_and_job_prove_fixed_runner_health(tmp_path: Path) -> No
     assert outputs["health"] == "up", outputs
     assert outputs["probe_state"] == "healthy"
     assert "run 29672288797 attempt 1" in outputs["evidence"]
+
+
+def test_terminal_run_with_lagging_job_polls_same_attempt_to_settled_success(
+    tmp_path: Path,
+) -> None:
+    result, outputs, jobs_count = _run_fixture_query(
+        tmp_path, "lagging-then-settled"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert jobs_count == 2
+    assert outputs["health"] == "up", outputs
+    assert outputs["probe_state"] == "healthy"
+    assert "run 29989764821 attempt 1" in outputs["evidence"]
+
+
+def test_persistent_lag_times_out_fail_closed_after_bounded_job_polls(
+    tmp_path: Path,
+) -> None:
+    result, outputs, jobs_count = _run_fixture_query(
+        tmp_path, "persistent-lag", attempts=3
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert jobs_count == 3
+    assert outputs["health"] == "down"
+    assert outputs["probe_state"] == "unhealthy"
+    assert "remained unsettled after 3 observations" in outputs["evidence"]
+
+
+def test_job_identity_drift_missing_label_and_non_success_fail_closed(
+    tmp_path: Path,
+) -> None:
+    cases = (
+        ("wrong-identity", "uncertain"),
+        ("changed-evidence", "uncertain"),
+        ("missing-label", "uncertain"),
+        ("failed", "unhealthy"),
+    )
+
+    for scenario, expected_state in cases:
+        result, outputs, _ = _run_fixture_query(tmp_path / scenario, scenario)
+
+        assert result.returncode == 0, result.stderr
+        assert outputs["health"] == "down"
+        assert outputs["probe_state"] == expected_state, outputs
 
 
 def test_production_actions_context_cannot_authorize_test_gh_helper(
@@ -613,6 +710,8 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert "secrets." not in route
     assert "GH_TOKEN: ${{ github.token }}" in route
     assert "HEARTBEAT_API_TIMEOUT_SECONDS: '5'" in route
+    assert "HEARTBEAT_JOB_POLL_ATTEMPTS: '3'" in route
+    assert "HEARTBEAT_JOB_POLL_INTERVAL_SECONDS: '2'" in route
     assert "HEARTBEAT_POLL_ATTEMPTS: '10'" in route
     assert "HEARTBEAT_POLL_INTERVAL_SECONDS: '5'" in route
     assert "HEARTBEAT_EXPECTED_EVENT:" in route
@@ -630,6 +729,9 @@ def test_ci_route_is_trusted_secretless_bounded_and_nonblocking() -> None:
     assert '.[0].run_id == $run_id' in query
     assert '.[0].head_sha == $head_sha' in query
     assert 'index("jovie-runner") != null' in query
+    assert 'jobs_endpoint="repos/$GH_REPO/actions/runs/$run_id/attempts/$run_attempt/jobs?per_page=100"' in query
+    assert '.[0].run_attempt == $run_attempt' in query
+    assert "HEARTBEAT_JOB_POLL_ATTEMPTS" in query
     assert 'degrade pending "current exact heartbeat' in query
     assert "for ((attempt = 1; attempt <= POLL_ATTEMPTS; attempt++))" in awaiter
     assert 'if [[ "$probe_state" != "pending" ]]' in awaiter


### PR DESCRIPTION
## Summary

- Poll the exact heartbeat run/attempt jobs endpoint within a bounded 3-observation, 2-second interval.
- Accept runner health only after the same job identity, run attempt, SHA, successful conclusion, runner identity, and `jovie-runner` label settle.
- Fail closed to hosted capacity on timeout, identity/evidence drift, malformed evidence, missing labels, or non-success.

## Incident rationale

This addresses [runner heartbeat terminal evidence inconsistency](https://github.com/JovieInc/Jovie/issues/14752): workflow run [29989764821](https://github.com/JovieInc/Jovie/actions/runs/29989764821) and its steps were terminal-success while exact job `89149681067` was still reported `in_progress`, causing a safe but false-down observer result. The fix preserves fail-closed routing while allowing bounded GitHub eventual-consistency lag to settle.

## Testing

- `pytest -q scripts/tests/test_runner_routing.py scripts/tests/test_agent_workflow_hygiene.py` — 54 passed
- `bash -n` and `shellcheck` on both touched shell files — passed
- canonical `actionlint` on all three touched workflows — passed
- web typecheck under Node 22.23.1 — passed
- `git diff --check` — passed
- `bug-to-test: satisfied` — executable regression coverage in `scripts/tests/test_runner_routing.py` covers lagging-to-settled success, bounded persistent lag, wrong identity, changed evidence, missing label, and failed conclusion

No routing variables, runners, incidents, queues, workflows, deploys, or live canaries were mutated.