### PR TITLE
fix(release): make performance budgets observational

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1031,7 +1031,13 @@ jobs:
             --route-id creator-contacts \
             --route-id creator-calendar \
             --route-id creator-tasks; then
-            fail_performance_gate "Canonical six-route browser budgets failed on the exact staged build."
+            # Performance is observational while the product stabilizes. Keep
+            # the exact-build/auth/deployment gates hard, but do not block a
+            # verified production release on latency or bundle budgets.
+            echo "::warning::Canonical six-route browser budgets exceeded on the exact staged build; continuing with a warning."
+            echo "performance_status=warn" >> "$GITHUB_OUTPUT"
+          else
+            echo "performance_status=passed" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Recheck main immediately before production promotion


### PR DESCRIPTION
## Summary
- Keep exact-build authentication, deployment identity, and functional release gates blocking.
- Treat the six-route browser performance budget as a warning while the product stabilizes.
- Continue production promotion when the performance budget fails, with an explicit warning receipt.

## Rationale
A slow product is preferable to a broken or undeployed product at this stage. Performance remains measured and visible; it no longer blocks verified functional releases.

## Verification
- 
- 

## Risk
This allows a release with degraded latency or bundle budgets, but does not bypass auth, deployment, migration, canary, or production identity gates.