### PR TITLE
fix(storybook): polyfill process for Chromatic browser extraction

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -45,10 +45,30 @@ const config: StorybookConfig = {
     disableTelemetry: true,
   },
   viteFinal: async config => {
-    // Handle Node.js modules for browser compatibility
+    // Handle Node.js modules for browser compatibility.
+    // Chromatic extracts stories in a real browser. Client components that
+    // reference process.env.* crash extraction with
+    // "ReferenceError: process is not defined" (seen on Sidebar.stories).
+    // Define individual keys only — never replace the whole `process` object
+    // with a JSON string (that breaks process.env.FOO member access).
     config.define = {
       ...config.define,
       global: 'globalThis',
+      'process.env.NODE_ENV': JSON.stringify(
+        process.env.NODE_ENV || 'development'
+      ),
+      'process.env.NEXT_PUBLIC_APP_VERSION': JSON.stringify(
+        process.env.NEXT_PUBLIC_APP_VERSION || '0.0.0-storybook'
+      ),
+      'process.env.NEXT_PUBLIC_BUILD_SHA': JSON.stringify(
+        process.env.NEXT_PUBLIC_BUILD_SHA || 'storybook'
+      ),
+      'process.env.NEXT_PUBLIC_CI': JSON.stringify(
+        process.env.NEXT_PUBLIC_CI || ''
+      ),
+      'process.env.NEXT_PUBLIC_DEMO_RECORDING': JSON.stringify(
+        process.env.NEXT_PUBLIC_DEMO_RECORDING || ''
+      ),
     };
 
     // Ensure TypeScript files are properly handled

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -16,7 +16,28 @@ import '../app/globals.css';
 const FIXED_NOW = new Date('2026-01-15T12:00:00.000Z');
 const STABLE_ID_PREFIX = 'sb-stable';
 
+function installProcessPolyfill(): void {
+  // Chromatic story extraction runs in a browser. Vite `define` rewrites most
+  // process.env.* references, but a global fallback prevents hard crashes if
+  // any residual bare `process` access remains in the story graph.
+  const g = globalThis as typeof globalThis & {
+    process?: { env?: Record<string, string | undefined> };
+  };
+  if (!g.process) {
+    g.process = { env: {} };
+  }
+  if (!g.process.env) {
+    g.process.env = {};
+  }
+  const env = g.process.env;
+  env.NODE_ENV = env.NODE_ENV || 'development';
+  env.NEXT_PUBLIC_APP_VERSION =
+    env.NEXT_PUBLIC_APP_VERSION || '0.0.0-storybook';
+  env.NEXT_PUBLIC_BUILD_SHA = env.NEXT_PUBLIC_BUILD_SHA || 'storybook';
+}
+
 function installDeterministicFixtures(): void {
+  installProcessPolyfill();
   if (typeof window === 'undefined') return;
   if (
     (window as Window & { __jovieStorybookFixtures?: boolean })


### PR DESCRIPTION
## Summary
- Chromatic MQ lane fails with `ReferenceError: process is not defined` during story extraction (`Sidebar.stories` graph).
- Add Vite `define` for common `process.env.*` keys used by client/story code.
- Add a small global `process` fallback in Storybook preview for residual bare `process` access.

## Why
Merge queue is blocked on Chromatic for Storybook/visual PRs (#14660). A11y/Chromatic were the reported bottleneck; this is the concrete Chromatic extraction crash.

## Test plan
- [ ] Chromatic Visual Regression check passes on this PR / merge group
- [ ] Storybook local still boots (`pnpm --filter @jovie/web run storybook`)
- [ ] No product runtime change outside Storybook config

## Notes
- Does not weaken gates; fixes the failure root cause.
- Separate unit-test flake on `suggested-actions-approve-route` passes locally on main; track if it reappears after this lands.