### PR TITLE
fix(storybook): pin final Vite build target to esnext

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -18,7 +18,6 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y',
     '@storybook/addon-vitest',
     '@chromatic-com/storybook',
-    '@storybook/addon-mcp',
   ],
   framework: {
     name: '@storybook/nextjs-vite',
@@ -409,9 +408,18 @@ const config: StorybookConfig = {
       },
     };
 
-    // Suppress "use client" directive warnings in build output
+    // Pin the FINAL production transpile target. viteFinal is the last hook over
+    // the Vite config, and Storybook's build step otherwise falls back to Vite's
+    // browser default (es2020), which hard-fails on object rest/destructuring in
+    // Storybook 10 + modern Next packages ("Transforming destructuring ... is not
+    // supported"). config.esbuild.target / optimizeDeps.esbuildOptions.target
+    // (set above) only cover dev prebundling, NOT the build-storybook transpile —
+    // so build.target must be set here too or `pnpm build-storybook` breaks in the
+    // merge queue. Merge onto ...config.build so upstream build settings and the
+    // rollupOptions.onwarn "use client" filter below are preserved.
     config.build = {
       ...config.build,
+      target: 'esnext',
       rollupOptions: {
         ...config.build?.rollupOptions,
         onwarn(warning, warn) {

--- a/apps/web/tests/unit/storybook/storybook-build-target.contract.test.ts
+++ b/apps/web/tests/unit/storybook/storybook-build-target.contract.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { InlineConfig } from 'vite';
+import { describe, expect, it } from 'vitest';
+import storybookConfig from '../../../.storybook/main';
+
+/**
+ * Deterministic contract test for apps/web/.storybook/main.ts.
+ *
+ * Regression guard for merge_group run 30127155907: Storybook's FINAL Vite
+ * transpile (run via `build-storybook`) fell back to Vite's default browser
+ * target (es2020) because viteFinal set `esbuild.target` and
+ * `optimizeDeps.esbuildOptions.target` to 'esnext' but never set
+ * `build.target`. es2020 hard-fails on object rest/destructuring emitted by
+ * Storybook 10 + modern Next packages, breaking the preview build in the
+ * merge queue.
+ *
+ * It also guards a second failure mode from the same run: an addon
+ * (`@storybook/addon-mcp`) was listed in `addons` but never installed in
+ * apps/web/package.json, so Storybook could not resolve it at build time.
+ *
+ * Pure and offline by design: it imports the config module and invokes
+ * `viteFinal` on a minimal input config — no real browser, no network, and
+ * no full Storybook build — so it stays deterministic in CI.
+ */
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+// tests/unit/storybook -> tests/unit -> tests -> apps/web
+const webAppDir = resolve(testDir, '..', '..', '..');
+
+type Addon = string | { name?: string };
+
+function addonName(addon: Addon): string {
+  return typeof addon === 'string' ? addon : (addon?.name ?? '');
+}
+
+function readWebPackageJson(): {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+} {
+  const pkgPath = resolve(webAppDir, 'package.json');
+  return JSON.parse(readFileSync(pkgPath, 'utf8'));
+}
+
+async function runViteFinal(): Promise<InlineConfig> {
+  const viteFinal = storybookConfig.viteFinal;
+  if (typeof viteFinal !== 'function') {
+    throw new Error('.storybook/main.ts must export a viteFinal function');
+  }
+  // Storybook passes (config, options); main.ts only reads `config`. Start
+  // from an empty config so assertions reflect exactly what viteFinal sets.
+  const result = await viteFinal({} as InlineConfig, {} as never);
+  return result as InlineConfig;
+}
+
+function esbuildTarget(config: InlineConfig): string | undefined {
+  return (config.esbuild as { target?: string } | undefined)?.target;
+}
+
+describe('storybook vite build config contract', () => {
+  it('pins the final build transpile target to esnext', async () => {
+    const config = await runViteFinal();
+
+    // Without this, build-storybook falls back to the es2020 browser default.
+    expect(config.build?.target).toBe('esnext');
+  });
+
+  it('keeps dev prebundling targets aligned with build', async () => {
+    const config = await runViteFinal();
+
+    // The three targets must agree; a drift caused run 30127155907.
+    expect(esbuildTarget(config)).toBe('esnext');
+    expect(config.optimizeDeps?.esbuildOptions?.target).toBe('esnext');
+    expect(config.build?.target).toBe('esnext');
+  });
+
+  it('preserves the use-client rollup onwarn filter', async () => {
+    const config = await runViteFinal();
+
+    // Setting build.target must not clobber the existing rollupOptions that
+    // silence MODULE_LEVEL_DIRECTIVE ("use client") build noise.
+    const onwarn = config.build?.rollupOptions?.onwarn;
+    expect(typeof onwarn).toBe('function');
+
+    const suppressed: unknown[] = [];
+    const warn = (w: unknown) => suppressed.push(w);
+    (onwarn as (warning: unknown, warn: (w: unknown) => void) => void)(
+      { code: 'MODULE_LEVEL_DIRECTIVE', message: 'directive "use client"' },
+      warn
+    );
+    expect(suppressed).toHaveLength(0);
+  });
+
+  it('does not configure the uninstalled @storybook/addon-mcp', () => {
+    const addons = (storybookConfig.addons ?? []) as Addon[];
+    const names = addons.map(addonName);
+    expect(names).not.toContain('@storybook/addon-mcp');
+
+    const pkg = readWebPackageJson();
+    const installed = {
+      ...(pkg.dependencies ?? {}),
+      ...(pkg.devDependencies ?? {}),
+    };
+    expect('@storybook/addon-mcp' in installed).toBe(false);
+  });
+
+  it('only configures addons installed in apps/web/package.json', () => {
+    // General guard for the whole class: any npm-package addon listed in
+    // `addons` must be a declared dependency, or Storybook cannot resolve it
+    // at build time (the exact failure @storybook/addon-mcp caused).
+    const pkg = readWebPackageJson();
+    const installed = new Set([
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ]);
+
+    const addons = (storybookConfig.addons ?? []) as Addon[];
+    const packageAddons = addons
+      .map(addonName)
+      .filter(
+        name =>
+          name.startsWith('@storybook/') || name.startsWith('@chromatic-com/')
+      );
+
+    // Sanity: we still ship the core a11y addon.
+    expect(packageAddons).toContain('@storybook/addon-a11y');
+
+    const missing = packageAddons.filter(name => !installed.has(name));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

The Storybook production transpile run by `build-storybook` was falling back to Vite's default **browser target (es2020)**, which hard-fails on the object rest/destructuring that Storybook 10 + modern Next packages emit (`Transforming destructuring to the configured target environment ... is not supported`). This broke the Storybook preview build in the merge queue — **merge_group run [30127155907](https://github.com/JovieInc/Jovie/actions/runs/30127155907)**.

Root cause: in `apps/web/.storybook/main.ts`, `viteFinal` sets the esnext target for **dev prebundling only** — `config.esbuild.target` and `config.optimizeDeps.esbuildOptions.target` — but never sets `config.build.target`. `viteFinal` is the last hook over the Vite config, so the production `build-storybook` transpile silently used the es2020 default.

A second failure from the same run: `@storybook/addon-mcp` was listed in `addons` but is **not installed** in `apps/web/package.json` (nor in `pnpm-lock.yaml`), so Storybook could not resolve it at build time.

## Changes

- **`apps/web/.storybook/main.ts`**
  - Add `target: 'esnext'` to `config.build`, merged onto the existing `...config.build` spread so the `rollupOptions.onwarn` "use client" (`MODULE_LEVEL_DIRECTIVE`) filter is preserved.
  - Remove `@storybook/addon-mcp` from `addons` (uninstalled). The other four addons (`addon-docs`, `addon-a11y`, `addon-vitest`, `@chromatic-com/storybook`) are unchanged.
- **`apps/web/tests/unit/storybook/storybook-build-target.contract.test.ts`** (new)
  - Deterministic, offline contract test. Imports the config, invokes `viteFinal({})`, and asserts:
    1. `config.build.target === 'esnext'`
    2. the three targets (`esbuild`, `optimizeDeps.esbuildOptions`, `build`) are aligned
    3. the `rollupOptions.onwarn` "use client" filter is preserved (still suppresses `MODULE_LEVEL_DIRECTIVE`)
    4. `@storybook/addon-mcp` is configured in neither `addons` nor `package.json`
    5. **general guard** — no `@storybook/*` or `@chromatic-com/*` addon listed in `addons` is missing from `apps/web/package.json` (prevents the whole "configured-but-uninstalled addon" class from recurring)

## Scope / constraints honored

- Did **not** touch stories, a11y policy, the lockfile, or CI workflows.
- No dependency changes → no lockfile churn (`addon-mcp` was never a declared dep).
- Two files changed, +142/−2.

## Verification

- `git diff --check` — clean (no whitespace / conflict markers).
- Offline harness that runs the real `viteFinal` and the exact test assertions: **5/5 pass** (`build.target`/`esbuild`/`optimizeDeps` all `esnext`; `onwarn` suppresses "use client" and passes other warnings; `addon-mcp` absent from addons + package.json).
- Biome formatting hand-audited against `biome.json` (≤80 cols, single quotes, `arrowParentheses: asNeeded`, spaces, trailing newline).

CI runs the authoritative `pnpm --filter @jovie/web run build-storybook`, the storybook contract test, and Biome on this PR through the normal gates.
