### PR TITLE
fix(ui): logo-box ban, muted shell, system B error buttons

### DIFF
--- a/apps/web/components/UnavailablePage.tsx
+++ b/apps/web/components/UnavailablePage.tsx
@@ -1,4 +1,7 @@
-import { Logo } from '@/components/atoms/Logo';
+import {
+  JOVIE_ICON_PATH,
+  JOVIE_ICON_VIEW_BOX,
+} from '@/components/atoms/jovie-icon-path';
 
 /**
  * Generic "service unavailable" page shown to blocked users.
@@ -9,15 +12,21 @@ import { Logo } from '@/components/atoms/Logo';
  *
  * Intentionally minimal. No error codes, no support links,
  * no language that indicates account-level enforcement.
- * Logo is non-interactive to avoid redirect loops for banned users.
+ * Logo is plain SVG — never a rounded box outside of app icons.
  */
 export function UnavailablePage() {
   return (
     <div className='system-b-unavailable-page'>
       <div className='system-b-unavailable-content'>
-        <div className='system-b-unavailable-mark' aria-hidden='true'>
-          <Logo aria-hidden size='lg' tone='white' variant='icon' />
-        </div>
+        <svg
+          viewBox={JOVIE_ICON_VIEW_BOX}
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          aria-hidden='true'
+          className='system-b-unavailable-mark'
+        >
+          <path fill='currentColor' d={JOVIE_ICON_PATH} />
+        </svg>
 
         <h1 className='system-b-unavailable-title'>
           Jovie is unavailable right now

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -58,7 +58,7 @@ export function DesktopTitlebar() {
               aria-label={sidebarToggleLabel}
               data-testid='electron-sidebar-toggle'
               className={cn(
-                'flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-secondary-token',
+                'flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-tertiary-token',
                 'transition-colors duration-subtle',
                 'hover:bg-white/[0.06] hover:text-primary-token',
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -98,7 +98,7 @@ export const AppShellFrame = memo(function AppShellFrame({
             // `isolate` gives <main> its own stacking context so the negative-z
             // chat ambient layer below paints above main's background but
             // beneath the in-flow header/content (#13386).
-            'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-surface-0',
+            'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--color-bg-surface-0)/90',
             isShellChatV1
               ? 'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
               : 'lg:border-l lg:border-subtle'

--- a/apps/web/components/providers/SystemBErrorFallback.tsx
+++ b/apps/web/components/providers/SystemBErrorFallback.tsx
@@ -72,7 +72,9 @@ export function SystemBErrorFallback({
                 >
                   <Button
                     type='button'
-                    variant={action.variant === 'secondary' ? 'secondary' : 'primary'}
+                    variant={
+                      action.variant === 'secondary' ? 'secondary' : 'primary'
+                    }
                     size='sm'
                   >
                     {action.label}
@@ -85,7 +87,9 @@ export function SystemBErrorFallback({
               <Button
                 key={`${action.type}-${action.label}`}
                 type='button'
-                variant={action.variant === 'secondary' ? 'secondary' : 'primary'}
+                variant={
+                  action.variant === 'secondary' ? 'secondary' : 'primary'
+                }
                 size='sm'
                 onClick={action.onClick}
               >

--- a/apps/web/components/providers/SystemBErrorFallback.tsx
+++ b/apps/web/components/providers/SystemBErrorFallback.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import {
   JOVIE_ICON_PATH,
   JOVIE_ICON_VIEW_BOX,
@@ -27,16 +28,6 @@ interface SystemBErrorFallbackProps {
   readonly role?: 'alert';
   readonly ariaLive?: 'assertive' | 'polite';
   readonly className?: string;
-}
-
-function actionClassName(
-  variant: SystemBErrorFallbackAction['variant'] = 'primary'
-): string {
-  return [
-    'system-b-error-fallback__action',
-    `system-b-error-fallback__action--${variant}`,
-    'focus-ring-transparent-offset',
-  ].join(' ');
 }
 
 function rootClassName(className: string | undefined): string {
@@ -77,22 +68,29 @@ export function SystemBErrorFallback({
                 <a
                   key={`${action.type}-${action.label}`}
                   href={action.href}
-                  className={actionClassName(action.variant)}
+                  className='system-b-error-fallback__action-link'
                 >
-                  {action.label}
+                  <Button
+                    type='button'
+                    variant={action.variant === 'secondary' ? 'secondary' : 'primary'}
+                    size='sm'
+                  >
+                    {action.label}
+                  </Button>
                 </a>
               );
             }
 
             return (
-              <button
+              <Button
                 key={`${action.type}-${action.label}`}
                 type='button'
+                variant={action.variant === 'secondary' ? 'secondary' : 'primary'}
+                size='sm'
                 onClick={action.onClick}
-                className={actionClassName(action.variant)}
               >
                 {action.label || 'Action'}
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/apps/web/tests/unit/providers/system-b-error-fallback.test.tsx
+++ b/apps/web/tests/unit/providers/system-b-error-fallback.test.tsx
@@ -47,8 +47,9 @@ describe('SystemBErrorFallback', () => {
       screen.getByText('An unexpected error occurred.')
     ).toBeInTheDocument();
     expect(screen.getByText('Error ID: digest-1')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Try Again' })).toHaveClass(
-      'system-b-error-fallback__action--primary'
+    expect(screen.getByRole('button', { name: 'Try Again' })).toHaveAttribute(
+      'data-variant',
+      'primary'
     );
     expect(screen.getByRole('link', { name: 'Go Home' })).toHaveAttribute(
       'href',
@@ -69,7 +70,7 @@ describe('SystemBErrorFallback', () => {
     expect(source).not.toContain('CSSProperties');
     expect(source).toContain('JOVIE_ICON_PATH');
     expect(source).toContain("fill='currentColor'");
-    expect(source).toContain('system-b-error-fallback__action--');
+    expect(source).toContain('system-b-error-fallback__action-link');
   });
 
   it('backs the primitive with System B tokens in the source of truth', async () => {


### PR DESCRIPTION
Logo out of box. Desktop shell 90% opacity. Error buttons use @jovie/ui Button.