### PR TITLE
feat(onboarding): align public Start entry with New Chat

### DIFF
--- a/apps/web/app/(dynamic)/start/page.test.ts
+++ b/apps/web/app/(dynamic)/start/page.test.ts
@@ -29,10 +29,12 @@ describe('StartPage', () => {
     });
   });
 
-  it('passes homepage intent and starter prompt params into the shell', async () => {
+  it('passes homepage intent and a validated starter handoff into the shell', async () => {
     const result = await StartPage({
       searchParams: Promise.resolve({
         intent_id: 'intent-1',
+        artist_name: 'David Guetta',
+        spotify_url: 'https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai',
         starter_prompt: "hey, I'm David Guetta. show me my Spotify.",
       }),
     });
@@ -41,7 +43,28 @@ describe('StartPage', () => {
       props: {
         intentId: 'intent-1',
         sessionLabel: 'pending',
-        starterPrompt: "hey, I'm David Guetta. show me my Spotify.",
+        starterHandoff: {
+          artistName: 'David Guetta',
+          kind: 'spotify_artist',
+          prompt: "hey, I'm David Guetta. show me my Spotify.",
+          spotifyUrl: 'https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai',
+        },
+      },
+    });
+  });
+
+  it('does not let bare URL params suppress the blank entry state', async () => {
+    const result = await StartPage({
+      searchParams: Promise.resolve({
+        spotify_url: 'https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai',
+        url: 'https://example.com/artist',
+      }),
+    });
+
+    expect(result).toMatchObject({
+      props: {
+        sessionLabel: 'pending',
+        starterHandoff: null,
       },
     });
   });

--- a/apps/web/app/(dynamic)/start/page.tsx
+++ b/apps/web/app/(dynamic)/start/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { OnboardingShell } from '@/components/features/onboarding/OnboardingShell';
 import { getStartRouteRedirect } from '@/lib/auth/access-route-redirect';
 import { resolveUserState } from '@/lib/auth/gate';
+import { resolveStartEntryHandoff } from '@/lib/onboarding/start-entry-handoff';
 
 /**
  * Canonical onboarding chat entry point.
@@ -38,10 +39,7 @@ export default async function StartPage(
   const params = await searchParams;
   const intentId =
     typeof params.intent_id === 'string' ? params.intent_id : undefined;
-  const starterPrompt =
-    typeof params.starter_prompt === 'string'
-      ? params.starter_prompt
-      : undefined;
+  const starterHandoff = resolveStartEntryHandoff(params);
 
   const authResult = await resolveUserState({ createDbUserIfMissing: false });
   const startRedirect = getStartRouteRedirect(authResult.state);
@@ -53,7 +51,7 @@ export default async function StartPage(
     <OnboardingShell
       intentId={intentId}
       sessionLabel='pending'
-      starterPrompt={starterPrompt}
+      starterHandoff={starterHandoff}
     />
   );
 }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -34,10 +34,14 @@ import {
 import { useAppFlag } from '@/lib/flags/client';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
 import { parseSocialLinkInput } from '@/lib/onboarding/social-link-parse';
+import type { StartEntryHandoff } from '@/lib/onboarding/start-entry-handoff';
 import { cn } from '@/lib/utils';
 import { ChatProposeCheckoutCard } from './ChatProposeCheckoutCard';
 import { ChatProposeNextStepCard } from './ChatProposeNextStepCard';
-import { OnboardingChatEmptyIntro } from './OnboardingChatEmptyIntro';
+import {
+  OnboardingChatEmptyIntro,
+  type OnboardingEntryMode,
+} from './OnboardingChatEmptyIntro';
 import type { OnboardingProfileBuilderState } from './OnboardingProfileRail';
 import { OnboardingProfileRail } from './OnboardingProfileRail';
 import {
@@ -98,8 +102,8 @@ interface OnboardingChatProps {
   readonly onProfileBuilderChange?: (
     state: OnboardingProfileBuilderState
   ) => void;
-  /** URL-provided starter prompt for demo and deep-link flows. */
-  readonly starterPrompt?: string;
+  /** Validated URL-provided context for an automatic first message. */
+  readonly starterHandoff?: StartEntryHandoff | null;
 }
 
 const BLOCKED_TURNSTILE_TOKEN_STATUSES: ReadonlySet<
@@ -528,13 +532,14 @@ interface OnboardingMessageRegionProps {
   readonly onSelectStarterSuggestion: (prompt: string) => void;
   readonly profileBuilderState: OnboardingProfileBuilderState;
   readonly shouldDockComposer: boolean;
-  readonly showEmptyIntro: boolean;
+  readonly entryMode: OnboardingEntryMode;
   readonly composerPickerOpen: boolean;
 }
 
 function OnboardingMessageRegion({
   composerPickerOpen,
   displayMessages,
+  entryMode,
   hasConversationStarted,
   isBusy,
   isStreaming,
@@ -548,7 +553,6 @@ function OnboardingMessageRegion({
   onSelectStarterSuggestion,
   profileBuilderState,
   shouldDockComposer,
-  showEmptyIntro,
 }: OnboardingMessageRegionProps) {
   if (shouldDockComposer) {
     return (
@@ -572,20 +576,14 @@ function OnboardingMessageRegion({
 
   if (!hasConversationStarted) {
     return (
-      <ChatEmptyStateComposerRegion
-        above={
-          showEmptyIntro ? (
-            <OnboardingChatEmptyIntro
-              onSelectSuggestion={onSelectStarterSuggestion}
-              dimmed={composerPickerOpen}
-              isBusy={isBusy}
-            />
-          ) : undefined
-        }
-      >
-        <div className='w-full' data-testid='onboarding-centered-composer'>
-          {onboardingComposerSurface}
-        </div>
+      <ChatEmptyStateComposerRegion hideWelcomeHeader>
+        <OnboardingChatEmptyIntro
+          composer={onboardingComposerSurface}
+          mode={entryMode}
+          onSelectSuggestion={onSelectStarterSuggestion}
+          dimmed={composerPickerOpen}
+          isBusy={isBusy}
+        />
       </ChatEmptyStateComposerRegion>
     );
   }
@@ -623,17 +621,21 @@ export function OnboardingChat({
   onProfileBuilderChange,
   onTurnstileRejected,
   onTurnstileRequired,
-  starterPrompt,
+  starterHandoff,
   turnstilePanel,
   turnstilePanelVisible = false,
   turnstileStatus,
   turnstileToken,
 }: OnboardingChatProps) {
-  const initialStarterPrompt = starterPrompt
-    ? sanitizeHomepagePrompt(starterPrompt)
-    : '';
+  const initialStarterPrompt = starterHandoff?.prompt ?? '';
   const hasInitialStarterPrompt = initialStarterPrompt.length > 0;
   const [input, setInput] = useState(initialStarterPrompt);
+  const [entryMode, setEntryMode] = useState<OnboardingEntryMode>(() => {
+    if (starterHandoff?.kind === 'spotify_artist') return 'spotify_handoff';
+    if (starterHandoff) return 'prompt_handoff';
+    if (intentId) return 'restoring_intent';
+    return 'blank';
+  });
   const latestInputRef = useRef(initialStarterPrompt);
   const [hasSentFirst, setHasSentFirst] = useState(false);
   const [verificationRequested, setVerificationRequested] = useState(false);
@@ -878,16 +880,15 @@ export function OnboardingChat({
       consumeHomepageIntent(intentId);
     }
 
-    if (!nextPrompt && starterPrompt) {
-      nextPrompt = sanitizeHomepagePrompt(starterPrompt);
-    }
-
     if (nextPrompt) {
       setComposerInput(nextPrompt);
       pendingStarterPromptRef.current = nextPrompt;
       hasInjectedStarterPromptRef.current = true;
+      setEntryMode('prompt_handoff');
+    } else {
+      setEntryMode('blank');
     }
-  }, [intentId, setComposerInput, starterPrompt]);
+  }, [intentId, setComposerInput]);
 
   useEffect(() => {
     const prompt = pendingStarterPromptRef.current;
@@ -1004,8 +1005,6 @@ export function OnboardingChat({
   const hasConversationStarted = messages.length > 0 || hasSentFirst;
   const shouldDockComposer =
     chatError !== null || userTurnCount > 1 || selectedArtist !== null;
-  const showEmptyIntro = !intentId && !starterPrompt;
-
   useEffect(() => {
     if (shouldDockComposer) return;
     const scrollContainer = scrollContainerRef.current;
@@ -1072,6 +1071,7 @@ export function OnboardingChat({
           <OnboardingMessageRegion
             composerPickerOpen={composerPickerOpen}
             displayMessages={displayMessages}
+            entryMode={entryMode}
             hasConversationStarted={hasConversationStarted}
             isBusy={isBusy}
             isStreaming={isStreaming}
@@ -1085,7 +1085,6 @@ export function OnboardingChat({
             onSelectStarterSuggestion={submitText}
             profileBuilderState={profileBuilderState}
             shouldDockComposer={shouldDockComposer}
-            showEmptyIntro={showEmptyIntro}
           />
         </div>
       </div>

--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.stories.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { OnboardingChatEmptyIntro } from './OnboardingChatEmptyIntro';
+
+function ComposerFixture() {
+  return (
+    <div className='flex min-h-14 w-full items-center rounded-2xl border border-subtle bg-surface-0 px-4 text-sm text-secondary-token shadow-card'>
+      Artist, release, or link...
+    </div>
+  );
+}
+
+const meta: Meta<typeof OnboardingChatEmptyIntro> = {
+  title: 'Onboarding/Public Start Entry',
+  component: OnboardingChatEmptyIntro,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className='flex min-h-screen items-center bg-surface-1 px-4 py-8 [color-scheme:dark]'>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    composer: <ComposerFixture />,
+    onSelectSuggestion: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BlankEntry: Story = {
+  args: {
+    mode: 'blank',
+  },
+};
+
+export const SpotifyHandoff: Story = {
+  args: {
+    mode: 'spotify_handoff',
+  },
+};
+
+export const RestoringStoredIntent: Story = {
+  args: {
+    mode: 'restoring_intent',
+  },
+};

--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
@@ -1,19 +1,16 @@
 'use client';
 
-import { Camera, Disc3, Eye, Link2, Music } from 'lucide-react';
+import { Camera, Disc3, Eye, Link2, LoaderCircle, Music } from 'lucide-react';
 import Link from 'next/link';
-import type { ComponentType, SVGProps } from 'react';
-import { ChatMessage } from '@/components/jovie/components';
-import {
-  CHAT_PROMPT_RAIL_CLASS,
-  CHAT_PROMPT_RAIL_SCROLL_CLASS,
-  getChatPromptPillClass,
-} from '@/components/jovie/components/chat-prompt-styles';
+import type { ComponentType, ReactNode, SVGProps } from 'react';
+import { BrandLogo } from '@/components/atoms/BrandLogo';
+import { getChatPromptPillClass } from '@/components/jovie/components/chat-prompt-styles';
 import type { ChatSuggestion } from '@/components/jovie/types';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  ONBOARDING_ENTRY_SUPPORT,
+  ONBOARDING_ENTRY_TITLE,
   ONBOARDING_STARTER_SUGGESTIONS,
-  ONBOARDING_WELCOME_MESSAGE,
 } from '@/lib/onboarding/empty-state';
 import { cn } from '@/lib/utils';
 
@@ -25,9 +22,15 @@ const ICON_MAP: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
   Music,
 };
 
-const WELCOME_MESSAGE_ID = 'onboarding-welcome-message';
+export type OnboardingEntryMode =
+  | 'blank'
+  | 'prompt_handoff'
+  | 'restoring_intent'
+  | 'spotify_handoff';
 
 interface OnboardingChatEmptyIntroProps {
+  readonly composer: ReactNode;
+  readonly mode: OnboardingEntryMode;
   readonly onSelectSuggestion: (prompt: string) => void;
   readonly dimmed?: boolean;
   readonly isBusy?: boolean;
@@ -52,88 +55,142 @@ function StarterSuggestionPill({
       }}
       disabled={disabled}
       className={cn(
-        'chat-pill snap-start',
-        disabled ? 'cursor-not-allowed opacity-55' : 'cursor-pointer',
-        getChatPromptPillClass()
+        'group inline-flex min-h-11 items-center px-1 focus-visible:outline-none focus-visible:[&>span]:ring-2 focus-visible:[&>span]:ring-white/25 active:[&>span]:scale-[0.98] motion-reduce:[&>span]:transform-none',
+        disabled ? 'cursor-not-allowed opacity-55' : 'cursor-pointer'
       )}
       aria-label={suggestion.label}
       aria-disabled={disabled}
     >
-      <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
-        {IconComponent ? (
-          <IconComponent className='h-3.5 w-3.5 shrink-0' />
-        ) : null}
-      </span>
-      <span className='min-w-0 flex-1 truncate leading-none'>
-        {suggestion.label}
+      <span
+        className={cn(
+          'chat-pill transition-[color,background-color,border-color,box-shadow,transform] duration-fast',
+          getChatPromptPillClass('compact')
+        )}
+      >
+        <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
+          {IconComponent ? (
+            <IconComponent className='h-3.5 w-3.5 shrink-0' />
+          ) : null}
+        </span>
+        <span className='min-w-0 flex-1 truncate leading-none'>
+          {suggestion.label}
+        </span>
       </span>
     </button>
   );
 }
 
+function getEntryCopy(mode: OnboardingEntryMode): {
+  readonly title: string;
+  readonly support: string;
+} {
+  switch (mode) {
+    case 'spotify_handoff':
+      return {
+        title: 'Getting Your Artist Ready',
+        support: 'Your message will send after a quick browser verification.',
+      };
+    case 'prompt_handoff':
+      return {
+        title: 'Getting This Ready',
+        support: 'Your message will send after a quick browser verification.',
+      };
+    case 'restoring_intent':
+      return {
+        title: 'Restoring Your Start',
+        support: 'Checking the handoff from your last step.',
+      };
+    case 'blank':
+      return {
+        title: ONBOARDING_ENTRY_TITLE,
+        support: ONBOARDING_ENTRY_SUPPORT,
+      };
+  }
+}
+
 export function OnboardingChatEmptyIntro({
+  composer,
+  mode,
   onSelectSuggestion,
   dimmed = false,
   isBusy = false,
 }: OnboardingChatEmptyIntroProps) {
+  const copy = getEntryCopy(mode);
+  const isBlank = mode === 'blank';
   const dimClass = dimmed
     ? 'opacity-0 transition-opacity duration-fast ease-out'
     : 'opacity-100 transition-opacity duration-fast ease-out';
 
   return (
     <div
-      className='mx-auto flex w-full max-w-[44rem] flex-col gap-4'
+      className='mx-auto flex w-full max-w-[45rem] flex-col items-center'
+      data-entry-mode={mode}
       data-testid='onboarding-empty-intro'
     >
-      {/* biome-ignore lint/a11y/useValidAriaRole: ChatMessage role is transcript semantics, not DOM aria-role */}
-      <ChatMessage
-        id={WELCOME_MESSAGE_ID}
-        role='assistant'
-        parts={[{ type: 'text', text: ONBOARDING_WELCOME_MESSAGE }]}
-        skipEntrance
-        renderTools={false}
-      />
-
       <div
-        className={cn('system-b-chat-suggested-prompts-rail-wrapper', dimClass)}
-        aria-hidden={dimmed}
-        inert={dimmed}
-        data-testid='onboarding-starter-suggestions'
+        aria-hidden='true'
+        className='mb-4 text-primary-token opacity-[0.18]'
       >
-        <div
-          className={cn(
-            CHAT_PROMPT_RAIL_SCROLL_CLASS,
-            'overscroll-x-contain px-1 sm:px-0'
-          )}
-        >
-          <div
-            className={cn(
-              CHAT_PROMPT_RAIL_CLASS,
-              'snap-x snap-mandatory whitespace-nowrap'
-            )}
-          >
-            {ONBOARDING_STARTER_SUGGESTIONS.map(suggestion => (
-              <StarterSuggestionPill
-                key={suggestion.label}
-                suggestion={suggestion}
-                onSelect={onSelectSuggestion}
-                disabled={isBusy}
-              />
-            ))}
-          </div>
-        </div>
+        <BrandLogo size={56} aria-hidden={true} />
       </div>
 
-      <p className='text-center text-xs leading-5 text-secondary-token'>
-        Already have an account?{' '}
-        <Link
-          href={APP_ROUTES.SIGNIN}
-          className='font-medium text-primary-token underline-offset-2 transition-colors duration-fast hover:underline'
-          data-testid='onboarding-sign-in-skip'
-        >
-          Sign in
-        </Link>
-      </p>
+      <div className='mb-6 text-center'>
+        <h1 className='text-2xl font-semibold text-primary-token'>
+          {copy.title}
+        </h1>
+        <p className='mt-2 text-sm leading-6 text-secondary-token'>
+          {copy.support}
+        </p>
+      </div>
+
+      <div className='w-full' data-testid='onboarding-centered-composer'>
+        {composer}
+      </div>
+
+      <div className='flex min-h-[7.5rem] w-full items-start justify-center pt-3'>
+        {isBlank ? (
+          <div
+            className={cn('flex w-full flex-col items-center', dimClass)}
+            aria-hidden={dimmed}
+            inert={dimmed}
+            data-testid='onboarding-starter-suggestions'
+          >
+            <div className='flex max-w-[40rem] flex-wrap justify-center gap-x-1'>
+              {ONBOARDING_STARTER_SUGGESTIONS.map(suggestion => (
+                <StarterSuggestionPill
+                  key={suggestion.label}
+                  suggestion={suggestion}
+                  onSelect={onSelectSuggestion}
+                  disabled={isBusy}
+                />
+              ))}
+            </div>
+
+            <p className='text-center text-xs leading-5 text-secondary-token'>
+              Already have an account?{' '}
+              <Link
+                href={APP_ROUTES.SIGNIN}
+                className='inline-flex min-h-11 items-center font-medium text-primary-token underline-offset-2 transition-colors duration-fast hover:underline focus-visible:underline focus-visible:outline-none'
+                data-testid='onboarding-sign-in-skip'
+              >
+                Sign in
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <div
+            className='inline-flex min-h-11 items-center gap-2 text-xs text-secondary-token'
+            role='status'
+            aria-live='polite'
+          >
+            <LoaderCircle
+              className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none'
+              aria-hidden='true'
+            />
+            Preparing your first message
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -7,6 +7,7 @@ import { SidebarProvider } from '@/components/organisms/Sidebar';
 import { track } from '@/lib/analytics';
 import { publicEnv } from '@/lib/env-public';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
+import type { StartEntryHandoff } from '@/lib/onboarding/start-entry-handoff';
 import {
   getBrowserTurnstileHostname,
   resolveTurnstileSiteKey,
@@ -35,14 +36,14 @@ interface OnboardingShellProps {
   readonly sessionLabel: string;
   /** ID for a homepage-captured starter prompt stored in localStorage. */
   readonly intentId?: string;
-  /** Optional URL-provided starter prompt for deterministic demo runs. */
-  readonly starterPrompt?: string;
+  /** Validated URL-provided context for an automatic first message. */
+  readonly starterHandoff?: StartEntryHandoff | null;
 }
 
 export function OnboardingShell({
   intentId,
   sessionLabel,
-  starterPrompt,
+  starterHandoff,
 }: OnboardingShellProps) {
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [profileBuilderState, setProfileBuilderState] =
@@ -172,7 +173,7 @@ export function OnboardingShell({
               intentId={intentId}
               onConversationActivity={handleConversationActivity}
               onProfileBuilderChange={setProfileBuilderState}
-              starterPrompt={starterPrompt}
+              starterHandoff={starterHandoff}
               turnstileToken={turnstileToken}
               turnstileStatus={turnstileState.status}
               turnstilePanel={turnstilePanel}

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
@@ -63,6 +63,20 @@ describe('ChatEmptyStateComposerRegion', () => {
     expect(screen.queryByTestId('chat-empty-state-greeting')).toBeNull();
   });
 
+  it('allows a public entry flow to provide its own centered welcome', () => {
+    render(
+      <ChatEmptyStateComposerRegion hideWelcomeHeader>
+        <div data-testid='public-entry'>Public entry</div>
+      </ChatEmptyStateComposerRegion>
+    );
+
+    const region = screen.getByTestId('chat-empty-state-composer-region');
+    expect(region.getAttribute('data-layout')).toBe('centered');
+    expect(screen.getByTestId('public-entry')).toBeTruthy();
+    expect(screen.queryByTestId('chat-empty-state-logo')).toBeNull();
+    expect(screen.queryByTestId('chat-empty-state-greeting')).toBeNull();
+  });
+
   it('docks the composer below a scrollable above slot (no mid-viewport absolute clip)', () => {
     render(
       <ChatEmptyStateComposerRegion

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -20,14 +20,16 @@ export function ChatEmptyStateComposerRegion({
   above,
   children,
   greetingName,
+  hideWelcomeHeader = false,
 }: {
   readonly above?: ReactNode;
   readonly children: ReactNode;
   readonly greetingName?: string | null;
+  readonly hideWelcomeHeader?: boolean;
 }) {
   const trimmedName = greetingName?.trim();
   const greeting = trimmedName ? `Hi, ${trimmedName}` : 'Hi there';
-  const showWelcomeHeader = !above;
+  const showWelcomeHeader = !above && !hideWelcomeHeader;
 
   if (above) {
     return (

--- a/apps/web/lib/onboarding/empty-state.test.ts
+++ b/apps/web/lib/onboarding/empty-state.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ONBOARDING_ENTRY_SUPPORT,
+  ONBOARDING_ENTRY_TITLE,
   ONBOARDING_STARTER_SUGGESTIONS,
-  ONBOARDING_WELCOME_MESSAGE,
 } from './empty-state';
 
 describe('onboarding empty state copy', () => {
-  it('includes memory disclosure, early-access disclosure, and one intake question', () => {
-    expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/remember/i);
-    expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/early access|waitlist/i);
-    expect(ONBOARDING_WELCOME_MESSAGE).toMatch(/what are you working on/i);
-    expect((ONBOARDING_WELCOME_MESSAGE.match(/\?/g) ?? []).length).toBe(1);
+  it('keeps the blank entry concise and artist-specific', () => {
+    expect(ONBOARDING_ENTRY_TITLE).toBe('What Are You Working On?');
+    expect(ONBOARDING_ENTRY_SUPPORT).toMatch(
+      /artist name, Spotify link, or next release/i
+    );
+    expect(`${ONBOARDING_ENTRY_TITLE} ${ONBOARDING_ENTRY_SUPPORT}`).not.toMatch(
+      /early access|waitlist|remember/i
+    );
   });
 
   it('exposes four starter suggestions with prompts', () => {

--- a/apps/web/lib/onboarding/empty-state.ts
+++ b/apps/web/lib/onboarding/empty-state.ts
@@ -1,12 +1,8 @@
 import type { ChatSuggestion } from '@/components/jovie/types';
 
-/**
- * Static opener shown before the visitor sends their first message.
- * Mirrors the canonical onboarding system-prompt opener so the UI and
- * model stay aligned on memory disclosure + one intake question.
- */
-export const ONBOARDING_WELCOME_MESSAGE =
-  "Hey — I'm Jovie. Early access is limited right now, so some artists land on the waitlist. I'll remember this chat so we can pick up where we left off if you sign up. What are you working on?";
+export const ONBOARDING_ENTRY_TITLE = 'What Are You Working On?';
+export const ONBOARDING_ENTRY_SUPPORT =
+  'Start with your artist name, Spotify link, or next release.';
 
 /** Starter pills for the anonymous /start empty state. */
 export const ONBOARDING_STARTER_SUGGESTIONS: readonly ChatSuggestion[] = [

--- a/apps/web/lib/onboarding/start-entry-handoff.test.ts
+++ b/apps/web/lib/onboarding/start-entry-handoff.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { resolveStartEntryHandoff } from './start-entry-handoff';
+
+describe('resolveStartEntryHandoff', () => {
+  it('accepts and sanitizes an explicit starter prompt', () => {
+    expect(
+      resolveStartEntryHandoff({
+        starter_prompt: '  Plan\u0000 my next release.  ',
+      })
+    ).toEqual({
+      kind: 'prompt',
+      prompt: 'Plan my next release.',
+    });
+  });
+
+  it('retains only canonical Spotify artist context', () => {
+    expect(
+      resolveStartEntryHandoff({
+        artist_name: '  Fictional Artist ',
+        spotify_url:
+          'open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we?si=tracking',
+        starter_prompt: 'Show me this artist.',
+      })
+    ).toEqual({
+      artistName: 'Fictional Artist',
+      kind: 'spotify_artist',
+      prompt: 'Show me this artist.',
+      spotifyUrl: 'https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we',
+    });
+  });
+
+  it.each([
+    { spotify_url: 'https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we' },
+    { url: 'https://example.com/artist' },
+    { arbitrary: 'Plan my release' },
+    { starter_prompt: ['Plan my release'] },
+    { starter_prompt: '\u0000 \u001F' },
+  ])('falls back to blank entry for unsupported params: %o', params => {
+    expect(resolveStartEntryHandoff(params)).toBeNull();
+  });
+
+  it('drops unsafe Spotify context without dropping a valid prompt', () => {
+    expect(
+      resolveStartEntryHandoff({
+        artist_name: 'Fictional Artist',
+        spotify_url: 'https://127.0.0.1/artist/private',
+        starter_prompt: 'Help me find my artist profile.',
+      })
+    ).toEqual({
+      kind: 'prompt',
+      prompt: 'Help me find my artist profile.',
+    });
+  });
+});

--- a/apps/web/lib/onboarding/start-entry-handoff.ts
+++ b/apps/web/lib/onboarding/start-entry-handoff.ts
@@ -1,0 +1,103 @@
+const STARTER_PROMPT_MAX_CHARS = 140;
+const ARTIST_NAME_MAX_CHARS = 80;
+const SPOTIFY_ARTIST_ID_PATTERN = /^[A-Za-z0-9]{22}$/;
+
+export interface StartEntryHandoff {
+  readonly kind: 'prompt' | 'spotify_artist';
+  readonly prompt: string;
+  readonly artistName?: string;
+  readonly spotifyUrl?: string;
+}
+
+type StartEntrySearchParams = Readonly<
+  Record<string, string | string[] | undefined>
+>;
+
+function readSingleParam(
+  params: StartEntrySearchParams,
+  key: string
+): string | undefined {
+  const value = params[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function sanitizeText(value: string, maxChars: number): string {
+  return value
+    .replaceAll(/[\u0000-\u001F\u007F]/g, '')
+    .trim()
+    .slice(0, maxChars);
+}
+
+function sanitizeSpotifyArtistUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const candidate = trimmed.startsWith('https://')
+    ? trimmed
+    : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+    if (
+      parsed.protocol !== 'https:' ||
+      parsed.hostname !== 'open.spotify.com' ||
+      parsed.port ||
+      parsed.username ||
+      parsed.password
+    ) {
+      return null;
+    }
+
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    if (
+      segments.length !== 2 ||
+      segments[0] !== 'artist' ||
+      !SPOTIFY_ARTIST_ID_PATTERN.test(segments[1] ?? '')
+    ) {
+      return null;
+    }
+
+    return `https://open.spotify.com/artist/${segments[1]}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the only URL-based handoff accepted by public `/start`.
+ *
+ * A sanitized `starter_prompt` is the explicit contract. Optional Spotify
+ * context is retained only when it is a canonical public artist URL. Bare
+ * `spotify_url`, `url`, and unrelated query strings never suppress the blank
+ * entry state.
+ */
+export function resolveStartEntryHandoff(
+  params: StartEntrySearchParams
+): StartEntryHandoff | null {
+  const rawPrompt = readSingleParam(params, 'starter_prompt');
+  if (!rawPrompt) return null;
+
+  const prompt = sanitizeText(rawPrompt, STARTER_PROMPT_MAX_CHARS);
+  if (!prompt) return null;
+
+  const rawSpotifyUrl = readSingleParam(params, 'spotify_url');
+  const spotifyUrl = rawSpotifyUrl
+    ? sanitizeSpotifyArtistUrl(rawSpotifyUrl)
+    : null;
+
+  if (!spotifyUrl) {
+    return { kind: 'prompt', prompt };
+  }
+
+  const rawArtistName = readSingleParam(params, 'artist_name');
+  const artistName = rawArtistName
+    ? sanitizeText(rawArtistName, ARTIST_NAME_MAX_CHARS)
+    : '';
+
+  return {
+    kind: 'spotify_artist',
+    prompt,
+    spotifyUrl,
+    ...(artistName ? { artistName } : {}),
+  };
+}

--- a/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OnboardingChat } from '@/components/features/onboarding/OnboardingChat';
-import { ONBOARDING_WELCOME_MESSAGE } from '@/lib/onboarding/empty-state';
+import { ONBOARDING_ENTRY_TITLE } from '@/lib/onboarding/empty-state';
 
 const chatMocks = vi.hoisted(() => ({
   messages: [] as Array<{
@@ -114,22 +114,42 @@ describe('OnboardingChat empty intro', () => {
     );
 
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
-    expect(screen.getByText(ONBOARDING_WELCOME_MESSAGE)).toBeTruthy();
+    expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
     expect(screen.getByTestId('onboarding-sign-in-skip')).toHaveAttribute(
       'href',
       '/signin'
     );
   });
 
-  it('hides welcome intro when a starter prompt deep link is provided', () => {
+  it('shows a compact processing state for a validated starter handoff', () => {
+    process.env.NODE_ENV = 'test';
     render(
       <OnboardingChat
-        starterPrompt='Help me plan my next release.'
+        starterHandoff={{
+          kind: 'prompt',
+          prompt: 'Help me plan my next release.',
+        }}
+        turnstileToken={null}
+        turnstileStatus='interactive'
+      />
+    );
+
+    expect(screen.getByText('Getting This Ready')).toBeTruthy();
+    expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
+  });
+
+  it('falls back to blank entry when a stored intent is missing', async () => {
+    render(
+      <OnboardingChat
+        intentId='missing-intent'
         turnstileToken='token'
         turnstileStatus='verified'
       />
     );
 
-    expect(screen.queryByTestId('onboarding-empty-intro')).toBeNull();
+    await waitFor(() => {
+      expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
+    });
+    expect(screen.getByTestId('onboarding-starter-suggestions')).toBeTruthy();
   });
 });

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -199,7 +199,9 @@ function TurnstileHarness({
         setInstruction('Verify you are human to send');
       }}
       onConversationActivity={onConversationActivity}
-      starterPrompt={starterPrompt}
+      starterHandoff={
+        starterPrompt ? { kind: 'prompt', prompt: starterPrompt } : null
+      }
     />
   );
 }
@@ -218,7 +220,7 @@ function ControlledStarterHarness({
       turnstileToken={turnstileToken}
       turnstileStatus={turnstileToken ? 'verified' : 'interactive'}
       onTurnstileRequired={onTurnstileRequired}
-      starterPrompt={starterPrompt}
+      starterHandoff={{ kind: 'prompt', prompt: starterPrompt }}
     />
   );
 }
@@ -278,7 +280,10 @@ describe('OnboardingChat Turnstile gating', () => {
   it('renders a starter prompt and reserves verification space before effects run', () => {
     render(
       <OnboardingChat
-        starterPrompt='  Hey, I want to get access to Jovie.  '
+        starterHandoff={{
+          kind: 'prompt',
+          prompt: 'Hey, I want to get access to Jovie.',
+        }}
         turnstilePanel={<div data-testid='test-turnstile-panel' />}
         turnstilePanelVisible={false}
         turnstileStatus='interactive'

--- a/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
@@ -2,32 +2,27 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { OnboardingChatEmptyIntro } from '@/components/features/onboarding/OnboardingChatEmptyIntro';
 import {
+  ONBOARDING_ENTRY_SUPPORT,
+  ONBOARDING_ENTRY_TITLE,
   ONBOARDING_STARTER_SUGGESTIONS,
-  ONBOARDING_WELCOME_MESSAGE,
 } from '@/lib/onboarding/empty-state';
 
-vi.mock('@/components/jovie/components', () => ({
-  ChatMessage: ({
-    parts,
-  }: {
-    readonly parts: Array<{ type: 'text'; text: string }>;
-  }) => (
-    <div data-testid='chat-message'>
-      {parts.map(part => part.text).join('')}
-    </div>
-  ),
-}));
-
 describe('OnboardingChatEmptyIntro', () => {
-  it('renders welcome message, starter cards, and sign-in skip', () => {
+  it('renders concise entry copy, composer, starters, and sign-in', () => {
     const onSelectSuggestion = vi.fn();
 
     render(
-      <OnboardingChatEmptyIntro onSelectSuggestion={onSelectSuggestion} />
+      <OnboardingChatEmptyIntro
+        composer={<div data-testid='test-composer' />}
+        mode='blank'
+        onSelectSuggestion={onSelectSuggestion}
+      />
     );
 
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
-    expect(screen.getByText(ONBOARDING_WELCOME_MESSAGE)).toBeTruthy();
+    expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
+    expect(screen.getByText(ONBOARDING_ENTRY_SUPPORT)).toBeTruthy();
+    expect(screen.getByTestId('test-composer')).toBeTruthy();
     expect(screen.getByTestId('onboarding-starter-suggestions')).toBeTruthy();
     expect(screen.getByTestId('onboarding-sign-in-skip')).toHaveAttribute(
       'href',
@@ -46,7 +41,11 @@ describe('OnboardingChatEmptyIntro', () => {
     const [firstSuggestion] = ONBOARDING_STARTER_SUGGESTIONS;
 
     render(
-      <OnboardingChatEmptyIntro onSelectSuggestion={onSelectSuggestion} />
+      <OnboardingChatEmptyIntro
+        composer={<div />}
+        mode='blank'
+        onSelectSuggestion={onSelectSuggestion}
+      />
     );
 
     fireEvent.click(
@@ -58,7 +57,12 @@ describe('OnboardingChatEmptyIntro', () => {
 
   it('dims suggestions while the slash picker is open', () => {
     const { container } = render(
-      <OnboardingChatEmptyIntro onSelectSuggestion={vi.fn()} dimmed />
+      <OnboardingChatEmptyIntro
+        composer={<div />}
+        mode='blank'
+        onSelectSuggestion={vi.fn()}
+        dimmed
+      />
     );
 
     const suggestions = container.querySelector(
@@ -66,5 +70,22 @@ describe('OnboardingChatEmptyIntro', () => {
     );
     expect(suggestions?.className).toContain('opacity-0');
     expect(suggestions?.getAttribute('inert')).not.toBeNull();
+  });
+
+  it('replaces blank controls with one stable handoff status', () => {
+    render(
+      <OnboardingChatEmptyIntro
+        composer={<div data-testid='test-composer' />}
+        mode='spotify_handoff'
+        onSelectSuggestion={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Getting Your Artist Ready')).toBeTruthy();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Preparing your first message'
+    );
+    expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
+    expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- align blank public `/start` with the canonical New Chat empty-state grammar while keeping public onboarding framing
- add an explicit, server-validated `starter_prompt` handoff contract with bounded Spotify URL support
- fall back cleanly to the blank entry for bare/invalid URL params and missing or expired stored intents
- add focused unit and Storybook state coverage for blank, prompt handoff, Spotify handoff, and restored intent states

## Scope
This draft intentionally excludes Turnstile transport/server changes, message-paused recovery UI, funnel/waitlist persistence, and URL-chip rendering. Those remain separate reviewable slices.

## Verification
- focused Vitest: 7 files, 38 tests passed
- web typecheck passed
- Biome passed on changed paths
- Storybook quality: 155 stories passed
- full mandatory pre-push partitioned test gate passed
- CI harness validation passed

<!-- linear-issue-id:JOV-4468 -->