### PR TITLE
fix(storybook): restore reliable accessibility test integration

### DIFF
--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -178,6 +178,7 @@ const preview: Preview = {
       ],
     },
     a11y: {
+      test: 'error',
       config: {
         rules: [
           {

--- a/apps/web/scripts/eval-lanes.test.mjs
+++ b/apps/web/scripts/eval-lanes.test.mjs
@@ -164,8 +164,9 @@ test('fast Vitest config owns the eval-lane regression suite', () => {
     join(webRoot, 'vitest.config.mts'),
     'utf8'
   );
-  expect(defaultConfig).toContain(
-    "export { default } from './vitest.config.fast.mts';"
+  expect(defaultConfig).toContain("import('./vitest.config.fast.mts')");
+  expect(defaultConfig).toMatch(
+    /process\.env\.STORYBOOK_CONFIG_DIR\s*\?\s*\(await import\('\.\/vitest\.config\.storybook\.mts'\)\)\.default\s*:\s*\(await import\('\.\/vitest\.config\.fast\.mts'\)\)\.default/
   );
 
   const fastConfig = readFileSync(

--- a/apps/web/tests/unit/LoadingSpinner.test.tsx
+++ b/apps/web/tests/unit/LoadingSpinner.test.tsx
@@ -57,7 +57,7 @@ describe('LoadingSpinner', () => {
       expect(backgroundRing).toHaveClass('motion-reduce:transition-none');
     });
 
-    it('spinning element uses slower animation for reduced motion users', () => {
+    it('stops the spinning animation for reduced motion users', () => {
       render(<LoadingSpinner />);
 
       const spinner = screen.getByRole('status');
@@ -69,10 +69,7 @@ describe('LoadingSpinner', () => {
         '.border-t-transparent'
       );
       expect(spinningElement).not.toBeNull();
-      // motion-reduce:animate-[spin_1.2s_linear_infinite] provides a slower, more comfortable animation
-      expect(spinningElement).toHaveClass(
-        'motion-reduce:animate-[spin_1.2s_linear_infinite]'
-      );
+      expect(spinningElement).toHaveClass('motion-reduce:animate-none');
     });
 
     it('has proper structure with accessible and hidden elements', () => {

--- a/apps/web/tests/unit/ci/storybook-a11y-config.test.ts
+++ b/apps/web/tests/unit/ci/storybook-a11y-config.test.ts
@@ -6,9 +6,20 @@ const previewSource = readFileSync(
   resolve(process.cwd(), '.storybook/preview.tsx'),
   'utf8'
 );
+const vitestConfigSource = readFileSync(
+  resolve(process.cwd(), 'vitest.config.mts'),
+  'utf8'
+);
 
 describe('Storybook accessibility test contract', () => {
   it('fails component tests when a story has an accessibility violation', () => {
     expect(previewSource).toMatch(/a11y:\s*\{\s*test:\s*['"]error['"],/);
+  });
+
+  it('routes the Storybook test widget to the browser test project', () => {
+    expect(vitestConfigSource).toContain('process.env.STORYBOOK_CONFIG_DIR');
+    expect(vitestConfigSource).toContain(
+      "import('./vitest.config.storybook.mts')"
+    );
   });
 });

--- a/apps/web/tests/unit/ci/storybook-a11y-config.test.ts
+++ b/apps/web/tests/unit/ci/storybook-a11y-config.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const previewSource = readFileSync(
+  resolve(process.cwd(), '.storybook/preview.tsx'),
+  'utf8'
+);
+
+describe('Storybook accessibility test contract', () => {
+  it('fails component tests when a story has an accessibility violation', () => {
+    expect(previewSource).toMatch(/a11y:\s*\{\s*test:\s*['"]error['"],/);
+  });
+});

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,2 +1,8 @@
-// Default Vitest config now uses the optimized fast settings for local development.
-export { default } from './vitest.config.fast.mts';
+// Storybook's test widget launches Vitest without a --config argument and sets
+// STORYBOOK_CONFIG_DIR for its child process. Route only that child to the
+// browser project; normal local and CI Vitest lanes keep the optimized config.
+const config = process.env.STORYBOOK_CONFIG_DIR
+  ? (await import('./vitest.config.storybook.mts')).default
+  : (await import('./vitest.config.fast.mts')).default;
+
+export default config;


### PR DESCRIPTION
## Summary
- restore fail-closed Storybook accessibility checks
- route the Storybook test widget child to the browser project without changing normal Vitest ownership
- preserve static reduced-motion behavior for the canonical loading indicator
- add regression contracts for Storybook and fast-test routing

## Verification
- focused AmountSelector and SurfaceState browser stories: 5 passed
- full Storybook browser + a11y + V8 coverage: 153 files passed, 2 pre-existing opt-outs skipped, 716 tests passed
- Storybook child routing: AmountSelector 4/4 passed
- regression tests: 16/16 passed
- LoadingSpinner: 9/9 passed
- web typecheck and Biome passed
- full 8-shard pre-push gate passed

## Runtime RCA / overlap
The interactive test widget now selects the correct Storybook project, but its server child still exceeds the upstream add-on hard 30s readiness window because the production Next config runs Workflow/WDK discovery before Storybook can strip those plugins. A clean run measured one discovery pass at 86s. That narrow main/config boundary is coordinated with the active visual-CI owner; this PR does not overwrite those files. CLI browser/a11y/coverage is green and remains the validated forward-only gate path.

No merge, enqueue, or deploy requested.

<!-- linear-issue-id:JOV-4473 -->