### PR TITLE
fix(vercel): skip unaffected preview builds

### DIFF
--- a/apps/web/tests/unit/ci/vercel-config.test.ts
+++ b/apps/web/tests/unit/ci/vercel-config.test.ts
@@ -1,4 +1,12 @@
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -6,13 +14,14 @@ import { describe, expect, it } from 'vitest';
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
 
-function readVercelFunctions(relativePath: string): Record<string, unknown> {
-  const configPath = resolve(repoRoot, relativePath);
-  const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
-    functions?: Record<string, unknown>;
-  };
+type VercelConfig = {
+  functions?: Record<string, unknown>;
+  ignoreCommand?: string;
+};
 
-  return config.functions ?? {};
+function readVercelConfig(relativePath: string): VercelConfig {
+  const configPath = resolve(repoRoot, relativePath);
+  return JSON.parse(readFileSync(configPath, 'utf8')) as VercelConfig;
 }
 
 describe('Vercel function config', () => {
@@ -20,7 +29,9 @@ describe('Vercel function config', () => {
     const configs = ['vercel.json', 'apps/web/vercel.json'];
 
     for (const configPath of configs) {
-      const functionGlobs = Object.keys(readVercelFunctions(configPath));
+      const functionGlobs = Object.keys(
+        readVercelConfig(configPath).functions ?? {}
+      );
 
       expect(functionGlobs.length, `${configPath} functions`).toBeGreaterThan(
         0
@@ -39,6 +50,61 @@ describe('Vercel function config', () => {
         ),
         configPath
       ).toBe(true);
+    }
+  });
+
+  it('always builds production branches and delegates preview relevance to turbo-ignore', () => {
+    const configs = ['vercel.json', 'apps/web/vercel.json'];
+    const ignoreCommands = configs.map(configPath => {
+      const command = readVercelConfig(configPath).ignoreCommand;
+      expect(command, configPath).toBeTypeOf('string');
+      return command as string;
+    });
+
+    expect(new Set(ignoreCommands).size).toBe(1);
+    const ignoreCommand = ignoreCommands[0];
+    const fakeBin = mkdtempSync(resolve(tmpdir(), 'jovie-vercel-ignore-'));
+    const fakeNpx = resolve(fakeBin, 'npx');
+    writeFileSync(
+      fakeNpx,
+      '#!/usr/bin/env bash\nprintf "%s\\n" "$*" > "$TURBO_IGNORE_CALL_LOG"\nexit "${TURBO_IGNORE_EXIT_CODE:-0}"\n'
+    );
+    chmodSync(fakeNpx, 0o755);
+
+    const runIgnoreCommand = (ref: string, exitCode = '0') => {
+      const callLog = resolve(fakeBin, `${ref.replaceAll('/', '-')}.log`);
+      const result = spawnSync('bash', ['-c', ignoreCommand], {
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          TURBO_IGNORE_CALL_LOG: callLog,
+          TURBO_IGNORE_EXIT_CODE: exitCode,
+          VERCEL_GIT_COMMIT_REF: ref,
+        },
+        encoding: 'utf8',
+      });
+
+      return { callLog, result };
+    };
+
+    for (const ref of ['main', 'production']) {
+      const { callLog, result } = runIgnoreCommand(ref);
+      expect(result.status, ref).toBe(1);
+      expect(existsSync(callLog), ref).toBe(false);
+    }
+
+    for (const ref of [
+      'docs-only',
+      'codex/docs-only',
+      'claude/docs-only',
+      'codegen-bot/docs-only',
+      'linear/docs-only',
+    ]) {
+      const { callLog, result } = runIgnoreCommand(ref);
+      expect(result.status, ref).toBe(0);
+      expect(readFileSync(callLog, 'utf8'), ref).toBe(
+        'turbo-ignore @jovie/web\n'
+      );
     }
   });
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,7 +2,7 @@
   "framework": "nextjs",
   "installCommand": "corepack enable && corepack pnpm install",
   "buildCommand": "corepack pnpm run build",
-  "ignoreCommand": "bash -c 'R=$VERCEL_GIT_COMMIT_REF;[[ $R == main || $R == production || $R =~ ^(codex|claude|codegen-bot|linear)/ ]] && exit 0;npx turbo-ignore @jovie/web'",
+  "ignoreCommand": "bash -c 'R=$VERCEL_GIT_COMMIT_REF;if [[ $R == main || $R == production ]]; then exit 1; fi;npx turbo-ignore @jovie/web'",
   "github": {
     "autoAlias": false
   },

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "framework": "nextjs",
   "installCommand": "corepack enable && corepack pnpm install",
   "buildCommand": "env -u TURBO_REMOTE_ONLY corepack pnpm turbo build --filter=@jovie/web",
-  "ignoreCommand": "bash -c 'R=$VERCEL_GIT_COMMIT_REF;[[ $R == main || $R == production || $R =~ ^(codex|claude|codegen-bot|linear)/ ]] && exit 0;npx turbo-ignore @jovie/web'",
+  "ignoreCommand": "bash -c 'R=$VERCEL_GIT_COMMIT_REF;if [[ $R == main || $R == production ]]; then exit 1; fi;npx turbo-ignore @jovie/web'",
   "github": {
     "autoAlias": false
   },


### PR DESCRIPTION
## Summary
- Keep Vercel builds enabled for `main` and `production` by returning exit code 1 from `ignoreCommand`.
- Route every non-production branch, including `codex/*`, `claude/*`, `codegen-bot/*`, and `linear/*`, through the existing `turbo-ignore @jovie/web` decision.
- Keep root and `apps/web` Vercel configs aligned and add a contract test covering production, ordinary preview, and agent branch behavior.

## Cost Impact
Reduces unnecessary Vercel preview build/deployment work for commits that do not affect `@jovie/web` or its internal dependencies. No new recurring API calls, jobs, or cron entries.

## Verification
- `node -e ...` — both Vercel configs parse as JSON.
- `bash -n ...` — both embedded ignore commands pass shell syntax validation.
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/vercel-config.test.ts` — 2 tests passed.
- `pnpm exec biome check apps/web/tests/unit/ci/vercel-config.test.ts` — passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm --filter @jovie/web run test:bug-to-test` — satisfied.
- `git diff --check origin/main...HEAD` — passed.

## Bug-to-test
Regression test added in `apps/web/tests/unit/ci/vercel-config.test.ts`.

## Risk
Production builds are explicitly preserved; preview deployments are not globally disabled. Non-production relevance remains delegated to the existing Turborepo dependency-aware ignore decision.
