### PR TITLE
fix(calendar): remove redundant route loading boundary

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarRouteSkeleton.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarRouteSkeleton.tsx
@@ -1,6 +1,3 @@
-'use client';
-
-import dynamic from 'next/dynamic';
 import { PageContent, PageShell } from '@/components/organisms/PageShell';
 import { PageToolbar } from '@/components/organisms/table';
 
@@ -102,18 +99,4 @@ export function CalendarRouteSkeleton() {
       </PageContent>
     </PageShell>
   );
-}
-
-const CalendarPageClient = dynamic(
-  () =>
-    import('./CalendarPageClient').then(mod => ({
-      default: mod.CalendarPageClient,
-    })),
-  {
-    loading: () => <CalendarRouteSkeleton />,
-  }
-);
-
-export function LazyCalendarPageClient() {
-  return <CalendarPageClient />;
 }

--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { APP_ROUTES } from '@/constants/routes';
 import { loadAppShellRouteContext } from '../app-shell-route-context';
-import { LazyCalendarPageClient } from './LazyCalendarPageClient';
+import { CalendarPageClient } from './CalendarPageClient';
 
 export const runtime = 'nodejs';
 
@@ -32,5 +32,5 @@ export default async function CalendarPage() {
     return routeContext.error;
   }
 
-  return <LazyCalendarPageClient />;
+  return <CalendarPageClient />;
 }

--- a/apps/web/app/app/(shell)/loading.test.tsx
+++ b/apps/web/app/app/(shell)/loading.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@/components/shell/LyricsRouteSkeleton', () => ({
 vi.mock('@/components/shell/TasksRouteSkeleton', () => ({
   TasksRouteSkeleton: () => null,
 }));
-vi.mock('./calendar/LazyCalendarPageClient', () => ({
+vi.mock('./calendar/CalendarRouteSkeleton', () => ({
   CalendarRouteSkeleton: () => null,
 }));
 vi.mock('./chat/loading', () => ({ default: () => null }));

--- a/apps/web/app/app/(shell)/loading.tsx
+++ b/apps/web/app/app/(shell)/loading.tsx
@@ -4,7 +4,7 @@ import { PageShell } from '@/components/organisms/PageShell';
 import { DashboardSegmentSkeleton } from '@/components/shell/DashboardSegmentSkeleton';
 import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
 import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
-import { CalendarRouteSkeleton } from './calendar/LazyCalendarPageClient';
+import { CalendarRouteSkeleton } from './calendar/CalendarRouteSkeleton';
 import ChatLoading from './chat/loading';
 import { ReleaseTableSkeleton } from './dashboard/releases/loading';
 import { LibraryLoadingState } from './library/LibrarySurface';

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -43,10 +43,8 @@ vi.mock('@/app/app/(shell)/dashboard/tour-dates/actions', () => ({
   loadTourDates: mocks.loadTourDates,
 }));
 
-vi.mock('@/app/app/(shell)/calendar/LazyCalendarPageClient', () => ({
-  LazyCalendarPageClient: () => (
-    <div data-testid='calendar-client'>Calendar</div>
-  ),
+vi.mock('@/app/app/(shell)/calendar/CalendarPageClient', () => ({
+  CalendarPageClient: () => <div data-testid='calendar-client'>Calendar</div>,
 }));
 
 const { default: CalendarPage } = await import(


### PR DESCRIPTION
## Summary

- render CalendarPageClient directly from the Calendar server route
- keep the existing route-shaped Calendar skeleton in the canonical shell loading boundary
- remove the redundant next/dynamic boundary that could leave warm navigation stuck on the skeleton after a successful 200 RSC prefetch
- update route and shell loading tests to enforce the direct boundary

## Production failure evidence

Production Controller run 30197317420 failed closed before promotion on exact main ab3476314c3aded6c6afe417fbe10aa248a658da. Calendar sample 1 completed in 24.6 ms; sample 2 timed out waiting for calendar-workspace. Vercel runtime logs for exact deployment dpl_2G54YkomxkK1iKaLLsujVFy5JeZ6 show the stalled /app/calendar prefetch returned 200 with no server error, isolating the stall to the redundant client loading boundary.

The 1000 ms budget, three-sample policy, authenticated browser state, retries, timeouts, and artifact guard are unchanged.

## Verification

- focused Calendar, shell loading, and performance manifest suite: 4 files / 31 tests passed
- full web suite: 2224 files / 17429 tests passed
- web typecheck passed
- Biome passed
- optimized Next production build passed
- affected pre-push verification passed
- local CodeRabbit review: 0 findings

## Risk

Low. The fully loaded Calendar UI and route-shaped skeleton are unchanged. This removes one client-only chunk waterfall and lets the existing Next route loading boundary own transitions.

Linear: JOV-4376