### PR TITLE
fix(release): coalesce stale production controller runs

### DIFF
--- a/.github/workflows/production-controller.yml
+++ b/.github/workflows/production-controller.yml
@@ -22,9 +22,66 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Hold only the read-only controller preflight for one bounded release-wave
+  # window. A newer main SHA supersedes this generation before exact CI
+  # authorization, so no staging deploy, migration, canary, promotion, or
+  # rollback mutation can start for a stale SHA.
+  coalesce-production:
+    name: Coalesce release wave
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      is_current: ${{ steps.coalesce.outputs.is_current }}
+    steps:
+      - name: Wait for newer main to land
+        id: coalesce
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+          # One bounded 60-second release-wave window. The immediate check
+          # avoids sleeping when this run is already stale.
+          COALESCE_DELAY_SECONDS: '60'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "is_current=false" >> "$GITHUB_OUTPUT"
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Controller expected SHA must be a full commit."
+            exit 1
+          }
+
+          current_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
+          [[ "$current_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Could not resolve exact current main during release coalescing."
+            exit 1
+          }
+          if [ "$current_main_sha" != "$EXPECTED_SHA" ]; then
+            echo "::notice::Controller generation $EXPECTED_SHA was superseded by $current_main_sha before the coalescing window."
+            exit 0
+          fi
+
+          echo "Current main is $EXPECTED_SHA; waiting ${COALESCE_DELAY_SECONDS}s for the release wave to settle."
+          sleep "$COALESCE_DELAY_SECONDS"
+          current_main_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha // empty')"
+          [[ "$current_main_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::Could not resolve exact current main at the end of release coalescing."
+            exit 1
+          }
+          if [ "$current_main_sha" != "$EXPECTED_SHA" ]; then
+            echo "::notice::Controller generation $EXPECTED_SHA was superseded by $current_main_sha during the coalescing window."
+            exit 0
+          fi
+
+          echo "is_current=true" >> "$GITHUB_OUTPUT"
+          echo "Release coalescing completed for current main $EXPECTED_SHA."
+
   authorize-production:
     name: Authorize exact main CI evidence
-    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
+    needs: [coalesce-production]
+    if: ${{ needs.coalesce-production.result == 'success' && needs.coalesce-production.outputs.is_current == 'true' && github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/production-controller.yml
+++ b/.github/workflows/production-controller.yml
@@ -28,6 +28,7 @@ jobs:
   # rollback mutation can start for a stale SHA.
   coalesce-production:
     name: Coalesce release wave
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -327,6 +327,9 @@ describe('merge_group workflow contract', () => {
     );
 
     expect(coalesce).toContain('timeout-minutes: 5');
+    expect(coalesce).toContain(
+      "github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'"
+    );
     expect(coalesce).toContain("COALESCE_DELAY_SECONDS: '60'");
     expect(coalesce).toContain('sleep "$COALESCE_DELAY_SECONDS"');
     expect(coalesce).toContain('echo "is_current=false" >> "$GITHUB_OUTPUT"');

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -316,6 +316,36 @@ describe('merge_group workflow contract', () => {
     expect(SECURITY_WORKFLOW).not.toMatch(/^\s*pull_request:/m);
   });
 
+  it('coalesces a short release wave before exact authorization and mutation', () => {
+    const coalesce = getJobBlock(
+      PRODUCTION_CONTROLLER_WORKFLOW,
+      'coalesce-production'
+    );
+    const authorize = getJobBlock(
+      PRODUCTION_CONTROLLER_WORKFLOW,
+      'authorize-production'
+    );
+
+    expect(coalesce).toContain('timeout-minutes: 5');
+    expect(coalesce).toContain("COALESCE_DELAY_SECONDS: '60'");
+    expect(coalesce).toContain('sleep "$COALESCE_DELAY_SECONDS"');
+    expect(coalesce).toContain('echo "is_current=false" >> "$GITHUB_OUTPUT"');
+    expect(coalesce).toContain('echo "is_current=true" >> "$GITHUB_OUTPUT"');
+    expect(coalesce).toContain('commits/main');
+    expect(authorize).toContain('needs: [coalesce-production]');
+    expect(authorize).toContain(
+      "needs.coalesce-production.outputs.is_current == 'true'"
+    );
+    expect(PRODUCTION_CONTROLLER_WORKFLOW).toContain(
+      'group: production-mutation'
+    );
+    expect(PRODUCTION_CONTROLLER_WORKFLOW).toContain(
+      'cancel-in-progress: false'
+    );
+    expect(coalesce).not.toContain('vercel ');
+    expect(coalesce).not.toContain('secrets: inherit');
+  });
+
   it('keeps merge groups out of manual evidence and deployment jobs', () => {
     expect(getJobBlock(CI_WORKFLOW, 'neon-db')).not.toContain(
       "github.event_name == 'push'"


### PR DESCRIPTION
## Summary
- Add a read-only, exact-main coalescing gate before production authorization.
- Hold the first current generation for one bounded 60-second release-wave window, then supersede it if a newer `main` SHA landed.
- Preserve exact-SHA CI authorization and the existing staging, migration, Better Auth smoke, canary, promotion, rollback, and production verification gates.

## Safety contract
- The coalescing job performs only read-only `gh api` calls and `sleep`; it contains no Vercel command and does not inherit secrets.
- It runs before `authorize-production`, so stale generations cannot reach `production-release` or any Vercel production mutation.
- The existing repo-wide `production-mutation` FIFO remains `cancel-in-progress: false`; no coalescing is added after mutation begins.
- A newer SHA supersedes the controller run before authorization. If the exact SHA remains current, the existing authorization and release DAG is unchanged.
- Rollback behavior is unchanged: the existing centralized rollback owner remains the only rollback path for confirmed structured regressions; uncertain gates still fail red without rollback.

## Chosen bounds
- Coalescing delay: 60 seconds, with an immediate pre-check and one final current-`main` check.
- Job timeout: 5 minutes. API failures remain fail-closed.

## Verification
- `actionlint .github/workflows/production-controller.yml`
- `pnpm exec vitest run --config scripts/vitest.config.mts lib/__tests__/merge-group-workflow-contract.test.mjs`
- `pnpm biome check scripts/lib/__tests__/merge-group-workflow-contract.test.mjs`
- `node --check scripts/lib/__tests__/merge-group-workflow-contract.test.mjs`
- `git diff --check`
