### PR TITLE
fix(storybook): unblock local preview + green vitest a11y suite

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -257,23 +257,128 @@ const config: StorybookConfig = {
           find: '@jovie/ui',
           replacement: path.resolve(__dirname, '../../../packages/ui'),
         },
+        // Force real React packages. Next's compiled react
+        // (next/dist/compiled/react) is CJS-without-default-export and breaks
+        // the Storybook preview ESM graph ("does not provide an export named
+        // 'default'"), leaving the iframe spinner forever.
+        {
+          find: /^react$/,
+          replacement: require.resolve('react'),
+        },
+        {
+          find: /^react-dom$/,
+          replacement: require.resolve('react-dom'),
+        },
+        {
+          find: /^react\/jsx-runtime$/,
+          replacement: require.resolve('react/jsx-runtime'),
+        },
+        {
+          find: /^react\/jsx-dev-runtime$/,
+          replacement: require.resolve('react/jsx-dev-runtime'),
+        },
         { find: '@', replacement: path.resolve(__dirname, '..') },
         ...normalizedAlias,
       ],
+      dedupe: ['react', 'react-dom'],
     };
 
-    // Configure Vite to handle TypeScript and JSX properly
+    // Storybook 10 + modern packages need a current esbuild target.
+    // `es2020` makes esbuild hard-fail on object rest/destructuring in
+    // Storybook/Next packages ("Transforming destructuring ... is not supported"),
+    // which either spams the log or fails the preview build entirely.
     config.esbuild = {
       ...config.esbuild,
-      target: 'es2020',
-      loader: 'tsx',
-      include: /\.(ts|tsx|js|jsx)$/,
+      target: 'esnext',
     };
 
-    // Exclude @clerk/elements from dependency optimization to prevent package.json lookup warning
+    // Keep optimizeDeps on, but never hold browser requests until crawl end.
+    // In this monorepo the crawl is huge; holding deps leaves the iframe spinner
+    // forever while /sb-vite/deps/* never materializes.
     config.optimizeDeps = {
       ...config.optimizeDeps,
       exclude: [...(config.optimizeDeps?.exclude || []), '@clerk/elements'],
+      holdUntilCrawlEnd: false,
+      esbuildOptions: {
+        ...(config.optimizeDeps?.esbuildOptions || {}),
+        target: 'esnext',
+      },
+    };
+
+    // Absolute-path imports of next/dist/compiled/react bypass resolve.alias.
+    // Intercept them in resolveId so the preview gets real React ESM.
+    const reactPkg = require.resolve('react');
+    const reactDomPkg = require.resolve('react-dom');
+    const jsxRuntime = require.resolve('react/jsx-runtime');
+    const jsxDevRuntime = require.resolve('react/jsx-dev-runtime');
+    const rewriteNextReactPlugin = {
+      name: 'jovie-storybook-rewrite-next-react',
+      enforce: 'pre' as const,
+      resolveId(source: string) {
+        const normalized = source.replace(/\\/g, '/');
+        if (normalized.includes('next/dist/compiled/react-dom')) {
+          return reactDomPkg;
+        }
+        if (normalized.includes('next/dist/compiled/react/jsx-dev-runtime')) {
+          return jsxDevRuntime;
+        }
+        if (normalized.includes('next/dist/compiled/react/jsx-runtime')) {
+          return jsxRuntime;
+        }
+        if (
+          normalized.includes('next/dist/compiled/react/index.js') ||
+          normalized.endsWith('next/dist/compiled/react') ||
+          normalized.includes('next/dist/compiled/react.js')
+        ) {
+          return reactPkg;
+        }
+        return null;
+      },
+    };
+
+    // Vercel Workflow / WDK Vite plugins (from next.config withWorkflow) emit
+    // continuous page reloads of app/.well-known/workflow/* and can starve
+    // Storybook's optimized-deps generation. Strip them for local Storybook.
+    const stripWorkflowPlugins = (plugins: unknown): unknown[] => {
+      const list = Array.isArray(plugins) ? plugins : plugins ? [plugins] : [];
+      return list.filter(plugin => {
+        const name =
+          plugin &&
+          typeof plugin === 'object' &&
+          'name' in plugin &&
+          typeof (plugin as { name?: unknown }).name === 'string'
+            ? String((plugin as { name: string }).name).toLowerCase()
+            : '';
+        if (!name) return true;
+        return !(
+          name.includes('workflow') ||
+          name.includes('wdk') ||
+          name.includes('vercel-toolbar')
+        );
+      });
+    };
+    config.plugins = [
+      rewriteNextReactPlugin,
+      ...stripWorkflowPlugins(config.plugins),
+    ] as typeof config.plugins;
+
+    // Ignore workflow generated routes so HMR does not thrash the preview iframe.
+    config.server = {
+      ...config.server,
+      watch: {
+        ...(config.server &&
+        typeof config.server === 'object' &&
+        'watch' in config.server &&
+        config.server.watch &&
+        typeof config.server.watch === 'object'
+          ? config.server.watch
+          : {}),
+        ignored: [
+          '**/app/.well-known/workflow/**',
+          '**/.well-known/workflow/**',
+          '**/node_modules/**',
+        ],
+      },
     };
 
     // Suppress "use client" directive warnings in build output

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -18,7 +18,7 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y',
     '@storybook/addon-vitest',
     '@chromatic-com/storybook',
-    '@storybook/addon-mcp'
+    '@storybook/addon-mcp',
   ],
   framework: {
     name: '@storybook/nextjs-vite',

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -18,6 +18,7 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y',
     '@storybook/addon-vitest',
     '@chromatic-com/storybook',
+    '@storybook/addon-mcp'
   ],
   framework: {
     name: '@storybook/nextjs-vite',
@@ -257,30 +258,21 @@ const config: StorybookConfig = {
           find: '@jovie/ui',
           replacement: path.resolve(__dirname, '../../../packages/ui'),
         },
-        // Force real React packages. Next's compiled react
-        // (next/dist/compiled/react) is CJS-without-default-export and breaks
-        // the Storybook preview ESM graph ("does not provide an export named
-        // 'default'"), leaving the iframe spinner forever.
-        {
-          find: /^react$/,
-          replacement: require.resolve('react'),
-        },
-        {
-          find: /^react-dom$/,
-          replacement: require.resolve('react-dom'),
-        },
-        {
-          find: /^react\/jsx-runtime$/,
-          replacement: require.resolve('react/jsx-runtime'),
-        },
-        {
-          find: /^react\/jsx-dev-runtime$/,
-          replacement: require.resolve('react/jsx-dev-runtime'),
-        },
+        // Keep React as bare package IDs (not absolute CJS paths). Absolute
+        // require.resolve('react') forces Vite to serve raw /@fs CJS without
+        // default-export interop, which breaks browser-mode story tests
+        // ("does not provide an export named 'default'"). Bare IDs let
+        // optimizeDeps prebundle + interop correctly. next/dist/compiled/react
+        // is rewritten to bare 'react' below.
         { find: '@', replacement: path.resolve(__dirname, '..') },
         ...normalizedAlias,
       ],
-      dedupe: ['react', 'react-dom'],
+      dedupe: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
     };
 
     // Storybook 10 + modern packages need a current esbuild target.
@@ -299,40 +291,76 @@ const config: StorybookConfig = {
       ...config.optimizeDeps,
       exclude: [...(config.optimizeDeps?.exclude || []), '@clerk/elements'],
       holdUntilCrawlEnd: false,
+      // React 19 CJS entries need default-export interop in the browser ESM graph.
+      needsInterop: [
+        ...new Set([
+          ...(config.optimizeDeps?.needsInterop || []),
+          'react',
+          'react-dom',
+          'react-dom/client',
+        ]),
+      ],
+      include: [
+        ...new Set([
+          ...(config.optimizeDeps?.include || []),
+          'react',
+          'react-dom',
+          'react/jsx-runtime',
+          'react/jsx-dev-runtime',
+          'react-dom/client',
+        ]),
+      ],
       esbuildOptions: {
         ...(config.optimizeDeps?.esbuildOptions || {}),
         target: 'esnext',
       },
     };
 
-    // Absolute-path imports of next/dist/compiled/react bypass resolve.alias.
-    // Intercept them in resolveId so the preview gets real React ESM.
-    const reactPkg = require.resolve('react');
-    const reactDomPkg = require.resolve('react-dom');
-    const jsxRuntime = require.resolve('react/jsx-runtime');
-    const jsxDevRuntime = require.resolve('react/jsx-dev-runtime');
+    // Absolute-path imports of next/dist/compiled/react bypass package resolution.
+    // Re-resolve through Vite so optimizeDeps + needsInterop still apply.
+    // Do NOT return bare 'react' (already-resolved) or absolute CJS paths
+    // (raw /@fs without default-export interop).
     const rewriteNextReactPlugin = {
       name: 'jovie-storybook-rewrite-next-react',
       enforce: 'pre' as const,
-      resolveId(source: string) {
+      async resolveId(
+        this: {
+          resolve: (
+            source: string,
+            importer: string | undefined,
+            options: { skipSelf?: boolean }
+          ) => Promise<{ id: string } | null>;
+        },
+        source: string,
+        importer: string | undefined
+      ) {
         const normalized = source.replace(/\\/g, '/');
+        if (!normalized.includes('next/dist/compiled/react')) {
+          return null;
+        }
+
+        let bare: string | null = null;
         if (normalized.includes('next/dist/compiled/react-dom')) {
-          return reactDomPkg;
-        }
-        if (normalized.includes('next/dist/compiled/react/jsx-dev-runtime')) {
-          return jsxDevRuntime;
-        }
-        if (normalized.includes('next/dist/compiled/react/jsx-runtime')) {
-          return jsxRuntime;
-        }
-        if (
+          bare = 'react-dom';
+        } else if (
+          normalized.includes('next/dist/compiled/react/jsx-dev-runtime')
+        ) {
+          bare = 'react/jsx-dev-runtime';
+        } else if (
+          normalized.includes('next/dist/compiled/react/jsx-runtime')
+        ) {
+          bare = 'react/jsx-runtime';
+        } else if (
           normalized.includes('next/dist/compiled/react/index.js') ||
           normalized.endsWith('next/dist/compiled/react') ||
           normalized.includes('next/dist/compiled/react.js')
         ) {
-          return reactPkg;
+          bare = 'react';
         }
-        return null;
+
+        if (!bare) return null;
+
+        return this.resolve(bare, importer, { skipSelf: true });
       },
     };
 

--- a/apps/web/vitest.config.storybook.mts
+++ b/apps/web/vitest.config.storybook.mts
@@ -2,12 +2,58 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Next's compiled React (next/dist/compiled/react*) is CJS without a default
+ * export. Rewrite those ids by re-resolving the real package name so Vite keeps
+ * the id on the package graph and can apply optimizeDeps + needsInterop.
+ *
+ * Critical: do NOT return a bare string 'react' (already-resolved, breaks load)
+ * and do NOT return require.resolve('react') absolute paths (served as raw
+ * /@fs CJS without default-export interop). Always use this.resolve().
+ */
+function rewriteNextCompiledReactPlugin(): Plugin {
+  return {
+    name: 'jovie-vitest-storybook-rewrite-next-react',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      const normalized = source.replace(/\\/g, '/');
+      if (!normalized.includes('next/dist/compiled/react')) {
+        return null;
+      }
+
+      let bare: string | null = null;
+      if (normalized.includes('next/dist/compiled/react-dom')) {
+        bare = 'react-dom';
+      } else if (normalized.includes('next/dist/compiled/react/jsx-dev-runtime')) {
+        bare = 'react/jsx-dev-runtime';
+      } else if (normalized.includes('next/dist/compiled/react/jsx-runtime')) {
+        bare = 'react/jsx-runtime';
+      } else if (
+        normalized.includes('next/dist/compiled/react/index.js') ||
+        normalized.endsWith('next/dist/compiled/react') ||
+        normalized.includes('next/dist/compiled/react.js')
+      ) {
+        bare = 'react';
+      }
+
+      if (!bare) return null;
+
+      return this.resolve(bare, importer, {
+        ...options,
+        skipSelf: true,
+      });
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
+    rewriteNextCompiledReactPlugin(),
     storybookTest({
       configDir: path.join(dirname, '.storybook'),
       tags: {
@@ -28,6 +74,20 @@ export default defineConfig({
     // (Storybook's internal React 18 compat chunk occasionally fails to load)
     retry: process.env.CI ? 3 : 0,
     fileParallelism: false,
+    deps: {
+      optimizer: {
+        web: {
+          enabled: true,
+          include: [
+            'react',
+            'react-dom',
+            'react/jsx-runtime',
+            'react/jsx-dev-runtime',
+            'react-dom/client',
+          ],
+        },
+      },
+    },
   },
   esbuild: {
     target: 'esnext',
@@ -49,6 +109,10 @@ export default defineConfig({
   optimizeDeps: {
     // Default Vite browser target (chrome87) cannot esbuild-prebundle modern ESM
     // (destructuring, etc.) pulled in transitively by Storybook stories.
+    holdUntilCrawlEnd: false,
+    // React 19 entrypoints are CJS. needsInterop forces the default-export
+    // shim that browser-mode ESM imports require.
+    needsInterop: ['react', 'react-dom', 'react-dom/client'],
     esbuildOptions: {
       target: 'esnext',
     },

--- a/apps/web/vitest.config.storybook.mts
+++ b/apps/web/vitest.config.storybook.mts
@@ -29,7 +29,9 @@ function rewriteNextCompiledReactPlugin(): Plugin {
       let bare: string | null = null;
       if (normalized.includes('next/dist/compiled/react-dom')) {
         bare = 'react-dom';
-      } else if (normalized.includes('next/dist/compiled/react/jsx-dev-runtime')) {
+      } else if (
+        normalized.includes('next/dist/compiled/react/jsx-dev-runtime')
+      ) {
         bare = 'react/jsx-dev-runtime';
       } else if (normalized.includes('next/dist/compiled/react/jsx-runtime')) {
         bare = 'react/jsx-runtime';

--- a/packages/ui/atoms/close-button.stories.tsx
+++ b/packages/ui/atoms/close-button.stories.tsx
@@ -11,11 +11,7 @@ type Story = StoryObj;
 
 export const Default: Story = {
   render: () => (
-    <button
-      type='button'
-      className={closeButtonClassName}
-      aria-label='Close'
-    >
+    <button type='button' className={closeButtonClassName} aria-label='Close'>
       <CloseButtonIcon />
     </button>
   ),

--- a/packages/ui/atoms/close-button.stories.tsx
+++ b/packages/ui/atoms/close-button.stories.tsx
@@ -13,7 +13,7 @@ export const Default: Story = {
   render: () => (
     <button
       type='button'
-      className={closeButtonClassName.join(' ')}
+      className={closeButtonClassName}
       aria-label='Close'
     >
       <CloseButtonIcon />
@@ -25,7 +25,7 @@ export const Disabled: Story = {
   render: () => (
     <button
       type='button'
-      className={closeButtonClassName.join(' ')}
+      className={closeButtonClassName}
       disabled
       aria-label='Close'
     >


### PR DESCRIPTION
## Summary
Unblocks Storybook local preview and makes the CI Storybook a11y lane green locally.

### Root causes
1. esbuild `es2020` target failed modern destructuring in Storybook/Next packages
2. Vite `optimizeDeps.holdUntilCrawlEnd` left the iframe spinner forever in this monorepo
3. `next/dist/compiled/react` is CJS without a default export — browser ESM/`import React from 'react'` breaks
4. Vitest browser mode served absolute CJS React `/@fs` paths without default-export interop
5. `close-button` story called `.join()` on an already-joined class string

### Fix
- Storybook `main.ts`: esnext targets, `holdUntilCrawlEnd: false`, React bare IDs + `this.resolve()` rewrite of `next/dist/compiled/react*`, strip workflow/vercel-toolbar plugins, `needsInterop` for React
- `vitest.config.storybook.mts`: same React rewrite strategy + optimizer interop for browser-mode a11y
- `close-button.stories.tsx`: use `closeButtonClassName` string directly

### Verification
```
pnpm --filter web test:a11y
# Test Files  160 passed | 2 skipped (162)
# Tests       750 passed (750)
# FULL_EXIT:0
```
Logs: `/tmp/storybook-test-receipts/test-a11y-r4.log`

## Test plan
- [x] `pnpm --filter web test:a11y` green locally
- [x] Logo story smoke (next/image path) green
- [ ] CI storybook-a11y path detection runs on this PR