### PR TITLE
fix(test): update PublicPageErrorFallback assertion for Button component

### DIFF
--- a/apps/web/tests/unit/public-page-error-fallback.test.tsx
+++ b/apps/web/tests/unit/public-page-error-fallback.test.tsx
@@ -62,11 +62,7 @@ describe('PublicPageErrorFallback', () => {
       'system-b-error-fallback'
     );
     expect(screen.getAllByRole('button')).toHaveLength(1);
-    expect(screen.getByRole('button', { name: 'Refresh' })).toHaveClass(
-      'system-b-error-fallback__action',
-      'system-b-error-fallback__action--primary',
-      'focus-ring-transparent-offset'
-    );
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 


### PR DESCRIPTION
## What

PR #14803 replaced `<button>`/`<a>` elements with `@jovie/ui <Button>` component in `SystemBErrorFallback.tsx`. The test `public-page-error-fallback.test.tsx` asserted old class names (`system-b-error-fallback__action`, `system-b-error-fallback__action--primary`, `focus-ring-transparent-offset`) that no longer exist.

## Change
Replaced the brittle class-name assertion with `toBeInTheDocument()` — the button is still rendered and clickable (confirmed by the `fireEvent.click` + `toHaveBeenCalledTimes(1)` assertions below).

## Why this was missed
The test passes on individual PR CI (the PR's branch `fix/live-ui` includes the `<Button>` changes but the test file isn't there yet). The mismatch only manifests on the merge_group combined head where both the test and component changes are present.

Closes merge-group CI bottleneck blocking #14803.