### PR TITLE
fix(ci): allow sanitized markdown auth-smoke artifacts

### DIFF
--- a/.github/workflows/postdeploy-probes.yml
+++ b/.github/workflows/postdeploy-probes.yml
@@ -463,6 +463,7 @@ jobs:
           echo "auth_smoke_status=passed" >> "$GITHUB_OUTPUT"
         env:
           EXPECTED_COMMIT_SHA: ${{ needs.resolve-target.outputs.commit_sha }}
+          PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'
           PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           PRODUCTION_BASE_URL_B64: ${{ needs.resolve-target.outputs.deployment_url_b64 }}
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
@@ -475,6 +476,7 @@ jobs:
           path: |
             apps/web/test-results/
           retention-days: 3
+          allow-markdown: 'true'
 
   lighthouse:
     name: Lighthouse CI (Landed Production)

--- a/.github/workflows/production-controller.yml
+++ b/.github/workflows/production-controller.yml
@@ -506,6 +506,7 @@ jobs:
           echo "auth_smoke_status=passed" >> "$GITHUB_OUTPUT"
         env:
           EXPECTED_COMMIT_SHA: ${{ needs.authorize-production.outputs.expected_sha }}
+          PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'
           PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           PRODUCTION_BASE_URL_B64: ${{ needs.production-release.outputs.production_deployment_url_b64 }}
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
@@ -518,6 +519,7 @@ jobs:
           path: |
             apps/web/test-results/
           retention-days: 3
+          allow-markdown: 'true'
   lighthouse-ci:
     name: Lighthouse CI (Production)
     needs: [authorize-production, production-release]

--- a/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+++ b/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
@@ -58,6 +58,8 @@ const imageUploads =
   );
 const markdownUploads = [
   'nightly-testing-agent.yml:nightly-agent-report-${{ github.run_id }}',
+  'postdeploy-probes.yml:postdeploy-auth-smoke-${{ github.run_id }}',
+  'production-controller.yml:post-deploy-auth-smoke-${{ github.run_id }}',
   'visual-regression.yml:visual-regression-report-${{ github.run_id }}-${{ github.run_attempt }}',
 ];
 const protectedJobs: Record<string, string[]> = {
@@ -805,6 +807,39 @@ describe('Playwright artifact secret boundary', () => {
       expect(audit.violations, `${job.file}:${job.id}`).toEqual([]);
     }
 
+    for (const [file, jobId, artifactName] of [
+      [
+        'postdeploy-probes.yml',
+        'auth-smoke',
+        'postdeploy-auth-smoke-${{ github.run_id }}',
+      ],
+      [
+        'production-controller.yml',
+        'ci-post-deploy-auth-smoke',
+        'post-deploy-auth-smoke-${{ github.run_id }}',
+      ],
+    ] as const) {
+      const workflow = readFileSync(join(workflowsRoot, file), 'utf8');
+      const job = workflowJobBlocks(workflow).find(block => block.id === jobId);
+      expect(job, `${file}:${jobId}`).toBeDefined();
+      if (!job) continue;
+      const producer = workflowStepBlocks(job.source).find(block =>
+        block.startsWith('      - name: Run production auth smoke tests\n')
+      );
+      const uploader = workflowStepBlocks(job.source).find(block =>
+        block.includes(safeUploadAction)
+      );
+      expect(producer, `${file}:${jobId}:producer`).toBeDefined();
+      expect(uploader, `${file}:${jobId}:uploader`).toBeDefined();
+      if (!producer || !uploader) continue;
+      expect(producer).toContain("PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'");
+      expect(yamlPropertyBlock(job.source, 'env', 4)).not.toContain(
+        'PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN'
+      );
+      expect(uploader).toContain(`name: ${artifactName}`);
+      expect(uploader).toContain("allow-markdown: 'true'");
+    }
+
     const fixtureCheckout = `      - uses: actions/checkout@0123456789abcdef
         with:
           persist-credentials: false`;
@@ -1459,6 +1494,7 @@ ${fixtureCheckout}
     write(join(policy, 'safe.md'), '# Safe diagnostics');
     write(join(policy, 'credential.md'), 'DATABASE_URL=fake-password');
     write(join(policy, 'artifact.bin'), 'opaque');
+    write(join(policy, 'artifact.trace'), 'opaque');
     for (const extension of 'avi har html mkv mov mp4 webm zip'.split(' '))
       write(join(policy, `artifact.${extension}`), 'unsafe');
     const findings = inspectPlaywrightArtifacts(
@@ -1475,6 +1511,10 @@ ${fixtureCheckout}
     });
     expect(findings).toContainEqual({
       path: join(policy, 'artifact.bin'),
+      category: 'unknown-binary',
+    });
+    expect(findings).toContainEqual({
+      path: join(policy, 'artifact.trace'),
       category: 'unknown-binary',
     });
     expect(


### PR DESCRIPTION
## RCA

A retried production auth smoke generated sanitized Playwright `error-context.md`. The guarded producer lacked the scoped Markdown allowance, so the guard classified it as unknown-binary and the safe uploader failed.

This commit scopes Markdown allowance only to the two production auth-smoke producers and matching safe uploaders. The guard remains fail-closed, and forbidden zip, trace, HAR, HTML, video, and unknown-binary artifacts remain blocked.

## Verification

- Focused workflow/artifact tests: 109/109 passed
- Protected pre-push affected test: 12/12 passed
- Exact Node 22.23.1 TypeScript check, actionlint, Biome, bug-to-test, CI harness, and diff checks passed

No smoke assertions, secrets, production rerun, merge, or deploy changes.