### PR TITLE
feat(audio): enforce single playback authority

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -42,6 +42,7 @@ import {
   entityCardArtStyle,
   KIND_PRESETS,
 } from '@/components/organisms/entity-card';
+import { GlobalAudioPreviewAction } from '@/components/organisms/GlobalAudioPreviewAction';
 import {
   type ContextMenuItemType,
   TableContextMenu,
@@ -741,13 +742,16 @@ function ChatReleaseEntityPanel({
                         <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
                         Preview
                       </div>
-                      <audio
-                        controls
-                        src={release.previewUrl}
-                        className='h-8 w-full'
-                      >
-                        <track kind='captions' />
-                      </audio>
+                      <GlobalAudioPreviewAction
+                        id={release.id}
+                        title={release.title}
+                        audioUrl={release.previewUrl}
+                        sourceKind='release-preview'
+                        releaseTitle={release.title}
+                        artistName={release.artistNames?.[0]}
+                        artworkUrl={release.artworkUrl}
+                        className='mt-2 w-full justify-center'
+                      />
                     </div>
                   ) : null}
 

--- a/apps/web/components/jovie/components/AudioPreviewStrip.tsx
+++ b/apps/web/components/jovie/components/AudioPreviewStrip.tsx
@@ -2,6 +2,8 @@
 
 import { FileAudio2, Loader2, X } from 'lucide-react';
 
+import { GlobalAudioPreviewAction } from '@/components/organisms/GlobalAudioPreviewAction';
+
 import type { PendingAudio } from '../hooks/useChatAudioAttachments';
 
 interface AudioPreviewStripProps {
@@ -66,14 +68,15 @@ export function AudioPreviewStrip({ audio, onRemove }: AudioPreviewStripProps) {
           </p>
         </div>
         {audio.status === 'ready' && audio.previewUrl ? (
-          <audio
-            controls
-            src={audio.previewUrl}
-            className='h-8 max-w-[9rem]'
-            data-testid='chat-audio-preview-player'
-          >
-            <track kind='captions' />
-          </audio>
+          <GlobalAudioPreviewAction
+            id={audio.id}
+            title={audio.name}
+            audioUrl={audio.previewUrl}
+            sourceKind='chat-upload-preview'
+            releaseTitle={audio.releaseTitle}
+            stopOnUnmount
+            className='shrink-0'
+          />
         ) : null}
       </div>
     </div>

--- a/apps/web/components/organisms/GlobalAudioPreviewAction.stories.tsx
+++ b/apps/web/components/organisms/GlobalAudioPreviewAction.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import toneMp3Url from '../../tests/fixtures/audio/tone.mp3?url';
+import toneWavUrl from '../../tests/fixtures/audio/tone.wav?url';
+import { GlobalAudioPreviewAction } from './GlobalAudioPreviewAction';
+
+const meta: Meta<typeof GlobalAudioPreviewAction> = {
+  title: 'Audio/GlobalAudioPreviewAction',
+  component: GlobalAudioPreviewAction,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Exercises the production singleton with browser-decoded fixture media.
+ *
+ * Both candidates deliberately share an id. Their typed provenance must keep
+ * them distinct while the active surface becomes status-only, leaving exactly
+ * one meaningful selection control for the other candidate.
+ */
+export const SinglePlaybackAuthority: Story = {
+  render: () => (
+    <div className='flex min-w-72 flex-col gap-3'>
+      <GlobalAudioPreviewAction
+        id='shared-preview'
+        title='Release WAV'
+        audioUrl={toneWavUrl}
+        sourceKind='release-preview'
+      />
+      <GlobalAudioPreviewAction
+        id='shared-preview'
+        title='Upload MP3'
+        audioUrl={toneMp3Url}
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: 'Preview Release WAV in player',
+      })
+    );
+
+    await waitFor(() => {
+      expect(canvas.getAllByRole('status')).toHaveLength(1);
+      expect(
+        canvas.getByRole('button', {
+          name: 'Preview Upload MP3 in player',
+        })
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: 'Preview Upload MP3 in player',
+      })
+    );
+
+    await waitFor(() => {
+      expect(canvas.getAllByRole('status')).toHaveLength(1);
+      expect(
+        canvas.getByRole('button', {
+          name: 'Preview Release WAV in player',
+        })
+      ).toBeInTheDocument();
+    });
+
+    expect(canvas.queryAllByTestId('global-audio-preview-action')).toHaveLength(
+      1
+    );
+    expect(canvasElement.querySelector('audio')).toBeNull();
+  },
+};

--- a/apps/web/components/organisms/GlobalAudioPreviewAction.tsx
+++ b/apps/web/components/organisms/GlobalAudioPreviewAction.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import {
+  type AudioPlaybackSourceKind,
+  getAudioPreviewSurfaceState,
+} from '@jovie/audio-contracts';
+import { Button } from '@jovie/ui';
+import { Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
+import { cn } from '@/lib/utils';
+
+interface GlobalAudioPreviewActionProps {
+  readonly id: string;
+  readonly title: string;
+  readonly audioUrl: string;
+  readonly sourceKind: Extract<
+    AudioPlaybackSourceKind,
+    'release-preview' | 'chat-upload-preview'
+  >;
+  readonly releaseTitle?: string;
+  readonly artistName?: string;
+  readonly artworkUrl?: string | null;
+  readonly stopOnUnmount?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Selects a preview for the shell-wide player without creating a second
+ * transport. Once selected, this surface is deliberately status-only.
+ */
+export function GlobalAudioPreviewAction({
+  id,
+  title,
+  audioUrl,
+  sourceKind,
+  releaseTitle,
+  artistName,
+  artworkUrl,
+  stopOnUnmount = false,
+  className,
+}: GlobalAudioPreviewActionProps) {
+  const { playbackState, toggleTrack, stop } = useTrackAudioPlayer();
+  const surfaceState = getAudioPreviewSurfaceState({
+    candidateId: id,
+    candidateSourceKind: sourceKind,
+    activeTrackId: playbackState.activeTrackId,
+    activeSourceKind: playbackState.sourceKind,
+    playbackStatus: playbackState.playbackStatus,
+    isPlaying: playbackState.isPlaying,
+  });
+  const isActive = surfaceState.id !== 'selectable';
+  const activeRef = useRef(isActive);
+  const stopRef = useRef(stop);
+
+  useEffect(() => {
+    activeRef.current = isActive;
+    stopRef.current = stop;
+  }, [isActive, stop]);
+
+  useEffect(() => {
+    if (!stopOnUnmount) return;
+    return () => {
+      if (activeRef.current) stopRef.current();
+    };
+  }, [audioUrl, id, sourceKind, stopOnUnmount]);
+
+  const handleSelect = useCallback(() => {
+    void toggleTrack({
+      id,
+      title,
+      audioUrl,
+      sourceKind,
+      releaseTitle,
+      artistName,
+      artworkUrl,
+    }).catch(() => {});
+  }, [
+    artistName,
+    artworkUrl,
+    audioUrl,
+    id,
+    releaseTitle,
+    sourceKind,
+    title,
+    toggleTrack,
+  ]);
+
+  if (isActive) {
+    return (
+      <span
+        className={cn(
+          'inline-flex min-h-11 items-center gap-1.5 text-xs font-medium text-secondary-token',
+          className
+        )}
+        role='status'
+        aria-live='polite'
+        data-testid='global-audio-preview-status'
+      >
+        {surfaceState.pending ? (
+          <Loader2
+            className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none'
+            aria-hidden='true'
+          />
+        ) : null}
+        {surfaceState.label}
+      </span>
+    );
+  }
+
+  return (
+    <Button
+      variant='secondary'
+      size='md'
+      onClick={handleSelect}
+      className={cn('min-h-11 text-xs', className)}
+      aria-label={`Preview ${title} in player`}
+      data-testid='global-audio-preview-action'
+    >
+      {surfaceState.label}
+    </Button>
+  );
+}

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -121,10 +121,12 @@ export function PersistentAudioBar() {
     toggleTrack({
       id: playbackState.activeTrackId,
       title: playbackState.trackTitle,
+      sourceKind: playbackState.sourceKind ?? undefined,
     }).catch(() => {});
   }, [
     playbackState.activeTrackId,
     playbackState.playbackStatus,
+    playbackState.sourceKind,
     playbackState.trackTitle,
     toggleTrack,
   ]);

--- a/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
+++ b/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
@@ -26,8 +26,14 @@ export function SidebarBottomNowPlayingBridge() {
     toggleTrack({
       id: playbackState.activeTrackId,
       title: playbackState.trackTitle,
+      sourceKind: playbackState.sourceKind ?? undefined,
     }).catch(() => {});
-  }, [playbackState.activeTrackId, playbackState.trackTitle, toggleTrack]);
+  }, [
+    playbackState.activeTrackId,
+    playbackState.sourceKind,
+    playbackState.trackTitle,
+    toggleTrack,
+  ]);
 
   const hasActiveTrack = Boolean(
     playbackState.activeTrackId && playbackState.trackTitle

--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -2,6 +2,7 @@
 
 import {
   type AudioPlaybackEvent,
+  type AudioPlaybackSourceKind,
   type AudioPlaybackStatus,
   getNextAudioPlaybackStatus,
 } from '@jovie/audio-contracts';
@@ -10,6 +11,7 @@ import { useCallback, useEffect, useState } from 'react';
 export interface AudioTrackSource {
   readonly id: string;
   readonly title: string;
+  readonly sourceKind?: AudioPlaybackSourceKind;
   /** Required when loading a new track; omit when resuming the same track. */
   readonly audioUrl?: string;
   /** ISRC code for the track — used to fetch a fresh preview URL if the stored one expires. */
@@ -27,6 +29,7 @@ export interface ToggleTrackOptions {
 
 export interface PlaybackState {
   readonly activeTrackId: string | null;
+  readonly sourceKind: AudioPlaybackSourceKind | null;
   readonly isPlaying: boolean;
   readonly playbackStatus: AudioPlaybackStatus;
   readonly lastErrorReason:
@@ -63,15 +66,38 @@ let _mediaSessionBound = false;
 /** ~4 Hz progress notify for cross-surface scrub without rAF thrash. */
 const PROGRESS_NOTIFY_MS = 250;
 
+function createAudioElement(): HTMLAudioElement {
+  const audio = new Audio();
+  audio.preload = 'metadata';
+  bindAudioEvents(audio);
+  return audio;
+}
+
 /** Lazily create the Audio element — safe to call during SSR (returns null server-side). */
 function getAudio(): HTMLAudioElement | null {
   if (typeof Audio === 'undefined') return null;
   if (!_audio) {
-    _audio = new Audio();
-    _audio.preload = 'metadata';
-    bindAudioEvents(_audio);
+    _audio = createAudioElement();
   }
   return _audio;
+}
+
+/**
+ * Give a new source exclusive ownership of browser media events.
+ *
+ * Clearing the prior element alone is insufficient: late events from an
+ * already-loaded source can otherwise mutate the canonical singleton state.
+ */
+function replaceAudioElement(): HTMLAudioElement | null {
+  if (typeof Audio === 'undefined') return null;
+  const previousAudio = _audio;
+  const nextAudio = createAudioElement();
+  _audio = nextAudio;
+  if (previousAudio) {
+    previousAudio.pause();
+    previousAudio.src = '';
+  }
+  return nextAudio;
 }
 
 function isPlayableTrack(track: AudioTrackSource): boolean {
@@ -116,6 +142,7 @@ function getQueueTrackAt(index: number): AudioTrackSource | null {
 
 let state: PlaybackState = {
   activeTrackId: null,
+  sourceKind: null,
   isPlaying: false,
   playbackStatus: 'idle',
   lastErrorReason: null,
@@ -288,6 +315,7 @@ function handlePlaybackFailure(
   clearPlaybackQueue();
   setState({
     activeTrackId: null,
+    sourceKind: null,
     isPlaying: false,
     playbackStatus: 'error',
     lastErrorReason: reason,
@@ -304,7 +332,12 @@ function handlePlaybackFailure(
 }
 
 async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
-  const audio = getAudio();
+  const sourceKind = track.sourceKind ?? 'catalog';
+  const audio =
+    state.activeTrackId &&
+    (state.activeTrackId !== track.id || state.sourceKind !== sourceKind)
+      ? replaceAudioElement()
+      : getAudio();
   if (!audio) return;
 
   if (!track.audioUrl) {
@@ -319,6 +352,7 @@ async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
   audio.src = track.audioUrl;
   setState({
     activeTrackId: track.id,
+    sourceKind,
     isPlaying: false,
     playbackStatus: 'loading',
     lastErrorReason: null,
@@ -360,7 +394,17 @@ function bindAudioEvents(el: HTMLAudioElement): void {
   // swallowed by the throttle when initialized to 0, dropping the first
   // progress update (surfaced as a shard-order-dependent unit test flake).
   let lastNotifiedAt = -Infinity;
-  el.addEventListener('timeupdate', () => {
+  const bindCurrentAudioEvent = (
+    event: keyof HTMLMediaElementEventMap,
+    handler: () => void
+  ) => {
+    el.addEventListener(event, () => {
+      if (_audio !== el) return;
+      handler();
+    });
+  };
+
+  bindCurrentAudioEvent('timeupdate', () => {
     // ~4 Hz keeps cross-surface scrub bars smooth without rAF thrash.
     const now =
       typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -372,51 +416,51 @@ function bindAudioEvents(el: HTMLAudioElement): void {
     });
   });
 
-  el.addEventListener('play', () =>
+  bindCurrentAudioEvent('play', () =>
     setState({
       isPlaying: true,
       playbackStatus: getTransitionStatus('play'),
       lastErrorReason: null,
     })
   );
-  el.addEventListener('playing', () =>
+  bindCurrentAudioEvent('playing', () =>
     setState({
       isPlaying: true,
       playbackStatus: getTransitionStatus('playing'),
       lastErrorReason: null,
     })
   );
-  el.addEventListener('pause', () =>
+  bindCurrentAudioEvent('pause', () =>
     setState({
       isPlaying: false,
       playbackStatus: getTransitionStatus('pause'),
     })
   );
-  el.addEventListener('waiting', () =>
+  bindCurrentAudioEvent('waiting', () =>
     setState({
       isPlaying: !el.paused,
       playbackStatus: getTransitionStatus('waiting'),
     })
   );
-  el.addEventListener('canplay', () =>
+  bindCurrentAudioEvent('canplay', () =>
     setState({
       isPlaying: !el.paused,
       playbackStatus: getTransitionStatus('canplay', el.paused),
     })
   );
-  el.addEventListener('seeking', () =>
+  bindCurrentAudioEvent('seeking', () =>
     setState({
       isPlaying: !el.paused,
       playbackStatus: getTransitionStatus('seeking'),
     })
   );
-  el.addEventListener('stalled', () =>
+  bindCurrentAudioEvent('stalled', () =>
     setState({
       isPlaying: !el.paused,
       playbackStatus: getTransitionStatus('stalled'),
     })
   );
-  el.addEventListener('ended', () => {
+  bindCurrentAudioEvent('ended', () => {
     const nextIndex = _queueIndex + 1;
     const nextTrack = getQueueTrackAt(nextIndex);
     if (nextTrack) {
@@ -431,12 +475,12 @@ function bindAudioEvents(el: HTMLAudioElement): void {
       ...getQueueSnapshot(),
     });
   });
-  el.addEventListener('loadedmetadata', () => {
+  bindCurrentAudioEvent('loadedmetadata', () => {
     setState({
       duration: Number.isFinite(el.duration) ? el.duration : 0,
     });
   });
-  el.addEventListener('seeked', () => {
+  bindCurrentAudioEvent('seeked', () => {
     lastNotifiedAt = -Infinity; // invalidate throttle so next timeupdate fires
     setState({
       isPlaying: !el.paused,
@@ -445,7 +489,7 @@ function bindAudioEvents(el: HTMLAudioElement): void {
       duration: Number.isFinite(el.duration) ? el.duration : 0,
     });
   });
-  el.addEventListener('error', () => {
+  bindCurrentAudioEvent('error', () => {
     // Guard: only handle errors when a track is actively loaded.
     // The audio element can fire stale error events (e.g., after tab
     // backgrounding/resuming) even when src is already cleared.
@@ -570,7 +614,8 @@ export function useTrackAudioPlayer() {
       }
 
       // Same track — toggle pause/resume
-      if (state.activeTrackId === track.id) {
+      const sourceKind = track.sourceKind ?? 'catalog';
+      if (state.activeTrackId === track.id && state.sourceKind === sourceKind) {
         if (audio.paused) {
           try {
             await audio.play();
@@ -622,6 +667,7 @@ export function useTrackAudioPlayer() {
     clearPlaybackQueue();
     setState({
       activeTrackId: null,
+      sourceKind: null,
       isPlaying: false,
       playbackStatus: 'idle',
       lastErrorReason: null,

--- a/apps/web/stryker.audio.config.mjs
+++ b/apps/web/stryker.audio.config.mjs
@@ -7,15 +7,21 @@ const config = {
   disableTypeChecks: false,
   reporters: ['progress', 'clear-text', 'json'],
   mutate: [
-    // Canonical playback transitions: cue jumps, browser media events,
-    // queue completion, and nested audio-focus interruptions.
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:263-271',
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:375-447',
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:502-541',
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:561-569',
+    // JOV-4391 authority boundary: replacement owns the new element and late
+    // events from the prior source cannot mutate singleton state.
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:94-95',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:97-100',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:401-404',
+    // Equal ids only toggle when their typed source provenance also matches.
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:617-630',
+    // Ephemeral preview cleanup follows the latest authority state; selection
+    // forwards the complete typed source into the singleton.
+    'components/organisms/GlobalAudioPreviewAction.tsx:56-65',
+    'components/organisms/GlobalAudioPreviewAction.tsx:68-77',
   ],
   testFiles: [
     'tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts',
+    'tests/components/organisms/GlobalAudioPreviewAction.test.tsx',
   ],
   ignorePatterns: [
     '.next',

--- a/apps/web/tests/components/organisms/GlobalAudioPreviewAction.test.tsx
+++ b/apps/web/tests/components/organisms/GlobalAudioPreviewAction.test.tsx
@@ -1,0 +1,227 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GlobalAudioPreviewAction } from '@/components/organisms/GlobalAudioPreviewAction';
+
+const { mockPlayer, mockStop, mockToggleTrack } = vi.hoisted(() => ({
+  mockStop: vi.fn(),
+  mockToggleTrack: vi.fn(() => Promise.resolve()),
+  mockPlayer: {
+    playbackState: {
+      activeTrackId: null as string | null,
+      sourceKind: null as string | null,
+      playbackStatus: 'idle',
+      isPlaying: false,
+    },
+  },
+}));
+
+vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
+  useTrackAudioPlayer: () => ({
+    playbackState: mockPlayer.playbackState,
+    toggleTrack: mockToggleTrack,
+    stop: mockStop,
+  }),
+}));
+
+const releaseProps = {
+  id: 'release-1',
+  title: 'Midnight Drive',
+  audioUrl: 'https://cdn.example.com/midnight.mp3',
+  sourceKind: 'release-preview' as const,
+  releaseTitle: 'Midnight Drive',
+  artistName: 'Ari',
+  artworkUrl: 'https://cdn.example.com/art.jpg',
+};
+
+describe('GlobalAudioPreviewAction', () => {
+  beforeEach(() => {
+    mockPlayer.playbackState = {
+      activeTrackId: null,
+      sourceKind: null,
+      playbackStatus: 'idle',
+      isPlaying: false,
+    };
+    mockStop.mockClear();
+    mockToggleTrack.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects typed preview provenance without rendering a local transport', () => {
+    render(<GlobalAudioPreviewAction {...releaseProps} />);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Preview Midnight Drive in player',
+      })
+    );
+
+    expect(mockToggleTrack).toHaveBeenCalledWith(releaseProps);
+    expect(document.querySelector('audio')).toBeNull();
+  });
+
+  it.each([
+    ['loading', false, 'Loading in Player', true],
+    ['buffering', false, 'Buffering in Player', true],
+    ['stalled', false, 'Buffering in Player', true],
+    ['seeking', false, 'Seeking in Player', true],
+    ['paused', false, 'Paused in Player', false],
+    ['playing', true, 'Playing in Player', false],
+  ])('renders %s as status-only', (playbackStatus, isPlaying, label, pending) => {
+    mockPlayer.playbackState = {
+      activeTrackId: releaseProps.id,
+      sourceKind: releaseProps.sourceKind,
+      playbackStatus,
+      isPlaying,
+    };
+
+    const { container } = render(
+      <GlobalAudioPreviewAction {...releaseProps} />
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(label);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(Boolean(container.querySelector('svg'))).toBe(pending);
+  });
+
+  it('does not confuse equal ids from different source kinds', () => {
+    mockPlayer.playbackState = {
+      activeTrackId: releaseProps.id,
+      sourceKind: 'chat-upload-preview',
+      playbackStatus: 'playing',
+      isPlaying: true,
+    };
+
+    render(<GlobalAudioPreviewAction {...releaseProps} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('does not confuse different ids from the same source kind', () => {
+    mockPlayer.playbackState = {
+      activeTrackId: 'release-2',
+      sourceKind: releaseProps.sourceKind,
+      playbackStatus: 'playing',
+      isPlaying: true,
+    };
+
+    render(<GlobalAudioPreviewAction {...releaseProps} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('stops ephemeral upload playback on unmount', () => {
+    mockPlayer.playbackState = {
+      activeTrackId: 'upload-1',
+      sourceKind: 'chat-upload-preview',
+      playbackStatus: 'playing',
+      isPlaying: true,
+    };
+    const { unmount } = render(
+      <GlobalAudioPreviewAction
+        id='upload-1'
+        title='Rough Mix.wav'
+        audioUrl='blob:https://jov.ie/upload-1'
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    );
+
+    unmount();
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the latest authority state when an upload becomes active', () => {
+    const { rerender, unmount } = render(
+      <GlobalAudioPreviewAction
+        id='upload-1'
+        title='Rough Mix.wav'
+        audioUrl='blob:https://jov.ie/upload-1'
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    );
+
+    mockPlayer.playbackState = {
+      activeTrackId: 'upload-1',
+      sourceKind: 'chat-upload-preview',
+      playbackStatus: 'playing',
+      isPlaying: true,
+    };
+    rerender(
+      <GlobalAudioPreviewAction
+        id='upload-1'
+        title='Rough Mix.wav'
+        audioUrl='blob:https://jov.ie/upload-1'
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    );
+    unmount();
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops an active upload before the surface adopts another source', () => {
+    mockPlayer.playbackState = {
+      activeTrackId: 'upload-1',
+      sourceKind: 'chat-upload-preview',
+      playbackStatus: 'playing',
+      isPlaying: true,
+    };
+    const { rerender } = render(
+      <GlobalAudioPreviewAction
+        id='upload-1'
+        title='Rough Mix.wav'
+        audioUrl='blob:https://jov.ie/upload-1'
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    );
+
+    rerender(
+      <GlobalAudioPreviewAction
+        id='upload-2'
+        title='New Mix.wav'
+        audioUrl='blob:https://jov.ie/upload-2'
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    );
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps durable release playback alive when its panel unmounts', () => {
+    mockPlayer.playbackState = {
+      activeTrackId: releaseProps.id,
+      sourceKind: releaseProps.sourceKind,
+      playbackStatus: 'playing',
+      isPlaying: true,
+    };
+    const { unmount } = render(<GlobalAudioPreviewAction {...releaseProps} />);
+
+    unmount();
+
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('does not stop an inactive ephemeral preview on unmount', () => {
+    const { unmount } = render(
+      <GlobalAudioPreviewAction
+        id='upload-1'
+        title='Rough Mix.wav'
+        audioUrl='blob:https://jov.ie/upload-1'
+        sourceKind='chat-upload-preview'
+        stopOnUnmount
+      />
+    );
+
+    unmount();
+
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -34,6 +34,11 @@ let searchParams = new URLSearchParams();
 
 const basePlaybackState = {
   activeTrackId: null as string | null,
+  sourceKind: null as
+    | 'catalog'
+    | 'release-preview'
+    | 'chat-upload-preview'
+    | null,
   isPlaying: false,
   playbackStatus: 'idle' as AudioPlaybackStatus,
   lastErrorReason: null as
@@ -122,6 +127,7 @@ function setPlaying(overrides: Partial<MockPlaybackState> = {}) {
   mockPlaybackState = {
     ...basePlaybackState,
     activeTrackId: 'track-1',
+    sourceKind: 'catalog',
     isPlaying: true,
     playbackStatus: 'playing',
     currentTime: 10,
@@ -215,6 +221,7 @@ describe('PersistentAudioBar', () => {
     expect(toggleTrack).toHaveBeenCalledWith({
       id: 'track-1',
       title: 'Midnight Drive',
+      sourceKind: 'catalog',
     });
   });
 
@@ -613,6 +620,7 @@ describe('PersistentAudioBar', () => {
     expect(toggleTrack).toHaveBeenCalledWith({
       id: 'track-1',
       title: 'Midnight Drive',
+      sourceKind: 'catalog',
     });
 
     fireEvent.keyDown(globalThis, { key: 'w' });

--- a/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
+++ b/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
@@ -7,6 +7,7 @@ import {
 
 let _state: Record<string, unknown> = {
   activeTrackId: null,
+  sourceKind: null,
   isPlaying: false,
   playbackStatus: 'idle',
   lastErrorReason: null,
@@ -17,13 +18,14 @@ let _state: Record<string, unknown> = {
   artistName: null,
   artworkUrl: null,
 };
+const toggleTrack = vi.fn().mockResolvedValue(undefined);
 
 const { stop } = vi.hoisted(() => ({ stop: vi.fn() }));
 
 vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
   useTrackAudioPlayer: () => ({
     playbackState: _state,
-    toggleTrack: vi.fn(),
+    toggleTrack,
     seek: vi.fn(),
     stop,
     onError: vi.fn(() => () => undefined),
@@ -36,6 +38,7 @@ beforeEach(() => {
   resetAudioChromeSnapshot();
   _state = {
     activeTrackId: null,
+    sourceKind: null,
     isPlaying: false,
     playbackStatus: 'idle',
     lastErrorReason: null,
@@ -74,6 +77,25 @@ describe('SidebarBottomNowPlayingBridge', () => {
     expect(screen.getByText('Lost in the Light')).toBeInTheDocument();
     expect(screen.getByText('Bahamas')).toBeInTheDocument();
     expect(screen.getByLabelText('Play')).toBeInTheDocument();
+  });
+
+  it('preserves typed source provenance when compact playback toggles', () => {
+    _state = {
+      ..._state,
+      activeTrackId: 'track-1',
+      sourceKind: 'release-preview',
+      trackTitle: 'Lost in the Light',
+      isPlaying: false,
+    };
+
+    render(<SidebarBottomNowPlayingBridge />);
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+
+    expect(toggleTrack).toHaveBeenCalledWith({
+      id: 'track-1',
+      sourceKind: 'release-preview',
+      title: 'Lost in the Light',
+    });
   });
 
   it('reserves the slot when the full player owns the active track', () => {

--- a/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
+++ b/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Map of event name -> listener callbacks registered on the mock Audio element
 let audioEventListeners: Record<string, Array<() => void>>;
+let audioEventListenerInstances: Array<Record<string, Array<() => void>>> = [];
 let mockAudio: {
   play: ReturnType<typeof vi.fn>;
   pause: ReturnType<typeof vi.fn>;
@@ -13,6 +14,7 @@ let mockAudio: {
   currentTime: number;
   duration: number;
 };
+let audioInstances: (typeof mockAudio)[] = [];
 let nextPlayMock: ReturnType<typeof vi.fn> | null = null;
 
 function createMockAudio() {
@@ -32,12 +34,18 @@ function createMockAudio() {
     currentTime: 0,
     duration: 0,
   };
+  audioEventListenerInstances.push(audioEventListeners);
+  audioInstances.push(mockAudio);
   nextPlayMock = null;
   return mockAudio;
 }
 
-function fireAudioEvent(event: string) {
-  const handlers = audioEventListeners[event];
+function fireAudioEvent(event: string, instanceIndex?: number) {
+  const listeners =
+    instanceIndex === undefined
+      ? audioEventListeners
+      : audioEventListenerInstances[instanceIndex];
+  const handlers = listeners?.[event];
   if (handlers) {
     for (const handler of handlers) {
       handler();
@@ -64,6 +72,8 @@ async function importFresh() {
 describe('useTrackAudioPlayer', () => {
   beforeEach(() => {
     vi.resetModules();
+    audioEventListenerInstances = [];
+    audioInstances = [];
     nextPlayMock = null;
   });
 
@@ -78,6 +88,7 @@ describe('useTrackAudioPlayer', () => {
       releaseTitle: 'Test Album',
       artistName: 'Test Artist',
       artworkUrl: 'https://cdn.example.com/art.jpg',
+      sourceKind: 'release-preview' as const,
     };
 
     await act(async () => {
@@ -90,6 +101,7 @@ describe('useTrackAudioPlayer', () => {
     });
 
     expect(result.current.playbackState.activeTrackId).toBe('track-1');
+    expect(result.current.playbackState.sourceKind).toBe('release-preview');
     expect(result.current.playbackState.trackTitle).toBe('Test Song');
     expect(result.current.playbackState.releaseTitle).toBe('Test Album');
     expect(result.current.playbackState.artistName).toBe('Test Artist');
@@ -121,17 +133,20 @@ describe('useTrackAudioPlayer', () => {
     });
 
     expect(result.current.playbackState.isPlaying).toBe(true);
+    expect(result.current.playbackState.sourceKind).toBe('catalog');
 
     // Toggle same track -> should pause
+    const pauseCountBeforeToggle = mockAudio.pause.mock.calls.length;
     await act(async () => {
       await result.current.toggleTrack(track);
     });
+    expect(mockAudio.pause).toHaveBeenCalledTimes(pauseCountBeforeToggle + 1);
     act(() => {
       mockAudio.paused = true;
       fireAudioEvent('pause');
     });
 
-    expect(mockAudio.pause).toHaveBeenCalled();
+    expect(audioInstances).toHaveLength(1);
     expect(result.current.playbackState.isPlaying).toBe(false);
     expect(result.current.playbackState.playbackStatus).toBe('paused');
 
@@ -148,6 +163,93 @@ describe('useTrackAudioPlayer', () => {
     expect(mockAudio.play).toHaveBeenCalledTimes(2);
     expect(result.current.playbackState.isPlaying).toBe(true);
     expect(result.current.playbackState.playbackStatus).toBe('playing');
+  });
+
+  it('fails closed when same-track resume is rejected', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    const track = {
+      id: 'track-1',
+      title: 'Test Song',
+      audioUrl: 'https://cdn.example.com/song.mp3',
+    };
+
+    await act(async () => {
+      await result.current.toggleTrack(track);
+    });
+    mockAudio.paused = true;
+    mockAudio.play.mockRejectedValueOnce(new Error('Resume blocked'));
+
+    await act(async () => {
+      await expect(result.current.toggleTrack(track)).rejects.toThrow(
+        'Resume blocked'
+      );
+    });
+
+    expect(result.current.playbackState).toMatchObject({
+      activeTrackId: null,
+      isPlaying: false,
+      playbackStatus: 'error',
+      lastErrorReason: 'play_rejected',
+    });
+    expect(mockAudio.src).toBe('');
+  });
+
+  it('replaces equal track ids when typed source provenance changes', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'shared-id',
+        title: 'Catalog Track',
+        audioUrl: 'https://cdn.example.com/catalog.mp3',
+      });
+      await result.current.toggleTrack({
+        id: 'shared-id',
+        title: 'Uploaded Mix',
+        audioUrl: 'blob:https://jov.ie/uploaded-mix',
+        sourceKind: 'chat-upload-preview',
+      });
+    });
+
+    expect(audioInstances).toHaveLength(2);
+    expect(audioInstances[0]?.src).toBe('');
+    expect(audioInstances[1]?.src).toBe('blob:https://jov.ie/uploaded-mix');
+    expect(result.current.playbackState.sourceKind).toBe('chat-upload-preview');
+    expect(result.current.playbackState.trackTitle).toBe('Uploaded Mix');
+  });
+
+  it('ignores stale media events after another source takes authority', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'shared-id',
+        title: 'Catalog Track',
+        audioUrl: 'https://cdn.example.com/catalog.mp3',
+      });
+      await result.current.toggleTrack({
+        id: 'shared-id',
+        title: 'Uploaded Mix',
+        audioUrl: 'blob:https://jov.ie/uploaded-mix',
+        sourceKind: 'chat-upload-preview',
+      });
+    });
+
+    act(() => {
+      fireAudioEvent('play', 0);
+      fireAudioEvent('error', 0);
+    });
+
+    expect(result.current.playbackState).toMatchObject({
+      activeTrackId: 'shared-id',
+      sourceKind: 'chat-upload-preview',
+      trackTitle: 'Uploaded Mix',
+      playbackStatus: 'loading',
+      lastErrorReason: null,
+    });
   });
 
   it('resets state and notifies error listeners on audio error', async () => {
@@ -181,6 +283,7 @@ describe('useTrackAudioPlayer', () => {
     });
 
     expect(result.current.playbackState.activeTrackId).toBeNull();
+    expect(result.current.playbackState.sourceKind).toBeNull();
     expect(result.current.playbackState.isPlaying).toBe(false);
     expect(result.current.playbackState.trackTitle).toBeNull();
     expect(result.current.playbackState.releaseTitle).toBeNull();
@@ -364,6 +467,7 @@ describe('useTrackAudioPlayer', () => {
     expect(mockAudio.src).toBe('');
     expect(firstMount.result.current.playbackState).toEqual({
       activeTrackId: null,
+      sourceKind: null,
       isPlaying: false,
       playbackStatus: 'idle',
       lastErrorReason: null,
@@ -963,20 +1067,12 @@ describe('useTrackAudioPlayer', () => {
     let resolveFirstPlay: (() => void) | undefined;
     let resolveSecondPlay: (() => void) | undefined;
 
-    nextPlayMock = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>(resolve => {
-            resolveFirstPlay = resolve;
-          })
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>(resolve => {
-            resolveSecondPlay = resolve;
-          })
-      );
+    nextPlayMock = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveFirstPlay = resolve;
+        })
+    );
 
     const useTrackAudioPlayer = await importFresh();
     const { result } = renderHook(() => useTrackAudioPlayer());
@@ -990,6 +1086,12 @@ describe('useTrackAudioPlayer', () => {
         title: 'First Song',
         audioUrl: 'https://cdn.example.com/first.mp3',
       });
+      nextPlayMock = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            resolveSecondPlay = resolve;
+          })
+      );
       secondToggle = result.current.toggleTrack({
         id: 'track-2',
         title: 'Second Song',
@@ -1002,8 +1104,10 @@ describe('useTrackAudioPlayer', () => {
       await firstToggle;
     });
 
-    expect(mockAudio.pause).toHaveBeenCalledTimes(2);
-    expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
+    expect(audioInstances).toHaveLength(2);
+    expect(audioInstances[0]?.pause).toHaveBeenCalledTimes(2);
+    expect(audioInstances[0]?.src).toBe('');
+    expect(audioInstances[1]?.src).toBe('https://cdn.example.com/second.mp3');
     expect(result.current.playbackState.activeTrackId).toBe('track-2');
     expect(result.current.playbackState.trackTitle).toBe('Second Song');
   });

--- a/apps/web/tests/unit/audio/single-playback-authority-source.test.ts
+++ b/apps/web/tests/unit/audio/single-playback-authority-source.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = join(process.cwd());
+const sourceRoots = [join(webRoot, 'app'), join(webRoot, 'components')];
+const publicShareSurface =
+  'components/features/library-asset-share/LibraryAssetShareSurface.tsx';
+
+function sourceFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap(entry => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.isFile() && /\.(ts|tsx)$/.test(entry.name) ? [path] : [];
+  });
+}
+
+describe('single playback authority source ratchet', () => {
+  it('keeps native audio isolated to the public asset share surface', () => {
+    const nativeAudioOwners = sourceRoots
+      .flatMap(sourceFiles)
+      .filter(file => statSync(file).isFile())
+      .filter(file => readFileSync(file, 'utf8').includes('<audio'))
+      .map(file => relative(webRoot, file));
+
+    expect(nativeAudioOwners).toEqual([publicShareSurface]);
+  });
+
+  it('mounts the native public player only from no-shell share routes', () => {
+    const publicRoutes = [
+      'app/a/[handle]/[slug]/page.tsx',
+      'app/p/[token]/page.tsx',
+    ];
+    const importNeedle =
+      '@/components/features/library-asset-share/LibraryAssetShareSurface';
+
+    for (const route of publicRoutes) {
+      expect(readFileSync(join(webRoot, route), 'utf8')).toContain(
+        importNeedle
+      );
+    }
+
+    const authenticatedShellSource = readFileSync(
+      join(webRoot, 'app/app/(shell)/layout.tsx'),
+      'utf8'
+    );
+    expect(authenticatedShellSource).not.toContain(importNeedle);
+  });
+});

--- a/apps/web/tests/unit/chat/AudioPreviewStrip.test.tsx
+++ b/apps/web/tests/unit/chat/AudioPreviewStrip.test.tsx
@@ -21,7 +21,7 @@ describe('AudioPreviewStrip', () => {
     expect(screen.getByText('Uploading audio…')).toBeTruthy();
   });
 
-  it('renders ready state with player', () => {
+  it('routes ready audio to the shell player without a native transport', () => {
     render(
       <AudioPreviewStrip
         audio={{
@@ -43,7 +43,12 @@ describe('AudioPreviewStrip', () => {
       />
     );
 
-    expect(screen.getByTestId('chat-audio-preview-player')).toBeTruthy();
+    expect(
+      screen.getByRole('button', {
+        name: 'Preview Take Me Over.wav in player',
+      })
+    ).toBeTruthy();
+    expect(document.querySelector('audio')).toBeNull();
     expect(
       screen.getByText('Matched Take Me Over · attaching audio')
     ).toBeTruthy();

--- a/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
+++ b/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
@@ -690,6 +690,51 @@ describe('ChatEntityRightPanelHost', () => {
     expect(screen.getByTestId('chat-release-entity-panel')).toBeInTheDocument();
   });
 
+  it('routes release previews to the persistent player without a native transport', async () => {
+    mockPreviewPanelOpen = false;
+    mockUseRegisterRightPanel.mockClear();
+    mockUseReleaseEntityQuery.mockReturnValue({
+      data: {
+        id: 'release-1',
+        title: 'Lost In The Light',
+        releaseType: 'single',
+        status: 'released',
+        slug: 'lost-in-the-light',
+        profileId: 'profile-1',
+        totalTracks: 1,
+        artistNames: ['Tim White'],
+        artworkUrl: 'https://cdn.example.com/art.jpg',
+        previewUrl: 'https://cdn.example.com/preview.mp3',
+        providers: [],
+      },
+      isLoading: false,
+    });
+
+    render(
+      <ChatEntityPanelProvider>
+        <OpenReleaseTarget />
+        <ChatEntityRightPanelHost
+          enablePreviewPanel={false}
+          enableChatEntityPanels
+          profileId='profile-1'
+        />
+      </ChatEntityPanelProvider>
+    );
+
+    await waitFor(() => {
+      expect(mockUseRegisterRightPanel.mock.calls.at(-1)?.[0]).not.toBeNull();
+    });
+    const registeredPanel = mockUseRegisterRightPanel.mock.calls.at(-1)?.[0];
+    const { container } = render(registeredPanel as React.ReactElement);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Preview Lost In The Light in player',
+      })
+    ).toBeInTheDocument();
+    expect(container.querySelector('audio')).toBeNull();
+  });
+
   it('dismisses context cards without clearing the full entity target', async () => {
     render(
       <ChatEntityPanelProvider>

--- a/packages/audio-contracts/playback.test.ts
+++ b/packages/audio-contracts/playback.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   AUDIO_PLAYBACK_EVENTS,
+  AUDIO_PLAYBACK_SOURCE_KINDS,
   AUDIO_PLAYBACK_STATUSES,
+  AUDIO_PREVIEW_SURFACE_REGISTRY,
   type AudioPlaybackEvent,
   type AudioPlaybackStatus,
+  getAudioPreviewSurfaceState,
   getNextAudioPlaybackStatus,
 } from './playback';
 
@@ -28,6 +31,65 @@ describe('audio playback transition registry', () => {
     expect(new Set(AUDIO_PLAYBACK_EVENTS).size).toBe(
       AUDIO_PLAYBACK_EVENTS.length
     );
+    expect(AUDIO_PLAYBACK_SOURCE_KINDS).toEqual([
+      'catalog',
+      'release-preview',
+      'chat-upload-preview',
+    ]);
+    expect(new Set(AUDIO_PLAYBACK_SOURCE_KINDS).size).toBe(
+      AUDIO_PLAYBACK_SOURCE_KINDS.length
+    );
+    expect(AUDIO_PREVIEW_SURFACE_REGISTRY).toEqual([
+      { id: 'selectable', label: 'Preview in Player', pending: false },
+      { id: 'loading', label: 'Loading in Player', pending: true },
+      { id: 'buffering', label: 'Buffering in Player', pending: true },
+      { id: 'seeking', label: 'Seeking in Player', pending: true },
+      { id: 'playing', label: 'Playing in Player', pending: false },
+      { id: 'paused', label: 'Paused in Player', pending: false },
+    ]);
+  });
+
+  it.each([
+    ['loading', false, 'loading'],
+    ['buffering', false, 'buffering'],
+    ['stalled', false, 'buffering'],
+    ['seeking', false, 'seeking'],
+    ['paused', false, 'paused'],
+    ['playing', true, 'playing'],
+  ] as const)('maps active %s playback to the canonical preview surface', (playbackStatus, isPlaying, expected) => {
+    expect(
+      getAudioPreviewSurfaceState({
+        candidateId: 'track-1',
+        candidateSourceKind: 'release-preview',
+        activeTrackId: 'track-1',
+        activeSourceKind: 'release-preview',
+        playbackStatus,
+        isPlaying,
+      }).id
+    ).toBe(expected);
+  });
+
+  it('requires both source identity fields before exposing active status', () => {
+    const base = {
+      candidateId: 'track-1',
+      candidateSourceKind: 'release-preview' as const,
+      playbackStatus: 'playing' as const,
+      isPlaying: true,
+    };
+    expect(
+      getAudioPreviewSurfaceState({
+        ...base,
+        activeTrackId: 'track-2',
+        activeSourceKind: 'release-preview',
+      }).id
+    ).toBe('selectable');
+    expect(
+      getAudioPreviewSurfaceState({
+        ...base,
+        activeTrackId: 'track-1',
+        activeSourceKind: 'chat-upload-preview',
+      }).id
+    ).toBe('selectable');
   });
 
   it('handles terminal and source lifecycle events', () => {

--- a/packages/audio-contracts/playback.ts
+++ b/packages/audio-contracts/playback.ts
@@ -32,6 +32,61 @@ export const AUDIO_PLAYBACK_EVENTS = [
 
 export type AudioPlaybackEvent = (typeof AUDIO_PLAYBACK_EVENTS)[number];
 
+/** Canonical, value-free provenance for every source routed through playback. */
+export const AUDIO_PLAYBACK_SOURCE_KINDS = [
+  'catalog',
+  'release-preview',
+  'chat-upload-preview',
+] as const;
+
+export type AudioPlaybackSourceKind =
+  (typeof AUDIO_PLAYBACK_SOURCE_KINDS)[number];
+
+export const AUDIO_PREVIEW_SURFACE_REGISTRY = [
+  { id: 'selectable', label: 'Preview in Player', pending: false },
+  { id: 'loading', label: 'Loading in Player', pending: true },
+  { id: 'buffering', label: 'Buffering in Player', pending: true },
+  { id: 'seeking', label: 'Seeking in Player', pending: true },
+  { id: 'playing', label: 'Playing in Player', pending: false },
+  { id: 'paused', label: 'Paused in Player', pending: false },
+] as const;
+
+export type AudioPreviewSurfaceState =
+  (typeof AUDIO_PREVIEW_SURFACE_REGISTRY)[number];
+
+export interface AudioPreviewSurfaceInput {
+  readonly candidateId: string;
+  readonly candidateSourceKind: AudioPlaybackSourceKind;
+  readonly activeTrackId: string | null;
+  readonly activeSourceKind: AudioPlaybackSourceKind | null;
+  readonly playbackStatus: AudioPlaybackStatus;
+  readonly isPlaying: boolean;
+}
+
+export function getAudioPreviewSurfaceState({
+  candidateId,
+  candidateSourceKind,
+  activeTrackId,
+  activeSourceKind,
+  playbackStatus,
+  isPlaying,
+}: AudioPreviewSurfaceInput): AudioPreviewSurfaceState {
+  if (
+    activeTrackId !== candidateId ||
+    activeSourceKind !== candidateSourceKind
+  ) {
+    return AUDIO_PREVIEW_SURFACE_REGISTRY[0];
+  }
+  if (playbackStatus === 'loading') return AUDIO_PREVIEW_SURFACE_REGISTRY[1];
+  if (playbackStatus === 'buffering' || playbackStatus === 'stalled') {
+    return AUDIO_PREVIEW_SURFACE_REGISTRY[2];
+  }
+  if (playbackStatus === 'seeking') return AUDIO_PREVIEW_SURFACE_REGISTRY[3];
+  return isPlaying
+    ? AUDIO_PREVIEW_SURFACE_REGISTRY[4]
+    : AUDIO_PREVIEW_SURFACE_REGISTRY[5];
+}
+
 export interface AudioPlaybackTransitionInput {
   readonly current: AudioPlaybackStatus;
   readonly event: AudioPlaybackEvent;


### PR DESCRIPTION
## Summary

- replaces authenticated chat release and upload native audio controls with one canonical global playback action
- adds typed audio source provenance and transition status across catalog, release-preview, and chat-upload-preview sources
- fail-closes stale media events, same-track resume rejection, source replacement, and ephemeral upload cleanup
- keeps the public share player outside the authenticated app-shell authority boundary

Linear: JOV-4391
Stack parent: #14917 (`84be3dfc06e70c02c777f88519f12bee4e748bb6`)

## Evidence

- Real Chromium + real media: switched Release WAV -> Upload MP3 through the production component; exactly one action, one active status, and zero native DOM audio controls remained visible
- Audio contracts: 163 tests passed
- Focused playback authority: 41 tests passed for `useTrackAudioPlayer` and `GlobalAudioPreviewAction`, with broader player/chat surface coverage also passing
- Audio-contract mutation: 816 mutants instrumented, 809 tested, 804 killed, 5 timed out, 0 survived; 100.00% mutation score
- Focused web authority mutation: 31/31 killed; 0 survived, timed out, or uncovered; 100.00% mutation score
- Full pre-push gate: Biome, proxy guard, Tailwind guard, typecheck, affected typecheck/lint, all 8 Vitest shards, and CI harness validation passed
- A first push attempt hit one load-sensitive timeout in unrelated `cleanup-photos.test.ts`; the exact file passed 2/2 in isolation in 2.41s, then passed in the successful full-gate retry

## Stack / release contract

This is a stacked draft. Before queueing, retarget or rebase it to `main` and obtain the full required main-target checks. This PR is not queued and makes no production-shipping claim.