### PR TITLE
fix(ui): soft-fade long sidebar chat titles

### DIFF
--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -79,6 +79,35 @@ describe('SidebarThreadsSection', () => {
     });
   });
 
+  it('soft-fades long chat titles instead of hard-clipping mid-glyph', () => {
+    render(
+      <SidebarThreadsSection
+        threads={[
+          {
+            id: 'long-title',
+            href: '/app/chat/long-title',
+            title: 'Ask Jovie about my audience growth plan for Q3',
+            status: 'complete',
+            updatedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ]}
+        activeThreadId={null}
+        tight
+        collapsed={false}
+      />
+    );
+
+    const title = screen.getByText(
+      'Ask Jovie about my audience growth plan for Q3'
+    );
+    expect(title).toHaveClass('overflow-hidden');
+    expect(title).toHaveClass('min-w-0');
+    expect(title).toHaveClass('whitespace-nowrap');
+    expect(title.className).toMatch(/mask-image:linear-gradient/);
+    // Must NOT hard-truncate with ellipsis mid-word presentation.
+    expect(title).not.toHaveClass('truncate');
+  });
+
   it('shows an all chats link when chats are present', () => {
     render(
       <SidebarThreadsSection

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -206,9 +206,12 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
     getSidebarNavRowClassName({
       active,
       tight,
-      className: hasThreadActions ? 'pr-8' : undefined,
+      // Always reserve trailing gutter so long titles never crash into the
+      // seam / overflow menu. Extra pr when actions are present.
+      className: hasThreadActions ? 'pr-8' : 'pr-2.5',
     }),
-    'text-left',
+    // Button atom is inline-flex; force grid so the title column can shrink.
+    'grid w-full min-w-0 text-left',
     active
       ? undefined
       : unread
@@ -229,10 +232,12 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
                 : 'bg-white/25'
         )}
       />
+      {/* Soft edge fade > hard ellipsis: titles stay readable without mid-glyph chops. */}
       <span
         className={cn(
-          'min-w-0 truncate text-left justify-self-start',
-          'text-xs',
+          'min-w-0 w-full justify-self-stretch overflow-hidden whitespace-nowrap text-left text-xs',
+          '[mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]',
+          '[-webkit-mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]',
           unread && 'font-medium'
         )}
       >
@@ -243,11 +248,16 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
   return (
     <div
       className={cn(
-        'group/thread relative flex items-center',
+        'group/thread relative flex w-full min-w-0 items-center',
         tight ? 'h-6' : 'h-7'
       )}
     >
-      <Tooltip label={thread.title} side='right' block>
+      <Tooltip
+        label={thread.title}
+        side='right'
+        block
+        className='min-w-0 w-full'
+      >
         {thread.href ? (
           <Link
             href={thread.href}

--- a/apps/web/components/shell/Tooltip.tsx
+++ b/apps/web/components/shell/Tooltip.tsx
@@ -96,7 +96,13 @@ function getTriggerChild({
     const onlyChild = Children.only(children);
     if (isElementWithClassName(onlyChild)) {
       return cloneElement(onlyChild, {
-        className: cn(onlyChild.props.className, className),
+        // Width constraints only — do not force flex/grid; the child owns layout
+        // (sidebar thread rows are CSS grid; flex would break title shrink).
+        className: cn(
+          onlyChild.props.className,
+          block && 'w-full min-w-0',
+          className
+        ),
         ref: (node: HTMLElement | null) => {
           triggerRef?.(node);
           const existingRef = onlyChild.props.ref;
@@ -125,7 +131,7 @@ function getTriggerChild({
   return (
     <span
       ref={triggerRef}
-      className={cn(block ? 'flex w-full' : 'inline-flex', className)}
+      className={cn(block ? 'flex w-full min-w-0' : 'inline-flex', className)}
     >
       {children}
     </span>


### PR DESCRIPTION
Sidebar thread rows: w-full min-w-0 grid, soft mask-image fade, trailing padding. Tooltip block keeps min-w-0 without overriding child layout.