### PR TITLE
fix(a11y): enforce violations as test errors instead of warnings

### DIFF
--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -178,6 +178,7 @@ const preview: Preview = {
       ],
     },
     a11y: {
+      test: 'error',
       config: {
         rules: [
           {


### PR DESCRIPTION
Changed a11y test mode from 'todo' (warnings) to 'error' (failures). One-line change in preview.tsx. Now broken components will actually fail Storybook a11y tests.