### PR TITLE
fix(storybook): match vitest project name for UI a11y panel

### DIFF
--- a/apps/web/vitest.config.storybook.mts
+++ b/apps/web/vitest.config.storybook.mts
@@ -5,18 +5,23 @@ import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+// Absolute configDir used by @storybook/addon-vitest when it filters projects as
+// `storybook:${STORYBOOK_CONFIG_DIR}`. A bare name like "storybook" never matches
+// and the Storybook UI a11y/test panel fails with:
+//   No projects matched the filter "storybook:/…/.storybook"
+const storybookConfigDir = path.join(dirname, '.storybook');
 
 export default defineConfig({
   plugins: [
     storybookTest({
-      configDir: path.join(dirname, '.storybook'),
+      configDir: storybookConfigDir,
       tags: {
         exclude: ['no-vitest'],
       },
     }),
   ],
   test: {
-    name: 'storybook',
+    name: `storybook:${storybookConfigDir}`,
     browser: {
       enabled: true,
       provider: playwright(),

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     projects: [
       './apps/web/vitest.config.mts',
+      './apps/web/vitest.config.storybook.mts',
       './packages/ui/vitest.config.mts',
       './scripts/vitest.config.mts',
     ],


### PR DESCRIPTION
## Summary
Storybook UI a11y/test panel failed with:

`No projects matched the filter "storybook:/…/.storybook"`

## Cause
`@storybook/addon-vitest` filters projects as `storybook:${STORYBOOK_CONFIG_DIR}`, but our Vitest storybook project was named bare `storybook` and was missing from the root Vitest projects list.

## Fix
- Name project `storybook:<abs-configDir>`
- Register `apps/web/vitest.config.storybook.mts` in root `vitest.config.mts`

## Test plan
- [x] Project name resolves to `storybook:/…/apps/web/.storybook`
- [ ] Restart Storybook → a11y panel starts Vitest without filter error
- [ ] `pnpm --filter @jovie/web run test:a11y` still works