### PR TITLE
test(ci): isolate merge-group unit contracts

### DIFF
--- a/apps/web/tests/unit/api/connectors/suggested-actions-approve-route.test.ts
+++ b/apps/web/tests/unit/api/connectors/suggested-actions-approve-route.test.ts
@@ -155,7 +155,14 @@ const ROUTE_PATH = '/api/connectors/suggested-actions/[id]/approve';
 
 describe('POST /api/connectors/suggested-actions/[id]/approve (real handler)', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+
+    // resetAllMocks clears implementations as well as queued one-shot results.
+    // Rebuild the fluent update chain so every test starts from the same DB
+    // state instead of consuming responses left by another test or file order.
+    mockDbUpdateWhere.mockReturnValue({ returning: mockDbUpdateReturning });
+    mockDbUpdateSet.mockReturnValue({ where: mockDbUpdateWhere });
+    mockDbUpdate.mockReturnValue({ set: mockDbUpdateSet });
   });
 
   it('returns 401 and performs no db/workflow work when unauthenticated', async () => {

--- a/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
+++ b/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
@@ -48,7 +48,7 @@ describe('fixed runner canary workflow', () => {
 
   it('pins checkout and does not persist credentials', () => {
     expect(workflow).toContain(
-      'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
+      'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
     );
     expect(workflow).toContain('ref: main');
     expect(workflow).toContain('persist-credentials: false');

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -427,7 +427,7 @@ describe('baked runner prerequisite contract', () => {
       '.github/runner-image/build-context.sh "$EXPECTED_SHA"'
     );
     expect(runnerImageOfflineProof).toContain(
-      'uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124'
+      'uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487'
     );
     expect(runnerImageOfflineProof).toContain(
       "runner-image-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-"


### PR DESCRIPTION
## Why

Authenticated merge-group run [30136837452](https://github.com/JovieInc/Jovie/actions/runs/30136837452) exposed three deterministic unit-contract blockers after dependency-pin updates and test reordering:

1. `fixed-runner-canary-workflow.test.ts` still asserted checkout v6 while the workflow pins checkout v7.
2. `runner-setup-action.test.ts` still asserted `crazy-max/ghaction-github-runtime` v3 while the workflow pins v4.
3. `suggested-actions-approve-route.test.ts` used `vi.clearAllMocks()`, which clears call history but preserves implementations and queued one-shot results. Sequential shard execution could therefore shift later statuses/errors.

## Changes

- Refresh the checkout contract to immutable SHA `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1).
  - Retains the existing `ref: main` and `persist-credentials: false` assertions.
- Refresh the GitHub runtime contract to immutable SHA `04d248b84655b509d8c44dc1d6f990c879747487` (v4.0.0).
- Replace `vi.clearAllMocks()` with `vi.resetAllMocks()` in the approve-route suite, then rebuild the fluent DB update chain before every test.
  - Clears call history, implementations, and queued `mockResolvedValueOnce` / `mockRejectedValueOnce` values.
  - Does not change production behavior or quarantine policy.

## Scope

Exactly three test files; no production, workflow, quarantine, package, or lockfile changes. Rollback is a focused revert of this one commit.

## Verification

- Exhaustive stale-pin search: no remaining `9c091bb...` or `3cb05d8...` test assertions.
- Workflow-to-contract comparison confirms the new exact SHAs and retained credential hardening.
- `git diff --check`: clean.
- Targeted files and merge-group shards 2/6/8 will self-prove in the native queue; this PR intentionally uses the one implementation + one CI retry budget.

Idempotency: `mq-unit-contract-isolation-20260724-v1`
