### PR TITLE
fix(release): inject SENTRY_AUTH_TOKEN during production build

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -941,7 +941,7 @@ jobs:
           }
           export -f production_stage
           doppler run --project jovie-web --config prd \
-            --only-secrets=BETTER_AUTH_URL,NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY \
+            --only-secrets=BETTER_AUTH_URL,NEXT_PUBLIC_BETTER_AUTH_URL,BETTER_AUTH_SECRET,DATABASE_URL,SESSION_SECRET,AI_GATEWAY_API_KEY,NEXT_PUBLIC_TURNSTILE_SITE_KEY,TURNSTILE_SECRET_KEY,SENTRY_AUTH_TOKEN \
             --no-fallback -- env -u DOPPLER_TOKEN bash -c production_stage
 
       - name: Setup Playwright for exact-build performance gate


### PR DESCRIPTION
## Problem
The production build's @sentry/nextjs plugin runs `sentry-cli` to upload sourcemaps during `vercel build --prod`. This requires `SENTRY_AUTH_TOKEN` in the environment.

The token exists in Doppler `prd` config but wasn't included in the `--only-secrets` list for the `stage-production` step. The build logged:
> `sentry reported an error: Invalid token (http status: 401)`

## Fix
Added `SENTRY_AUTH_TOKEN` to the Doppler `--only-secrets` list on the `stage-production` build step.

## Verification
- The token in Doppler (`c1c28d...`) is valid (returns HTTP 200 to Sentry API)
- Staging builds don't trigger Sentry (`sentryMode: none`) — unaffected
- Production builds will now inject the working token for sourcemap upload