### PR TITLE
fix(ci): retry transient GitHub API failures in production-controller

### DIFF
--- a/.github/workflows/production-controller.yml
+++ b/.github/workflows/production-controller.yml
@@ -61,6 +61,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Retry helper for idempotent GET calls — transient GitHub API blips
+          # should never block production deployment.
+          __gh_get() {
+            local url="$1" jq_filter="$2" max_tries=3 delay=2 result
+            for ((try=1; try<=max_tries; try++)); do
+              result="$(gh api "$url" --jq "$jq_filter" 2>/dev/null)" && {
+                echo "$result"
+                return 0
+              }
+              if [ "$try" -lt "$max_tries" ]; then
+                echo "::warning::gh api $url failed (attempt $try/$max_tries), retrying in ${delay}s..."
+                sleep "$delay"
+                delay=$((delay * 2))
+              fi
+            done
+            echo "::error::gh api $url failed after $max_tries attempts." >&2
+            return 1
+          }
+
           {
             echo "authorized=false"
             echo "is_current=false"
@@ -102,7 +122,7 @@ jobs:
             exit 1
           fi
 
-          current_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
+          current_main_sha="$(__gh_get "repos/$REPOSITORY/commits/main" '.sha // empty')"
           [[ "$current_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
             echo "::error::Could not resolve exact current main while authorizing production."
             exit 1
@@ -248,7 +268,7 @@ jobs:
               exit 1
             fi
 
-            final_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
+            final_main_sha="$(__gh_get "repos/$REPOSITORY/commits/main" '.sha // empty')"
             [[ "$final_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
               echo "::error::Could not resolve exact main at the production authorization boundary."
               exit 1


### PR DESCRIPTION
## Summary

Add `__gh_get` retry wrapper (3 attempts, exponential backoff) around the `gh api` calls that resolve the main branch SHA. Transient GitHub API blips should never block production deployment.

## Changes

- **Authorize step** — `current_main_sha` lookup now retries on failure
- **Verify step** — `final_main_sha` verification now retries on failure
- Retry: 3 attempts, 2s → 4s → 8s exponential backoff with `::warning::` annotations

Closes: https://linear.app/jovie/issue/JOV-XXXX