### PR TITLE
fix(release): wait for production auth hydration

### DIFF
--- a/apps/web/tests/e2e/smoke-prod-auth.spec.ts
+++ b/apps/web/tests/e2e/smoke-prod-auth.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../helpers/vercel-preview';
 import { primeOriginBoundVercelBypass } from './utils/prime-vercel-bypass';
 import { resolveProductionAuthCredentials } from './utils/production-auth-credentials';
+import { prepareProductionAuthEmailForm } from './utils/production-auth-interaction';
 import { waitForProductionAuthOtp } from './utils/production-auth-otp';
 import { SMOKE_TIMEOUTS, waitForHydration } from './utils/smoke-test-utils';
 
@@ -42,27 +43,6 @@ function getProdCredentials() {
   return credentials;
 }
 
-async function getIdentifierInput(page: Page) {
-  return page
-    .locator(
-      'input[name="identifier"], input[type="email"], input[autocomplete="email"]'
-    )
-    .first();
-}
-
-async function getSubmitButton(page: Page) {
-  return page
-    .locator(
-      [
-        'button[type="submit"]',
-        'button:has-text("Continue")',
-        'button:has-text("Sign in")',
-        'button:has-text("Verify")',
-      ].join(', ')
-    )
-    .first();
-}
-
 type SignInResult =
   | 'authenticated'
   | 'verification-required'
@@ -96,6 +76,7 @@ async function detectNextStep(
           return 'password';
         }
         if (
+          document.querySelector('[data-auth-email-code-step="code"]') ||
           document.querySelector(
             'input[name="code"], input[autocomplete="one-time-code"], input[inputmode="numeric"]'
           )
@@ -117,8 +98,10 @@ async function signInViaRenderedFlow(
   expectedOrigin: string
 ): Promise<SignInResult> {
   assertExactNavigationUrl(page.url(), expectedOrigin, 'Rendered sign-in flow');
-  const identifierInput = await getIdentifierInput(page);
-  const hasIdentifierInput = await identifierInput
+  const emailForm = page
+    .locator('form[data-auth-email-code-step="email"]')
+    .first();
+  const hasIdentifierInput = await emailForm
     .isVisible({ timeout: 15_000 })
     .catch(() => false);
 
@@ -132,9 +115,12 @@ async function signInViaRenderedFlow(
     return 'signin-form-unavailable';
   }
 
-  await identifierInput.fill(credentials.email);
+  const { submitButton } = await prepareProductionAuthEmailForm(
+    page,
+    credentials.email
+  );
   const otpRequestedAtMs = Date.now();
-  await (await getSubmitButton(page)).click();
+  await submitButton.click();
 
   const nextStep = await detectNextStep(page, expectedOrigin);
 
@@ -148,7 +134,10 @@ async function signInViaRenderedFlow(
       .first();
     await expect(passwordInput).toBeVisible({ timeout: 10_000 });
     await passwordInput.fill(credentials.password);
-    await (await getSubmitButton(page)).click();
+    await page
+      .locator('form:has(input[type="password"]) button[type="submit"]')
+      .first()
+      .click();
     await page.waitForURL(
       url => url.origin === expectedOrigin && url.pathname.startsWith('/app'),
       { timeout: 30_000 }
@@ -158,9 +147,12 @@ async function signInViaRenderedFlow(
   }
 
   if (nextStep === 'email_code') {
-    const codeInput = page
+    const codeForm = page
+      .locator('form[data-auth-email-code-step="code"]')
+      .first();
+    const codeInput = codeForm
       .locator(
-        'input[name="code"], input[autocomplete="one-time-code"], input[inputmode="numeric"]'
+        '[data-testid="otp-autofill-input"], input[name="code"], input[autocomplete="one-time-code"], input[inputmode="numeric"]'
       )
       .first();
     await expect(codeInput).toBeVisible({ timeout: 10_000 });
@@ -170,12 +162,12 @@ async function signInViaRenderedFlow(
         email: credentials.email,
         startedAtMs: otpRequestedAtMs,
       }));
-    await codeInput.fill(verificationCode);
-    await (await getSubmitButton(page)).click();
-    await page.waitForURL(
+    const authenticatedRedirect = page.waitForURL(
       url => url.origin === expectedOrigin && url.pathname.startsWith('/app'),
       { timeout: 30_000 }
     );
+    await codeInput.fill(verificationCode);
+    await authenticatedRedirect;
     assertExactNavigationUrl(page.url(), expectedOrigin, 'Email-code redirect');
     return 'authenticated';
   }

--- a/apps/web/tests/e2e/utils/production-auth-interaction.ts
+++ b/apps/web/tests/e2e/utils/production-auth-interaction.ts
@@ -1,0 +1,52 @@
+import type { Locator, Page } from '@playwright/test';
+
+const EMAIL_FORM_SELECTOR = 'form[data-auth-email-code-step="email"]';
+const IDENTIFIER_INPUT_SELECTOR = [
+  'input[name="identifier"]',
+  'input[name="emailAddress"]',
+  'input[type="email"]',
+  'input[autocomplete="email"]',
+].join(', ');
+
+export interface ProductionAuthEmailFormControls {
+  readonly identifierInput: Locator;
+  readonly submitButton: Locator;
+}
+
+/**
+ * Wait for the production auth page to be interactive before mutating its
+ * controlled email input. Filling at `domcontentloaded` can race React
+ * hydration: the DOM value changes, but the component state stays empty and
+ * the submit button remains disabled.
+ */
+export async function prepareProductionAuthEmailForm(
+  page: Page,
+  email: string,
+  timeoutMs = 15_000
+): Promise<ProductionAuthEmailFormControls> {
+  await page.waitForLoadState('load', { timeout: timeoutMs });
+
+  const form = page.locator(EMAIL_FORM_SELECTOR).first();
+  await form.waitFor({ state: 'visible', timeout: timeoutMs });
+
+  const identifierInput = form.locator(IDENTIFIER_INPUT_SELECTOR).first();
+  const submitButton = form.locator('button[type="submit"]').first();
+  await identifierInput.waitFor({ state: 'visible', timeout: timeoutMs });
+  await submitButton.waitFor({ state: 'visible', timeout: timeoutMs });
+
+  // Reapply the controlled value only after the load/hydration boundary.
+  await identifierInput.fill('');
+  await identifierInput.fill(email);
+  await page.waitForFunction(
+    selector => {
+      const button = document.querySelector(
+        `${selector} button[type="submit"]`
+      );
+      return button instanceof HTMLButtonElement && !button.disabled;
+    },
+    EMAIL_FORM_SELECTOR,
+    { timeout: timeoutMs }
+  );
+
+  return { identifierInput, submitButton };
+}

--- a/apps/web/tests/unit/e2e/production-auth-interaction.test.ts
+++ b/apps/web/tests/unit/e2e/production-auth-interaction.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { prepareProductionAuthEmailForm } from '../../e2e/utils/production-auth-interaction';
+
+describe('production auth interaction hydration gate', () => {
+  it('waits for full load before refilling the controlled email and enabling submit', async () => {
+    document.body.innerHTML = `
+      <form data-auth-email-code-step="email">
+        <input name="emailAddress" type="email" autocomplete="email" />
+        <button type="submit">Email me a Code</button>
+      </form>
+    `;
+
+    const calls: string[] = [];
+    const identifierInput = {
+      waitFor: vi.fn(async () => {
+        calls.push('input-visible');
+      }),
+      fill: vi.fn(async (value: string) => {
+        calls.push(`fill:${value}`);
+      }),
+    };
+    const submitButton = {
+      waitFor: vi.fn(async () => {
+        calls.push('submit-visible');
+      }),
+    };
+    const form = {
+      waitFor: vi.fn(async () => {
+        calls.push('form-visible');
+      }),
+      locator: vi.fn((selector: string) =>
+        selector === 'button[type="submit"]'
+          ? { ...submitButton, first: () => submitButton }
+          : { ...identifierInput, first: () => identifierInput }
+      ),
+    };
+    const page = {
+      waitForLoadState: vi.fn(async () => {
+        calls.push('load');
+      }),
+      locator: vi.fn(() => ({ ...form, first: () => form })),
+      waitForFunction: vi.fn(
+        async (predicate: (selector: string) => boolean, selector: string) => {
+          calls.push('submit-enabled');
+          expect(predicate(selector)).toBe(true);
+        }
+      ),
+    };
+
+    const controls = await prepareProductionAuthEmailForm(
+      page as never,
+      'smoke@example.com'
+    );
+
+    expect(controls).toEqual({ identifierInput, submitButton });
+    expect(calls).toEqual([
+      'load',
+      'form-visible',
+      'input-visible',
+      'submit-visible',
+      'fill:',
+      'fill:smoke@example.com',
+      'submit-enabled',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- wait for the production sign-in page load and controlled email form to become interactive before filling
- scope email, password, and OTP controls to the rendered auth step
- treat OTP completion as the submission boundary and wait concurrently for the authenticated redirect
- add regression coverage for the hydration ordering that blocked the exact-build production proof

## Verification
- 123 focused release/auth/artifact tests passed
- full web suite: 2,221 files and 17,422 tests passed
- pre-push affected bundle: all 8 shards passed
- web source typecheck passed
- Biome and ESLint passed
- live non-submitting jov.ie/signin structural check confirmed the scoped submit becomes enabled after the post-load refill

Linear: JOV-4376