### PR TITLE
fix(chat): authorize artist context with profile claims

### DIFF
--- a/apps/web/app/api/chat/artist-context-identity.test.ts
+++ b/apps/web/app/api/chat/artist-context-identity.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveProfileAccess } from '@/lib/auth/profile-access';
+
+const ROUTE_SOURCE = readFileSync(
+  resolve(process.cwd(), 'app/api/chat/route.ts'),
+  'utf8'
+);
+
+function getFetchArtistContextSource(): string {
+  const start = ROUTE_SOURCE.indexOf('async function fetchArtistContext(');
+  const end = ROUTE_SOURCE.indexOf('\n/**\n * Find a release by title', start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return ROUTE_SOURCE.slice(start, end);
+}
+
+describe('chat artist-context identity contract', () => {
+  it('uses the canonical profile-access policy before loading artist context', () => {
+    const source = getFetchArtistContextSource();
+
+    expect(source).toContain('getExactProfileAccess(db, appUserId, profileId)');
+    expect(source).toContain('if (!access.ok)');
+    expect(source).not.toContain('users.clerkId');
+    expect(source).not.toContain('creatorProfiles.userId');
+  });
+
+  it('passes the getOptionalAuth app user ID into artist-context resolution', () => {
+    expect(ROUTE_SOURCE).toContain(
+      'const { userId } = await getOptionalAuth()'
+    );
+    expect(ROUTE_SOURCE).toContain(
+      'const context = await fetchArtistContext(profileId, userId)'
+    );
+  });
+
+  it.each([
+    { role: 'owner', name: 'canonical owner' },
+    { role: 'manager', name: 'canonical manager' },
+  ])('authorizes a $name even when the legacy owner differs', ({ role }) => {
+    expect(
+      resolveProfileAccess({
+        appUserId: USER_A,
+        profileId: PROFILE_ID,
+        userRows: [{ id: USER_A }],
+        profileRows: [{ id: PROFILE_ID, legacyUserId: USER_B }],
+        claimRows: [{ userId: USER_A, role }],
+      })
+    ).toMatchObject({ ok: true, profileId: PROFILE_ID });
+  });
+
+  it('denies a stale legacy owner after canonical ownership transfers', () => {
+    expect(
+      resolveProfileAccess({
+        appUserId: USER_A,
+        profileId: PROFILE_ID,
+        userRows: [{ id: USER_A }],
+        profileRows: [{ id: PROFILE_ID, legacyUserId: USER_A }],
+        claimRows: [{ userId: USER_B, role: 'owner' }],
+      })
+    ).toEqual({ ok: false, reason: 'forbidden' });
+  });
+
+  it.each([
+    { legacyUserId: USER_B, name: 'unrelated legacy owner' },
+    { legacyUserId: null, name: 'missing legacy owner' },
+  ])('denies an unrelated user with $name and no claims', ({
+    legacyUserId,
+  }) => {
+    expect(
+      resolveProfileAccess({
+        appUserId: USER_A,
+        profileId: PROFILE_ID,
+        userRows: [{ id: USER_A }],
+        profileRows: [{ id: PROFILE_ID, legacyUserId }],
+        claimRows: [],
+      })
+    ).toEqual({ ok: false, reason: 'forbidden' });
+  });
+});
+
+const USER_A = '00000000-0000-4000-8000-000000000001';
+const USER_B = '00000000-0000-4000-8000-000000000002';
+const PROFILE_ID = '00000000-0000-4000-8000-000000000010';

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -47,6 +47,7 @@ import { createImportBioFromUrlTool } from '@/lib/ai/tools/import-bio-from-url';
 import { createProfileEditTool } from '@/lib/ai/tools/profile-edit';
 import { createVoicePromoTool } from '@/lib/ai/tools/voice-promo';
 import { getOptionalAuth } from '@/lib/auth/cached';
+import { getExactProfileAccess } from '@/lib/auth/profile-access';
 import { getSessionContext } from '@/lib/auth/session';
 import { resolveChatAccountContext } from '@/lib/chat/account-context';
 import { createAccountChatTools } from '@/lib/chat/account-tools';
@@ -113,7 +114,6 @@ import {
 import { wrapToolSetFailSoft } from '@/lib/chat/wrap-tool-execute';
 import { db } from '@/lib/db';
 import { clickEvents, tips } from '@/lib/db/schema/analytics';
-import { users } from '@/lib/db/schema/auth';
 import { socialLinks } from '@/lib/db/schema/links';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { sqlAny } from '@/lib/db/sql-helpers';
@@ -207,13 +207,17 @@ const CHAT_KILL_SWITCH_GATES = {
 
 /**
  * Fetches artist context server-side from the database.
- * Validates that the profile belongs to the authenticated user.
+ * Validates that the authenticated user can manage the profile.
  */
 async function fetchArtistContext(
   profileId: string,
-  clerkUserId: string
+  appUserId: string
 ): Promise<ArtistContext | null> {
-  // Fetch profile with ownership check via user join
+  const access = await getExactProfileAccess(db, appUserId, profileId);
+  if (!access.ok) {
+    return null;
+  }
+
   const [result] = await db
     .select({
       displayName: creatorProfiles.displayName,
@@ -225,14 +229,12 @@ async function fetchArtistContext(
       spotifyUrl: creatorProfiles.spotifyUrl,
       appleMusicUrl: creatorProfiles.appleMusicUrl,
       profileViews: creatorProfiles.profileViews,
-      userClerkId: users.clerkId,
     })
     .from(creatorProfiles)
-    .leftJoin(users, eq(users.id, creatorProfiles.userId))
     .where(eq(creatorProfiles.id, profileId))
     .limit(1);
 
-  if (result?.userClerkId !== clerkUserId) {
+  if (!result) {
     return null;
   }
 


### PR DESCRIPTION
## Description

Authenticated dashboard chat was passing the canonical Better Auth app user UUID into artist-context loading, while the loader authorized through a legacy identity/ownership field. That mismatch returned no artist context for the supported creator-ready persona. The loader now uses the canonical profile access policy: owner and manager claims are authoritative, and legacy ownership is fallback-only when no claims exist.

This PR is intentionally limited to the authenticated artist-context path. It does not claim to repair the separate public `/start` onboarding paused-message incident, which exits through the anonymous onboarding handler before this code runs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] New tests added

Focused evidence:
- `artist-context-identity.test.ts`: 7 passed
- `profile-access.test.ts`: 22 passed
- `tests/unit/api/chat/route.test.ts`: 5 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`: passed
- pre-push affected verification: 9 tests passed; lint, typecheck, CI harness passed
- creator-ready local session: `/api/chat` returned `200 text/event-stream` with conversation and turn IDs and streamed the assistant response

### Bug-to-Test Rule

- [x] Regression test added or updated
- [x] `bug-to-test: satisfied`

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console logging added
- [x] TypeScript types are properly defined

## Database Changes

None. No production data, secrets, schema, migrations, or configuration changed.

## Deployment Notes

No special deployment configuration. Normal CI and merge gates apply.

## Design Skill Evidence

`design-canonical: not applicable` — route authorization and regression coverage only; no UI or styling changes.

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with target branch (`09b46ccb8d3cfb5caaf4b22e3be45464c4b896f5`)
- [x] Documentation updated (not needed; no documented contract changed)
- [x] Changelog updated (not needed for this route/test-only repair)
