### PR TITLE
perf(calendar): render workspace before data queries

### DIFF
--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -1,18 +1,6 @@
 import type { Metadata } from 'next';
 import { APP_ROUTES } from '@/constants/routes';
-import { captureError } from '@/lib/error-tracking';
-import { queryKeys } from '@/lib/queries';
-import { HydrateClient } from '@/lib/queries/HydrateClient';
-import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
-import type { EventRecord } from '@/lib/queries/useEventsQuery';
-import { loadReleaseMatrix } from '@/lib/releases/release-matrix-loader';
-import type {
-  TicketStatus,
-  TourDateProviderValue,
-  TourDateViewModel,
-} from '@/lib/tour-dates/types';
 import { loadAppShellRouteContext } from '../app-shell-route-context';
-import { loadTourDates } from '../dashboard/tour-dates/actions';
 import { LazyCalendarPageClient } from './LazyCalendarPageClient';
 
 export const runtime = 'nodejs';
@@ -23,69 +11,6 @@ export const metadata: Metadata = {
 };
 
 const CALENDAR_ROUTE = APP_ROUTES.CALENDAR;
-
-function formatProvider(provider: TourDateProviderValue): string {
-  if (provider === 'bandsintown') return 'Bandsintown';
-  if (provider === 'songkick') return 'Songkick';
-  if (provider === 'admin_import') return 'Admin Import';
-  return 'Manual';
-}
-
-function formatStatus(status: TicketStatus): string | undefined {
-  if (status === 'sold_out') return 'Sold out';
-  if (status === 'cancelled') return 'Cancelled';
-  return undefined;
-}
-
-function formatLocation(
-  city: string,
-  region: string | null,
-  country: string | null
-): string {
-  if (region) return `${city}, ${region}`;
-  if (country) return `${city}, ${country}`;
-  return city;
-}
-
-function tourDateToCalendarEvent(td: TourDateViewModel): EventRecord {
-  const location = formatLocation(td.city, td.region, td.country);
-  const providerLabel = formatProvider(td.provider);
-  return {
-    id: td.id,
-    title: td.title || td.venueName || td.city,
-    subtitle: `${location} · ${providerLabel}`,
-    eventDate: td.startDate,
-    timezone: td.timezone,
-    eventType: td.eventType,
-    confirmationStatus: td.confirmationStatus,
-    providerKey: td.provider,
-    reviewedAt: td.reviewedAt,
-    lastSyncedAt: td.lastSyncedAt,
-    venue: td.venueName,
-    city: location,
-    provider: providerLabel,
-    status: formatStatus(td.ticketStatus),
-    ticketUrl: td.ticketUrl ?? undefined,
-  };
-}
-
-async function prefetchCalendarQueries(profileId: string) {
-  const queryClient = getQueryClient();
-
-  await Promise.all([
-    queryClient.fetchQuery({
-      queryKey: queryKeys.releases.matrix(profileId),
-      queryFn: () => loadReleaseMatrix(profileId),
-    }),
-    queryClient.fetchQuery({
-      queryKey: queryKeys.events.list(profileId),
-      queryFn: async () => {
-        const dates = await loadTourDates(profileId);
-        return dates.map(tourDateToCalendarEvent);
-      },
-    }),
-  ]);
-}
 
 /**
  * Calendar route — unified month-grid view of releases + events.
@@ -107,20 +32,5 @@ export default async function CalendarPage() {
     return routeContext.error;
   }
 
-  const profileId = routeContext.profileId;
-  if (profileId) {
-    try {
-      await prefetchCalendarQueries(profileId);
-    } catch (error) {
-      void captureError('Calendar prefetch failed on calendar page', error, {
-        route: CALENDAR_ROUTE,
-      });
-    }
-  }
-
-  return (
-    <HydrateClient state={getDehydratedState()}>
-      <LazyCalendarPageClient />
-    </HydrateClient>
-  );
+  return <LazyCalendarPageClient />;
 }

--- a/apps/web/tests/unit/calendar/calendar-client-query-loading.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-client-query-loading.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { CalendarPageClient } from '@/app/app/(shell)/calendar/CalendarPageClient';
+
+const mocks = vi.hoisted(() => ({
+  loadReleaseMatrix: vi.fn(),
+  loadTourDates: vi.fn(),
+  useDashboardData: vi.fn(),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: mocks.useDashboardData,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/tour-dates/events-actions', () => ({
+  confirmEvent: vi.fn(),
+  confirmEvents: vi.fn(),
+  loadTourDates: mocks.loadTourDates,
+  rejectEvent: vi.fn(),
+  rejectEvents: vi.fn(),
+  undoRejectEvent: vi.fn(),
+}));
+
+vi.mock('@/components/features/dashboard/NavigationDestinationReady', () => ({
+  NavigationDestinationReady: () => null,
+}));
+
+vi.mock('@/lib/releases/release-matrix-loader', () => ({
+  loadReleaseMatrix: mocks.loadReleaseMatrix,
+}));
+
+vi.mock('@/lib/queries/useEventsQuery', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const { queryKeys, STANDARD_NO_REMOUNT_CACHE } = await import(
+    '@/lib/queries'
+  );
+
+  return {
+    useEventsQuery: (profileId: string) =>
+      useQuery({
+        queryKey: queryKeys.events.list(profileId),
+        queryFn: ({ signal: _signal }) => mocks.loadTourDates(profileId),
+        ...STANDARD_NO_REMOUNT_CACHE,
+        enabled: Boolean(profileId),
+      }),
+  };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(next => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function QueryHarness({ children }: { readonly children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('CalendarPageClient query loading', () => {
+  it('renders the stable workspace before client-owned data queries settle', async () => {
+    const releases = deferred<[]>();
+    const events = deferred<[]>();
+    mocks.loadReleaseMatrix.mockReturnValueOnce(releases.promise);
+    mocks.loadTourDates.mockReturnValueOnce(events.promise);
+    mocks.useDashboardData.mockReturnValue({
+      selectedProfile: { id: 'profile-1' },
+    });
+
+    render(<CalendarPageClient />, { wrapper: QueryHarness });
+
+    expect(screen.getByTestId('calendar-workspace')).toBeInTheDocument();
+    expect(screen.getByText('Loading calendar…')).not.toHaveClass('invisible');
+
+    await waitFor(() => {
+      expect(mocks.loadReleaseMatrix).toHaveBeenCalledWith('profile-1');
+      expect(mocks.loadTourDates).toHaveBeenCalledWith('profile-1');
+    });
+
+    releases.resolve([]);
+    events.resolve([]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading calendar…')).toHaveClass('invisible');
+    });
+  });
+});

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -1,23 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
-import { queryKeys } from '@/lib/queries';
 
 const mocks = vi.hoisted(() => ({
   getCachedAuth: vi.fn(),
   getDashboardShellData: vi.fn(),
-  getDehydratedState: vi.fn(() => ({ dehydrated: true })),
-  getQueryClient: vi.fn(),
   loadReleaseMatrix: vi.fn(),
   loadTourDates: vi.fn(),
   redirect: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
-  fetchQuery: vi.fn(
-    async <T,>(options: { readonly queryFn: () => Promise<T> }) =>
-      options.queryFn()
-  ),
   captureError: vi.fn(),
 }));
 
@@ -31,25 +23,6 @@ vi.mock('@/lib/auth/cached', () => ({
 
 vi.mock('@/lib/error-tracking', () => ({
   captureError: mocks.captureError,
-}));
-
-vi.mock('@/lib/queries/HydrateClient', () => ({
-  HydrateClient: ({
-    children,
-    state,
-  }: {
-    readonly children: ReactNode;
-    readonly state: unknown;
-  }) => (
-    <div data-state={JSON.stringify(state)} data-testid='hydrate-client'>
-      {children}
-    </div>
-  ),
-}));
-
-vi.mock('@/lib/queries/server', () => ({
-  getDehydratedState: mocks.getDehydratedState,
-  getQueryClient: mocks.getQueryClient,
 }));
 
 vi.mock('@/features/feedback/PageErrorState', () => ({
@@ -94,9 +67,6 @@ describe('CalendarPage', () => {
       dashboardLoadError: null,
       needsOnboarding: false,
       selectedProfile,
-    });
-    mocks.getQueryClient.mockReturnValue({
-      fetchQuery: mocks.fetchQuery,
     });
     mocks.loadReleaseMatrix.mockResolvedValue([
       {
@@ -156,7 +126,8 @@ describe('CalendarPage', () => {
       dashboardLoadError,
       { route: APP_ROUTES.CALENDAR }
     );
-    expect(mocks.fetchQuery).not.toHaveBeenCalled();
+    expect(mocks.loadReleaseMatrix).not.toHaveBeenCalled();
+    expect(mocks.loadTourDates).not.toHaveBeenCalled();
   });
 
   it('redirects onboarded auth sessions that still need onboarding', async () => {
@@ -170,28 +141,15 @@ describe('CalendarPage', () => {
       `REDIRECT:${APP_ROUTES.START}`
     );
 
-    expect(mocks.fetchQuery).not.toHaveBeenCalled();
+    expect(mocks.loadReleaseMatrix).not.toHaveBeenCalled();
+    expect(mocks.loadTourDates).not.toHaveBeenCalled();
   });
 
-  it('hydrates release matrix and events for the selected profile', async () => {
+  it('renders without blocking on release and event queries', async () => {
     render(await CalendarPage());
 
-    expect(screen.getByTestId('hydrate-client')).toHaveAttribute(
-      'data-state',
-      '{"dehydrated":true}'
-    );
     expect(screen.getByTestId('calendar-client')).toBeInTheDocument();
-    expect(mocks.fetchQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: queryKeys.releases.matrix('profile-1'),
-      })
-    );
-    expect(mocks.fetchQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: queryKeys.events.list('profile-1'),
-      })
-    );
-    expect(mocks.loadReleaseMatrix).toHaveBeenCalledWith('profile-1');
-    expect(mocks.loadTourDates).toHaveBeenCalledWith('profile-1');
+    expect(mocks.loadReleaseMatrix).not.toHaveBeenCalled();
+    expect(mocks.loadTourDates).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- stop blocking the Calendar route on duplicate server-side release and tour-date prefetches
- render the stable 42-cell Calendar workspace immediately while the existing client-owned queries load concurrently
- add regression coverage proving the workspace renders before both data queries settle

## Root cause
The Calendar route awaited `loadReleaseMatrix` and `loadTourDates` before rendering even though `CalendarPageClient` already owns those queries. Exact-main production verification measured Calendar skeleton-ready at **1183.3 ms** against the hard **1000 ms** budget (prior canonical baseline: **884 ms**). The rest of the six-route shell matrix passed, including Tasks at **705.7 ms** after the preceding fix.

## Verification
- focused Calendar tests: 3 files / 10 tests passed
- full web suite: 2222 files / 17424 tests passed (9 files and 75 tests skipped; 6 todo)
- web typecheck: passed
- monorepo typecheck: passed across 11 packages
- server-boundary lint: passed
- Biome: 7344 files clean
- production build: passed; 465 static pages generated and runtime trace contract verified
- pre-commit and pre-push gates: passed

## Bug-to-test
`calendar-client-query-loading.test.tsx` leaves both release and event promises pending, asserts the stable Calendar workspace is already visible, confirms both client-owned queries start, then verifies the reserved loading state clears after they settle.

Linear: JOV-4376
