### PR TITLE
fix(shell): keep mobile profile previews above headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ### Fixed
 
+- **Profile previews now fully cover the mobile app shell (JOV-4464):** opening the full-screen profile preview no longer leaves the shell header painted above the drawer, while desktop right-rail layering stays unchanged.
 - [internal] **Hermes/OpenClaw agent config health**: adds a launchd-backed sentinel for recurring Telegram-dispatched agent failures, catching stale Hermes fallback models, paid OpenRouter fallbacks, and schema-clobbered OpenClaw `memorySearch` blocks before gateway churn.
 - **Smoother dashboard interactions (JOV-3800)**: opening a release, contact, or tour-date panel from chat now shows the details instantly instead of a brief loading state; settings pages no longer nudge when a change is being saved; and the calendar keeps its layout steady while it first loads.
 - [internal] Pre-push Biome gate scopes to changed files (mirroring CI) instead of a repo-wide `biome check .`, so pre-existing Biome drift on `main` no longer blocks `git push` from every worktree and stops training agents toward the `JOVIE_SKIP_PRE_PUSH_GATE=1` escape hatch (GitHub #12475).

--- a/apps/web/components/shell/AppShellRightRail.tsx
+++ b/apps/web/components/shell/AppShellRightRail.tsx
@@ -30,10 +30,12 @@ export function AppShellRightRail({
       data-testid='app-shell-right-rail'
       aria-label='Context Panel'
       className={cn(
+        // Mobile drawers are fixed descendants of this stacking context, so the
+        // rail must sit above the z-20 shell header. Desktop returns to z-10.
         // self-stretch (not self-start): the rail sits beside the non-scrolling
         // shell clip and must fill the content-row height so open drawers clip
         // inside the rail instead of floating over the transcript (JOV-3958).
-        'sticky top-0 z-10 flex h-full min-h-0 shrink-0 flex-col self-stretch overflow-hidden',
+        'sticky top-0 z-30 lg:z-10 flex h-full min-h-0 shrink-0 flex-col self-stretch overflow-hidden',
         // Mirror the left sidebar mount language so inner drawer width changes
         // reclaim canvas space with the same cinematic timing.
         'transition-[width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none',

--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -16,6 +16,8 @@ describe('AppShellRightRail', () => {
     expect(rail).toHaveClass(
       'sticky',
       'top-0',
+      'z-30',
+      'lg:z-10',
       'h-full',
       'min-h-0',
       'self-stretch',
@@ -24,6 +26,7 @@ describe('AppShellRightRail', () => {
       'ease-cinematic'
     );
     expect(rail).not.toHaveClass('self-start');
+    expect(rail).not.toHaveClass('z-10');
     expect(rail).toContainElement(screen.getByTestId('fixture-panel'));
   });
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4464 -->

## Summary
- raise the app-shell right-rail stacking context above the mobile shell header
- preserve the existing desktop rail layer at lg and above
- add focused regression coverage for the responsive stacking contract
- record the user-visible fix under the existing Unreleased changelog

## Production evidence
A fresh 375x812 load of `/app/profile` opens the profile preview, but the z-20 shell header paints above it because the fixed drawer is trapped inside a z-10 parent stacking context. Evidence is attached to JOV-4464.

## Bug-to-Test
`bug-to-test: satisfied` by `apps/web/components/shell/__tests__/AppShellRightRail.test.tsx`.

## Test Coverage
- AppShellRightRail: 100% statements, functions, and lines in focused V8 coverage
- 13 focused shell tests passed: right-rail contract, shell frame, and shell-variant parity
- responsive paths covered: mobile/tablet z-30 and desktop lg:z-10

## Pre-Landing Review
No issues found. SQL/data, race, trust-boundary, shell-injection, enum, completeness, and frontend checklist passes are clean. No Greptile comments.

## Verification
- web typecheck passed
- Biome passed for the changed files and all apps/web files
- pre-push affected verification passed, including typecheck, lint, Tailwind guard, a11y staged check, design-system ratchet, and CI harness validation
- bug-to-test policy gate passed

## Documentation
- `CHANGELOG.md`: added one user-facing Unreleased fix entry; architecture and shell docs remain accurate
- VERSION unchanged by policy; feature branches never stamp release versions

## Linear follow-ups
- JOV-4463 remains the design-gated Tour Dates empty-state enrichment; it is outside this stacking fix

## Risk
Low, responsive stacking-only change. Desktop explicitly returns to z-10 at lg. No auth, data, billing, migration, or release-control behavior changed.

Closes JOV-4464