### PR TITLE
fix(ci): allow markdown performance smoke artifacts

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -955,6 +955,7 @@ jobs:
         env:
           EXPECTED_COMMIT_SHA: ${{ inputs.expected_sha }}
           PRODUCTION_DEPLOYMENT_URL_B64: ${{ steps.stage-production.outputs.production_deployment_url_b64 }}
+          PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'
           PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
         run: |

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1042,6 +1042,9 @@ describe('deploy workflow Vercel env resolution', () => {
       'PRODUCTION_DEPLOYMENT_URL_B64: ${{ steps.stage-production.outputs.production_deployment_url_b64 }}'
     );
     expect(performanceStep).toContain(
+      "PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'"
+    );
+    expect(performanceStep).toContain(
       'PERFORMANCE_AUTH_STATE_PATH="$auth_state"'
     );
     expect(performanceStep).toContain('--auth-path "$auth_state"');
@@ -1107,7 +1110,7 @@ describe('deploy workflow Vercel env resolution', () => {
     );
     expect(
       workflow.match(/PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'/g)
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(oauthStep).toContain(
       'pnpm exec playwright test tests/e2e/oauth-providers.spec.ts'
     );

--- a/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
+++ b/apps/web/tests/unit/ci/playwright-artifact-secrets.test.ts
@@ -1225,7 +1225,7 @@ ${fixtureCheckout}
     );
     expect(
       productionRelease.match(/PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'/g)
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     const action = readFileSync(
       join(githubRoot, 'actions/upload-safe-playwright-artifact/action.yml'),
       'utf8'
@@ -1380,6 +1380,60 @@ ${fixtureCheckout}
     expect(readFileSync(guardScript, 'utf8')).toContain(
       "binding() + '|' + stageName + '\\n'"
     );
+  });
+
+  it('requires step-scoped Markdown allowance for every production smoke producer', () => {
+    const expected = [
+      'postdeploy-probes.yml:auth-smoke:Run production auth smoke tests',
+      'production-controller.yml:ci-post-deploy-auth-smoke:Run production auth smoke tests',
+      'production-release.yml:promote-production:Prove canonical navigation budgets on exact staged build',
+    ];
+    const discovered = readdirSync(workflowsRoot)
+      .filter(name => /\.ya?ml$/.test(name))
+      .flatMap(file => {
+        const source = readFileSync(join(workflowsRoot, file), 'utf8');
+        return workflowJobBlocks(source).flatMap(job =>
+          workflowStepBlocks(job.source)
+            .filter(
+              step =>
+                step.includes(
+                  'node "$GITHUB_WORKSPACE/.github/scripts/guard-playwright-artifacts.mjs"'
+                ) && step.includes('tests/e2e/smoke-prod-auth.spec.ts')
+            )
+            .map(step => ({
+              file,
+              job: job.id,
+              step: step.match(/^      - name: (.+)$/m)?.[1] ?? '',
+            }))
+        );
+      })
+      .map(({ file, job, step }) => `${file}:${job}:${step}`)
+      .sort();
+
+    expect(discovered).toEqual([...expected].sort());
+
+    for (const item of expected) {
+      const [file, jobId, stepName] = item.split(':');
+      const source = readFileSync(join(workflowsRoot, file!), 'utf8');
+      const job = workflowJobBlocks(source).find(({ id }) => id === jobId);
+      expect(job, item).toBeDefined();
+      if (!job) continue;
+      const producer = workflowStepBlocks(job.source).find(step =>
+        step.startsWith(`      - name: ${stepName}\n`)
+      );
+      expect(producer, item).toBeDefined();
+      if (!producer) continue;
+
+      expect(yamlPropertyBlock(producer, 'env', 8), item).toContain(
+        "PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN: 'true'"
+      );
+      expect(yamlPropertyBlock(job.source, 'env', 4), item).not.toContain(
+        'PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN'
+      );
+      expect(yamlPropertyBlock(source, 'env', 0), item).not.toContain(
+        'PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN'
+      );
+    }
   });
 
   it('detects structured, attachment, labeled, and exact environment secrets', () => {


### PR DESCRIPTION
Root cause: Production Controller run 30220497688, job 89843316486, failed at step "Prove canonical navigation budgets on exact staged build". The smoke-prod-auth Playwright test was flaky but passed on retry; guard-playwright-artifacts then rejected sanitized test-results/.../error-context.md as unknown-binary, so authenticated state establishment failed.

Fix: add PLAYWRIGHT_ARTIFACT_ALLOW_MARKDOWN=true only to that exact performance-gate producer step. Forbidden zip/trace/HAR/HTML/video/unknown-binary/secret guards remain unchanged.

Evidence: protected retry passed with repo-pinned Node 22.23.1; focused CI workflow/artifact tests 110/110; actionlint; diff check; Biome; web typecheck; CI harness; bug-to-test. Inventory regression proves all three production smoke-prod-auth guard invocations have step-scoped Markdown allowance, and a real .trace remains rejected as unknown-binary.