### PR TITLE
fix(ci): merge-queue CI contract/isolation repair

### DIFF
--- a/apps/web/tests/unit/api/connectors/suggested-actions-approve-route.test.ts
+++ b/apps/web/tests/unit/api/connectors/suggested-actions-approve-route.test.ts
@@ -155,7 +155,20 @@ const ROUTE_PATH = '/api/connectors/suggested-actions/[id]/approve';
 
 describe('POST /api/connectors/suggested-actions/[id]/approve (real handler)', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // Full reset — clears call history, pending once-values, and default
+    // implementations. Re-establish the mock chain so db.update().set().where()
+    // returns correctly chained mock functions for every test. Without this,
+    // pending mockResolvedValueOnce from a prior test can break the next test
+    // running in the same fork (sporadically observed in --shard=6/10 CI runs).
+    vi.resetAllMocks();
+
+    // Re-establish the db.update().set().where().returning() mock chain
+    // because resetAllMocks clears the vi.hoisted() factory implementations.
+    mockDbUpdate.mockImplementation(() => ({ set: mockDbUpdateSet }));
+    mockDbUpdateSet.mockImplementation(() => ({ where: mockDbUpdateWhere }));
+    mockDbUpdateWhere.mockImplementation(() => ({
+      returning: mockDbUpdateReturning,
+    }));
   });
 
   it('returns 401 and performs no db/workflow work when unauthenticated', async () => {

--- a/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
+++ b/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
@@ -48,7 +48,7 @@ describe('fixed runner canary workflow', () => {
 
   it('pins checkout and does not persist credentials', () => {
     expect(workflow).toContain(
-      'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
+      'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
     );
     expect(workflow).toContain('ref: main');
     expect(workflow).toContain('persist-credentials: false');

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -427,7 +427,7 @@ describe('baked runner prerequisite contract', () => {
       '.github/runner-image/build-context.sh "$EXPECTED_SHA"'
     );
     expect(runnerImageOfflineProof).toContain(
-      'uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124'
+      'uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487'
     );
     expect(runnerImageOfflineProof).toContain(
       "runner-image-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-"


### PR DESCRIPTION
## Summary

Updates unit tests to match current pinned action SHAs and fixes test isolation cascade in suggested-actions-approve-route.

## Changes

### Shard 2 — `fixed-runner-canary-workflow.test.ts`
- Update expected `actions/checkout` SHA from `9c091bb` (v7.0.0) to `3d3c42e` (v7.0.1) to match the workflow after `actions/checkout` bump (#14756)

### Shard 8 — `runner-setup-action.test.ts`
- Update expected `crazy-max/ghaction-github-runtime` SHA from `3cb05d8` (v3) to `04d248b` (v4.0.0) to match the workflow after the dep bump (#14755)

### Shard 6 — `suggested-actions-approve-route.test.ts`
- Replace `vi.clearAllMocks()` with `vi.resetAllMocks()` + re-established mock chain in `beforeEach` to eliminate cascading mock-state leakage between tests (observed in CI `--shard=6/10` runs)

## Verification
- [x] All 3 target files pass locally (`vitest run --pool=forks`)
- [x] Shard 2/10: 218 files, 2082 tests passed
- [x] Shard 6/10: 218 files, 1521 tests passed  
- [x] Shard 8/10: 218 files, 1757 tests passed
- [x] Biome: no new issues
- [x] `git diff --check`: no whitespace issues
- [x] Zero outbound network (unit tests, local mocks, no HTTP/DB calls)

Packet: `mq-unit-contract-isolation-20260724-v1`