### PR TITLE
WIP: standardize subtle press feedback

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -211,7 +211,7 @@ This is the subtraction principle applied specifically to container boundaries. 
 
 - Hover states must not move layout or shift components without a product reason.
 - Do **NOT** use `translate`, `scale`, lift-on-hover, or floating-card motion on buttons, cards, screenshots, auth surfaces, or marketing panels as a default polish move.
-- Press/click feedback may use a subtle `scale(0.96)` when it is tactile and interruptible; provide a static opt-out when the motion would distract.
+- Press/click feedback uses the shared `--scale-press` token (`0.98`) when tactile feedback is useful. Shared controls must disable the transform under reduced motion and provide a static opt-out where motion would distract.
 - Menus, panels, drawers, and sidebars may use intentional `translate`/`scale` motion for open/close because the movement communicates spatial state.
 - Prefer background-color, border-color, text-color, opacity, or shadow changes for hover feedback.
 - If motion is necessary because the UI is directly manipulating something spatial, it must be intentional and clearly tied to that interaction.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -530,6 +530,17 @@ the app feeling consistent even as new components land.
 
 These are surface-side aliases of `--ds-motion-*` tokens (DS_FOUNDATION_V1).
 
+### Interaction feedback
+
+- Press feedback uses the shared `--scale-press` token. The canonical value is
+  `0.98`: enough tactile response to register without visible shrink or jump.
+- Shared interactive primitives, including Button, apply the token once.
+  Feature code must not add its own `whileTap` scale or hardcoded active scale.
+- Hover and focus feedback do not scale controls. Use semantic surface, text,
+  border, opacity, or shadow changes that preserve geometry.
+- `prefers-reduced-motion: reduce` disables press transforms. Components that
+  intentionally opt out use the shared Button `static` contract.
+
 **Rule of thumb:** if the user's eye has to track the move (panel sliding in,
 surface growing), it's cinematic. If the user notices it only as feedback
 (button color change, focus ring), it's subtle. Never invent a third tier

--- a/apps/web/components/features/pricing/PricingCTA.tsx
+++ b/apps/web/components/features/pricing/PricingCTA.tsx
@@ -1,12 +1,11 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { motion } from 'motion/react';
 
 // Animation constants
 const CONTAINER_ANIMATION_DURATION = 0.5;
 const CONTAINER_ANIMATION_DELAY = 0.4;
-const BUTTON_HOVER_SCALE = 1.02;
-const BUTTON_TAP_SCALE = 0.98;
 
 interface PricingCTAProps
   extends Readonly<{
@@ -37,15 +36,14 @@ export function PricingCTA({ onUpgrade, isLoading }: PricingCTAProps) {
             </p>
           </div>
           <div className='flex justify-end'>
-            <motion.button
+            <Button
               onClick={onUpgrade}
-              disabled={isLoading}
-              className='inline-flex items-center justify-center rounded-md px-6 py-3 text-base font-medium transition-colors duration-subtle cursor-pointer bg-btn-primary text-btn-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:opacity-70 disabled:cursor-not-allowed'
-              whileHover={{ scale: BUTTON_HOVER_SCALE }}
-              whileTap={{ scale: BUTTON_TAP_SCALE }}
+              loading={isLoading}
+              size='lg'
+              className='px-6 text-base'
             >
               {isLoading ? 'Processing...' : 'Upgrade to Pro →'}
-            </motion.button>
+            </Button>
           </div>
         </div>
       </div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1780,7 +1780,7 @@ html[data-profile-initial-mode]
 
   /* Canonical press-feedback scale for pressable elements
      (.claude/rules/ui.md + .claude/rules/motion.md — tactile, interruptible) */
-  --scale-press: 0.96;
+  --scale-press: 0.98;
 
   /* Pre-composed transition patterns (extracted from Linear)
      Use duration custom properties so prefers-reduced-motion overrides work */

--- a/apps/web/tests/unit/design-system/press-motion-contract.test.ts
+++ b/apps/web/tests/unit/design-system/press-motion-contract.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = join(import.meta.dirname, '..', '..', '..');
+const REPO_ROOT = join(WEB_ROOT, '..', '..');
+
+function readWeb(relativePath: string): string {
+  return readFileSync(join(WEB_ROOT, relativePath), 'utf8');
+}
+
+describe('shared press-motion contract', () => {
+  it('keeps the canonical press scale subtle and reduced-motion safe', () => {
+    const designSystem = readWeb('styles/design-system.css');
+    const button = readFileSync(
+      join(REPO_ROOT, 'packages/ui/atoms/button.tsx'),
+      'utf8'
+    );
+
+    expect(designSystem).toMatch(/--scale-press:\s*0\.98;/);
+    expect(button).toContain('active:scale-[var(--scale-press)]');
+    expect(button).toContain('motion-reduce:active:scale-100');
+    expect(button).not.toContain('active:scale-[0.96]');
+  });
+
+  it.each([
+    'components/features/dashboard/organisms/DashboardHeader.tsx',
+    'components/features/dashboard/dashboard-nav/NavMenuItem.tsx',
+    'components/organisms/user-button/UserButton.tsx',
+    'components/jovie/components/SlashCommandMenu.tsx',
+    'components/jovie/components/ChatComposerToolbar.tsx',
+    'components/jovie/components/ChatMessage.tsx',
+    'components/features/pricing/PricingCTA.tsx',
+  ])('%s does not fork hardcoded press or hover scaling', relativePath => {
+    const source = readWeb(relativePath);
+
+    expect(source).not.toMatch(/active:scale-\[(?!var\(--scale-press\))/);
+    expect(source).not.toMatch(/whileTap=\{\{\s*scale:/);
+    expect(source).not.toMatch(/whileHover=\{\{\s*scale:/);
+  });
+
+  it('routes the representative standalone CTA through the shared Button primitive', () => {
+    const pricingCta = readWeb('components/features/pricing/PricingCTA.tsx');
+
+    expect(pricingCta).toContain("import { Button } from '@jovie/ui'");
+    expect(pricingCta).toContain('<Button');
+    expect(pricingCta).not.toContain('<motion.button');
+  });
+});

--- a/packages/ui/atoms/button.test.tsx
+++ b/packages/ui/atoms/button.test.tsx
@@ -137,11 +137,14 @@ describe('Button', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Press' }).className).toContain(
-      'active:scale-[0.96]'
+      'active:scale-[var(--scale-press)]'
+    );
+    expect(screen.getByRole('button', { name: 'Press' }).className).toContain(
+      'motion-reduce:active:scale-100'
     );
     expect(
       screen.getByRole('button', { name: 'Static' }).className
-    ).not.toContain('active:scale-[0.96]');
+    ).not.toContain('active:scale-[var(--scale-press)]');
   });
 
   it('uses the Jovie focus token', () => {

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -240,7 +240,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         normalizedVariant.destructive &&
           DESTRUCTIVE_CLASSES[normalizedVariant.variant],
         className,
-        !isStatic && !isDisabled && 'active:scale-[0.96]',
+        !isStatic &&
+          !isDisabled &&
+          'active:scale-[var(--scale-press)] motion-reduce:active:scale-100',
         isDisabled && 'pointer-events-none'
       ),
       'aria-disabled': isDisabled || undefined,


### PR DESCRIPTION
Draft — CI feedback loop in progress.

Linear: JOV-4469

## Scope
- standardize the shared press scale at 0.98
- make shared Button press feedback reduced-motion safe
- remove the bespoke PricingCTA scale animation in favor of the canonical Button
- document and enforce the no-layout-shift interaction contract

## Local verification
- shared Button: 19/19
- press-motion contract: 9/9
- web and UI typechecks: passed
- Biome: passed
- required pre-push suite: all 8 shards passed
- CI harness validation and generated-doc checks: passed

## Gate note
Two earlier pre-push attempts surfaced unrelated load-only 5s timeouts in generate-insights and profile route rollback tests. Both passed immediately in isolation and both passed inside this final full 8-shard run. No hook or CI gate was bypassed.