### PR TITLE
perf(contacts): render table before data query

### DIFF
--- a/apps/web/app/app/(shell)/contacts/ContactsPageClient.tsx
+++ b/apps/web/app/app/(shell)/contacts/ContactsPageClient.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ContactsManager } from '@/features/dashboard/organisms/ContactsManager';
+import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { useContactsQuery } from '@/lib/queries';
+import type { DashboardContact } from '@/types/contacts';
+
+const EMPTY_CONTACTS: DashboardContact[] = [];
+
+export function ContactsPageClient({
+  profileId,
+  artistName,
+  artistHandle,
+}: {
+  readonly profileId: string;
+  readonly artistName: string;
+  readonly artistHandle: string;
+}) {
+  const { data, isError, isLoading } = useContactsQuery(profileId);
+
+  if (isError && !data) {
+    return (
+      <div
+        className='flex h-full min-h-0 items-center justify-center'
+        data-testid='contacts-table'
+      >
+        <PageErrorState message='Failed to load contacts. Please refresh the page.' />
+      </div>
+    );
+  }
+
+  return (
+    <ContactsManager
+      profileId={profileId}
+      artistName={artistName}
+      artistHandle={artistHandle}
+      initialContacts={data ?? EMPTY_CONTACTS}
+      isLoading={isLoading}
+    />
+  );
+}

--- a/apps/web/app/app/(shell)/contacts/page.tsx
+++ b/apps/web/app/app/(shell)/contacts/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from 'next';
 import { APP_ROUTES } from '@/constants/routes';
-import { ContactsManager } from '@/features/dashboard/organisms/ContactsManager';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { captureError } from '@/lib/error-tracking';
 import { loadAppShellRouteContext } from '../app-shell-route-context';
-import { getProfileContactsForOwner } from '../dashboard/contacts/actions';
+import { ContactsPageClient } from './ContactsPageClient';
 
 export const runtime = 'nodejs';
 
@@ -30,25 +28,11 @@ export default async function ContactsPage() {
     );
   }
 
-  try {
-    const contacts = await getProfileContactsForOwner(profile.id);
-
-    return (
-      <ContactsManager
-        profileId={profile.id}
-        artistName={profile.displayName?.trim() || profile.username}
-        artistHandle={profile.usernameNormalized ?? profile.username}
-        initialContacts={contacts}
-      />
-    );
-  } catch (error) {
-    void captureError('Contacts load failed on contacts page', error, {
-      route: APP_ROUTES.CONTACTS,
-      profileId: profile.id,
-    });
-
-    return (
-      <PageErrorState message='Failed to load contacts. Please refresh the page.' />
-    );
-  }
+  return (
+    <ContactsPageClient
+      profileId={profile.id}
+      artistName={profile.displayName?.trim() || profile.username}
+      artistHandle={profile.usernameNormalized ?? profile.username}
+    />
+  );
 }

--- a/apps/web/components/features/dashboard/organisms/ContactsManager.tsx
+++ b/apps/web/components/features/dashboard/organisms/ContactsManager.tsx
@@ -12,6 +12,7 @@ export interface ContactsManagerProps {
   readonly artistName: string;
   readonly artistHandle: string;
   readonly initialContacts: DashboardContact[];
+  readonly isLoading?: boolean;
 }
 
 export function ContactsManager({
@@ -19,6 +20,7 @@ export function ContactsManager({
   artistName,
   artistHandle,
   initialContacts,
+  isLoading = false,
 }: ContactsManagerProps) {
   const {
     contacts,
@@ -44,10 +46,11 @@ export function ContactsManager({
 
   return (
     <>
-      <NavigationDestinationReady destination='contacts' />
+      <NavigationDestinationReady destination='contacts' ready={!isLoading} />
       <ContactsTable
         contacts={contacts}
         artistName={artistName}
+        isLoading={isLoading}
         onUpdate={updateContact}
         onSave={handleSave}
         onDelete={handleDelete}

--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -25,6 +25,7 @@ import { buildContactActions } from './contact-actions';
 interface ContactsTableProps {
   readonly contacts: EditableContact[];
   readonly artistName: string;
+  readonly isLoading?: boolean;
   readonly onUpdate: (id: string, updates: Partial<EditableContact>) => void;
   readonly onSave: (contact: EditableContact) => Promise<string | undefined>;
   readonly onDelete: (contact: EditableContact) => void;
@@ -34,6 +35,7 @@ interface ContactsTableProps {
 export const ContactsTable = memo(function ContactsTable({
   contacts,
   artistName,
+  isLoading = false,
   onUpdate,
   onSave,
   onDelete,
@@ -187,7 +189,7 @@ export const ContactsTable = memo(function ContactsTable({
     [selectedContactId]
   );
 
-  const isEmpty = contacts.length === 0;
+  const isEmpty = !isLoading && contacts.length === 0;
 
   return (
     <div className='flex h-full min-h-0 flex-row' data-testid='contacts-table'>
@@ -229,7 +231,7 @@ export const ContactsTable = memo(function ContactsTable({
             <UnifiedTable
               data={contacts}
               columns={columns}
-              isLoading={false}
+              isLoading={isLoading}
               getRowId={contact => contact.id}
               minWidth={`${TABLE_MIN_WIDTHS.MEDIUM}px`}
               className='text-app'

--- a/apps/web/tests/unit/app/contacts-page-client.test.tsx
+++ b/apps/web/tests/unit/app/contacts-page-client.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { contactsManagerMock, useContactsQueryMock } = vi.hoisted(() => ({
+  contactsManagerMock: vi.fn(),
+  useContactsQueryMock: vi.fn(),
+}));
+
+vi.mock('@/features/dashboard/organisms/ContactsManager', () => ({
+  ContactsManager: (props: { readonly isLoading: boolean }) => {
+    contactsManagerMock(props);
+    return (
+      <div
+        data-loading={String(props.isLoading)}
+        data-testid='contacts-table'
+      />
+    );
+  },
+}));
+
+vi.mock('@/lib/queries', () => ({
+  useContactsQuery: useContactsQueryMock,
+}));
+
+import { ContactsPageClient } from '@/app/app/(shell)/contacts/ContactsPageClient';
+
+const baseProps = {
+  profileId: 'profile_123',
+  artistName: 'Tim White',
+  artistHandle: 'tim-white',
+};
+
+describe('ContactsPageClient', () => {
+  beforeEach(() => {
+    contactsManagerMock.mockReset();
+    useContactsQueryMock.mockReset();
+  });
+
+  it('renders the stable contacts workspace while its query is pending', () => {
+    useContactsQueryMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+      isLoading: true,
+    });
+
+    render(<ContactsPageClient {...baseProps} />);
+
+    expect(screen.getByTestId('contacts-table')).toHaveAttribute(
+      'data-loading',
+      'true'
+    );
+    expect(useContactsQueryMock).toHaveBeenCalledWith('profile_123');
+    expect(contactsManagerMock).toHaveBeenCalledWith({
+      ...baseProps,
+      initialContacts: [],
+      isLoading: true,
+    });
+  });
+
+  it('hydrates the workspace with client-owned query data', () => {
+    const contacts = [{ id: 'contact_1', role: 'bookings' }];
+    useContactsQueryMock.mockReturnValue({
+      data: contacts,
+      isError: false,
+      isLoading: false,
+    });
+
+    render(<ContactsPageClient {...baseProps} />);
+
+    expect(contactsManagerMock).toHaveBeenCalledWith({
+      ...baseProps,
+      initialContacts: contacts,
+      isLoading: false,
+    });
+  });
+
+  it('keeps a stable ready surface when contact loading fails', () => {
+    useContactsQueryMock.mockReturnValue({
+      data: undefined,
+      isError: true,
+      isLoading: false,
+    });
+
+    render(<ContactsPageClient {...baseProps} />);
+
+    expect(screen.getByTestId('contacts-table')).toBeInTheDocument();
+    expect(
+      screen.getByText('Failed to load contacts. Please refresh the page.')
+    ).toBeInTheDocument();
+    expect(contactsManagerMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps cached contacts visible when a background refetch fails', () => {
+    const contacts = [{ id: 'contact_1', role: 'bookings' }];
+    useContactsQueryMock.mockReturnValue({
+      data: contacts,
+      isError: true,
+      isLoading: false,
+    });
+
+    render(<ContactsPageClient {...baseProps} />);
+
+    expect(contactsManagerMock).toHaveBeenCalledWith({
+      ...baseProps,
+      initialContacts: contacts,
+      isLoading: false,
+    });
+    expect(
+      screen.queryByText('Failed to load contacts. Please refresh the page.')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/app/contacts-page.test.tsx
+++ b/apps/web/tests/unit/app/contacts-page.test.tsx
@@ -2,35 +2,20 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 
-const {
-  captureErrorMock,
-  getContactsMock,
-  loadRouteContextMock,
-  contactsManagerMock,
-} = vi.hoisted(() => ({
-  captureErrorMock: vi.fn(),
-  getContactsMock: vi.fn(),
+const { loadRouteContextMock, contactsPageClientMock } = vi.hoisted(() => ({
   loadRouteContextMock: vi.fn(),
-  contactsManagerMock: vi.fn(),
+  contactsPageClientMock: vi.fn(),
 }));
 
 vi.mock('@/app/app/(shell)/app-shell-route-context', () => ({
   loadAppShellRouteContext: loadRouteContextMock,
 }));
 
-vi.mock('@/app/app/(shell)/dashboard/contacts/actions', () => ({
-  getProfileContactsForOwner: getContactsMock,
-}));
-
-vi.mock('@/features/dashboard/organisms/ContactsManager', () => ({
-  ContactsManager: (props: unknown) => {
-    contactsManagerMock(props);
+vi.mock('@/app/app/(shell)/contacts/ContactsPageClient', () => ({
+  ContactsPageClient: (props: unknown) => {
+    contactsPageClientMock(props);
     return <div>Contacts workspace</div>;
   },
-}));
-
-vi.mock('@/lib/error-tracking', () => ({
-  captureError: captureErrorMock,
 }));
 
 import ContactsPage from '@/app/app/(shell)/contacts/page';
@@ -44,10 +29,8 @@ const profile = {
 
 describe('canonical contacts page', () => {
   beforeEach(() => {
-    captureErrorMock.mockReset();
-    getContactsMock.mockReset();
     loadRouteContextMock.mockReset();
-    contactsManagerMock.mockReset();
+    contactsPageClientMock.mockReset();
     loadRouteContextMock.mockResolvedValue({
       ok: true,
       profileId: profile.id,
@@ -55,10 +38,7 @@ describe('canonical contacts page', () => {
     });
   });
 
-  it('renders the real table workspace without redirecting through Settings', async () => {
-    const contacts = [{ id: 'contact_1', role: 'bookings' }];
-    getContactsMock.mockResolvedValue(contacts);
-
+  it('renders without blocking on the contacts query', async () => {
     render(await ContactsPage());
 
     expect(loadRouteContextMock).toHaveBeenCalledWith({
@@ -67,12 +47,10 @@ describe('canonical contacts page', () => {
       dashboardErrorMessage:
         'Failed to load contacts. Please refresh the page.',
     });
-    expect(getContactsMock).toHaveBeenCalledWith(profile.id);
-    expect(contactsManagerMock).toHaveBeenCalledWith({
+    expect(contactsPageClientMock).toHaveBeenCalledWith({
       profileId: profile.id,
       artistName: profile.displayName,
       artistHandle: profile.usernameNormalized,
-      initialContacts: contacts,
     });
     expect(screen.getByText('Contacts workspace')).toBeInTheDocument();
   });
@@ -86,23 +64,7 @@ describe('canonical contacts page', () => {
     render(await ContactsPage());
 
     expect(screen.getByText('Route error')).toBeInTheDocument();
-    expect(getContactsMock).not.toHaveBeenCalled();
-  });
-
-  it('renders a stable error state when contact loading fails', async () => {
-    const error = new Error('contacts unavailable');
-    getContactsMock.mockRejectedValue(error);
-
-    render(await ContactsPage());
-
-    expect(
-      screen.getByText('Failed to load contacts. Please refresh the page.')
-    ).toBeInTheDocument();
-    expect(captureErrorMock).toHaveBeenCalledWith(
-      'Contacts load failed on contacts page',
-      error,
-      { route: APP_ROUTES.CONTACTS, profileId: profile.id }
-    );
+    expect(contactsPageClientMock).not.toHaveBeenCalled();
   });
 
   it('fails visibly when no artist profile is available', async () => {
@@ -119,6 +81,6 @@ describe('canonical contacts page', () => {
         'Unable to load your artist profile. Please refresh the page.'
       )
     ).toBeInTheDocument();
-    expect(getContactsMock).not.toHaveBeenCalled();
+    expect(contactsPageClientMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/components/organisms/table', async importOriginal => {
     UnifiedTable: ({
       data,
       getRowClassName,
+      isLoading,
       onRowClick,
     }: {
       readonly data: EditableContact[];
@@ -41,6 +42,7 @@ vi.mock('@/components/organisms/table', async importOriginal => {
         row: EditableContact,
         index: number
       ) => string;
+      readonly isLoading?: boolean;
       readonly onRowClick?: (row: EditableContact) => void;
     }) => {
       const firstRowClassName = data[0]
@@ -50,6 +52,7 @@ vi.mock('@/components/organisms/table', async importOriginal => {
       return (
         <div
           data-first-row-class={firstRowClassName}
+          data-loading={String(isLoading)}
           data-testid='contacts-unified-table'
         >
           {data[0] ? (
@@ -145,5 +148,26 @@ describe('ContactsTable', () => {
     );
     expect(setHeaderActions).toHaveBeenCalled();
     expect(setTableMeta).toHaveBeenCalled();
+  });
+
+  it('forwards loading state to the table instead of showing a false empty state', () => {
+    render(
+      <ContactsTable
+        contacts={[]}
+        artistName='Tim White'
+        isLoading
+        onUpdate={() => undefined}
+        onSave={async () => undefined}
+        onDelete={() => undefined}
+        onAddContact={() => undefined}
+      />
+    );
+
+    expect(screen.getByTestId('contacts-table')).toBeInTheDocument();
+    expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
+      'data-loading',
+      'true'
+    );
+    expect(screen.queryByText('No Contacts Yet')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -17,6 +17,10 @@ import {
 import redirectBaseline from './shell-redirect-stubs.baseline.json';
 
 const SHELL_ROOT = path.resolve(__dirname, '../../../app/app/(shell)');
+const CONTACTS_CLIENT_PATH = path.join(
+  SHELL_ROOT,
+  'contacts/ContactsPageClient.tsx'
+);
 
 const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app': 'Shell root entry page',
@@ -157,11 +161,14 @@ describe('shell route coverage', () => {
 
   it('keeps the canonical Contacts destination as a real workspace', () => {
     const contactsPage = pageByRoute.get(APP_ROUTES.CONTACTS);
+    const contactsClient = fs.readFileSync(CONTACTS_CLIENT_PATH, 'utf8');
 
     expect(contactsPage).toBeDefined();
     expect(contactsPage?.source).not.toMatch(/\bredirect\(/);
-    expect(contactsPage?.source).toContain('ContactsManager');
-    expect(contactsPage?.source).toContain('getProfileContactsForOwner');
+    expect(contactsPage?.source).toContain('ContactsPageClient');
+    expect(contactsPage?.source).not.toContain('getProfileContactsForOwner');
+    expect(contactsClient).toContain('ContactsManager');
+    expect(contactsClient).toContain('useContactsQuery');
   });
 
   it('non-nav shell pages are intentional internals or baselined redirects', () => {


### PR DESCRIPTION
## Description

Removes the blocking server-side Contacts fetch from `/app/contacts`. The canonical route now renders a stable client workspace immediately, shows the existing table skeleton while `useContactsQuery` loads, and only marks the navigation destination ready after the query settles.

The exact-main Production Controller measured Contacts skeleton visibility at 2239.0 ms against the hard 1000 ms budget on `b3bf4c1de48fa96aff69685ff332a071664d8ea3`. The server page was awaiting the full contacts query before the performance selector could exist.

Cached contacts remain visible if a background refetch fails; an initial query failure keeps a stable Contacts surface with the existing error state.

Linear: JOV-4376

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Testing

- [x] Unit tests pass
- [x] New tests added
- [x] Full web suite: 2,223 files / 17,428 tests passed
- [x] Monorepo typecheck: 11/11 packages passed
- [x] Biome: 7,347 web files passed
- [x] Production build passed
- [x] Server-boundary lint passed

### Bug-to-Test Rule

- [x] Regression tests cover the pending query workspace, client hydration, initial failure, cached-data refetch failure, loading skeleton forwarding, and the shell route architecture guard.
- [x] bug-to-test: satisfied

## Performance and UX

- Stable `data-testid="contacts-table"` exists before the contacts query resolves.
- The table shows loading state instead of a false empty state.
- `NavigationDestinationReady` remains false until loading completes.
- No layout structure is swapped during successful hydration.

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] Performance considerations addressed

## Accessibility

No interaction, focus, semantics, color, or icon behavior changed. The existing table and error components remain authoritative.

## Deployment Notes

No migrations, environment variables, feature flags, or third-party changes.

## Design Skill Evidence

design-canonical: not applicable — this changes data-loading ownership and preserves the existing Contacts UI.

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with target branch
- [x] All local checks pass
- [x] Documentation not required