### PR TITLE
fix(release): serialize production OTP smoke

### DIFF
--- a/apps/web/tests/e2e/smoke-prod-auth.spec.ts
+++ b/apps/web/tests/e2e/smoke-prod-auth.spec.ts
@@ -179,6 +179,10 @@ async function signInViaRenderedFlow(
 }
 
 test.describe('Production Auth Smoke @production-smoke', () => {
+  // Both checks use the same dedicated production identity. Requesting a new
+  // Better Auth OTP invalidates the prior code, so these flows must not race
+  // under the repository-wide fullyParallel Playwright configuration.
+  test.describe.configure({ mode: 'serial' });
   test.setTimeout(120_000);
 
   test.beforeEach(async ({ context }, testInfo) => {

--- a/apps/web/tests/unit/e2e/production-auth-smoke-serialization.test.ts
+++ b/apps/web/tests/unit/e2e/production-auth-smoke-serialization.test.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PRODUCTION_AUTH_SMOKE_PATH = path.resolve(
+  __dirname,
+  '../../e2e/smoke-prod-auth.spec.ts'
+);
+
+describe('production auth smoke concurrency contract', () => {
+  it('serializes OTP flows that share the dedicated production identity', () => {
+    const source = fs.readFileSync(PRODUCTION_AUTH_SMOKE_PATH, 'utf8');
+
+    expect(source).toContain("test.describe.configure({ mode: 'serial' });");
+  });
+});


### PR DESCRIPTION
## Description

Repairs the final `Production Verified` blocker from controller run `30195704453` without weakening any release gate.

The post-deploy auth smoke ran both production tests concurrently under the repository-wide `fullyParallel` Playwright configuration. Both flows use the same dedicated Better Auth production identity and request fresh OTPs, so one request can invalidate the other. Evidence: `sign-in works and dashboard loads` passed while `dashboard tab navigation works` timed out on its first OTP redirect, then passed on retry when it ran alone. The resulting failure trace was correctly rejected by the fail-closed Playwright artifact guard.

This PR marks the production-auth describe block serial. The two tests still run independently with the same assertions, retries, timeouts, real OTP source, artifact guard, and exact-deployment checks; they simply cannot invalidate each other’s OTPs.

Linear: JOV-4376

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Regression test added
- [x] Focused production-auth unit tests: 3 files / 8 tests passed
- [x] Full web suite: 2,224 files / 17,429 tests passed
- [x] Monorepo typecheck: 11/11 packages passed
- [x] Biome: 7,348 web files passed
- [x] Pre-push affected verification passed

### Bug-to-Test Rule

- [x] Regression contract fails if the shared-account production auth suite is no longer serialized.
- [x] bug-to-test: satisfied

## Safety

- No runtime application code changes.
- No retry, timeout, assertion, OTP, artifact, or release gate is relaxed.
- The Playwright artifact guard remains fail closed.
- Native queue enrollment and production promotion remain controller-owned.

## Design Skill Evidence

design-canonical: not applicable — release verification only.

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with target branch
- [x] All local checks pass
- [x] Documentation not required