### PR TITLE
perf(tasks): remove board prefetch from initial route

### DIFF
--- a/apps/web/app/app/(shell)/tasks/TasksRoute.tsx
+++ b/apps/web/app/app/(shell)/tasks/TasksRoute.tsx
@@ -8,7 +8,7 @@ import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
 import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
 import { loadAppShellRouteContext } from '../app-shell-route-context';
-import { getTaskBoard, getTasks } from '../dashboard/tasks/task-actions';
+import { getTasks } from '../dashboard/tasks/task-actions';
 
 export async function TasksRoute() {
   const routeContext = await loadAppShellRouteContext({
@@ -30,22 +30,13 @@ export async function TasksRoute() {
   if (profileId) {
     const queryClient = getQueryClient();
     try {
-      await Promise.all([
-        queryClient.fetchQuery({
-          queryKey: queryKeys.tasks.list(
-            profileId,
-            DEFAULT_TASK_WORKSPACE_FILTERS
-          ),
-          queryFn: () => getTasks(DEFAULT_TASK_WORKSPACE_FILTERS),
-        }),
-        queryClient.fetchQuery({
-          queryKey: queryKeys.tasks.board(
-            profileId,
-            DEFAULT_TASK_WORKSPACE_FILTERS
-          ),
-          queryFn: () => getTaskBoard(DEFAULT_TASK_WORKSPACE_FILTERS),
-        }),
-      ]);
+      await queryClient.fetchQuery({
+        queryKey: queryKeys.tasks.list(
+          profileId,
+          DEFAULT_TASK_WORKSPACE_FILTERS
+        ),
+        queryFn: () => getTasks(DEFAULT_TASK_WORKSPACE_FILTERS),
+      });
     } catch (error) {
       void captureError('Tasks prefetch failed on tasks page', error, {
         route: APP_ROUTES.TASKS,

--- a/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
@@ -139,12 +139,12 @@ describe('tasks page routes', () => {
     expect(mockFetchQuery).not.toHaveBeenCalled();
   });
 
-  it('server-prefetches default task data before rendering the workspace', async () => {
+  it('prefetches only the default list before rendering the workspace', async () => {
     render(await TasksPage());
 
-    expect(mockFetchQuery).toHaveBeenCalledTimes(2);
+    expect(mockFetchQuery).toHaveBeenCalledTimes(1);
     expect(mockGetTasks).toHaveBeenCalledWith({ limit: 100 });
-    expect(mockGetTaskBoard).toHaveBeenCalledWith({ limit: 100 });
+    expect(mockGetTaskBoard).not.toHaveBeenCalled();
     expect(screen.getByTestId('hydrate-client')).toBeInTheDocument();
     expect(screen.getByTestId('tasks-page-client')).toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Description

Removes the task-board prefetch from the initial `/app/tasks` server render. The default list remains hydrated on the server; board data continues to load through the existing client query only when the board view is used.

Production Controller run 30187805976 measured `/app/tasks` skeleton-to-content at 1090.4 ms median (n=3), above the 1000 ms gate. The removed board prefetch performed four status counts plus four task-list queries before the default list view could render.

## Type of Change

- [x] Performance improvement

## Testing

- [x] Unit tests pass
- [x] New regression test updated
- [x] Full web suite: 2,221 files passed; 17,422 tests passed; 75 skipped; 6 todo
- [x] Web typecheck and production build pass
- [x] Pre-push affected verification passes on Node 22.23.1 / pnpm 9.15.4

### Bug-to-Test Rule

- [x] Regression test updated: `dashboard-tasks-page.test.tsx` proves initial render fetches only the default list and never the board.
- [x] bug-to-test: satisfied

## Behavior / Risk

- Loading, entitlement, error, empty, and populated states are unchanged.
- No visual, accessibility, database, environment, or feature-flag changes.
- The board view retains its existing client-side query and cache behavior.
- Exact staged and production performance proof remains required before JOV-4376 is complete.

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new logging or types
- [x] Performance considerations addressed

## Design Skill Evidence

design-canonical: not applicable — no rendered UI or layout changes.

## Related Issues

Linear: JOV-4376

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with target branch
- [ ] All CI checks pass
- [x] Documentation not needed
- [x] Changelog not needed
