### PR TITLE
fix(release): fail closed on authenticated readiness and performance

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1031,11 +1031,7 @@ jobs:
             --route-id creator-contacts \
             --route-id creator-calendar \
             --route-id creator-tasks; then
-            # Performance is observational while the product stabilizes. Keep
-            # the exact-build/auth/deployment gates hard, but do not block a
-            # verified production release on latency or bundle budgets.
-            echo "::warning::Canonical six-route browser budgets exceeded on the exact staged build; continuing with a warning."
-            echo "performance_status=warn" >> "$GITHUB_OUTPUT"
+            fail_performance_gate "Canonical six-route browser budgets failed on the exact staged build."
           else
             echo "performance_status=passed" >> "$GITHUB_OUTPUT"
           fi

--- a/apps/web/tests/e2e/smoke-prod-auth.spec.ts
+++ b/apps/web/tests/e2e/smoke-prod-auth.spec.ts
@@ -7,7 +7,10 @@ import {
 } from '../helpers/vercel-preview';
 import { primeOriginBoundVercelBypass } from './utils/prime-vercel-bypass';
 import { resolveProductionAuthCredentials } from './utils/production-auth-credentials';
-import { prepareProductionAuthEmailForm } from './utils/production-auth-interaction';
+import {
+  prepareProductionAuthEmailForm,
+  waitForProductionDashboardContent,
+} from './utils/production-auth-interaction';
 import { waitForProductionAuthOtp } from './utils/production-auth-otp';
 import { SMOKE_TIMEOUTS, waitForHydration } from './utils/smoke-test-utils';
 
@@ -232,11 +235,10 @@ test.describe('Production Auth Smoke @production-smoke', () => {
       }
     );
 
-    const mainText = await main.innerText().catch(() => '');
-    expect(
-      mainText.length,
-      'Dashboard should have real content (not empty)'
-    ).toBeGreaterThan(30);
+    const mainText = await waitForProductionDashboardContent(
+      page,
+      SMOKE_TIMEOUTS.VISIBILITY
+    );
 
     const lower = mainText.toLowerCase();
     expect(lower).not.toContain('application error');

--- a/apps/web/tests/e2e/utils/production-auth-interaction.ts
+++ b/apps/web/tests/e2e/utils/production-auth-interaction.ts
@@ -13,6 +13,8 @@ export interface ProductionAuthEmailFormControls {
   readonly submitButton: Locator;
 }
 
+const DASHBOARD_MAIN_SELECTOR = 'main';
+
 /**
  * Wait for the production auth page to be interactive before mutating its
  * controlled email input. Filling at `domcontentloaded` can race React
@@ -49,4 +51,29 @@ export async function prepareProductionAuthEmailForm(
   );
 
   return { identifierInput, submitButton };
+}
+
+/**
+ * Wait for the authenticated dashboard to render meaningful content.
+ * The app shell can expose a visible, temporarily empty <main> while the
+ * redirected React Server Component payload is still settling.
+ */
+export async function waitForProductionDashboardContent(
+  page: Page,
+  timeoutMs = 15_000,
+  minLength = 30
+): Promise<string> {
+  const contentHandle = await page.waitForFunction(
+    ({ selector, minimumLength }) => {
+      const main = document.querySelector(selector);
+      if (!(main instanceof HTMLElement)) return false;
+
+      const text = (main.innerText || main.textContent || '').trim();
+      return text.length > minimumLength ? text : false;
+    },
+    { selector: DASHBOARD_MAIN_SELECTOR, minimumLength: minLength },
+    { timeout: timeoutMs }
+  );
+
+  return contentHandle.jsonValue() as Promise<string>;
 }

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1046,6 +1046,11 @@ describe('deploy workflow Vercel env resolution', () => {
     );
     expect(performanceStep).toContain('--auth-path "$auth_state"');
     expect(performanceStep).toContain('--runs 3');
+    expect(performanceStep).toContain(
+      'fail_performance_gate "Canonical six-route browser budgets failed on the exact staged build."'
+    );
+    expect(performanceStep).not.toContain('performance_status=warn');
+    expect(performanceStep).not.toContain('continuing with a warning');
     for (const routeId of [
       'creator-inbox-nav',
       'creator-chat-nav',

--- a/apps/web/tests/unit/e2e/production-auth-interaction.test.ts
+++ b/apps/web/tests/unit/e2e/production-auth-interaction.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { prepareProductionAuthEmailForm } from '../../e2e/utils/production-auth-interaction';
+import {
+  prepareProductionAuthEmailForm,
+  waitForProductionDashboardContent,
+} from '../../e2e/utils/production-auth-interaction';
 
 describe('production auth interaction hydration gate', () => {
   it('waits for full load before refilling the controlled email and enabling submit', async () => {
@@ -62,5 +65,45 @@ describe('production auth interaction hydration gate', () => {
       'fill:smoke@example.com',
       'submit-enabled',
     ]);
+  });
+
+  it('waits for meaningful dashboard content instead of sampling an empty main', async () => {
+    document.body.innerHTML = '<main></main>';
+
+    const page = {
+      waitForFunction: vi.fn(
+        async (
+          predicate: (options: {
+            selector: string;
+            minimumLength: number;
+          }) => string | false,
+          options: { selector: string; minimumLength: number }
+        ) => {
+          expect(predicate(options)).toBe(false);
+
+          const main = document.querySelector('main');
+          expect(main).not.toBeNull();
+          if (main) {
+            main.textContent =
+              'Your dashboard is ready with real authenticated content.';
+          }
+
+          const content = predicate(options);
+          expect(content).toBe(
+            'Your dashboard is ready with real authenticated content.'
+          );
+          return { jsonValue: vi.fn(async () => content) };
+        }
+      ),
+    };
+
+    await expect(
+      waitForProductionDashboardContent(page as never, 20_000)
+    ).resolves.toBe('Your dashboard is ready with real authenticated content.');
+    expect(page.waitForFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { selector: 'main', minimumLength: 30 },
+      { timeout: 20_000 }
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Wait for meaningful authenticated dashboard content before accepting the production OTP smoke.
- Preserve the Playwright artifact secret guard and its fail-closed retry behavior.
- Restore blocking canonical six-route performance budgets after #14863 made them observational.
- Add regression coverage proving empty dashboard shells are not sampled and performance warnings cannot bypass promotion.

## Root cause
Production Controller run 30189223564 completed OTP sign-in, but the smoke sampled a visible, temporarily empty `<main>` before the redirected RSC content settled. The retry passed but produced an unverifiable binary Playwright artifact, which the existing secret guard correctly blocked.

While this recovery was in progress, #14863 changed exact-build performance failures to warnings. That conflicts with the existing production contract and the JOV-4376 requirement to land the Tasks latency fix under the existing 1,000 ms budget, so this PR restores the hard failure.

## Verification
- `pnpm biome check --write apps/web` — 7,344 files checked, no fixes.
- Web typecheck — passed.
- Bug-to-test gate — satisfied.
- Focused release/auth/security tests — 111/111 passed.
- Enforced pre-push full web suite — 2,221 files passed, 17,423 tests passed.
- CI harness validation and generated-doc checks — passed.
- Pre-commit and pre-push secret scans — passed.

## Risk
High-risk release workflow and auth smoke path. This does not weaken retries, secret scanning, artifact policy, performance thresholds, deployment identity, or native queue controls. It restores fail-closed performance semantics and makes authenticated readiness deterministic.