### PR TITLE
test(auth): accept direct app UUID settings writes

### DIFF
--- a/apps/web/tests/unit/auth/post-ba-app-id-contract.test.ts
+++ b/apps/web/tests/unit/auth/post-ba-app-id-contract.test.ts
@@ -21,10 +21,6 @@ const APP_ID_SCOPED_SOURCES = [
     expectedPredicates: 2,
   },
   {
-    relativePath: 'app/app/(shell)/dashboard/actions/settings.ts',
-    expectedPredicates: 1,
-  },
-  {
     relativePath: 'app/app/(shell)/admin/actions.ts',
     expectedPredicates: 1,
   },
@@ -73,6 +69,23 @@ describe('post-Better Auth app user ID contract', () => {
     const source = readWebSource(relativePath);
 
     expect(source.match(/appUserIdFilter\(/g)).toHaveLength(expectedPredicates);
+    expect(source).not.toMatch(/eq\(users\.clerkId,\s*\w+\)/);
+  });
+
+  it('persists sidebar settings with the authenticated app UUID', () => {
+    const source = readWebSource(
+      'app/app/(shell)/dashboard/actions/settings.ts'
+    );
+    const resolvesAppUserBeforeWrite =
+      source.includes('.where(appUserIdFilter(appUserId))') &&
+      source.includes('userId: user.id');
+    const writesSessionAppUserIdDirectly =
+      source.includes('withDbSession(async appUserId =>') &&
+      source.includes('userId: appUserId');
+
+    expect(resolvesAppUserBeforeWrite || writesSessionAppUserIdDirectly).toBe(
+      true
+    );
     expect(source).not.toMatch(/eq\(users\.clerkId,\s*\w+\)/);
   });
 


### PR DESCRIPTION
## Description

Updates the post-Better-Auth ownership contract so sidebar settings may use either:

- the existing tested app-ID lookup followed by `user.id`, or
- the authenticated `withDbSession` app UUID directly.

The direct-write form is the intentional shape in #14870. The contract continues to reject legacy `users.clerkId` ownership, so this repairs the merge-group incompatibility without weakening the auth boundary.

## Testing

- `pnpm --filter web exec vitest run tests/unit/auth/post-ba-app-id-contract.test.ts` — 9/9 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `pnpm biome check apps/web/tests/unit/auth/post-ba-app-id-contract.test.ts` — passed
- pre-push affected verification, repository lint, CI harness — passed

### Bug-to-Test Rule

Regression test updated at the smallest layer that caught the merge-group failure.

`bug-to-test: satisfied`

## Risk

Test-only change. It preserves fail-closed rejection of legacy Clerk-ID predicates.

## Related

- Unblocks #14870
- Related Linear issue: JOV-4453

design-canonical: not applicable
