### PR TITLE
docs(storybook): correct LoadingSpinner reduced-motion guidance

### DIFF
--- a/apps/web/components/atoms/LoadingSpinner.stories.tsx
+++ b/apps/web/components/atoms/LoadingSpinner.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 
 const meta: Meta<typeof LoadingSpinner> = {
@@ -45,27 +46,35 @@ export const ReducedMotion: Story = {
       </div>
       <div className='text-center'>
         <p className='text-sm text-gray-600 dark:text-gray-400'>
-          With prefers-reduced-motion: Slower spin animation (1.2s instead of
-          1s)
+          With prefers-reduced-motion: Static progress ring (no rotation)
         </p>
       </div>
       <div className='p-4 bg-gray-100 dark:bg-gray-800 rounded-lg'>
         <p className='text-sm mb-2 font-medium'>How it works:</p>
         <ul className='text-sm text-gray-600 dark:text-gray-400 list-disc pl-5 space-y-1'>
-          <li>Standard spin animation (1s) for most users</li>
+          <li>Spin animation for users without a reduced-motion preference</li>
+          <li>Static progress ring when prefers-reduced-motion is enabled</li>
+          <li>Uses motion-reduce:animate-none to stop rotation</li>
           <li>
-            Slower, less intense animation (1.2s) when prefers-reduced-motion is
-            enabled
-          </li>
-          <li>
-            Uses motion-reduce:animate-[spin_1.2s_linear_infinite] utility class
+            Resets transform optimization with motion-reduce:will-change-auto
           </li>
           <li>Transitions are disabled via motion-reduce:transition-none</li>
           <li>
-            Respects user accessibility preferences while maintaining feedback
+            The ring remains visible so the in-flight status is still clear
           </li>
         </ul>
       </div>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(
+        'With prefers-reduced-motion: Static progress ring (no rotation)'
+      )
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText(/slower spin animation/i)
+    ).not.toBeInTheDocument();
+  },
 };


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4474 -->

## Summary

- replaces the stale slower-spin explanation in the `LoadingSpinner` reduced-motion story with the approved static progress-ring fallback
- adds a Storybook play assertion that requires the static-fallback copy and rejects the old slower-spin claim

## Dependency

- Draft and blocked on #14907, which contains the approved `ProgressIndicator`/`Spinner` static reduced-motion implementation.
- Current `main@e336794c875a9f636e89770b4cbe8db8e489109c` still uses and tests the older slower-spin behavior. Do not mark this PR ready or enqueue it until #14907 lands and this branch is rebased.

## Scope

- one file: `apps/web/components/atoms/LoadingSpinner.stories.tsx`
- no component, runtime, Storybook infrastructure, test-disable, queue, or deploy changes

## Bug-to-Test

bug-to-test: satisfied — the `ReducedMotion` story play assertion verifies the static fallback copy and rejects the stale slower-spin claim.

## Verification

- [x] Focused Storybook browser Vitest: 1 file, 4 stories passed
- [x] Focused component + Storybook quality unit tests: 2 files, 10 tests passed
- [x] Storybook product quality guard: 154 stories scanned, clean
- [x] Web typecheck passed
- [x] Pre-push affected bundle passed: typecheck, lint, arbitrary-value ratchet, Tailwind guard, CI harness
- [x] Live Storybook review: `http://127.0.0.1:6017/iframe.html?id=ui-loadingspinner--reduced-motion&viewMode=story`
- [x] Screenshot: `/private/tmp/jovie-loading-spinner-reduced-motion.png`

## Review

- Pre-Landing Review: No issues found.
- Design Review (lite): No issues found.
- Browser console: the existing Storybook `next-themes` client-render script warning remains; no `LoadingSpinner` or play-assertion errors.

## Linear follow-ups

- none