### PR TITLE
feat(shell): add admin workspace switcher

### DIFF
--- a/apps/web/components/jovie/components/picker-rows.tsx
+++ b/apps/web/components/jovie/components/picker-rows.tsx
@@ -15,6 +15,7 @@
 import {
   Calendar,
   CheckSquare,
+  Columns2,
   Image as ImageIcon,
   Link2Off,
   Link as LinkIcon,
@@ -44,6 +45,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   Music,
   Users,
   CheckSquare,
+  Columns2,
   Settings,
   Calendar,
 };

--- a/apps/web/components/molecules/WorkspaceSelector.test.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.test.tsx
@@ -68,4 +68,28 @@ describe('WorkspaceSelector', () => {
       '/app/support'
     );
   });
+
+  it('falls back to the first workspace for an unknown current id', () => {
+    render(
+      <WorkspaceSelector
+        currentWorkspaceId={'missing' as (typeof workspaces)[number]['id']}
+        workspaces={workspaces}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Switch Workspace' })
+    ).toHaveTextContent('Jovie');
+  });
+
+  it('renders nothing for an empty workspace registry', () => {
+    const { container } = render(
+      <WorkspaceSelector
+        currentWorkspaceId='missing'
+        workspaces={[] as const}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/apps/web/components/molecules/WorkspaceSelector.test.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkspaceSelector } from './WorkspaceSelector';
+
+vi.mock('@jovie/ui', () => ({
+  DropdownMenu: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { readonly children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { readonly children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const workspaces = [
+  {
+    id: 'customer',
+    label: 'Jovie',
+    href: '/app',
+    brandVariant: 'jovie',
+  },
+  {
+    id: 'ov',
+    label: 'OV',
+    href: '/app/ov',
+    brandVariant: 'ov',
+  },
+  {
+    id: 'support',
+    label: 'Support',
+    href: '/app/support',
+    brandVariant: 'jovie',
+  },
+] as const;
+
+describe('WorkspaceSelector', () => {
+  it('renders the active workspace in a stable selector trigger', () => {
+    render(
+      <WorkspaceSelector currentWorkspaceId='ov' workspaces={workspaces} />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Switch Workspace' })
+    ).toHaveTextContent('OV');
+  });
+
+  it('renders every supplied workspace with the active destination marked', () => {
+    render(
+      <WorkspaceSelector currentWorkspaceId='ov' workspaces={workspaces} />
+    );
+
+    expect(screen.getByRole('link', { name: 'Jovie' })).toHaveAttribute(
+      'href',
+      '/app'
+    );
+    expect(screen.getByRole('link', { name: 'OV' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(screen.getByRole('link', { name: 'Support' })).toHaveAttribute(
+      'href',
+      '/app/support'
+    );
+  });
+});

--- a/apps/web/components/molecules/WorkspaceSelector.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.tsx
@@ -37,7 +37,7 @@ export function WorkspaceSelector<Id extends string>({
           data-electron-no-drag='true'
           style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
           className={cn(
-            'flex h-7 w-full items-center gap-1.5 rounded-lg px-2.5 transition-colors duration-normal ease-interactive hover:bg-sidebar-accent/55 focus-visible:outline-none focus-visible:bg-sidebar-accent/55',
+            'flex h-7 w-full items-center gap-1.5 rounded-lg px-2.5 transition-colors duration-subtle ease-subtle hover:bg-sidebar-accent/55 focus-visible:outline-none focus-visible:bg-sidebar-accent/55',
             'group-data-[collapsible=icon]:justify-center'
           )}
         >

--- a/apps/web/components/molecules/WorkspaceSelector.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@jovie/ui';
+import { Check, ChevronDown } from 'lucide-react';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import { BrandLogo } from '@/components/atoms/BrandLogo';
+import type { AppShellWorkspace } from '@/lib/app-shell/workspaces';
+import { cn } from '@/lib/utils';
+
+interface WorkspaceSelectorProps<Id extends string> {
+  readonly currentWorkspaceId: Id;
+  readonly workspaces: readonly AppShellWorkspace<Id>[];
+}
+
+export function WorkspaceSelector<Id extends string>({
+  currentWorkspaceId,
+  workspaces,
+}: WorkspaceSelectorProps<Id>) {
+  const currentWorkspace =
+    workspaces.find(workspace => workspace.id === currentWorkspaceId) ??
+    workspaces[0];
+
+  if (!currentWorkspace) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type='button'
+          aria-label='Switch Workspace'
+          data-electron-no-drag='true'
+          style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
+          className={cn(
+            'flex h-7 w-full items-center gap-1.5 rounded-lg px-2.5 transition-colors duration-normal ease-interactive hover:bg-sidebar-accent/55 focus-visible:outline-none focus-visible:bg-sidebar-accent/55',
+            'group-data-[collapsible=icon]:justify-center'
+          )}
+        >
+          <BrandLogo
+            size={14}
+            tone='auto'
+            variant={currentWorkspace.brandVariant}
+            rounded={false}
+            className='shrink-0 rounded-sm'
+            aria-hidden
+          />
+          <span className='truncate flex-1 text-left text-app tracking-tight text-sidebar-item-foreground [font-weight:var(--font-weight-nav)] group-data-[collapsible=icon]:hidden'>
+            {currentWorkspace.label}
+          </span>
+          <ChevronDown
+            className='size-2.5 shrink-0 text-sidebar-item-icon group-data-[collapsible=icon]:hidden'
+            aria-hidden='true'
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='start' sideOffset={4} className='w-48'>
+        {workspaces.map(workspace => {
+          const isCurrent = workspace.id === currentWorkspace.id;
+          return (
+            <DropdownMenuItem key={workspace.id} asChild>
+              <Link
+                href={workspace.href}
+                aria-current={isCurrent ? 'page' : undefined}
+                className='flex items-center gap-2'
+              >
+                <BrandLogo
+                  size={14}
+                  tone='auto'
+                  variant={workspace.brandVariant}
+                  rounded={false}
+                  className='shrink-0 rounded-sm'
+                  aria-hidden
+                />
+                <span className='min-w-0 flex-1 truncate'>
+                  {workspace.label}
+                </span>
+                {isCurrent ? (
+                  <Check
+                    className='size-3.5 shrink-0 text-primary-token'
+                    aria-hidden='true'
+                  />
+                ) : null}
+              </Link>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/components/organisms/CommandPalette.tsx
+++ b/apps/web/components/organisms/CommandPalette.tsx
@@ -11,13 +11,20 @@
  *   - injecting the "Recent chats" section as an additional source.
  */
 
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { DashboardDataContext } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { CmdKPalette } from '@/components/organisms/CmdKPalette';
 import { type PaletteSection } from '@/components/organisms/SharedCommandPalette';
 import { APP_ROUTES } from '@/constants/routes';
+import {
+  APP_SHELL_WORKSPACES,
+  getCurrentAppShellWorkspace,
+  getNextAppShellWorkspace,
+} from '@/lib/app-shell/workspaces';
 import type { EntityRef } from '@/lib/commands/entities';
+import type { NavCommand } from '@/lib/commands/registry';
+import { WORKSPACE_SWITCH_SHORTCUT } from '@/lib/keyboard-shortcuts';
 import { useChatConversationsQuery } from '@/lib/queries';
 import { isFormElement } from '@/lib/utils/keyboard';
 import { OPEN_COMMAND_PALETTE_EVENT } from './command-palette-events';
@@ -34,15 +41,22 @@ export function CommandPalette() {
   if (!dashboardData) {
     return null;
   }
-  return <CommandPaletteInner profileId={dashboardData.selectedProfile?.id} />;
+  return (
+    <CommandPaletteInner
+      profileId={dashboardData.selectedProfile?.id}
+      isAdmin={dashboardData.isAdmin}
+    />
+  );
 }
 
 interface CommandPaletteInnerProps {
   readonly profileId: string | undefined;
+  readonly isAdmin: boolean;
 }
 
-function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
+function CommandPaletteInner({ profileId, isAdmin }: CommandPaletteInnerProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
 
   // Global ⌘K / Ctrl+K trigger.
@@ -84,6 +98,30 @@ function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
   // entity section so the shared list+keyboard machinery picks them up.
   const additionalSections = useMemo<PaletteSection[]>(() => {
     const sections: PaletteSection[] = [];
+    if (isAdmin) {
+      const currentWorkspace = getCurrentAppShellWorkspace(pathname);
+      const nextWorkspace = getNextAppShellWorkspace(
+        APP_SHELL_WORKSPACES,
+        currentWorkspace.id
+      );
+      if (nextWorkspace) {
+        const nav: NavCommand = {
+          kind: 'nav',
+          id: 'switch-workspace',
+          label: `Switch to ${nextWorkspace.label}`,
+          description: 'Change the active workspace.',
+          iconName: 'Columns2',
+          surfaces: ['cmdk'],
+          href: nextWorkspace.href,
+          shortcutLabel: WORKSPACE_SWITCH_SHORTCUT.keys,
+        };
+        sections.push({
+          id: 'workspace-actions',
+          label: 'Workspace',
+          items: [{ kind: 'nav', nav }],
+        });
+      }
+    }
     if (conversations && conversations.length > 0) {
       sections.push({
         id: 'recent-chats',
@@ -103,7 +141,7 @@ function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
       });
     }
     return sections;
-  }, [conversations]);
+  }, [conversations, isAdmin, pathname]);
 
   const handleAdditionalSelect = useCallback(
     (id: string) => {
@@ -111,9 +149,18 @@ function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
       if (id.startsWith('thread:')) {
         const threadId = id.slice('thread:'.length);
         router.push(`${APP_ROUTES.CHAT}/${threadId}`);
+        return;
+      }
+      if (id === 'switch-workspace') {
+        const currentWorkspace = getCurrentAppShellWorkspace(pathname);
+        const nextWorkspace = getNextAppShellWorkspace(
+          APP_SHELL_WORKSPACES,
+          currentWorkspace.id
+        );
+        if (nextWorkspace) router.push(nextWorkspace.href);
       }
     },
-    [router]
+    [pathname, router]
   );
 
   return (

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -245,9 +245,11 @@ export function PaletteList({
             {section.items.map((item, localIdx) => {
               const flatIdx = start + localIdx;
               const shortcutLabel =
-                showIndexedShortcuts && flatIdx < 3
-                  ? `${CMD_KEY_LABEL}${flatIdx + 1}`
-                  : undefined;
+                item.kind === 'nav' && item.nav.shortcutLabel
+                  ? item.nav.shortcutLabel
+                  : showIndexedShortcuts && flatIdx < 3
+                    ? `${CMD_KEY_LABEL}${flatIdx + 1}`
+                    : undefined;
               if (variant === 'cmdk') {
                 return (
                   <CmdKPaletteRow

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -14,6 +14,7 @@ import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataConte
 import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { toast } from '@/components/feedback';
 import { SidebarCollapseButton } from '@/components/molecules/sidebar-collapse-button';
+import { WorkspaceSelector } from '@/components/molecules/WorkspaceSelector';
 import {
   Sidebar,
   SidebarContent,
@@ -42,6 +43,7 @@ import { SidebarUpgradeBanner } from '@/features/feedback/SidebarUpgradeBanner';
 import { useAuthSafe } from '@/hooks/useClerkSafe';
 import { copyToClipboard } from '@/hooks/useClipboard';
 import { useProfileData } from '@/hooks/useProfileData';
+import { APP_SHELL_WORKSPACES } from '@/lib/app-shell/workspaces';
 import { BRAND_WORDMARKS, type BrandVariant } from '@/lib/brand/tokens';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import { env } from '@/lib/env-client';
@@ -230,7 +232,8 @@ function SettingsNavigation({
 /** Logo (clean header) or back button for settings/library */
 function SidebarHeaderNav({
   isRouteSidebar,
-  isAdmin,
+  isOperatorSection,
+  canSwitchWorkspaces,
   hasMultipleProfiles,
   isDemoRoute,
   variant = 'jovie',
@@ -238,7 +241,8 @@ function SidebarHeaderNav({
   routeBackLabel = 'Back to App',
 }: Readonly<{
   isRouteSidebar: boolean;
-  isAdmin: boolean;
+  isOperatorSection: boolean;
+  canSwitchWorkspaces: boolean;
   hasMultipleProfiles: boolean;
   isDemoRoute: boolean;
   variant?: BrandVariant;
@@ -292,7 +296,15 @@ function SidebarHeaderNav({
             </div>
           );
         }
-        if (hasMultipleProfiles && !isAdmin) {
+        if (canSwitchWorkspaces) {
+          return (
+            <WorkspaceSelector
+              currentWorkspaceId={variant === 'ov' ? 'ov' : 'customer'}
+              workspaces={APP_SHELL_WORKSPACES}
+            />
+          );
+        }
+        if (hasMultipleProfiles && !isOperatorSection) {
           return <ProfileSwitcher />;
         }
         // Clean header: brand logo + wordmark for identity (matches Linear's
@@ -438,14 +450,14 @@ export function UnifiedSidebar({
   section,
   variant = 'jovie',
 }: UnifiedSidebarProps) {
-  const { creatorProfiles } = useDashboardData();
+  const { creatorProfiles, isAdmin: canSwitchWorkspaces } = useDashboardData();
   const sidebarOverride = useShellSidebarOverride();
   const pathname = usePathname();
   const isDemoRoute = isDemoRoutePath(pathname);
   const isInSettings = section === 'settings';
-  const isAdmin = section === 'admin' || section === 'ov';
+  const isOperatorSection = section === 'admin' || section === 'ov';
   const isRouteSidebar = isInSettings || sidebarOverride !== null;
-  const usesStandardAppNavigation = !isAdmin && !isRouteSidebar;
+  const usesStandardAppNavigation = !isOperatorSection && !isRouteSidebar;
   const hasMultipleProfiles = creatorProfiles.length >= 2;
 
   const { profileHref } = useProfileData(usesStandardAppNavigation);
@@ -472,7 +484,8 @@ export function UnifiedSidebar({
       >
         <SidebarHeaderNav
           isRouteSidebar={isRouteSidebar}
-          isAdmin={isAdmin}
+          isOperatorSection={isOperatorSection}
+          canSwitchWorkspaces={canSwitchWorkspaces}
           hasMultipleProfiles={hasMultipleProfiles}
           isDemoRoute={isDemoRoute}
           variant={variant}

--- a/apps/web/hooks/useGlobalShortcutActions.test.tsx
+++ b/apps/web/hooks/useGlobalShortcutActions.test.tsx
@@ -118,6 +118,22 @@ describe('useGlobalShortcutActions (JOV-1827)', () => {
     expect(push).toHaveBeenCalledWith('/app');
   });
 
+  it('uses the physical W key when Option changes the macOS key value', () => {
+    shortcutState.isAdmin = true;
+    shortcutState.pathname = '/app';
+    push.mockClear();
+    render(<Probe />);
+
+    fireEvent.keyDown(window, {
+      key: '„',
+      code: 'KeyW',
+      altKey: true,
+      shiftKey: true,
+    });
+
+    expect(push).toHaveBeenCalledWith('/app/ov');
+  });
+
   it('does not expose workspace switching to non-admins', () => {
     shortcutState.isAdmin = false;
     shortcutState.pathname = '/app';
@@ -128,6 +144,59 @@ describe('useGlobalShortcutActions (JOV-1827)', () => {
       key: 'w',
       altKey: true,
       shiftKey: true,
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('does not switch workspaces while typing or composing', () => {
+    shortcutState.isAdmin = true;
+    shortcutState.pathname = '/app';
+    push.mockClear();
+    const { container } = render(
+      <>
+        <input />
+        <Probe />
+      </>
+    );
+
+    const input = container.querySelector('input')!;
+    fireEvent.keyDown(input, {
+      key: 'w',
+      code: 'KeyW',
+      altKey: true,
+      shiftKey: true,
+    });
+    fireEvent.keyDown(window, {
+      key: 'w',
+      code: 'KeyW',
+      altKey: true,
+      shiftKey: true,
+      isComposing: true,
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('does not switch workspaces with conflicting command modifiers', () => {
+    shortcutState.isAdmin = true;
+    shortcutState.pathname = '/app';
+    push.mockClear();
+    render(<Probe />);
+
+    fireEvent.keyDown(window, {
+      key: 'w',
+      code: 'KeyW',
+      altKey: true,
+      shiftKey: true,
+      metaKey: true,
+    });
+    fireEvent.keyDown(window, {
+      key: 'w',
+      code: 'KeyW',
+      altKey: true,
+      shiftKey: true,
+      ctrlKey: true,
     });
 
     expect(push).not.toHaveBeenCalled();

--- a/apps/web/hooks/useGlobalShortcutActions.test.tsx
+++ b/apps/web/hooks/useGlobalShortcutActions.test.tsx
@@ -1,8 +1,15 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
+import { DashboardDataContext } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 
 const cycleTheme = vi.fn();
 const signOut = vi.fn();
+const push = vi.fn();
+const shortcutState = vi.hoisted(() => ({
+  isAdmin: true,
+  pathname: '/app',
+}));
 
 vi.mock('@/hooks/useClerkSafe', () => ({
   useAuthSafe: () => ({ signOut }),
@@ -10,18 +17,38 @@ vi.mock('@/hooks/useClerkSafe', () => ({
 vi.mock('@/components/site/theme-toggle/useThemeToggle', () => ({
   useThemeToggle: () => ({ cycleTheme }),
 }));
+vi.mock('next/navigation', () => ({
+  usePathname: () => shortcutState.pathname,
+  useRouter: () => ({ push }),
+}));
 
 import { useGlobalShortcutActions } from './useGlobalShortcutActions';
 
-function Probe() {
+function ShortcutProbe() {
   useGlobalShortcutActions();
   return <div data-testid='probe' />;
+}
+
+function Probe({ withProvider = true }: { readonly withProvider?: boolean }) {
+  const node = <ShortcutProbe />;
+  if (!withProvider) return node;
+  return (
+    <DashboardDataContext.Provider
+      value={
+        {
+          isAdmin: shortcutState.isAdmin,
+        } as DashboardData
+      }
+    >
+      {node}
+    </DashboardDataContext.Provider>
+  );
 }
 
 describe('useGlobalShortcutActions (JOV-1827)', () => {
   it('cycles theme on Alt+T outside inputs', () => {
     cycleTheme.mockClear();
-    render(<Probe />);
+    render(<Probe withProvider={false} />);
     fireEvent.keyDown(window, { key: 't', altKey: true });
     expect(cycleTheme).toHaveBeenCalledTimes(1);
   });
@@ -59,5 +86,64 @@ describe('useGlobalShortcutActions (JOV-1827)', () => {
     render(<Probe />);
     fireEvent.keyDown(window, { key: 't', metaKey: true });
     expect(cycleTheme).not.toHaveBeenCalled();
+  });
+
+  it('switches an admin from Jovie to OV on Alt+Shift+W', () => {
+    shortcutState.isAdmin = true;
+    shortcutState.pathname = '/app/tasks';
+    push.mockClear();
+    render(<Probe />);
+
+    fireEvent.keyDown(window, {
+      key: 'w',
+      altKey: true,
+      shiftKey: true,
+    });
+
+    expect(push).toHaveBeenCalledWith('/app/ov');
+  });
+
+  it('switches an admin from OV back to Jovie', () => {
+    shortcutState.isAdmin = true;
+    shortcutState.pathname = '/app/ov/ops';
+    push.mockClear();
+    render(<Probe />);
+
+    fireEvent.keyDown(window, {
+      key: 'w',
+      altKey: true,
+      shiftKey: true,
+    });
+
+    expect(push).toHaveBeenCalledWith('/app');
+  });
+
+  it('does not expose workspace switching to non-admins', () => {
+    shortcutState.isAdmin = false;
+    shortcutState.pathname = '/app';
+    push.mockClear();
+    render(<Probe />);
+
+    fireEvent.keyDown(window, {
+      key: 'w',
+      altKey: true,
+      shiftKey: true,
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the dashboard provider is absent', () => {
+    shortcutState.isAdmin = false;
+    push.mockClear();
+    render(<Probe withProvider={false} />);
+
+    fireEvent.keyDown(window, {
+      key: 'w',
+      altKey: true,
+      shiftKey: true,
+    });
+
+    expect(push).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/hooks/useGlobalShortcutActions.ts
+++ b/apps/web/hooks/useGlobalShortcutActions.ts
@@ -14,14 +14,26 @@
  * Hook-order: every `useEffect` here is unconditional and runs once.
  */
 
-import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useContext, useEffect } from 'react';
+import { DashboardDataContext } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { useThemeToggle } from '@/components/site/theme-toggle/useThemeToggle';
 import { useAuthSafe } from '@/hooks/useClerkSafe';
+import {
+  APP_SHELL_WORKSPACES,
+  getCurrentAppShellWorkspace,
+  getNextAppShellWorkspace,
+} from '@/lib/app-shell/workspaces';
+import { WORKSPACE_SWITCH_KEY } from '@/lib/keyboard-shortcuts';
 import { isFormElement } from '@/lib/utils/keyboard';
 
 export function useGlobalShortcutActions() {
   const { cycleTheme } = useThemeToggle();
   const { signOut } = useAuthSafe();
+  const dashboardData = useContext(DashboardDataContext);
+  const isAdmin = dashboardData?.isAdmin ?? false;
+  const pathname = usePathname();
+  const router = useRouter();
 
   // Alt+T → cycle theme (skip when typing in inputs).
   useEffect(() => {
@@ -50,4 +62,24 @@ export function useGlobalShortcutActions() {
     globalThis.addEventListener('keydown', onKey);
     return () => globalThis.removeEventListener('keydown', onKey);
   }, [signOut]);
+
+  // Alt+Shift+W → cycle to the next authorized workspace.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!isAdmin || e.isComposing) return;
+      if (!e.altKey || !e.shiftKey || e.metaKey || e.ctrlKey) return;
+      if (e.key.toLowerCase() !== WORKSPACE_SWITCH_KEY) return;
+      if (isFormElement(e.target)) return;
+      const currentWorkspace = getCurrentAppShellWorkspace(pathname);
+      const nextWorkspace = getNextAppShellWorkspace(
+        APP_SHELL_WORKSPACES,
+        currentWorkspace.id
+      );
+      if (!nextWorkspace) return;
+      e.preventDefault();
+      router.push(nextWorkspace.href);
+    }
+    globalThis.addEventListener('keydown', onKey);
+    return () => globalThis.removeEventListener('keydown', onKey);
+  }, [isAdmin, pathname, router]);
 }

--- a/apps/web/hooks/useGlobalShortcutActions.ts
+++ b/apps/web/hooks/useGlobalShortcutActions.ts
@@ -68,7 +68,12 @@ export function useGlobalShortcutActions() {
     function onKey(e: KeyboardEvent) {
       if (!isAdmin || e.isComposing) return;
       if (!e.altKey || !e.shiftKey || e.metaKey || e.ctrlKey) return;
-      if (e.key.toLowerCase() !== WORKSPACE_SWITCH_KEY) return;
+      // Option modifies `event.key` into a symbol on macOS. Prefer the
+      // physical key code so the displayed ⌥ ⇧ W binding works there, while
+      // retaining `key` as a fallback for synthetic/older environments.
+      if (e.code !== 'KeyW' && e.key.toLowerCase() !== WORKSPACE_SWITCH_KEY) {
+        return;
+      }
       if (isFormElement(e.target)) return;
       const currentWorkspace = getCurrentAppShellWorkspace(pathname);
       const nextWorkspace = getNextAppShellWorkspace(

--- a/apps/web/lib/app-shell/workspaces.test.ts
+++ b/apps/web/lib/app-shell/workspaces.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  APP_SHELL_WORKSPACES,
+  type AppShellWorkspace,
+  getCurrentAppShellWorkspace,
+  getNextAppShellWorkspace,
+} from './workspaces';
+
+describe('app shell workspaces', () => {
+  it('resolves the current workspace from the canonical route mode', () => {
+    expect(getCurrentAppShellWorkspace('/app/tasks').id).toBe('customer');
+    expect(getCurrentAppShellWorkspace('/app/ov/ops').id).toBe('ov');
+  });
+
+  it('cycles the two shipped workspaces', () => {
+    expect(getNextAppShellWorkspace(APP_SHELL_WORKSPACES, 'customer')?.id).toBe(
+      'ov'
+    );
+    expect(getNextAppShellWorkspace(APP_SHELL_WORKSPACES, 'ov')?.id).toBe(
+      'customer'
+    );
+  });
+
+  it('supports an ordered list of more than two workspaces', () => {
+    const workspaces = [
+      ...APP_SHELL_WORKSPACES,
+      {
+        id: 'support',
+        label: 'Support',
+        href: '/app/support',
+        brandVariant: 'jovie',
+      },
+    ] as const satisfies readonly AppShellWorkspace[];
+
+    expect(getNextAppShellWorkspace(workspaces, 'ov')?.id).toBe('support');
+    expect(getNextAppShellWorkspace(workspaces, 'support')?.id).toBe(
+      'customer'
+    );
+  });
+});

--- a/apps/web/lib/app-shell/workspaces.test.ts
+++ b/apps/web/lib/app-shell/workspaces.test.ts
@@ -37,4 +37,19 @@ describe('app shell workspaces', () => {
       'customer'
     );
   });
+
+  it('fails closed for an empty registry', () => {
+    expect(
+      getNextAppShellWorkspace([] as readonly AppShellWorkspace[], 'missing')
+    ).toBeUndefined();
+  });
+
+  it('starts at the first workspace when the current id is unknown at runtime', () => {
+    expect(
+      getNextAppShellWorkspace(
+        APP_SHELL_WORKSPACES as readonly AppShellWorkspace[],
+        'missing'
+      )?.id
+    ).toBe('customer');
+  });
 });

--- a/apps/web/lib/app-shell/workspaces.ts
+++ b/apps/web/lib/app-shell/workspaces.ts
@@ -1,0 +1,45 @@
+import { APP_ROUTES } from '@/constants/routes';
+import type { BrandVariant } from '@/lib/brand/tokens';
+import type { AppShellMode } from '@/types/app-shell';
+import { resolveAppShellModeFromPathname } from './mode';
+
+export interface AppShellWorkspace<Id extends string = string> {
+  readonly id: Id;
+  readonly label: string;
+  readonly href: string;
+  readonly brandVariant: BrandVariant;
+}
+
+export const APP_SHELL_WORKSPACES = [
+  {
+    id: 'customer',
+    label: 'Jovie',
+    href: APP_ROUTES.DASHBOARD,
+    brandVariant: 'jovie',
+  },
+  {
+    id: 'ov',
+    label: 'OV',
+    href: APP_ROUTES.OV,
+    brandVariant: 'ov',
+  },
+] as const satisfies readonly AppShellWorkspace<AppShellMode>[];
+
+export function getNextAppShellWorkspace<Workspace extends AppShellWorkspace>(
+  workspaces: readonly Workspace[],
+  currentId: Workspace['id']
+): Workspace | undefined {
+  if (workspaces.length === 0) return undefined;
+  const currentIndex = workspaces.findIndex(
+    workspace => workspace.id === currentId
+  );
+  return workspaces[(currentIndex + 1) % workspaces.length] ?? workspaces[0];
+}
+
+export function getCurrentAppShellWorkspace(pathname: string | null) {
+  const mode = resolveAppShellModeFromPathname(pathname);
+  return (
+    APP_SHELL_WORKSPACES.find(workspace => workspace.id === mode) ??
+    APP_SHELL_WORKSPACES[0]
+  );
+}

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -122,6 +122,8 @@ export interface NavCommand {
   readonly iconName: string;
   readonly surfaces: readonly CommandSurface[];
   readonly href: string;
+  /** Optional shortcut hint rendered on the cmd+k row. */
+  readonly shortcutLabel?: string;
 }
 
 export type Command = SkillCommand | NavCommand;

--- a/apps/web/lib/keyboard-shortcuts.test.ts
+++ b/apps/web/lib/keyboard-shortcuts.test.ts
@@ -193,6 +193,17 @@ describe('keyboard-shortcuts definitions', () => {
       expect(themeShortcut!.keys).toMatch(/T$/);
     });
 
+    it('includes the admin workspace switch shortcut', () => {
+      const workspaceShortcut = KEYBOARD_SHORTCUTS.find(
+        s => s.id === 'switch-workspace'
+      );
+      expect(workspaceShortcut?.shortcutKey).toBe('Alt+Shift+w');
+      expect(workspaceShortcut?.decision).toEqual({
+        status: 'required',
+        binding: 'useGlobalShortcutActions',
+      });
+    });
+
     it('includes sidebar toggle shortcut', () => {
       const sidebarShortcut = KEYBOARD_SHORTCUTS.find(
         s => s.id === 'toggle-sidebar'

--- a/apps/web/lib/keyboard-shortcuts.test.ts
+++ b/apps/web/lib/keyboard-shortcuts.test.ts
@@ -5,6 +5,7 @@ import {
   NAV_SHORTCUTS,
   SHORTCUT_CATEGORY_LABELS,
   type ShortcutCategory,
+  WORKSPACE_SWITCH_SHORTCUT,
 } from './keyboard-shortcuts';
 
 describe('keyboard-shortcuts definitions', () => {
@@ -193,12 +194,12 @@ describe('keyboard-shortcuts definitions', () => {
       expect(themeShortcut!.keys).toMatch(/T$/);
     });
 
-    it('includes the admin workspace switch shortcut', () => {
-      const workspaceShortcut = KEYBOARD_SHORTCUTS.find(
-        s => s.id === 'switch-workspace'
+    it('keeps the admin workspace binding out of the public help catalog', () => {
+      expect(KEYBOARD_SHORTCUTS.some(s => s.id === 'switch-workspace')).toBe(
+        false
       );
-      expect(workspaceShortcut?.shortcutKey).toBe('Alt+Shift+w');
-      expect(workspaceShortcut?.decision).toEqual({
+      expect(WORKSPACE_SWITCH_SHORTCUT.shortcutKey).toBe('Alt+Shift+w');
+      expect(WORKSPACE_SWITCH_SHORTCUT.decision).toEqual({
         status: 'required',
         binding: 'useGlobalShortcutActions',
       });

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -32,6 +32,8 @@ export const GLYPH_CMD = String.fromCodePoint(0x2318);
 export const GLYPH_OPT = String.fromCodePoint(0x2325);
 export const GLYPH_SHIFT = String.fromCodePoint(0x21e7);
 export const GLYPH_ARROW_RIGHT = String.fromCodePoint(0x2192);
+export const WORKSPACE_SWITCH_KEY = 'w';
+export const WORKSPACE_SWITCH_SHORTCUT_KEY = 'Alt+Shift+w';
 
 /**
  * Shipping gate — every shortcut must declare its status before merge.
@@ -281,6 +283,16 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     shortcutKey: 'Alt+Shift+Q',
     decision: { status: 'required', binding: 'useGlobalShortcutActions' },
   },
+  {
+    id: 'switch-workspace',
+    label: 'Switch workspace',
+    keys: `${GLYPH_OPT} ${GLYPH_SHIFT} W`,
+    description: 'Switch between Jovie and OV',
+    category: 'actions',
+    icon: Columns2,
+    shortcutKey: WORKSPACE_SWITCH_SHORTCUT_KEY,
+    decision: { status: 'required', binding: 'useGlobalShortcutActions' },
+  },
 
   // Player shortcuts — scope: 'player' means only fires when audio player has focus.
   // Bare single-key shortcuts here are intentional and safe in that scoped context.
@@ -372,6 +384,10 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     decision: { status: 'required', binding: 'ContextMenuOverlay' },
   },
 ];
+
+export const WORKSPACE_SWITCH_SHORTCUT = KEYBOARD_SHORTCUTS.find(
+  shortcut => shortcut.id === 'switch-workspace'
+)!;
 
 /**
  * Map from nav item ID to shortcut for quick lookup

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -89,6 +89,20 @@ export interface KeyboardShortcut {
 export type ShortcutCategory = 'general' | 'navigation' | 'actions' | 'player';
 
 /**
+ * Admin-only workspace binding metadata. This intentionally stays outside the
+ * public shortcut catalog so non-admin help surfaces cannot reveal OV.
+ */
+export const WORKSPACE_SWITCH_SHORTCUT: KeyboardShortcut = {
+  id: 'switch-workspace',
+  label: 'Switch workspace',
+  keys: `${GLYPH_OPT} ${GLYPH_SHIFT} W`,
+  description: 'Switch the active workspace',
+  category: 'actions',
+  shortcutKey: WORKSPACE_SWITCH_SHORTCUT_KEY,
+  decision: { status: 'required', binding: 'useGlobalShortcutActions' },
+};
+
+/**
  * All keyboard shortcuts organized by category
  */
 export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
@@ -283,17 +297,6 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     shortcutKey: 'Alt+Shift+Q',
     decision: { status: 'required', binding: 'useGlobalShortcutActions' },
   },
-  {
-    id: 'switch-workspace',
-    label: 'Switch workspace',
-    keys: `${GLYPH_OPT} ${GLYPH_SHIFT} W`,
-    description: 'Switch between Jovie and OV',
-    category: 'actions',
-    icon: Columns2,
-    shortcutKey: WORKSPACE_SWITCH_SHORTCUT_KEY,
-    decision: { status: 'required', binding: 'useGlobalShortcutActions' },
-  },
-
   // Player shortcuts — scope: 'player' means only fires when audio player has focus.
   // Bare single-key shortcuts here are intentional and safe in that scoped context.
   {
@@ -384,10 +387,6 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     decision: { status: 'required', binding: 'ContextMenuOverlay' },
   },
 ];
-
-export const WORKSPACE_SWITCH_SHORTCUT = KEYBOARD_SHORTCUTS.find(
-  shortcut => shortcut.id === 'switch-workspace'
-)!;
 
 /**
  * Map from nav item ID to shortcut for quick lookup

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -113,10 +113,14 @@ function renderUnifiedSidebar({
   overrideContent,
   pathname = APP_ROUTES.LIBRARY,
   section = 'library',
+  isAdmin = false,
+  variant,
 }: {
   readonly overrideContent?: ReactNode;
   readonly pathname?: string;
   readonly section?: 'admin' | 'dashboard' | 'library' | 'ov' | 'settings';
+  readonly isAdmin?: boolean;
+  readonly variant?: 'jovie' | 'ov';
 } = {}) {
   unifiedPathnameMock.mockReturnValue(pathname);
   const queryClient = new QueryClient({
@@ -126,7 +130,7 @@ function renderUnifiedSidebar({
   return render(
     <QueryClientProvider client={queryClient}>
       <AppFlagProvider initialFlags={APP_FLAG_DEFAULTS}>
-        <DashboardDataProvider value={dashboardData}>
+        <DashboardDataProvider value={{ ...dashboardData, isAdmin }}>
           <TooltipProvider>
             <SidebarProvider>
               <ShellSidebarOverrideProvider>
@@ -135,7 +139,7 @@ function renderUnifiedSidebar({
                     {overrideContent}
                   </LibrarySidebarOverride>
                 ) : null}
-                <UnifiedSidebar section={section} />
+                <UnifiedSidebar section={section} variant={variant} />
               </ShellSidebarOverrideProvider>
             </SidebarProvider>
           </TooltipProvider>
@@ -215,6 +219,45 @@ describe('UnifiedSidebar library route', () => {
     expect(
       screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
+  });
+
+  it('turns the logo into a workspace selector for admins', () => {
+    renderUnifiedSidebar({
+      pathname: APP_ROUTES.DASHBOARD,
+      section: 'dashboard',
+      isAdmin: true,
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Switch Workspace' })
+    ).toHaveTextContent('Jovie');
+  });
+
+  it('does not expose the workspace selector to non-admins', () => {
+    renderUnifiedSidebar({
+      pathname: APP_ROUTES.DASHBOARD,
+      section: 'dashboard',
+      isAdmin: false,
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'Switch Workspace' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Jovie', { selector: 'span' })).toBeInTheDocument();
+  });
+
+  it('shows OV as the active admin workspace without changing header height', () => {
+    const { container } = renderUnifiedSidebar({
+      pathname: APP_ROUTES.OV,
+      section: 'ov',
+      isAdmin: true,
+      variant: 'ov',
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Switch Workspace' });
+    expect(trigger).toHaveTextContent('OV');
+    expect(trigger).toHaveClass('h-7');
+    expect(container.querySelector('[data-brand-variant="ov"]')).not.toBeNull();
   });
 
   it('renders dedicated operator navigation without the customer dashboard nav', () => {

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -174,6 +174,20 @@ describe('CommandPalette', () => {
     expect(pushMock).toHaveBeenCalledWith('/app/ov');
   });
 
+  it('routes the admin workspace action from OV back to Jovie', () => {
+    pushMock.mockClear();
+    pathnameMock.mockReturnValue('/app/ov/ops');
+    render(withDashboard(<CommandPalette />, true));
+    fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
+
+    const action = screen
+      .getAllByRole('option')
+      .find(el => el.textContent?.includes('Switch to Jovie'));
+    fireEvent.mouseDown(action!);
+
+    expect(pushMock).toHaveBeenCalledWith('/app');
+  });
+
   it('does not leak the workspace action to non-admins', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -14,9 +14,11 @@ import { DashboardDataContext } from '@/app/app/(shell)/dashboard/DashboardDataC
 import { CommandPalette } from '@/components/organisms/CommandPalette';
 
 const pushMock = vi.fn();
+const pathnameMock = vi.hoisted(() => vi.fn(() => '/app'));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  usePathname: () => pathnameMock(),
 }));
 
 vi.mock('next/image', () => ({
@@ -82,7 +84,7 @@ vi.mock('@/lib/queries', async () => {
   };
 });
 
-function makeDashboard(): DashboardData {
+function makeDashboard(isAdmin = false): DashboardData {
   return {
     user: { id: 'user-1' },
     creatorProfiles: [],
@@ -91,7 +93,7 @@ function makeDashboard(): DashboardData {
     sidebarCollapsed: false,
     hasSocialLinks: false,
     hasMusicLinks: false,
-    isAdmin: false,
+    isAdmin,
     tippingStats: {
       tipClicks: 0,
       tipsSubmitted: 0,
@@ -108,9 +110,9 @@ function makeDashboard(): DashboardData {
   };
 }
 
-function withDashboard(node: ReactNode) {
+function withDashboard(node: ReactNode, isAdmin = false) {
   return (
-    <DashboardDataContext.Provider value={makeDashboard()}>
+    <DashboardDataContext.Provider value={makeDashboard(isAdmin)}>
       {node}
     </DashboardDataContext.Provider>
   );
@@ -144,6 +146,40 @@ describe('CommandPalette', () => {
     expect(screen.getByText('Recent Chats')).toBeInTheDocument();
     expect(screen.getByText('Q1 release plan')).toBeInTheDocument();
     expect(screen.getByText('Untitled chat')).toBeInTheDocument();
+  });
+
+  it('shows the admin workspace action and its shortcut', () => {
+    pathnameMock.mockReturnValue('/app');
+    render(withDashboard(<CommandPalette />, true));
+    fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
+
+    const action = screen
+      .getAllByRole('option')
+      .find(el => el.textContent?.includes('Switch to OV'));
+    expect(action).toBeDefined();
+    expect(action).toHaveTextContent('⌥ ⇧ W');
+  });
+
+  it('routes the admin workspace action to the next workspace', () => {
+    pushMock.mockClear();
+    pathnameMock.mockReturnValue('/app');
+    render(withDashboard(<CommandPalette />, true));
+    fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
+
+    const action = screen
+      .getAllByRole('option')
+      .find(el => el.textContent?.includes('Switch to OV'));
+    fireEvent.mouseDown(action!);
+
+    expect(pushMock).toHaveBeenCalledWith('/app/ov');
+  });
+
+  it('does not leak the workspace action to non-admins', () => {
+    render(withDashboard(<CommandPalette />));
+    fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
+
+    expect(screen.queryByText('Switch to OV')).not.toBeInTheDocument();
+    expect(screen.queryByText('Switch to Jovie')).not.toBeInTheDocument();
   });
 
   it('routes a recent-chat commit to the chat route', () => {


### PR DESCRIPTION
## Summary
- turn the top-left brand slot into an admin-only Jovie/OV workspace selector
- add an admin-only command-palette action and Alt+Shift+W shortcut that cycle the workspace registry
- keep non-admin shell behavior static and fail closed when dashboard authorization context is absent

## Acceptance evidence
- selection navigates to canonical workspace URLs, so the active mode persists across reloads
- registry accepts any ordered number of workspaces while shipping exactly Jovie and OV
- selector retains the existing h-7 header geometry and uses a portaled menu, preventing layout shift
- command palette displays the shortcut on the workspace row
- macOS Option-key symbol behavior is covered through the physical KeyW code
- public keyboard help excludes the admin-only workspace binding

## Verification
- production typecheck: pass
- repository lint: 7,352 files clean
- server-boundary and native-dialog guards: pass
- optimized Next.js build: pass (465 static pages)
- full web suite: 2,227 files / 17,448 tests passed; 75 intentional skips and 6 todos
- focused workspace suite: 7 files / 74 tests passed
- core workspace coverage: 100% lines and functions, 91.37% branches

## Visual review
- hierarchy: pass, workspace identity replaces rather than adds header chrome
- spacing and density: pass, canonical compact sidebar geometry retained
- interaction states: pass, pointer, keyboard, open, active, collapsed, and denied states covered
- contrast and tokens: pass, semantic sidebar/text tokens only
- layout stability: pass, fixed h-7 trigger and portaled menu add no sibling reflow

Linear: JOV-4084