### PR TITLE
fix: handle EEXIST race in lighthouse-vercel-bypass parallel workers

### DIFF
--- a/apps/web/scripts/lighthouse-vercel-bypass.cjs
+++ b/apps/web/scripts/lighthouse-vercel-bypass.cjs
@@ -50,7 +50,11 @@ function recordSensitiveValues(path, values) {
     if (err.code === 'EEXIST' && existsSync(path)) {
       // Race: another worker created the file between our existsSync check and
       // the O_EXCL open.  Re-open for append without O_EXCL.
-      descriptor = openSync(path, constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW, 0o600);
+      descriptor = openSync(
+        path,
+        constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW,
+        0o600
+      );
     } else {
       throw err;
     }

--- a/apps/web/scripts/lighthouse-vercel-bypass.cjs
+++ b/apps/web/scripts/lighthouse-vercel-bypass.cjs
@@ -43,7 +43,18 @@ function recordSensitiveValues(path, values) {
   } else {
     flags |= constants.O_CREAT | constants.O_EXCL;
   }
-  const descriptor = openSync(path, flags, 0o600);
+  let descriptor;
+  try {
+    descriptor = openSync(path, flags, 0o600);
+  } catch (err) {
+    if (err.code === 'EEXIST' && existsSync(path)) {
+      // Race: another worker created the file between our existsSync check and
+      // the O_EXCL open.  Re-open for append without O_EXCL.
+      descriptor = openSync(path, constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW, 0o600);
+    } else {
+      throw err;
+    }
+  }
   try {
     const stat = fstatSync(descriptor, { bigint: true });
     if (


### PR DESCRIPTION
## Problem

The Production Controller's canary health gate (staging) fails intermittently with:
```
Error: EEXIST: file already exists, open '/home/runner/work/_temp/playwright-dynamic-cookie-values'
```

at `lighthouse-vercel-bypass.cjs:46`.

Root cause: `recordSensitiveValues` uses `O_CREAT | O_EXCL` (exclusive create) to safely
write the sensitive-values receipt. When parallel Playwright workers both pass the
`existsSync` check and then race to the `O_EXCL` open, one worker wins and the other
crashes with EEXIST.

This blocks production deploys by failing the canary health gate.

## Fix

Catch EEXIST from `openSync` and fall back to opening for append without `O_EXCL`
when the file now exists (created by the competing worker). The lstat check before
O_EXCL already verified the path isn't a symlink, so the re-open is safe.

## Verification

- The same `recordSensitiveValues` function is called by multiple Playwright workers
- After this fix, a worker that loses the O_EXCL race will gracefully append instead of crashing
- No security regression: the lstat-based identity check (lines 35-42) already validated
  the file is a regular file (not symlink) before the race window