### PR TITLE
feat(profile): add spatial profile primitives

### DIFF
--- a/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
@@ -9,7 +9,8 @@
  *  - Tab click handler calls onTabSelect with correct mode
  *  - Grid column count matches visible tab count
  *  - No horizontal overflow at narrow viewports (320px) — structural check
- *  - 44×44pt touch target minimum via min-h-13 class
+ *  - Compact 48px floating capsule with full-cell interaction geometry
+ *  - Labels remain screen-reader-only
  *  - Empty Events tabs remain reachable so the surface can show alert signup
  */
 
@@ -184,11 +185,21 @@ describe('BottomTabBar — grid layout', () => {
     expect(grid?.getAttribute('style')).toContain('repeat(4,');
   });
 
-  it('all primary tab buttons have min-h-13 for 44pt touch target compliance', () => {
+  it('keeps visible chrome compact while each full grid cell remains interactive', () => {
     const { container } = render(<BottomTabBar {...makeProps()} />);
+    const nav = screen.getByTestId('profile-bottom-nav');
+    expect(nav.className).toContain('h-12');
+    expect(nav.className).toContain('rounded-full');
+
+    const grid = container.querySelector('[style*="grid-template-columns"]');
+    expect(grid?.className).toContain('h-11');
+    expect(grid?.className).toContain('-my-0.5');
+
     const buttons = container.querySelectorAll('button');
     for (const btn of buttons) {
-      expect(btn.className).toContain('min-h-13');
+      expect(btn.className).toContain('h-full');
+      expect(btn.className).not.toContain('min-h-13');
+      expect(btn.querySelector('span')?.className).toContain('sr-only');
     }
   });
 

--- a/apps/web/components/features/profile/nav/BottomTabBar.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.tsx
@@ -90,7 +90,8 @@ export interface BottomTabBarProps {
  * Content rendered above this bar must reserve `--profile-bottom-nav-height`
  * — see `CONTENT_SAFE_AREA_BOTTOM_PADDING` in `lib/profile/nav-constants.ts`.
  *
- * Touch targets meet the 44×44pt minimum via `min-h-13` on each button.
+ * The visible treatment stays compact. The full grid cell is interactive, so
+ * touch geometry does not require a visible 44px button around every glyph.
  */
 export function BottomTabBar({
   activeTab,
@@ -105,14 +106,18 @@ export function BottomTabBar({
   return (
     <div
       className={cn(
-        '-mx-(--page-pad) shrink-0 border-t border-[color:var(--profile-dock-border)] bg-[color:var(--profile-dock-bg)] px-1.5 pb-[max(env(safe-area-inset-bottom),10px)] pt-1 backdrop-blur-2xl',
+        'shrink-0 pb-[max(env(safe-area-inset-bottom),10px)] pt-2',
         className
       )}
       data-testid='profile-tab-bar'
     >
-      <nav aria-label='Profile Navigation' data-testid='profile-bottom-nav'>
+      <nav
+        aria-label='Profile Navigation'
+        data-testid='profile-bottom-nav'
+        className='h-12 rounded-full border border-[color:var(--profile-dock-border)] bg-[color:var(--profile-dock-bg)] p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_14px_34px_rgba(0,0,0,0.32)] backdrop-blur-2xl'
+      >
         <div
-          className='grid items-center gap-1'
+          className='-my-0.5 grid h-11 items-center gap-1'
           style={{
             gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
           }}
@@ -127,9 +132,8 @@ export function BottomTabBar({
                 key={tab.mode}
                 type='button'
                 onClick={() => onTabSelect(tab.mode)}
-                // 44×44pt minimum touch target (spec §2 a11y requirement).
                 className={cn(
-                  'relative flex min-h-13 min-w-0 flex-col items-center justify-center gap-0.5 rounded-(--profile-action-radius) px-1.5 py-1.5 text-center transition-[background-color,color] duration-subtle',
+                  'relative flex h-full min-w-0 touch-manipulation items-center justify-center rounded-full text-center transition-[color,transform] duration-subtle ease-subtle active:scale-[0.94] motion-reduce:transform-none',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                   isActive
                     ? 'text-white dark:text-white'
@@ -141,9 +145,10 @@ export function BottomTabBar({
               >
                 <Icon
                   className={cn(
-                    'h-5 w-5 shrink-0',
+                    'h-5 w-5 shrink-0 transition-[color,stroke-width] duration-subtle',
                     isActive ? 'text-white dark:text-white' : 'text-white/52'
                   )}
+                  strokeWidth={isActive ? 2.35 : 1.8}
                   aria-hidden='true'
                 />
                 <span

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -50,7 +50,7 @@ interface EntityCardProps {
    * share one design. 'default' keeps the legacy per-treatment layout
    * (chat/app consumers).
    */
-  readonly anatomy?: 'default' | 'unified';
+  readonly anatomy?: 'default' | 'unified' | 'profile-landscape';
 }
 
 type SizeConfig = {
@@ -91,16 +91,23 @@ function EntityCtaControl({
   cta,
   block,
   unified = false,
+  landscape = false,
 }: Readonly<{
   cta: EntityCardCta;
   block: boolean;
   unified?: boolean;
+  landscape?: boolean;
 }>) {
   // Unified anatomy: a CTA with no target is not a button at all — render it
   // as plain muted meta text (e.g. "No Tickets"), never with button chrome.
   if (unified && (cta.disabled || (!cta.href && !cta.onClick))) {
     return (
-      <span className='flex h-9 w-full items-center text-xs text-tertiary-token'>
+      <span
+        className={cn(
+          'flex items-center text-xs text-tertiary-token',
+          landscape ? 'h-8 w-auto' : 'h-9 w-full'
+        )}
+      >
         {cta.label}
       </span>
     );
@@ -110,7 +117,9 @@ function EntityCtaControl({
     'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
     // Unified anatomy: full-width 36px CTA (two CTAs share the row evenly).
     unified
-      ? 'h-9 min-w-0 flex-1'
+      ? landscape
+        ? 'h-8 min-w-0 flex-none'
+        : 'h-9 min-w-0 flex-1'
       : block
         ? 'h-11 w-full'
         : 'h-11 min-w-0 flex-1',
@@ -226,25 +235,29 @@ export function EntityCard({
   anatomy = 'default',
 }: EntityCardProps) {
   const size = SIZE[treatment];
-  const isUnified = anatomy === 'unified';
+  const isProfileLandscape = anatomy === 'profile-landscape';
+  const isUnified = anatomy === 'unified' || isProfileLandscape;
+  const isLandscapeNonMedia = isProfileLandscape && model.kind === 'alerts';
   // Composition shape (#11899): fixed card aspect + semantic media geometry.
   // Album/product/show artwork is square; video thumbnails stay landscape.
   // Text truncates inside the shape; the CTA footer never moves.
   const shapeClassName = shape
     ? cn(getProfileCardShapeClassName(shape), 'overflow-hidden')
     : null;
-  const artClassName = isUnified
-    ? // Unified anatomy: the art zone is a full-width square (album art is
-      // square by default; non-square art object-covers the square zone).
-      'aspect-square rounded-none'
-    : artFit === 'fill'
-      ? 'min-h-0 w-full flex-1 rounded-xl'
-      : shape
-        ? cn(
-            model.kind === 'video' ? 'aspect-video' : 'aspect-square',
-            treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
-          )
-        : size.artClass;
+  const artClassName = isProfileLandscape
+    ? 'aspect-square self-stretch w-auto rounded'
+    : isUnified
+      ? // Unified anatomy: the art zone is a full-width square (album art is
+        // square by default; non-square art object-covers the square zone).
+        'aspect-square rounded-none'
+      : artFit === 'fill'
+        ? 'min-h-0 w-full flex-1 rounded-xl'
+        : shape
+          ? cn(
+              model.kind === 'video' ? 'aspect-video' : 'aspect-square',
+              treatment === 'big' ? 'rounded-2xl' : 'rounded-xl'
+            )
+          : size.artClass;
   const titleClampClassName = isUnified
     ? 'line-clamp-1'
     : shape && treatment !== 'big'
@@ -281,10 +294,13 @@ export function EntityCard({
       testId={dataTestId ?? `entity-card-${model.kind}`}
       onClick={onClick}
       className={cn(
-        'group flex min-w-0 flex-col text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-focus-ring)',
-        treatment === 'big' || isUnified
-          ? 'gap-0 overflow-hidden p-0'
-          : 'gap-3 p-3',
+        'group flex min-w-0 text-left transition-[background-color,border-color] duration-subtle focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-focus-ring)',
+        isProfileLandscape ? 'flex-row' : 'flex-col',
+        isProfileLandscape
+          ? cn('gap-0 overflow-hidden', isLandscapeNonMedia ? 'p-0' : 'p-1.5')
+          : treatment === 'big' || isUnified
+            ? 'gap-0 overflow-hidden p-0'
+            : 'gap-3 p-3',
         isPearl
           ? 'rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl hover:bg-(--profile-pearl-bg-hover)'
           : 'rounded-2xl border border-subtle bg-surface-1 shadow-card hover:border-default',
@@ -292,54 +308,64 @@ export function EntityCard({
         className
       )}
     >
-      <div
-        className={cn(
-          'relative flex w-full items-center justify-center overflow-hidden border border-subtle',
-          !isUnified && artFit === 'fill' ? null : 'shrink-0',
-          artClassName,
-          (treatment === 'big' || isUnified) && 'rounded-none border-0',
-          isUnified && 'border-b border-subtle'
-        )}
-        style={artStyle}
-      >
-        {model.imageUrl ? (
-          <ImageWithFallback
-            src={model.imageUrl}
-            alt={model.imageAlt}
-            fill
-            priority={priority}
-            sizes={
-              treatment === 'big' ? '320px' : '(max-width: 767px) 70vw, 300px'
-            }
-            className={
-              // Unified anatomy: square art in a square zone — cover crops
-              // non-square art instead of letterboxing it.
-              isUnified || model.kind !== 'music'
-                ? 'object-cover'
-                : 'object-contain'
-            }
-            fallbackVariant={preset.fallbackVariant}
-            fallbackClassName='bg-transparent'
-          />
-        ) : model.datePill ? (
-          <div className='flex flex-col items-center justify-center text-primary-token'>
-            <span className='text-2xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
-              {model.datePill.month}
-            </span>
-            <span className='text-[34px] font-bold leading-none tracking-tighter tabular-nums'>
-              {model.datePill.day}
-            </span>
-          </div>
-        ) : (
-          <Icon
-            className={cn(
-              'text-tertiary-token',
-              isUnified ? 'h-8 w-8' : 'h-7 w-7'
-            )}
-            aria-hidden='true'
-          />
-        )}
-      </div>
+      {isLandscapeNonMedia ? null : (
+        <div
+          className={cn(
+            'relative flex w-full items-center justify-center overflow-hidden',
+            !isUnified && artFit === 'fill' ? null : 'shrink-0',
+            artClassName,
+            !isUnified && 'border border-subtle',
+            (treatment === 'big' || isUnified) &&
+              !isProfileLandscape &&
+              'rounded-none border-0',
+            isUnified && !isProfileLandscape && 'border-b border-subtle',
+            isProfileLandscape && 'border-0'
+          )}
+          style={artStyle}
+        >
+          {model.imageUrl ? (
+            <ImageWithFallback
+              src={model.imageUrl}
+              alt={model.imageAlt}
+              fill
+              priority={priority}
+              sizes={
+                isProfileLandscape
+                  ? '(max-width: 767px) 44vw, 180px'
+                  : treatment === 'big'
+                    ? '320px'
+                    : '(max-width: 767px) 70vw, 300px'
+              }
+              className={
+                // Unified anatomy: square art in a square zone — cover crops
+                // non-square art instead of letterboxing it.
+                isUnified || model.kind !== 'music'
+                  ? 'object-cover'
+                  : 'object-contain'
+              }
+              fallbackVariant={preset.fallbackVariant}
+              fallbackClassName='bg-transparent'
+            />
+          ) : model.datePill ? (
+            <div className='flex flex-col items-center justify-center text-primary-token'>
+              <span className='text-2xs font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
+                {model.datePill.month}
+              </span>
+              <span className='text-[34px] font-bold leading-none tracking-tighter tabular-nums'>
+                {model.datePill.day}
+              </span>
+            </div>
+          ) : (
+            <Icon
+              className={cn(
+                'text-tertiary-token',
+                isUnified ? 'h-8 w-8' : 'h-7 w-7'
+              )}
+              aria-hidden='true'
+            />
+          )}
+        </div>
+      )}
 
       <div
         className={cn(
@@ -350,7 +376,9 @@ export function EntityCard({
           // eyebrow + title + CTA always fit; the meta line hides entirely
           // below the card-height threshold where it would clip (see
           // .entity-card-meta in design-system.css).
-          isUnified && 'px-3 py-1.5'
+          isProfileLandscape
+            ? 'justify-center py-2 pl-3 pr-2'
+            : isUnified && 'px-3 py-1.5'
         )}
       >
         {/* Text zone — when the card is height-locked it clips so the CTA
@@ -362,7 +390,12 @@ export function EntityCard({
             isUnified ? 'gap-1' : 'gap-1.5'
           )}
         >
-          <div className='flex min-w-0 items-center justify-between gap-2'>
+          <div
+            className={cn(
+              'flex min-w-0 items-center justify-between gap-2',
+              isProfileLandscape && 'hidden'
+            )}
+          >
             <span
               className={cn(
                 'inline-flex min-w-0 items-center gap-1.5 text-3xs font-semibold leading-none text-tertiary-token',
@@ -401,7 +434,8 @@ export function EntityCard({
             <p
               className={cn(
                 'min-w-0 truncate text-[11.5px] text-tertiary-token',
-                isUnified && 'entity-card-meta'
+                isUnified && 'entity-card-meta',
+                isProfileLandscape && 'text-secondary-token'
               )}
             >
               {metaText}
@@ -426,9 +460,11 @@ export function EntityCard({
             isUnified ? null : 'pt-1',
             PROFILE_CARD_FOOTER_ANCHOR_CLASSNAME,
             isUnified
-              ? isInteractive
-                ? 'flex-row items-stretch'
-                : 'flex-col items-stretch'
+              ? isProfileLandscape
+                ? 'flex-row items-center'
+                : isInteractive
+                  ? 'flex-row items-stretch'
+                  : 'flex-col items-stretch'
               : isInteractive
                 ? size.ctaBlock
                   ? 'flex-col items-stretch'
@@ -446,6 +482,7 @@ export function EntityCard({
                   cta={model.cta}
                   block={size.ctaBlock}
                   unified={isUnified}
+                  landscape={isProfileLandscape}
                 />
               ) : null}
               {model.secondaryCta ? (
@@ -453,6 +490,7 @@ export function EntityCard({
                   cta={model.secondaryCta}
                   block={size.ctaBlock}
                   unified={isUnified}
+                  landscape={isProfileLandscape}
                 />
               ) : null}
             </>
@@ -463,13 +501,19 @@ export function EntityCard({
             // plain muted meta text instead of button chrome.
             model.cta ? (
               model.cta.disabled || (!model.cta.href && !cardHref) ? (
-                <span className='flex h-9 w-full items-center text-xs text-tertiary-token'>
+                <span
+                  className={cn(
+                    'flex items-center text-xs text-tertiary-token',
+                    isProfileLandscape ? 'h-8 w-auto' : 'h-9 w-full'
+                  )}
+                >
                   {model.cta.label}
                 </span>
               ) : (
                 <span
                   className={cn(
-                    'inline-flex h-9 w-full shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:bg-btn-primary-hover'
+                    'inline-flex shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-[background-color,transform] duration-subtle group-hover:bg-btn-primary-hover group-active:scale-[0.96] motion-reduce:transform-none',
+                    isProfileLandscape ? 'h-8 w-fit' : 'h-9 w-full'
                   )}
                 >
                   {model.cta.label}

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -157,4 +157,95 @@ describe('EntityCarousel profile geometry', () => {
     const carousel = screen.getByTestId('profile-home-carousel');
     expect(carousel.querySelectorAll(':scope > li')).toHaveLength(1);
   });
+
+  it('renders one full-width landscape card per mandatory snap', () => {
+    const withCta: EntityCardModel[] = [
+      {
+        ...items[0],
+        meta: 'Single · 2026',
+        cta: { label: 'Listen', href: '/tim/release-1' },
+      },
+    ];
+
+    render(
+      <EntityCarousel
+        items={withCta}
+        layout='profile-landscape'
+        dataTestId='profile-home-carousel'
+      />
+    );
+
+    const carousel = screen.getByTestId('profile-home-carousel');
+    expect(carousel).toHaveAttribute('data-layout', 'profile-landscape');
+    expect(carousel.className).toContain('snap-mandatory');
+
+    const footprint = carousel.querySelector(':scope > li');
+    expect(footprint).toHaveAttribute('data-layout', 'profile-landscape');
+    expect(footprint?.className).toContain('w-full');
+    expect(footprint?.className).toContain('snap-always');
+
+    const image = screen.getByRole('img', { name: 'Release one' });
+    expect(image.parentElement?.className).toContain('aspect-square');
+    expect(image.parentElement?.className).toMatch(/(?:^|\s)rounded(?:\s|$)/);
+    expect(image.parentElement?.className).toContain('border-0');
+    expect(image.parentElement?.className).not.toContain('border-r');
+
+    const cta = screen.getByText('Listen');
+    expect(cta.className).toContain('h-8');
+    expect(cta.className).toContain('w-fit');
+    expect(cta.className).not.toContain('w-full');
+  });
+
+  it('keeps landscape leading and trailing slots in identical full-width footprints', () => {
+    render(
+      <EntityCarousel
+        items={items}
+        layout='profile-landscape'
+        leading={<section data-testid='slot-leading' />}
+        trailing={<section data-testid='slot-trailing' />}
+      />
+    );
+
+    const carousel = screen.getByTestId('entity-carousel');
+    const footprints = [...carousel.querySelectorAll(':scope > li')];
+    expect(footprints).toHaveLength(4);
+    expect(
+      footprints.every(
+        footprint =>
+          footprint.className.includes('w-full') &&
+          footprint.getAttribute('data-layout') === 'profile-landscape'
+      )
+    ).toBe(true);
+  });
+
+  it('keeps missing artwork in the same square, subtly rounded media slot', () => {
+    render(
+      <EntityCarousel
+        layout='profile-landscape'
+        items={[
+          {
+            id: 'release-without-art',
+            kind: 'music',
+            href: '/tim/release-without-art',
+            imageUrl: null,
+            imageAlt: 'Release without artwork',
+            title: 'A Very Long Release Title Without Artwork',
+            meta: 'Single · 2026',
+            cta: { label: 'Listen', href: '/tim/release-without-art' },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    const card = screen.getByTestId('entity-card-music');
+    const media = card.querySelector('.aspect-square');
+    expect(media?.className).toMatch(/(?:^|\s)rounded(?:\s|$)/);
+    expect(media?.className).toContain('border-0');
+    expect(
+      screen.getByRole('heading', {
+        name: 'A Very Long Release Title Without Artwork',
+      })
+    ).toHaveClass('line-clamp-1');
+  });
 });

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -6,9 +6,12 @@ import { cn } from '@/lib/utils';
 import { EntityCard } from './EntityCard';
 import type { EntityCardModel, EntitySurface } from './types';
 
+export type EntityCarouselLayout = 'portrait' | 'profile-landscape';
+
 interface EntityCarouselProps {
   readonly items: readonly EntityCardModel[];
   readonly surface?: EntitySurface;
+  readonly layout?: EntityCarouselLayout;
   readonly className?: string;
   readonly dataTestId?: string;
   /**
@@ -32,14 +35,15 @@ const CARD_ITEM_CLASSNAME =
  * false hierarchy, crop the trailing cards, and make the rail look vertically
  * scrollable inside the fixed profile shell.
  *
- * Geometry lives in `.profile-entity-card` (design-system.css): 3:4 aspect
- * ratio, height locked to the track (h-full), width derived from height,
- * capped so no card exceeds ~78vw. The track fills the remaining viewport
- * height (h-full) so primary content never needs vertical scrolling.
+ * Geometry lives in `.profile-entity-card` (design-system.css). Portrait is
+ * the default 3:4, height-locked treatment. `profile-landscape` is the compact
+ * public-profile exception: a full-content-width 9:4 card with one mandatory
+ * snap per viewport and no neighboring-card preview at rest.
  */
 export function EntityCarousel({
   items,
   surface = 'pearl',
+  layout = 'portrait',
   className,
   dataTestId,
   leading,
@@ -72,7 +76,7 @@ export function EntityCarousel({
     const observer = new IntersectionObserver(
       entries => {
         for (const entry of entries) {
-          if (!entry.isIntersecting) {
+          if (!entry.isIntersecting || entry.intersectionRatio < 0.5) {
             continue;
           }
 
@@ -121,7 +125,10 @@ export function EntityCarousel({
       entries => {
         for (const entry of entries) {
           const node = entry.target as HTMLElement;
-          node.dataset.edge = entry.isIntersecting ? 'false' : 'true';
+          node.dataset.edge =
+            entry.isIntersecting && entry.intersectionRatio >= 0.95
+              ? 'false'
+              : 'true';
         }
       },
       { root: track, threshold: 0.95 }
@@ -138,6 +145,11 @@ export function EntityCarousel({
     return null;
   }
 
+  const cardItemClassName = cn(
+    CARD_ITEM_CLASSNAME,
+    layout === 'profile-landscape' && 'w-full'
+  );
+
   return (
     <ul
       ref={trackRef}
@@ -146,9 +158,14 @@ export function EntityCarousel({
         className
       )}
       data-testid={dataTestId ?? 'entity-carousel'}
+      data-layout={layout}
     >
       {leading ? (
-        <li data-carousel-slot='leading' className={CARD_ITEM_CLASSNAME}>
+        <li
+          data-carousel-slot='leading'
+          data-layout={layout}
+          className={cardItemClassName}
+        >
           {leading}
         </li>
       ) : null}
@@ -160,17 +177,18 @@ export function EntityCarousel({
               itemRefs.current[index] = node;
             }}
             data-carousel-index={index}
-            className={CARD_ITEM_CLASSNAME}
+            data-layout={layout}
+            className={cardItemClassName}
           >
             <EntityCard
               model={model}
               treatment='detailed'
-              // Unified profile-card anatomy: full-bleed square art, text
-              // zone, and a full-width CTA — the same design as the featured
-              // PAC card. The hero keeps image priority; carousel art stays
-              // lazy so the LCP image never competes with the cover photo.
+              // The hero keeps image priority; carousel art stays lazy so the
+              // LCP image never competes with the cover photo.
               surface={surface}
-              anatomy='unified'
+              anatomy={
+                layout === 'profile-landscape' ? 'profile-landscape' : 'unified'
+              }
               className='h-full w-full overflow-hidden'
               onClick={
                 onCardClick ? () => onCardClick(index, model) : undefined
@@ -180,7 +198,11 @@ export function EntityCarousel({
         );
       })}
       {trailing ? (
-        <li data-carousel-slot='trailing' className={CARD_ITEM_CLASSNAME}>
+        <li
+          data-carousel-slot='trailing'
+          data-layout={layout}
+          className={cardItemClassName}
+        >
           {trailing}
         </li>
       ) : null}

--- a/apps/web/hooks/useUserLocation.test.ts
+++ b/apps/web/hooks/useUserLocation.test.ts
@@ -1,0 +1,169 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUserLocation } from './useUserLocation';
+
+const CACHE_KEY = 'jovie_user_location';
+const CACHE_EXPIRY_KEY = 'jovie_user_location_expiry';
+
+function installNavigator({
+  geolocation = true,
+  permissions = true,
+  permissionState = 'prompt',
+}: Readonly<{
+  geolocation?: boolean;
+  permissions?: boolean;
+  permissionState?: PermissionState;
+}> = {}) {
+  const getCurrentPosition = vi.fn();
+  const query = vi.fn().mockResolvedValue({ state: permissionState });
+
+  vi.stubGlobal('navigator', {
+    geolocation: geolocation ? { getCurrentPosition } : undefined,
+    permissions: permissions ? { query } : undefined,
+  });
+
+  return { getCurrentPosition, query };
+}
+
+describe('useUserLocation permission modes', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+  });
+
+  it('uses a valid cached location without consulting browser permissions', async () => {
+    const { getCurrentPosition, query } = installNavigator({
+      permissionState: 'prompt',
+    });
+    sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ latitude: 34.0522, longitude: -118.2437 })
+    );
+    sessionStorage.setItem(CACHE_EXPIRY_KEY, String(Date.now() + 60_000));
+
+    const { result } = renderHook(() =>
+      useUserLocation({ permissionMode: 'granted-only' })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.location).toEqual({
+      latitude: 34.0522,
+      longitude: -118.2437,
+    });
+    expect(query).not.toHaveBeenCalled();
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'prompt',
+    'denied',
+  ] as const)('never opens geolocation when granted-only permission is %s', async permissionState => {
+    const { getCurrentPosition, query } = installNavigator({
+      permissionState,
+    });
+
+    const { result } = renderHook(() =>
+      useUserLocation({ permissionMode: 'granted-only' })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(query).toHaveBeenCalledWith({ name: 'geolocation' });
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+    expect(result.current.location).toBeNull();
+  });
+
+  it('reads location when permission was already granted', async () => {
+    const { getCurrentPosition } = installNavigator({
+      permissionState: 'granted',
+    });
+    getCurrentPosition.mockImplementation(success => {
+      success({
+        coords: { latitude: 51.5072, longitude: -0.1276 },
+      } as GeolocationPosition);
+    });
+
+    const { result } = renderHook(() =>
+      useUserLocation({ permissionMode: 'granted-only' })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(result.current.location).toEqual({
+      latitude: 51.5072,
+      longitude: -0.1276,
+    });
+  });
+
+  it('preserves request mode for consumers that intentionally ask permission', async () => {
+    const { getCurrentPosition, query } = installNavigator({
+      permissionState: 'prompt',
+    });
+    getCurrentPosition.mockImplementation(success => {
+      success({
+        coords: { latitude: 40.7128, longitude: -74.006 },
+      } as GeolocationPosition);
+    });
+
+    const { result } = renderHook(() => useUserLocation());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(query).not.toHaveBeenCalled();
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back without prompting when Permissions API is unavailable', async () => {
+    const { getCurrentPosition } = installNavigator({ permissions: false });
+
+    const { result } = renderHook(() =>
+      useUserLocation({ permissionMode: 'granted-only' })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+    expect(result.current.location).toBeNull();
+  });
+
+  it('reports unsupported geolocation without attempting permission lookup', async () => {
+    const { getCurrentPosition, query } = installNavigator({
+      geolocation: false,
+    });
+
+    const { result } = renderHook(() =>
+      useUserLocation({ permissionMode: 'granted-only' })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('Geolocation not supported');
+    expect(query).not.toHaveBeenCalled();
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it('stops waiting after the fixed timeout when granted geolocation stalls', async () => {
+    vi.useFakeTimers();
+    const { getCurrentPosition } = installNavigator({
+      permissionState: 'granted',
+    });
+
+    const { result } = renderHook(() =>
+      useUserLocation({ permissionMode: 'granted-only' })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('Location request timed out');
+    expect(result.current.location).toBeNull();
+  });
+});

--- a/apps/web/hooks/useUserLocation.ts
+++ b/apps/web/hooks/useUserLocation.ts
@@ -13,8 +13,16 @@ interface UseUserLocationResult {
   error: string | null;
 }
 
-interface UseUserLocationOptions {
+export type UserLocationPermissionMode = 'request' | 'granted-only';
+
+export interface UseUserLocationOptions {
   readonly enabled?: boolean;
+  /**
+   * `request` preserves the legacy behavior and may open the browser prompt.
+   * `granted-only` may use a cached or already-granted location, but never
+   * turns a `prompt` permission state into browser chrome on page entry.
+   */
+  readonly permissionMode?: UserLocationPermissionMode;
 }
 
 const LOCATION_CACHE_KEY = 'jovie_user_location';
@@ -29,6 +37,7 @@ const GEOLOCATION_TIMEOUT_MS = 5000; // 5 second timeout for fast UX
  */
 export function useUserLocation({
   enabled = true,
+  permissionMode = 'request',
 }: UseUserLocationOptions = {}): UseUserLocationResult {
   const [location, setLocation] = useState<UserLocation | null>(null);
   const [isLoading, setIsLoading] = useState(enabled);
@@ -60,49 +69,80 @@ export function useUserLocation({
       return;
     }
 
-    let timeoutId: ReturnType<typeof setTimeout>;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     let didTimeout = false;
+    let cancelled = false;
 
-    // Set a timeout to stop waiting and show default order
-    timeoutId = setTimeout(() => {
-      didTimeout = true;
-      setError('Location request timed out');
-      setIsLoading(false);
-    }, GEOLOCATION_TIMEOUT_MS);
+    const requestCurrentPosition = () => {
+      if (cancelled) return;
 
-    navigator.geolocation.getCurrentPosition(
-      position => {
-        if (didTimeout) return;
-        clearTimeout(timeoutId);
-
-        const userLocation: UserLocation = {
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-        };
-
-        // Cache the location
-        cacheLocation(userLocation);
-        setLocation(userLocation);
+      // Set a timeout to stop waiting and show default order.
+      timeoutId = setTimeout(() => {
+        if (cancelled) return;
+        didTimeout = true;
+        setError('Location request timed out');
         setIsLoading(false);
-      },
-      err => {
-        if (didTimeout) return;
-        clearTimeout(timeoutId);
+      }, GEOLOCATION_TIMEOUT_MS);
 
-        setError(err.message);
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          if (cancelled || didTimeout) return;
+          if (timeoutId) clearTimeout(timeoutId);
+
+          const userLocation: UserLocation = {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          };
+
+          cacheLocation(userLocation);
+          setLocation(userLocation);
+          setIsLoading(false);
+        },
+        err => {
+          if (cancelled || didTimeout) return;
+          if (timeoutId) clearTimeout(timeoutId);
+
+          setError(err.message);
+          setIsLoading(false);
+        },
+        {
+          enableHighAccuracy: false,
+          timeout: GEOLOCATION_TIMEOUT_MS,
+          maximumAge: CACHE_DURATION_MS,
+        }
+      );
+    };
+
+    if (permissionMode === 'granted-only') {
+      // Permissions is not uniformly available on older Safari builds. In
+      // that case, fail quietly to the deterministic date order rather than
+      // risking a surprise browser prompt.
+      if (!navigator.permissions?.query) {
         setIsLoading(false);
-      },
-      {
-        enableHighAccuracy: false, // Low accuracy is faster and sufficient for city-level
-        timeout: GEOLOCATION_TIMEOUT_MS,
-        maximumAge: CACHE_DURATION_MS, // Accept cached browser location
+      } else {
+        void navigator.permissions
+          .query({ name: 'geolocation' })
+          .then(permission => {
+            if (cancelled) return;
+            if (permission.state === 'granted') {
+              requestCurrentPosition();
+              return;
+            }
+            setIsLoading(false);
+          })
+          .catch(() => {
+            if (!cancelled) setIsLoading(false);
+          });
       }
-    );
+    } else {
+      requestCurrentPosition();
+    }
 
     return () => {
-      clearTimeout(timeoutId);
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [enabled]);
+  }, [enabled, permissionMode]);
 
   return { location, isLoading, error };
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -362,19 +362,35 @@
     opacity var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing);
 }
 
+/* Direction C public-profile rail: one full-content-width card per snap. The
+   9:4 footprint gives the inset square media roughly 42% of the card width,
+   leaving a compact copy/action column. Its 4px artwork radius steps down from
+   the 18px card surface and avoids clipping the artwork with the card border.
+   Portrait remains the default for every other EntityCarousel consumer. */
+:where(.profile-entity-card[data-layout="profile-landscape"]) {
+  aspect-ratio: 9 / 4;
+  width: 100%;
+  height: auto;
+  max-height: none;
+  align-self: flex-start;
+  container-type: inline-size;
+}
+
 /* Unified card anatomy: the art zone is a full-width square, so the text
    zone + CTA share (card height − card width). Progressive disclosure keeps
    every line whole instead of clipping mid-line: the meta line hides below
    the height where it fits (~448px), and the eyebrow hides below the height
    where it fits next to the title (~360px) — title and CTA always fit. */
 @container (max-height: 447px) {
-  :where(.profile-entity-card) .entity-card-meta {
+  :where(.profile-entity-card:not([data-layout="profile-landscape"]))
+    .entity-card-meta {
     display: none;
   }
 }
 
 @container (max-height: 359px) {
-  :where(.profile-entity-card) .entity-card-eyebrow {
+  :where(.profile-entity-card:not([data-layout="profile-landscape"]))
+    .entity-card-eyebrow {
     display: none;
   }
 }
@@ -384,6 +400,13 @@
 :where(.profile-entity-card[data-edge="true"]) {
   transform: scale(0.96);
   opacity: 0.75;
+}
+
+:where(
+  .profile-entity-card[data-layout="profile-landscape"][data-edge="true"]
+) {
+  transform: scale(0.985);
+  opacity: 0.82;
 }
 
 /* Chromeless top-chrome icon buttons (back / overflow menu): glyph-only by
@@ -443,6 +466,38 @@
   display: none;
   width: 0;
   height: 0;
+}
+
+/* Compact profile tab entry. The outgoing panel is replaced in-place, so this
+   transform never participates in layout and cannot move the dock or header. */
+:where(.profile-primary-tab-transition) {
+  animation: profile-tab-enter var(--ds-motion-subtle-duration)
+    var(--ds-motion-subtle-easing) both;
+}
+
+:where(.profile-primary-tab-transition[data-direction="-1"]) {
+  --profile-tab-enter-offset: -6px;
+}
+
+:where(.profile-primary-tab-transition[data-direction="1"]) {
+  --profile-tab-enter-offset: 6px;
+}
+
+@keyframes profile-tab-enter {
+  from {
+    opacity: 0;
+    transform: translateX(var(--profile-tab-enter-offset, 6px));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where(.profile-primary-tab-transition) {
+    animation: none;
+  }
 }
 
 :where(.profile-aeo-content__heading),


### PR DESCRIPTION
## Summary
- add profile-specific landscape carousel/card anatomy with full-width snap geometry
- add granted-only geolocation and content-height profile drawer contracts
- add shared motion/material tokens and semantic profile heading support

## Design
Direction C · Spatial Glass. Keeps album artwork borderless with subtle radii and stepped container elevation.

## Verification
- 155 affected profile/location/layout-shift tests
- full web typecheck
- Biome on all changed files
- repository pre-push affected verification bundle: 8/8 shards green

## Stack
1 of 2. Follow-up surface PR targets this branch.

## Release hold
Draft while exact-current-main Production Controller is red; do not queue or merge until production is recovered.