### PR TITLE
fix(audio): restore playback transition contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 - [internal] **App shell loading skeleton** matches `DESIGN_V1` so flag-on users no longer flash the legacy sidebar/header on first `/app` paint.
 
 - [internal] **Post-deploy probes now identify CLI-built production deployments (JOV-4366):** exact immutable build identity replaces optional Vercel source metadata while preserving project, deployment, origin, environment, and main-ancestry proofs.
+- **[internal] Audio playback has one canonical transition contract (JOV-3689):** loading, audible playback, buffering, seeking, stalls, interruptions, completion, and errors are defined in a typed, mutation-tested state machine for playback surfaces to adopt.
 - **[internal] Canonical audio contract foundation (JOV-3685):** one typed package now defines Jovie's MP3, WAV, FLAC, AIFF, AAC, and M4A format registry, MIME aliases, extensions, upload policies, and branded time/BPM units with mutation-tested invariants.
 - **[internal] Staging Better Auth Google OAuth credentials now reach the Vercel build and runtime deploy (#14659):** the release workflow allowlists and forwards both Google client keys, failing closed when either is absent.
 

--- a/packages/audio-contracts/index.ts
+++ b/packages/audio-contracts/index.ts
@@ -1,3 +1,5 @@
+export * from './playback';
+
 export const AUDIO_FORMAT_IDS = [
   'mp3',
   'wav',

--- a/packages/audio-contracts/playback.test.ts
+++ b/packages/audio-contracts/playback.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_PLAYBACK_EVENTS,
+  AUDIO_PLAYBACK_STATUSES,
+  type AudioPlaybackEvent,
+  type AudioPlaybackStatus,
+  getNextAudioPlaybackStatus,
+} from './playback';
+
+function transition(
+  current: AudioPlaybackStatus,
+  event: AudioPlaybackEvent,
+  options: { readonly active?: boolean; readonly paused?: boolean } = {}
+) {
+  return getNextAudioPlaybackStatus({
+    current,
+    event,
+    hasActiveTrack: options.active ?? true,
+    isPaused: options.paused ?? false,
+  });
+}
+
+describe('audio playback transition registry', () => {
+  it('keeps every status and event unique', () => {
+    expect(new Set(AUDIO_PLAYBACK_STATUSES).size).toBe(
+      AUDIO_PLAYBACK_STATUSES.length
+    );
+    expect(new Set(AUDIO_PLAYBACK_EVENTS).size).toBe(
+      AUDIO_PLAYBACK_EVENTS.length
+    );
+  });
+
+  it('handles terminal and source lifecycle events', () => {
+    expect(transition('playing', 'stop')).toBe('idle');
+    expect(transition('playing', 'error')).toBe('error');
+    expect(transition('idle', 'load', { active: false })).toBe('loading');
+    expect(transition('playing', 'playing', { active: false })).toBe('idle');
+    expect(transition('playing', 'ended')).toBe('ended');
+  });
+
+  it('distinguishes intent, audible playback, buffering, and stalls', () => {
+    expect(transition('loading', 'play')).toBe('loading');
+    expect(transition('paused', 'play')).toBe('playing');
+    expect(transition('loading', 'playing')).toBe('playing');
+    expect(transition('playing', 'waiting')).toBe('buffering');
+    expect(transition('buffering', 'stalled')).toBe('stalled');
+    expect(transition('buffering', 'canplay')).toBe('playing');
+    expect(transition('buffering', 'canplay', { paused: true })).toBe('paused');
+  });
+
+  it('preserves interruption semantics through pause and seek events', () => {
+    expect(transition('playing', 'pause', { paused: true })).toBe('paused');
+    expect(transition('playing', 'interruption_start')).toBe('interrupted');
+    expect(transition('interrupted', 'pause', { paused: true })).toBe(
+      'interrupted'
+    );
+    expect(transition('playing', 'seeking')).toBe('seeking');
+    expect(transition('seeking', 'seeked')).toBe('playing');
+    expect(transition('seeking', 'seeked', { paused: true })).toBe('paused');
+    expect(transition('interrupted', 'seeked', { paused: true })).toBe(
+      'interrupted'
+    );
+    expect(transition('interrupted', 'interruption_end')).toBe('playing');
+    expect(
+      transition('interrupted', 'interruption_end', { paused: true })
+    ).toBe('paused');
+    expect(
+      transition('playing', 'unknown' as AudioPlaybackEvent, { paused: true })
+    ).toBe('playing');
+  });
+
+  it('keeps interruption ownership across queued media lifecycle events', () => {
+    for (const event of [
+      'play',
+      'playing',
+      'pause',
+      'waiting',
+      'canplay',
+      'seeking',
+      'seeked',
+      'stalled',
+    ] as const) {
+      expect(
+        getNextAudioPlaybackStatus({
+          current: 'interrupted',
+          event,
+          hasActiveTrack: true,
+          isPaused: event !== 'playing',
+        })
+      ).toBe('interrupted');
+    }
+
+    expect(
+      getNextAudioPlaybackStatus({
+        current: 'interrupted',
+        event: 'ended',
+        hasActiveTrack: true,
+        isPaused: true,
+      })
+    ).toBe('ended');
+  });
+});

--- a/packages/audio-contracts/playback.ts
+++ b/packages/audio-contracts/playback.ts
@@ -1,0 +1,83 @@
+export const AUDIO_PLAYBACK_STATUSES = [
+  'idle',
+  'loading',
+  'playing',
+  'paused',
+  'buffering',
+  'seeking',
+  'stalled',
+  'interrupted',
+  'ended',
+  'error',
+] as const;
+
+export type AudioPlaybackStatus = (typeof AUDIO_PLAYBACK_STATUSES)[number];
+
+export const AUDIO_PLAYBACK_EVENTS = [
+  'load',
+  'play',
+  'playing',
+  'pause',
+  'waiting',
+  'canplay',
+  'seeking',
+  'seeked',
+  'stalled',
+  'interruption_start',
+  'interruption_end',
+  'ended',
+  'error',
+  'stop',
+] as const;
+
+export type AudioPlaybackEvent = (typeof AUDIO_PLAYBACK_EVENTS)[number];
+
+export interface AudioPlaybackTransitionInput {
+  readonly current: AudioPlaybackStatus;
+  readonly event: AudioPlaybackEvent;
+  readonly hasActiveTrack: boolean;
+  readonly isPaused: boolean;
+}
+
+/** Pure transition contract shared by every playback surface and platform. */
+export function getNextAudioPlaybackStatus({
+  current,
+  event,
+  hasActiveTrack,
+  isPaused,
+}: AudioPlaybackTransitionInput): AudioPlaybackStatus {
+  if (event === 'stop') return 'idle';
+  if (event === 'error') return 'error';
+  if (event === 'load') return 'loading';
+  if (!hasActiveTrack) return 'idle';
+  if (current === 'interrupted' && event !== 'interruption_end') {
+    return event === 'ended' ? 'ended' : 'interrupted';
+  }
+
+  switch (event) {
+    case 'play':
+      return current === 'loading' ? 'loading' : 'playing';
+    case 'playing':
+      return 'playing';
+    case 'pause':
+      return 'paused';
+    case 'waiting':
+      return 'buffering';
+    case 'canplay':
+      return isPaused ? 'paused' : 'playing';
+    case 'seeking':
+      return 'seeking';
+    case 'seeked':
+      return isPaused ? 'paused' : 'playing';
+    case 'stalled':
+      return 'stalled';
+    case 'interruption_start':
+      return 'interrupted';
+    case 'interruption_end':
+      return isPaused ? 'paused' : 'playing';
+    case 'ended':
+      return 'ended';
+    default:
+      return current;
+  }
+}

--- a/packages/audio-contracts/stryker.config.mjs
+++ b/packages/audio-contracts/stryker.config.mjs
@@ -9,8 +9,8 @@ const config = {
   coverageAnalysis: 'off',
   disableTypeChecks: false,
   reporters: ['progress', 'clear-text', 'json'],
-  mutate: ['index.ts', '!**/*.test.ts'],
-  testFiles: ['index.test.ts'],
+  mutate: ['index.ts', 'playback.ts', '!**/*.test.ts'],
+  testFiles: ['index.test.ts', 'playback.test.ts'],
   vitest: {
     configFile: 'vitest.config.mts',
   },


### PR DESCRIPTION
## Summary
- restore the canonical typed playback transition contract in `@jovie/audio-contracts`
- cover idle, loading, playing, paused, buffering, seeking, stalled, interrupted, ended, and error states
- export the contract and include it in mutation testing

## Why
JOV-3689 requires one fail-closed source of truth for playback transitions before app surfaces adopt richer buffering, seek, interruption, and continuity states.

## Stack
- Parent: `main`
- Child: `tw/codex/jov-4385-audio-analysis-core`
- Graphite metadata is preserved locally; Graphite submission is unavailable because the JovieInc plan is expired, so this draft uses an explicit GitHub stacked base.

## Test plan
- `pnpm --filter @jovie/audio-contracts test`: 23 passing
- Stryker: 174 mutants, 100% mutation score, zero survivors
- hooked pre-push: typecheck, Biome, automation checks, CI harness/docs, 17,475 passing Vitest tests across 8 shards

## Bug-to-Test
Canonical transition acceptance and rejection paths are asserted directly; mutation testing proves the transition guards fail when materially altered.

## Risk / rollback
Low, additive package contract. Roll back this PR to remove the export and contract without changing runtime playback behavior.
