### PR TITLE
fix(storybook): set build.target esnext — unblock merge-queue Storybook lane

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -409,9 +409,18 @@ const config: StorybookConfig = {
       },
     };
 
-    // Suppress "use client" directive warnings in build output
+    // Suppress "use client" directive warnings in build output.
+    // build.target must match the esnext esbuild/optimizeDeps targets above:
+    // `storybook build` lowers final chunks with esbuild against build.target
+    // (default 'modules' = chrome87/edge88/es2020/firefox78/safari14), and that
+    // lowering hard-fails on object rest/destructuring in Storybook/Next
+    // packages ("Transforming destructuring to the configured target
+    // environment ... is not supported yet") — the exact merge-queue failure in
+    // issue #14841. The preview bundle only runs in current Chromium (CI +
+    // Chromatic), so esnext is safe.
     config.build = {
       ...config.build,
+      target: 'esnext',
       rollupOptions: {
         ...config.build?.rollupOptions,
         onwarn(warning, warn) {


### PR DESCRIPTION
## Problem

Every `merge_group` CI run fails in `Storybook Visual + A11y (combined)` with esbuild hard-failing while lowering final chunks:

```
assets/badge-!~{00h}~.js:37:55: ERROR: Transforming destructuring to the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides) is not supported yet
```

Merge queue is blocked — 4 consecutive merge_group failures; #14834 / #14660 can't land. (#14841)

## Root cause (differs from the issue's cache hypothesis)

- The `-!~{00h}~.js` names are **Rollup hash placeholders on in-flight chunks during the production build's esbuild lowering pass** — not cached artifacts. No cache is involved: `ci-storybook-visual` runs `pnpm --filter @jovie/web run build-storybook` directly on `ubuntu-latest` with a fresh `pnpm install` (no turbo task, no `actions/cache` step).
- The "works on `pull_request` / fails on `merge_group`" asymmetry is because the Storybook lane **only runs on `merge_group`** (`github.event_name == 'merge_group'` in its `if`) — it was never exercised on PR events at all.
- `apps/web/.storybook/main.ts#viteFinal` already forces `config.esbuild.target = 'esnext'` and `optimizeDeps.esbuildOptions.target = 'esnext'` (with a comment documenting this exact destructuring hard-fail), but **`config.build.target` was never set**. `storybook build` (production Vite build) lowers final chunks against `build.target`, whose default (`'modules'`) is exactly `['es2020','edge88','firefox78','chrome87','safari14']` — the verbatim target list in the error (the "+ 2 overrides" are Vite's `dynamic-import`/`import-meta` supported flags).

## What changed

One setting in `apps/web/.storybook/main.ts`: `config.build.target = 'esnext'`, aligning the production chunk-lowering target with the existing esnext transform/optimizeDeps targets, plus a comment explaining why. The Storybook preview bundle only runs in current Chromium (CI vitest browser mode + Chromatic), so `esnext` is safe.

Constraints honored: no concurrency-group / cache-key changes, no visual-gate removal, no ci.yml changes at all.

## Why a main-side fix works for the queued stack

The failing lane is defined by the in-flight visual-gates stack (#14652 → #14660); merge groups build the PR branch **merged with main**, so once this lands on main the next merge group for #14660 picks up the corrected `build.target` automatically (`.storybook/main.ts` on main already has the packages/ui glob and the esnext esbuild block; the stack's only delta in this file is alias mocks in a different hunk — no conflict).

## Assumptions

- The dispatch's turbo-cache hypothesis is not supported by the job definition (evidence above); fix targets the config root cause instead of adding cache-clearing that would be a no-op.
- `esnext` for the Storybook preview bundle is acceptable (matches the existing in-file rationale at the `config.esbuild` block).

## Verification

- `python` patch applied with unique-anchor assertion; `node --experimental-strip-types --check apps/web/.storybook/main.ts` → exit 0.
- Verbatim target-list match between the error message and Vite's default `build.target: 'modules'` set confirms the untouched default is in effect during `storybook build`.
- **Full local repro deferred:** `pnpm install` in the sandbox is blocked (registry.npmjs.org 403; network-access request pending, polled ~10 min). The authoritative repro lane (`ci-storybook-visual`) only exists on `merge_group` runs, so the definitive test is the next merge group after this lands. CI repro commands for the record:
  ```
  pnpm install --frozen-lockfile
  pnpm --filter @jovie/web run build-storybook   # fails pre-fix on merge-group tree 3dff4875, must exit 0 post-fix
  ```

Dispatch: P0 #14841 (merge-queue unblock). Fixes #14841
