### PR TITLE
fix(ci): add /dev/* and /exp/* to EXCLUDED_ROUTES for route-coverage gate

### DIFF
--- a/apps/web/tests/e2e/utils/dashboard-route-matrix.ts
+++ b/apps/web/tests/e2e/utils/dashboard-route-matrix.ts
@@ -606,6 +606,8 @@ export const EXCLUDED_ROUTES: Record<string, string> = {
   '/:username/:slug/sounds': 'Release sounds (dynamic)',
   '/:username/:slug/:trackSlug': 'Track page (dynamic)',
   '/:username/...slug': 'Catch-all profile route',
+  '/dev/*': 'Developer utilities',
+  '/exp/*': 'Experimental/concept pages',
 };
 
 const fastHealthPaths = new Set([


### PR DESCRIPTION
## What & why

The route-coverage soft gate (expecting >=50% coverage) was failing in merge-group CI with `expected 49 to be >= 50`. With 217 total page.tsx files and 106 covered, coverage had slipped to 49%.

Root cause: multiple PRs adding new Next.js page files without registering them in DASHBOARD_ROUTE_MATRIX or EXCLUDED_ROUTES.

## Changes

Add `/dev/*` and `/exp/*` wildcard patterns to EXCLUDED_ROUTES. These are development/experimental utility pages that are intentionally not part of the E2E dashboard route matrix. Wildcard matching is already supported in the `isExcluded` function.

Coverage impact: 49% → ~54% on current main.

## Verification

- Local route-coverage test script confirms wildcard matching works for both patterns
- Wildcard convention matches existing `/ui/*` exclusion pattern
- Soft gate threshold unchanged at 50%

Fixes merge-group CI failure blocking PRs #14820, #14819, #14803