### PR TITLE
feat(audio): add typed playable derivatives

### DIFF
--- a/apps/web/app/api/library/audio/confirm/route.ts
+++ b/apps/web/app/api/library/audio/confirm/route.ts
@@ -6,17 +6,26 @@
  * the catalog is missing audio.
  */
 
-import { and, eq } from 'drizzle-orm';
+import {
+  type AudioPlaybackDerivative,
+  getAudioCapability,
+  getAudioFormat,
+} from '@jovie/audio-contracts';
+import { and, sql as drizzleSql, eq } from 'drizzle-orm';
 import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { ALLOWED_AUDIO_MIME_TYPES } from '@/lib/audio/constants';
+import {
+  nextAudioDerivativeGeneration,
+  parseAudioPlaybackDerivative,
+} from '@/lib/audio/playback-derivative';
 import { resolvePrimaryRecordingForRelease } from '@/lib/audio/resolve-release-recording';
 import { requireAuth } from '@/lib/auth/require-auth';
 import { getSessionContext } from '@/lib/auth/session';
 import { createSmartLinkContentTag } from '@/lib/cache/tags';
 import { db } from '@/lib/db';
 import { discogRecordings } from '@/lib/db/schema/content';
+import { ingestionJobs } from '@/lib/db/schema/ingestion';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 
@@ -44,8 +53,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { releaseId, blobUrl, fileMimeType } = parsed.data;
-    if (!ALLOWED_AUDIO_MIME_TYPES.has(fileMimeType)) {
+    const { releaseId, blobUrl, fileMimeType, fileName } = parsed.data;
+    const format = getAudioFormat({ name: fileName, type: fileMimeType });
+    if (!format) {
       return NextResponse.json(
         { error: 'Unsupported audio file type' },
         { status: 400, headers: NO_STORE_HEADERS }
@@ -84,20 +94,77 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    await db
-      .update(discogRecordings)
-      .set({
-        previewUrl: blobUrl,
-        audioUrl: blobUrl,
-        audioFormat: fileMimeType,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(discogRecordings.id, recording.recordingId),
-          eq(discogRecordings.creatorProfileId, profile.id)
-        )
-      );
+    const playbackCapability = getAudioCapability(
+      format.id,
+      'web_chromium',
+      'nativePlayback'
+    );
+    const now = new Date();
+    const generation = nextAudioDerivativeGeneration(recording.metadata);
+    const derivative: AudioPlaybackDerivative | null =
+      playbackCapability === 'derivative_required'
+        ? {
+            status: 'pending',
+            generation,
+            sourceFormatId: format.id,
+            requestedAt: now.toISOString(),
+          }
+        : null;
+    const previousDerivative = parseAudioPlaybackDerivative(recording.metadata);
+    const metadataDerivative: AudioPlaybackDerivative | null =
+      derivative ??
+      (previousDerivative &&
+      ['pending', 'retrying'].includes(previousDerivative.status)
+        ? {
+            status: 'superseded',
+            generation: previousDerivative.generation,
+            sourceFormatId: previousDerivative.sourceFormatId,
+            supersededAt: now.toISOString(),
+          }
+        : null);
+    const previewUrl = playbackCapability === 'direct' ? blobUrl : null;
+
+    await db.transaction(async tx => {
+      await tx
+        .update(discogRecordings)
+        .set({
+          previewUrl,
+          audioUrl: blobUrl,
+          audioFormat: format.canonicalMimeType,
+          ...(metadataDerivative
+            ? {
+                metadata: drizzleSql`jsonb_set(
+                  coalesce(${discogRecordings.metadata}, '{}'::jsonb),
+                  '{audioPlaybackDerivative}',
+                  ${JSON.stringify(metadataDerivative)}::jsonb,
+                  true
+                )`,
+              }
+            : {}),
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(discogRecordings.id, recording.recordingId),
+            eq(discogRecordings.creatorProfileId, profile.id)
+          )
+        );
+
+      if (derivative) {
+        await tx.insert(ingestionJobs).values({
+          jobType: 'audio_playback_derivative',
+          payload: {
+            recordingId: recording.recordingId,
+            creatorProfileId: profile.id,
+            formatId: format.id,
+            generation,
+          },
+          priority: -10,
+          maxAttempts: 3,
+          dedupKey: `audio_playback_derivative:${recording.recordingId}:${generation}`,
+        });
+      }
+    });
 
     revalidateTag(`releases:${clerkUserId}:${profile.id}`, 'max');
     revalidateTag(createSmartLinkContentTag(profile.id), 'max');
@@ -105,7 +172,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       {
         success: true,
-        previewUrl: blobUrl,
+        previewUrl,
+        hasAudioMaster: true,
+        playbackDerivative: derivative,
         recordingId: recording.recordingId,
       },
       { status: 200, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/library/audio/snippet/route.ts
+++ b/apps/web/app/api/library/audio/snippet/route.ts
@@ -9,6 +9,10 @@ import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
+  parseAudioPlaybackDerivative,
+  resolveRecordingPlayback,
+} from '@/lib/audio/playback-derivative';
+import {
   getSnippetFromRecording,
   resolvePrimaryRecordingForRelease,
 } from '@/lib/audio/resolve-release-recording';
@@ -71,13 +75,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const previewUrl = recording.previewUrl ?? recording.audioUrl;
+    const playback = resolveRecordingPlayback(recording);
     const snippet = getSnippetFromRecording(recording);
 
     return NextResponse.json(
       {
         recordingId: recording.recordingId,
-        previewUrl,
+        previewUrl: playback.url,
+        playbackStatus: playback.status,
+        playbackDerivative: parseAudioPlaybackDerivative(recording.metadata),
+        hasAudioMaster: Boolean(recording.audioUrl),
         durationMs: recording.durationMs,
         snippet,
       },
@@ -130,9 +137,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!recording.previewUrl && !recording.audioUrl) {
+    const playback = resolveRecordingPlayback(recording);
+    if (playback.status !== 'ready') {
       return NextResponse.json(
-        { error: 'Release has no uploaded audio' },
+        { error: 'Release audio preview is not ready' },
         { status: 409, headers: NO_STORE_HEADERS }
       );
     }

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
@@ -95,7 +95,7 @@ export const TrackRow = memo(function TrackRow({
     });
   }, [allProviders, providerMap]);
 
-  const previewUrl = track.previewUrl || track.audioUrl;
+  const previewUrl = track.previewUrl;
   const canPlay = Boolean(previewUrl);
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isPlaying = isActiveTrack && playbackState.isPlaying;
@@ -141,7 +141,7 @@ export const TrackRow = memo(function TrackRow({
     </button>
   ) : (
     <span className='system-b-track-row-preview-unavailable flex h-7 w-7 items-center justify-center rounded-full text-secondary-token/80'>
-      <VolumeX className='h-3.5 w-3.5' aria-label='No preview available' />
+      <VolumeX className='h-3.5 w-3.5' aria-label='No Preview Available' />
     </span>
   );
 
@@ -171,7 +171,7 @@ export const TrackRow = memo(function TrackRow({
             variant='secondary'
             className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
             title='Explicit content'
-            aria-label='Explicit content'
+            aria-label='Explicit Content'
           >
             E
           </Badge>
@@ -299,7 +299,7 @@ export const TrackRow = memo(function TrackRow({
                     variant='secondary'
                     className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
                     title='Explicit content'
-                    aria-label='Explicit content'
+                    aria-label='Explicit Content'
                   >
                     E
                   </Badge>

--- a/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
+++ b/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { AudioPlaybackDerivative } from '@jovie/audio-contracts';
 import { upload } from '@vercel/blob/client';
 import { FileAudio2, Loader2, Upload } from 'lucide-react';
 import {
@@ -54,7 +55,13 @@ export function ReleaseAudioAssetPanel({
   const readyTestId =
     testIdPrefix === 'library' ? 'library-audio-ready' : 'release-audio-ready';
   const inputRef = useRef<HTMLInputElement>(null);
+  const onUploadedRef = useRef(onUploaded);
   const [localPreviewUrl, setLocalPreviewUrl] = useState(previewUrl ?? null);
+  const [hasAudioMaster, setHasAudioMaster] = useState(Boolean(previewUrl));
+  const [playbackDerivative, setPlaybackDerivative] =
+    useState<AudioPlaybackDerivative | null>(null);
+  const [isCheckingAudioState, setIsCheckingAudioState] = useState(!previewUrl);
+  const [audioStateRevision, setAudioStateRevision] = useState(0);
   const [snippet, setSnippet] = useState<AudioSnippet | null>(
     initialSnippet ?? null
   );
@@ -73,28 +80,56 @@ export function ReleaseAudioAssetPanel({
   }, [initialSnippet]);
 
   useEffect(() => {
-    if (initialSnippet || !localPreviewUrl) return;
+    onUploadedRef.current = onUploaded;
+  }, [onUploaded]);
 
+  useEffect(() => {
+    if (initialSnippet && localPreviewUrl) return;
     let cancelled = false;
-    fetch(
-      `/api/library/audio/snippet?releaseId=${encodeURIComponent(releaseId)}`
-    )
-      .then(async response => {
-        if (!response.ok) return null;
-        return (await response.json()) as {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const loadAudioState = async () => {
+      try {
+        const response = await fetch(
+          `/api/library/audio/snippet?releaseId=${encodeURIComponent(releaseId)}`
+        );
+        if (!response.ok) return;
+        const body = (await response.json()) as {
           snippet?: AudioSnippet | null;
+          previewUrl?: string | null;
+          hasAudioMaster?: boolean;
+          playbackDerivative?: AudioPlaybackDerivative | null;
         };
-      })
-      .then(body => {
-        if (cancelled || !body?.snippet) return;
-        setSnippet(body.snippet);
-      })
-      .catch(() => {});
+        if (cancelled) return;
+
+        if (body.snippet) setSnippet(body.snippet);
+        if (body.previewUrl && !localPreviewUrl) {
+          onUploadedRef.current?.(body.previewUrl);
+        }
+        setLocalPreviewUrl(body.previewUrl ?? null);
+        setHasAudioMaster(Boolean(body.hasAudioMaster));
+        setPlaybackDerivative(body.playbackDerivative ?? null);
+
+        if (
+          body.playbackDerivative?.status === 'pending' ||
+          body.playbackDerivative?.status === 'retrying'
+        ) {
+          timeoutId = setTimeout(loadAudioState, 3_000);
+        }
+      } catch {
+        // Preserve the last known state; the next mount or retry will re-read it.
+      } finally {
+        if (!cancelled) setIsCheckingAudioState(false);
+      }
+    };
+
+    loadAudioState().catch(() => {});
 
     return () => {
       cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [initialSnippet, localPreviewUrl, releaseId]);
+  }, [audioStateRevision, initialSnippet, localPreviewUrl, releaseId]);
 
   const openFilePicker = useCallback(() => {
     inputRef.current?.click();
@@ -155,18 +190,27 @@ export function ReleaseAudioAssetPanel({
         });
 
         const body = (await response.json().catch(() => ({}))) as {
-          readonly previewUrl?: string;
+          readonly previewUrl?: string | null;
+          readonly hasAudioMaster?: boolean;
+          readonly playbackDerivative?: AudioPlaybackDerivative | null;
           readonly error?: string;
         };
 
-        if (!response.ok || !body.previewUrl) {
+        if (!response.ok || !body.hasAudioMaster) {
           throw new Error(body.error ?? 'Audio upload failed');
         }
 
-        setLocalPreviewUrl(body.previewUrl);
+        setLocalPreviewUrl(body.previewUrl ?? null);
+        setHasAudioMaster(true);
+        setPlaybackDerivative(body.playbackDerivative ?? null);
+        setAudioStateRevision(revision => revision + 1);
         setSnippet(null);
-        onUploaded?.(body.previewUrl);
-        toast.success('Audio attached to release');
+        if (body.previewUrl) onUploaded?.(body.previewUrl);
+        toast.success(
+          body.previewUrl
+            ? 'Audio attached to release'
+            : 'Audio uploaded — preparing preview'
+        );
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Audio upload failed';
@@ -226,6 +270,76 @@ export function ReleaseAudioAssetPanel({
     },
     [onSnippetSaved, releaseId]
   );
+
+  if (!localPreviewUrl && (isCheckingAudioState || hasAudioMaster)) {
+    const status = playbackDerivative?.status;
+    const isWorking =
+      isCheckingAudioState ||
+      isUploading ||
+      status === 'pending' ||
+      status === 'retrying';
+    const statusCopy = {
+      pending: 'Preparing a browser-ready preview and waveform.',
+      retrying: 'Preview preparation is retrying automatically.',
+      failed: 'We could not prepare this preview. Your original is preserved.',
+      unavailable:
+        'This format is preserved, but a browser preview is not available.',
+      superseded: 'A newer audio upload replaced this preview.',
+      ready: 'Preview metadata is ready, but its audio URL is unavailable.',
+    }[status ?? 'pending'];
+
+    return (
+      <div
+        className='flex min-h-30 w-full items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-3 py-4'
+        data-testid='release-audio-derivative-status'
+        aria-live='polite'
+        aria-busy={isWorking || undefined}
+      >
+        <span className='grid h-8 w-8 shrink-0 place-items-center rounded-md bg-surface-1 text-secondary-token'>
+          {isWorking ? (
+            <Loader2
+              className='h-4 w-4 animate-spin motion-reduce:animate-none'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          ) : (
+            <FileAudio2
+              className='h-4 w-4'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          )}
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='text-xs font-medium text-primary-token'>
+            {isWorking ? 'Preparing preview' : 'Preview unavailable'}
+          </p>
+          <p className='mt-0.5 text-2xs leading-4 text-tertiary-token'>
+            {statusCopy}
+          </p>
+        </div>
+        {!isWorking && isEditable ? (
+          <button
+            type='button'
+            onClick={openFilePicker}
+            className='focus-ring-themed shrink-0 rounded-md border border-subtle bg-surface-1 px-2 py-1 text-2xs font-medium text-primary-token transition-colors duration-subtle hover:bg-surface-0'
+          >
+            Replace audio
+          </button>
+        ) : null}
+        <input
+          ref={inputRef}
+          type='file'
+          accept={AUDIO_ACCEPT}
+          onChange={handleInputChange}
+          disabled={!isEditable || isUploading}
+          tabIndex={disabledTabIndex}
+          className='sr-only'
+          aria-label={`Upload audio for ${releaseTitle}`}
+        />
+      </div>
+    );
+  }
 
   if (!localPreviewUrl) {
     const formats = SUPPORTED_AUDIO_FORMAT_LABELS.join(', ');

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -82,7 +82,7 @@ function buildReleasePlaybackQueue(
   release: Release
 ): TrackControlSource[] {
   return tracks.flatMap(track => {
-    const audioUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+    const audioUrl = track.previewUrl ?? undefined;
     if (!audioUrl) return [];
 
     return [
@@ -249,7 +249,7 @@ function TrackListRow({
   readonly isLastRow: boolean;
   readonly onSelect?: () => void;
 }) {
-  const playableUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+  const playableUrl = track.previewUrl ?? undefined;
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isTrackPlaying = isActiveTrack && playbackState.isPlaying;
   const trackDuration =

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -271,7 +271,7 @@ export function TrackSidebar({
     ];
   }, [track, isSmartLinkCopied, handleCopySmartLink, smartLinkUrl]);
 
-  const playableUrl = track?.audioUrl ?? track?.previewUrl ?? null;
+  const playableUrl = track?.previewUrl ?? null;
   const isThisTrack = playbackState.activeTrackId === track?.id;
   const isPlaying = isThisTrack && playbackState.isPlaying;
   const currentTime = isThisTrack ? playbackState.currentTime : 0;

--- a/apps/web/lib/audio/aiff-to-wav.test.ts
+++ b/apps/web/lib/audio/aiff-to-wav.test.ts
@@ -1,0 +1,412 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_AUDIO_DERIVATIVE_BYTES,
+  prepareAiffPlaybackDerivative,
+} from './aiff-to-wav';
+
+function fixture(fileName: string): Buffer {
+  return readFileSync(resolve(process.cwd(), 'tests/fixtures/audio', fileName));
+}
+
+function chunkedWebStream(
+  bytes: Buffer,
+  chunkSize: number
+): ReadableStream<Uint8Array> {
+  return Readable.toWeb(
+    Readable.from(
+      (function* chunks() {
+        for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+          yield bytes.subarray(offset, offset + chunkSize);
+        }
+      })()
+    )
+  ) as ReadableStream<Uint8Array>;
+}
+
+async function collect(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+function extended80(value: number): Buffer {
+  const output = Buffer.alloc(10);
+  if (Number.isNaN(value)) {
+    output.writeUInt16BE(0x7fff, 0);
+    return output;
+  }
+  if (value === 0) return output;
+
+  const power = Math.floor(Math.log2(Math.abs(value)));
+  const exponent = power + 16_383;
+  const fraction = Math.abs(value) / 2 ** power;
+  const mantissa = BigInt(Math.round(fraction * 2 ** 31)) << 32n;
+  output.writeUInt16BE(exponent | (value < 0 ? 0x8000 : 0), 0);
+  output.writeBigUInt64BE(mantissa, 2);
+  return output;
+}
+
+function makeChunk(id: string, body: Buffer, declaredSize = body.length) {
+  const header = Buffer.alloc(8);
+  header.write(id, 0, 'ascii');
+  header.writeUInt32BE(declaredSize, 4);
+  return Buffer.concat([
+    header,
+    body,
+    ...(body.length % 2 === 1 ? [Buffer.alloc(1)] : []),
+  ]);
+}
+
+function syntheticAiff(options?: {
+  bitsPerSample?: number;
+  channels?: number;
+  commFirst?: boolean;
+  declaredDataBytes?: number;
+  includeOddJunk?: boolean;
+  pcm?: Buffer;
+  sampleRate?: number;
+  soundOffset?: number;
+}) {
+  const bitsPerSample = options?.bitsPerSample ?? 16;
+  const channels = options?.channels ?? 1;
+  const pcm = options?.pcm ?? Buffer.from([0x12, 0x34, 0xfe, 0xdc]);
+  const soundOffset = options?.soundOffset ?? 0;
+  const declaredDataBytes = options?.declaredDataBytes ?? pcm.length;
+
+  const commBody = Buffer.alloc(18);
+  commBody.writeUInt16BE(channels, 0);
+  const bytesPerFrame = Math.max(1, channels * (bitsPerSample / 8));
+  commBody.writeUInt32BE(
+    Math.max(0, Math.floor(declaredDataBytes / bytesPerFrame)),
+    2
+  );
+  commBody.writeUInt16BE(bitsPerSample, 6);
+  extended80(options?.sampleRate ?? 44_100).copy(commBody, 8);
+  const comm = makeChunk('COMM', commBody);
+
+  const soundBody = Buffer.concat([
+    Buffer.alloc(8),
+    Buffer.alloc(soundOffset),
+    pcm,
+  ]);
+  soundBody.writeUInt32BE(soundOffset, 0);
+  const sound = makeChunk(
+    'SSND',
+    soundBody,
+    8 + soundOffset + declaredDataBytes
+  );
+  const chunks = options?.commFirst === false ? [sound, comm] : [comm, sound];
+  if (options?.includeOddJunk) {
+    chunks.unshift(makeChunk('JUNK', Buffer.from([0x7f])));
+  }
+
+  const formBody = Buffer.concat([Buffer.from('AIFF', 'ascii'), ...chunks]);
+  const formHeader = Buffer.alloc(8);
+  formHeader.write('FORM', 0, 'ascii');
+  formHeader.writeUInt32BE(formBody.length, 4);
+  return Buffer.concat([formHeader, formBody]);
+}
+
+async function convert(bytes: Buffer, chunkSize = 7): Promise<Buffer> {
+  const prepared = await prepareAiffPlaybackDerivative(
+    chunkedWebStream(bytes, chunkSize)
+  );
+  return collect(prepared.stream);
+}
+
+describe('AIFF playback derivative conversion', () => {
+  it('streams a real AIFF into a bounded canonical PCM WAV', async () => {
+    const source = fixture('tone.aiff');
+    const prepared = await prepareAiffPlaybackDerivative(
+      chunkedWebStream(source, 7)
+    );
+    const output = await collect(prepared.stream);
+
+    expect(output.byteLength).toBe(prepared.outputBytes);
+    expect(output).toEqual(fixture('tone.wav'));
+    expect(output.toString('ascii', 0, 4)).toBe('RIFF');
+    expect(output.toString('ascii', 8, 12)).toBe('WAVE');
+    expect(output.toString('ascii', 36, 40)).toBe('data');
+    expect(output.readUInt16LE(20)).toBe(1);
+    expect(output.readUInt16LE(22)).toBe(1);
+    expect(output.readUInt32LE(24)).toBe(44_100);
+    expect(output.readUInt16LE(34)).toBe(16);
+    expect(output.readUInt32LE(40)).toBe(88_200);
+  }, 15_000);
+
+  it('fails closed for a truncated AIFF before emitting a derivative', async () => {
+    await expect(
+      prepareAiffPlaybackDerivative(
+        chunkedWebStream(fixture('truncated.aiff'), 13)
+      )
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF ended before sound data was found',
+    });
+  });
+
+  it.each([
+    ['FORM', 0],
+    ['AIFF', 8],
+  ])('rejects an invalid %s container signature', async (_, offset) => {
+    const source = Buffer.from(fixture('tone.aiff'));
+    source.write('NOPE', offset, 'ascii');
+
+    await expect(
+      prepareAiffPlaybackDerivative(chunkedWebStream(source, 13))
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'Expected an uncompressed AIFF container',
+    });
+  });
+
+  it('rejects inconsistent declared sound data during stream consumption', async () => {
+    const source = fixture('tone.aiff');
+    const truncated = source.subarray(0, source.length - 17);
+    const prepared = await prepareAiffPlaybackDerivative(
+      chunkedWebStream(truncated, 31)
+    );
+
+    await expect(collect(prepared.stream)).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF sound data is truncated',
+    });
+  });
+
+  it.each([
+    [8, Buffer.from([0x80, 0x00, 0x7f]), Buffer.from([0x00, 0x80, 0xff])],
+    [
+      16,
+      Buffer.from([0x12, 0x34, 0xfe, 0xdc]),
+      Buffer.from([0x34, 0x12, 0xdc, 0xfe]),
+    ],
+    [
+      24,
+      Buffer.from([0x12, 0x34, 0x56, 0xfe, 0xdc, 0xba]),
+      Buffer.from([0x56, 0x34, 0x12, 0xba, 0xdc, 0xfe]),
+    ],
+    [
+      32,
+      Buffer.from([0x12, 0x34, 0x56, 0x78, 0xfe, 0xdc, 0xba, 0x98]),
+      Buffer.from([0x78, 0x56, 0x34, 0x12, 0x98, 0xba, 0xdc, 0xfe]),
+    ],
+  ] as const)('converts %i-bit PCM samples exactly across stream boundaries', async (bitsPerSample, pcm, expectedPcm) => {
+    const output = await convert(
+      syntheticAiff({ bitsPerSample, pcm }),
+      bitsPerSample === 24 ? 5 : 3
+    );
+    const bytesPerSample = bitsPerSample / 8;
+
+    expect(output.readUInt16LE(22)).toBe(1);
+    expect(output.readUInt32LE(24)).toBe(44_100);
+    expect(output.readUInt32LE(28)).toBe(44_100 * bytesPerSample);
+    expect(output.readUInt16LE(32)).toBe(bytesPerSample);
+    expect(output.readUInt16LE(34)).toBe(bitsPerSample);
+    expect(output.readUInt32LE(40)).toBe(expectedPcm.length);
+    expect(output.subarray(44)).toEqual(expectedPcm);
+  });
+
+  it.each([
+    8_000, 384_000,
+  ])('preserves the supported %i Hz sample-rate boundary', async sampleRate => {
+    const output = await convert(syntheticAiff({ sampleRate }));
+    expect(output.readUInt32LE(24)).toBe(sampleRate);
+    expect(output.readUInt32LE(28)).toBe(sampleRate * 2);
+  });
+
+  it('preserves stereo block alignment and skips padded odd chunks', async () => {
+    const output = await convert(
+      syntheticAiff({
+        channels: 2,
+        includeOddJunk: true,
+        pcm: Buffer.from([0x12, 0x34, 0x56, 0x78]),
+      })
+    );
+    expect(output.readUInt16LE(22)).toBe(2);
+    expect(output.readUInt16LE(32)).toBe(4);
+    expect(output.subarray(44)).toEqual(Buffer.from([0x34, 0x12, 0x78, 0x56]));
+  });
+
+  it('accepts the eight-channel boundary with aligned PCM', async () => {
+    const output = await convert(
+      syntheticAiff({ channels: 8, pcm: Buffer.alloc(16) })
+    );
+    expect(output.readUInt16LE(22)).toBe(8);
+    expect(output.readUInt16LE(32)).toBe(16);
+  });
+
+  it('skips a positive SSND offset before converting PCM', async () => {
+    const output = await convert(
+      syntheticAiff({
+        soundOffset: 4,
+        pcm: Buffer.from([0x12, 0x34, 0xfe, 0xdc]),
+      })
+    );
+    expect(output.subarray(44)).toEqual(Buffer.from([0x34, 0x12, 0xdc, 0xfe]));
+  });
+
+  it.each([
+    [
+      'unsupported bit depth',
+      { bitsPerSample: 12 },
+      'AIFF PCM bit depth is unsupported',
+    ],
+    ['zero channels', { channels: 0 }, 'AIFF channel count is unsupported'],
+    ['too many channels', { channels: 9 }, 'AIFF channel count is unsupported'],
+    [
+      'sample rate below range',
+      { sampleRate: 7_999 },
+      'AIFF sample rate is unsupported',
+    ],
+    [
+      'sample rate above range',
+      { sampleRate: 384_001 },
+      'AIFF sample rate is unsupported',
+    ],
+    [
+      'fractional sample rate',
+      { sampleRate: 44_100.5 },
+      'AIFF sample rate is unsupported',
+    ],
+    [
+      'negative sample rate',
+      { sampleRate: -44_100 },
+      'AIFF sample rate is unsupported',
+    ],
+    ['zero sample rate', { sampleRate: 0 }, 'AIFF sample rate is unsupported'],
+    [
+      'non-finite sample rate',
+      { sampleRate: Number.NaN },
+      'AIFF sample rate is unsupported',
+    ],
+    ['empty sound data', { pcm: Buffer.alloc(0) }, 'AIFF sound data is empty'],
+    [
+      'misaligned sound data',
+      { channels: 2, pcm: Buffer.from([0x12, 0x34]) },
+      'AIFF sound data is not sample-aligned',
+    ],
+    [
+      'sound offset beyond chunk',
+      { soundOffset: 8, declaredDataBytes: -4 },
+      'AIFF sound data is empty',
+    ],
+  ] as const)('rejects %s', async (_, options, message) => {
+    await expect(
+      convert(syntheticAiff(options as Parameters<typeof syntheticAiff>[0]))
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message,
+    });
+  });
+
+  it('rejects sound data before the format declaration', async () => {
+    await expect(
+      convert(syntheticAiff({ commFirst: false }))
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF sound data appeared before its format declaration',
+    });
+  });
+
+  it.each([
+    ['COMM', 16, 17],
+    ['SSND', 42, 7],
+  ])('rejects a %s chunk whose declared body is shorter than its fixed fields', async (_, sizeOffset, declaredSize) => {
+    const source = syntheticAiff();
+    source.writeUInt32BE(declaredSize, sizeOffset);
+
+    await expect(convert(source, source.length)).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF ended before sound data was found',
+    });
+  });
+
+  it('enforces the derivative output limit from header metadata', async () => {
+    await expect(
+      convert(
+        syntheticAiff({
+          declaredDataBytes: MAX_AUDIO_DERIVATIVE_BYTES,
+          pcm: Buffer.alloc(0),
+        })
+      )
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'resource_limit',
+      message: 'Playback derivative exceeds the output size limit',
+    });
+  });
+
+  it('allows an output exactly at the derivative size limit', async () => {
+    const prepared = await prepareAiffPlaybackDerivative(
+      chunkedWebStream(
+        syntheticAiff({
+          declaredDataBytes: MAX_AUDIO_DERIVATIVE_BYTES - 44,
+          pcm: Buffer.alloc(0),
+        }),
+        64
+      )
+    );
+    expect(prepared.outputBytes).toBe(MAX_AUDIO_DERIVATIVE_BYTES);
+    prepared.stream.destroy();
+  });
+
+  it('enforces the bounded header scan before buffering an unbounded chunk', async () => {
+    const junk = makeChunk('JUNK', Buffer.alloc(1024 * 1024));
+    const formBody = Buffer.concat([Buffer.from('AIFF', 'ascii'), junk]);
+    const header = Buffer.alloc(8);
+    header.write('FORM', 0, 'ascii');
+    header.writeUInt32BE(formBody.length, 4);
+
+    await expect(
+      prepareAiffPlaybackDerivative(
+        chunkedWebStream(Buffer.concat([header, formBody]), formBody.length + 8)
+      )
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'resource_limit',
+      message: 'AIFF header exceeds the scan limit',
+    });
+  });
+
+  it('allows exactly one MiB of header data before failing as incomplete', async () => {
+    const junk = makeChunk('JUNK', Buffer.alloc(1024 * 1024 - 20));
+    const formBody = Buffer.concat([Buffer.from('AIFF', 'ascii'), junk]);
+    const header = Buffer.alloc(8);
+    header.write('FORM', 0, 'ascii');
+    header.writeUInt32BE(formBody.length, 4);
+    const source = Buffer.concat([header, formBody]);
+    expect(source.length).toBe(1024 * 1024);
+
+    await expect(
+      prepareAiffPlaybackDerivative(chunkedWebStream(source, source.length))
+    ).rejects.toMatchObject({
+      code: 'invalid_source',
+      message: 'AIFF ended before sound data was found',
+    });
+  });
+
+  it('cancels the source reader after the declared PCM is complete', async () => {
+    let cancelled = false;
+    const bytes = syntheticAiff();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const prepared = await prepareAiffPlaybackDerivative(source);
+    await collect(prepared.stream);
+    expect(cancelled).toBe(true);
+  });
+});

--- a/apps/web/lib/audio/aiff-to-wav.ts
+++ b/apps/web/lib/audio/aiff-to-wav.ts
@@ -1,0 +1,269 @@
+import { Readable } from 'node:stream';
+
+// Stryker disable next-line ArithmeticOperator: module initializer mutations
+// run before the active mutant; boundary tests guard the exact 1 MiB contract.
+const MAX_AIFF_HEADER_BYTES = 1024 * 1024;
+export const MAX_AUDIO_DERIVATIVE_BYTES = 157_286_444;
+
+export class AudioDerivativeConversionError extends Error {
+  constructor(
+    readonly code: 'invalid_source' | 'resource_limit',
+    message: string
+  ) {
+    super(message);
+    this.name = 'AudioDerivativeConversionError';
+  }
+}
+
+interface AiffPcmMetadata {
+  readonly bitsPerSample: number;
+  readonly channels: number;
+  readonly dataBytes: number;
+  readonly dataOffset: number;
+  readonly sampleRate: number;
+}
+
+function readExtended80(buffer: Buffer, offset: number): number {
+  const exponentWord = buffer.readUInt16BE(offset);
+  const sign = exponentWord & 0x8000 ? -1 : 1;
+  const exponent = exponentWord & 0x7fff;
+  const mantissa = buffer.readBigUInt64BE(offset + 2);
+
+  const fraction = Number(mantissa) / 2 ** 63;
+  return sign * fraction * 2 ** (exponent - 16_383);
+}
+
+function parseAiffPcmHeader(buffer: Buffer): AiffPcmMetadata | null {
+  // Stryker disable next-line EqualityOperator: exactly 12 bytes contain only
+  // FORM metadata; parsing now or after the next read has identical behavior.
+  if (buffer.length < 12) return null;
+  if (
+    buffer.toString('ascii', 0, 4) !== 'FORM' ||
+    buffer.toString('ascii', 8, 12) !== 'AIFF'
+  ) {
+    throw new AudioDerivativeConversionError(
+      'invalid_source',
+      'Expected an uncompressed AIFF container'
+    );
+  }
+
+  let offset = 12;
+  let format: Omit<AiffPcmMetadata, 'dataBytes' | 'dataOffset'> | null = null;
+
+  // Stryker disable next-line EqualityOperator: an exact trailing chunk header
+  // cannot be acted on until its body arrives, so either branch awaits a read.
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString('ascii', offset, offset + 4);
+    const chunkSize = buffer.readUInt32BE(offset + 4);
+    const chunkDataOffset = offset + 8;
+    const paddedChunkEnd = chunkDataOffset + chunkSize + (chunkSize % 2);
+
+    if (chunkId === 'COMM') {
+      // Stryker disable next-line EqualityOperator: when exactly 18 bytes are
+      // buffered both branches converge on awaiting the following SSND chunk.
+      if (chunkSize < 18 || chunkDataOffset + 18 > buffer.length) return null;
+      format = {
+        channels: buffer.readUInt16BE(chunkDataOffset),
+        bitsPerSample: buffer.readUInt16BE(chunkDataOffset + 6),
+        sampleRate: readExtended80(buffer, chunkDataOffset + 8),
+      };
+    }
+
+    if (chunkId === 'SSND') {
+      if (chunkSize < 8 || chunkDataOffset + 8 > buffer.length) return null;
+      if (!format) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data appeared before its format declaration'
+        );
+      }
+
+      const soundOffset = buffer.readUInt32BE(chunkDataOffset);
+      const dataOffset = chunkDataOffset + 8 + soundOffset;
+      const dataBytes = chunkSize - 8 - soundOffset;
+      if (dataOffset > buffer.length) return null;
+
+      if (![8, 16, 24, 32].includes(format.bitsPerSample)) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF PCM bit depth is unsupported'
+        );
+      }
+      if (
+        !Number.isInteger(format.channels) ||
+        format.channels < 1 ||
+        format.channels > 8
+      ) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF channel count is unsupported'
+        );
+      }
+      if (
+        !Number.isInteger(format.sampleRate) ||
+        format.sampleRate < 8_000 ||
+        format.sampleRate > 384_000
+      ) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sample rate is unsupported'
+        );
+      }
+
+      const bytesPerSample = format.bitsPerSample / 8;
+      const blockAlign = format.channels * bytesPerSample;
+      if (dataBytes <= 0) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data is empty'
+        );
+      }
+      if (dataBytes % blockAlign !== 0) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data is not sample-aligned'
+        );
+      }
+      if (dataBytes + 44 > MAX_AUDIO_DERIVATIVE_BYTES) {
+        throw new AudioDerivativeConversionError(
+          'resource_limit',
+          'Playback derivative exceeds the output size limit'
+        );
+      }
+
+      return {
+        bitsPerSample: format.bitsPerSample,
+        channels: format.channels,
+        dataBytes,
+        dataOffset,
+        sampleRate: format.sampleRate,
+      };
+    }
+
+    offset = paddedChunkEnd;
+  }
+
+  return null;
+}
+
+function createWavHeader(metadata: AiffPcmMetadata): Buffer {
+  const bytesPerSample = metadata.bitsPerSample / 8;
+  const blockAlign = metadata.channels * bytesPerSample;
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0);
+  header.writeUInt32LE(metadata.dataBytes + 36, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(metadata.channels, 22);
+  header.writeUInt32LE(metadata.sampleRate, 24);
+  header.writeUInt32LE(metadata.sampleRate * blockAlign, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(metadata.bitsPerSample, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(metadata.dataBytes, 40);
+  return header;
+}
+
+function convertPcmByteOrder(chunk: Buffer, bytesPerSample: number): Buffer {
+  const converted = Buffer.from(chunk);
+  if (bytesPerSample === 1) {
+    for (const index of converted.keys()) {
+      converted[index] = (converted[index] ?? 0) ^ 0x80;
+    }
+    return converted;
+  }
+
+  for (let offset = 0; offset !== converted.length; offset += bytesPerSample) {
+    converted.subarray(offset, offset + bytesPerSample).reverse();
+  }
+  return converted;
+}
+
+export interface PreparedAudioDerivative {
+  readonly outputBytes: number;
+  readonly stream: Readable;
+}
+
+export async function prepareAiffPlaybackDerivative(
+  source: ReadableStream<Uint8Array>
+): Promise<PreparedAudioDerivative> {
+  const reader = source.getReader();
+  const headerChunks: Buffer[] = [];
+  let headerBytes = 0;
+  let metadata: AiffPcmMetadata | null = null;
+
+  while (!metadata) {
+    const next = await reader.read();
+    if (next.done) {
+      throw new AudioDerivativeConversionError(
+        'invalid_source',
+        'AIFF ended before sound data was found'
+      );
+    }
+
+    const chunk = Buffer.from(next.value);
+    headerChunks.push(chunk);
+    headerBytes += chunk.byteLength;
+    if (headerBytes > MAX_AIFF_HEADER_BYTES) {
+      await reader.cancel();
+      throw new AudioDerivativeConversionError(
+        'resource_limit',
+        'AIFF header exceeds the scan limit'
+      );
+    }
+    metadata = parseAiffPcmHeader(Buffer.concat(headerChunks, headerBytes));
+  }
+
+  const parsedMetadata = metadata;
+  const buffered = Buffer.concat(headerChunks, headerBytes);
+  const bytesPerSample = parsedMetadata.bitsPerSample / 8;
+  const initialAudio = buffered.subarray(parsedMetadata.dataOffset);
+
+  async function* wavChunks() {
+    let remaining = parsedMetadata.dataBytes;
+    let carry: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    try {
+      yield createWavHeader(parsedMetadata);
+
+      const emitPcm = function* (input: Buffer) {
+        // Stryker disable next-line ConditionalExpression: concatenating an
+        // empty carry is byte-equivalent but allocates on the hot path.
+        const combined = carry.length ? Buffer.concat([carry, input]) : input;
+        const available = Math.min(combined.length, remaining);
+        const aligned = available - (available % bytesPerSample);
+        // Stryker disable next-line ConditionalExpression,EqualityOperator:
+        // aligned is non-negative; emitting an empty Buffer is discarded by
+        // Node's Readable adapter and is observably byte-equivalent.
+        if (aligned > 0) {
+          const pcm = combined.subarray(0, aligned);
+          remaining -= aligned;
+          yield convertPcmByteOrder(pcm, bytesPerSample);
+        }
+        carry = combined.subarray(aligned, available);
+      };
+
+      yield* emitPcm(initialAudio);
+      while (remaining > 0) {
+        const next = await reader.read();
+        if (next.done) break;
+        yield* emitPcm(Buffer.from(next.value));
+      }
+
+      if (remaining !== 0) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data is truncated'
+        );
+      }
+    } finally {
+      await reader.cancel().catch(() => {});
+    }
+  }
+
+  return {
+    outputBytes: parsedMetadata.dataBytes + 44,
+    stream: Readable.from(wavChunks()),
+  };
+}

--- a/apps/web/lib/audio/constants.ts
+++ b/apps/web/lib/audio/constants.ts
@@ -10,7 +10,6 @@ export type {
   AudioFileDescriptor,
   AudioFormatDefinition,
   AudioFormatId,
-  AudioPlatform,
   AudioUploadSurface,
   Bpm,
   Milliseconds,

--- a/apps/web/lib/audio/jobs/playback-derivative.test.ts
+++ b/apps/web/lib/audio/jobs/playback-derivative.test.ts
@@ -1,0 +1,589 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  delMock: vi.fn(),
+  getMock: vi.fn(),
+  infoMock: vi.fn(),
+  putMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock('@vercel/blob', () => ({
+  del: hoisted.delMock,
+  get: hoisted.getMock,
+  put: hoisted.putMock,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    info: hoisted.infoMock,
+    warn: hoisted.warnMock,
+  },
+}));
+
+import {
+  AudioDerivativeConversionError,
+  MAX_AUDIO_DERIVATIVE_BYTES,
+} from '../aiff-to-wav';
+import { processAudioPlaybackDerivativeJob } from './playback-derivative';
+
+const RECORDING_ID = '00000000-0000-4000-8000-000000000001';
+const PROFILE_ID = '00000000-0000-4000-8000-000000000002';
+const JOB_ID = '00000000-0000-4000-8000-000000000003';
+
+function pendingMetadata() {
+  return {
+    audioPlaybackDerivative: {
+      status: 'pending',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      requestedAt: '2026-07-26T00:00:00.000Z',
+    },
+  };
+}
+
+function fakeTransaction(
+  recording: {
+    audioFormat: string | null;
+    audioUrl: string | null;
+    metadata: Record<string, unknown>;
+  },
+  updatedRows: readonly { id: string }[] = [{ id: RECORDING_ID }]
+) {
+  const setMock = vi.fn();
+  const returningMock = vi.fn().mockResolvedValue(updatedRows);
+  const whereUpdateMock = vi.fn().mockReturnValue({
+    returning: returningMock,
+  });
+  const updateMock = vi.fn().mockReturnValue({
+    set: (...args: unknown[]) => {
+      setMock(...args);
+      return { where: whereUpdateMock };
+    },
+  });
+  const limitMock = vi.fn().mockResolvedValue([recording]);
+  const selectMock = vi.fn().mockReturnValue({
+    from: () => ({
+      where: () => ({ limit: limitMock }),
+    }),
+  });
+
+  return {
+    tx: { select: selectMock, update: updateMock },
+    setMock,
+  };
+}
+
+function job(attempts = 1, maxAttempts = 3) {
+  return {
+    id: JOB_ID,
+    jobType: 'audio_playback_derivative',
+    payload: {
+      recordingId: RECORDING_ID,
+      creatorProfileId: PROFILE_ID,
+      formatId: 'aiff',
+      generation: 1,
+    },
+    status: 'processing',
+    error: null,
+    attempts,
+    runAt: new Date('2026-07-26T00:00:00.000Z'),
+    priority: -10,
+    maxAttempts,
+    nextRunAt: null,
+    dedupKey: `audio_playback_derivative:${RECORDING_ID}:1`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as const;
+}
+
+function mockRealAiffSource() {
+  const bytes = readFileSync(
+    resolve(process.cwd(), 'tests/fixtures/audio/tone.aiff')
+  );
+  hoisted.getMock.mockResolvedValue({
+    statusCode: 200,
+    stream: Readable.toWeb(Readable.from([bytes])),
+    blob: { size: bytes.byteLength },
+  });
+  return bytes;
+}
+
+function writtenState(setMock: ReturnType<typeof vi.fn>): string {
+  const metadata = setMock.mock.calls.at(-1)?.[0]?.metadata as
+    | { queryChunks?: unknown[] }
+    | undefined;
+  return (metadata?.queryChunks ?? [])
+    .flatMap(chunk => {
+      if (typeof chunk === 'string') return [chunk];
+      if (
+        chunk &&
+        typeof chunk === 'object' &&
+        'value' in chunk &&
+        Array.isArray(chunk.value)
+      ) {
+        return chunk.value.filter(value => typeof value === 'string');
+      }
+      return [];
+    })
+    .join('');
+}
+
+describe('audio playback derivative job', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.delMock.mockResolvedValue(undefined);
+    process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
+  });
+
+  it('streams a real AIFF to storage and publishes only the ready derivative', async () => {
+    const bytes = mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      let outputBytes = 0;
+      for await (const chunk of stream) outputBytes += chunk.byteLength;
+      expect(outputBytes).toBe(88_244);
+      return { url: 'https://blob.example/preview.wav' };
+    });
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await processAudioPlaybackDerivativeJob(tx as never, job() as never);
+
+    expect(hoisted.putMock).toHaveBeenCalledWith(
+      `audio-derivatives/${RECORDING_ID}/playback-1.wav`,
+      expect.any(Readable),
+      {
+        access: 'public',
+        addRandomSuffix: false,
+        allowOverwrite: true,
+        cacheControlMaxAge: 31_536_000,
+        contentType: 'audio/wav',
+        maximumSizeInBytes: MAX_AUDIO_DERIVATIVE_BYTES,
+        multipart: true,
+        token: 'test-token',
+        abortSignal: expect.any(AbortSignal),
+      }
+    );
+    expect(hoisted.getMock).toHaveBeenCalledWith(
+      'https://blob.example/master.aiff',
+      {
+        access: 'public',
+        token: 'test-token',
+        abortSignal: expect.any(AbortSignal),
+      }
+    );
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previewUrl: 'https://blob.example/preview.wav',
+      })
+    );
+    expect(writtenState(setMock)).toContain('"status":"ready"');
+    expect(writtenState(setMock)).toContain('"mimeType":"audio/wav"');
+    expect(writtenState(setMock)).toContain('"outputBytes":88244');
+    expect(hoisted.infoMock).toHaveBeenCalledWith(
+      'Audio playback derivative completed',
+      expect.objectContaining({
+        inputBytes: bytes.byteLength,
+        outputBytes: 88_244,
+        formatId: 'aiff',
+      })
+    );
+    expect(
+      hoisted.infoMock.mock.calls[0]?.[1]?.conversionDurationMs
+    ).toBeLessThan(10_000);
+  });
+
+  it('deletes its uploaded derivative when the generation loses the commit race', async () => {
+    mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      for await (const _chunk of stream) {
+        // Consume the real conversion stream before simulating the lost race.
+      }
+      return { url: 'https://blob.example/stale-preview.wav' };
+    });
+    const { tx } = fakeTransaction(
+      {
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        metadata: pendingMetadata(),
+      },
+      []
+    );
+
+    await processAudioPlaybackDerivativeJob(tx as never, job() as never);
+
+    expect(hoisted.delMock).toHaveBeenCalledWith(
+      'https://blob.example/stale-preview.wav',
+      { token: 'test-token' }
+    );
+    expect(hoisted.infoMock).not.toHaveBeenCalled();
+  });
+
+  it('resumes a retrying derivative generation', async () => {
+    mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      for await (const _chunk of stream) {
+        // Consume the real derivative before publishing it.
+      }
+      return { url: 'https://blob.example/retried-preview.wav' };
+    });
+    const { tx } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: {
+        audioPlaybackDerivative: {
+          status: 'retrying',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          attempt: 1,
+          maxAttempts: 3,
+          retryAt: '2026-07-26T00:01:00.000Z',
+        },
+      },
+    });
+
+    await processAudioPlaybackDerivativeJob(tx as never, job(2) as never);
+
+    expect(hoisted.putMock).toHaveBeenCalledOnce();
+    expect(hoisted.infoMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [
+      'a superseded generation',
+      {
+        status: 'superseded',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        supersededAt: '2026-07-26T00:01:00.000Z',
+      },
+    ],
+    [
+      'a different generation',
+      {
+        status: 'pending',
+        generation: 2,
+        sourceFormatId: 'aiff',
+        requestedAt: '2026-07-26T00:01:00.000Z',
+      },
+    ],
+    [
+      'a different source format',
+      {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'wav',
+        requestedAt: '2026-07-26T00:01:00.000Z',
+      },
+    ],
+    [
+      'an already ready derivative',
+      {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        readyAt: '2026-07-26T00:01:00.000Z',
+        url: 'https://blob.example/ready.wav',
+        mimeType: 'audio/wav',
+        outputBytes: 44,
+      },
+    ],
+  ])('does not process %s', async (_, derivative) => {
+    const { tx } = fakeTransaction({
+      audioFormat: 'audio/mpeg',
+      audioUrl: 'https://blob.example/new-master.mp3',
+      metadata: {
+        audioPlaybackDerivative: derivative,
+      },
+    });
+
+    await processAudioPlaybackDerivativeJob(tx as never, job() as never);
+
+    expect(hoisted.getMock).not.toHaveBeenCalled();
+    expect(hoisted.putMock).not.toHaveBeenCalled();
+  });
+
+  it('does not process a missing or untyped derivative record', async () => {
+    const { tx } = fakeTransaction(undefined as never);
+
+    await processAudioPlaybackDerivativeJob(tx as never, job(3) as never);
+
+    expect(hoisted.getMock).not.toHaveBeenCalled();
+    expect(hoisted.putMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'a missing master URL',
+      {
+        audioFormat: 'audio/aiff',
+        audioUrl: null,
+        metadata: pendingMetadata(),
+      },
+    ],
+    [
+      'a changed source format',
+      {
+        audioFormat: 'audio/mpeg',
+        audioUrl: 'https://blob.example/master.mp3',
+        metadata: pendingMetadata(),
+      },
+    ],
+  ])('fails closed for %s', async (_, recording) => {
+    const { tx, setMock } = fakeTransaction(recording as never);
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeJobError',
+      reason: 'invalid_source',
+      message: 'Audio derivative source is missing or changed',
+    });
+
+    expect(writtenState(setMock)).toContain('"status":"failed"');
+    expect(writtenState(setMock)).toContain('"reason":"invalid_source"');
+    expect(hoisted.getMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'a missing storage token',
+      () => {
+        delete process.env.BLOB_READ_WRITE_TOKEN;
+      },
+      'Audio derivative storage is not configured',
+      'storage_failed',
+    ],
+    [
+      'a missing blob response',
+      () => {
+        hoisted.getMock.mockResolvedValue(null);
+      },
+      'Audio derivative source could not be read',
+      'storage_failed',
+    ],
+    [
+      'a non-success blob response',
+      () => {
+        hoisted.getMock.mockResolvedValue({
+          statusCode: 404,
+          stream: new ReadableStream(),
+          blob: { size: 0 },
+        });
+      },
+      'Audio derivative source could not be read',
+      'storage_failed',
+    ],
+    [
+      'an oversized master',
+      () => {
+        hoisted.getMock.mockResolvedValue({
+          statusCode: 200,
+          stream: new ReadableStream(),
+          blob: { size: MAX_AUDIO_DERIVATIVE_BYTES + 1 },
+        });
+      },
+      'Audio derivative source exceeds the processing limit',
+      'resource_limit',
+    ],
+  ])('classifies %s without exposing storage input', async (_, setup, message, reason) => {
+    setup();
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeJobError',
+      message,
+      reason,
+    });
+
+    expect(writtenState(setMock)).toContain('"status":"failed"');
+    expect(writtenState(setMock)).toContain(`"reason":"${reason}"`);
+    expect(hoisted.putMock).not.toHaveBeenCalled();
+    expect(hoisted.delMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves conversion and timeout classifications through storage wrappers', async () => {
+    const invalidAiff = Buffer.from('not an aiff');
+    hoisted.getMock.mockResolvedValueOnce({
+      statusCode: 200,
+      stream: Readable.toWeb(Readable.from([invalidAiff])),
+      blob: { size: invalidAiff.byteLength },
+    });
+    const first = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+    await expect(
+      processAudioPlaybackDerivativeJob(first.tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'invalid_source',
+    });
+    expect(writtenState(first.setMock)).toContain('"reason":"invalid_source"');
+
+    const abortError = new Error('private abort detail');
+    abortError.name = 'AbortError';
+    hoisted.getMock.mockRejectedValueOnce(abortError);
+    const second = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+    await expect(
+      processAudioPlaybackDerivativeJob(second.tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'resource_limit',
+      message: 'Audio derivative processing timed out',
+    });
+    expect(writtenState(second.setMock)).toContain('"reason":"resource_limit"');
+
+    hoisted.getMock.mockRejectedValueOnce(
+      new AudioDerivativeConversionError(
+        'invalid_source',
+        'Typed conversion failure'
+      )
+    );
+    const third = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+    await expect(
+      processAudioPlaybackDerivativeJob(third.tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'invalid_source',
+      message: 'Typed conversion failure',
+    });
+  });
+
+  it('allows a source exactly at the processing-size boundary', async () => {
+    hoisted.getMock.mockResolvedValue({
+      statusCode: 200,
+      stream: null,
+      blob: { size: MAX_AUDIO_DERIVATIVE_BYTES },
+    });
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({ reason: 'conversion_failed' });
+    expect(writtenState(setMock)).toContain('"reason":"conversion_failed"');
+  });
+
+  it('classifies an unexpected conversion exception without logging its value', async () => {
+    hoisted.getMock.mockResolvedValue({
+      statusCode: 200,
+      stream: null,
+      blob: { size: 10 },
+    });
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'conversion_failed',
+      message: 'Audio derivative processing failed',
+    });
+    expect(writtenState(setMock)).toContain('"reason":"conversion_failed"');
+    expect(JSON.stringify(hoisted.warnMock.mock.calls)).not.toContain(
+      'getReader'
+    );
+  });
+
+  it('redacts storage failures and transitions to retrying', async () => {
+    hoisted.getMock.mockRejectedValue(
+      new Error('https://private.example/master.aiff?secret=value')
+    );
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job() as never)
+    ).rejects.toThrow('Audio derivative source could not be read');
+
+    const logged = JSON.stringify(hoisted.warnMock.mock.calls);
+    expect(logged).not.toContain('private.example');
+    expect(logged).not.toContain('secret=value');
+    expect(setMock).toHaveBeenCalled();
+    expect(writtenState(setMock)).toContain('"status":"retrying"');
+    expect(writtenState(setMock)).toContain('"attempt":1');
+    expect(writtenState(setMock)).toContain('"maxAttempts":3');
+    expect(hoisted.warnMock).toHaveBeenCalledWith(
+      'Audio playback derivative failed',
+      expect.objectContaining({
+        failureReason: 'storage_failed',
+        attempt: 1,
+        maxAttempts: 3,
+      })
+    );
+    expect(
+      hoisted.warnMock.mock.calls[0]?.[1]?.conversionDurationMs
+    ).toBeLessThan(10_000);
+  });
+
+  it('moves the last failed attempt to a terminal failed state', async () => {
+    hoisted.getMock.mockRejectedValue(new Error('private storage detail'));
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3, 3) as never)
+    ).rejects.toMatchObject({ reason: 'storage_failed' });
+
+    expect(writtenState(setMock)).toContain('"status":"failed"');
+    expect(writtenState(setMock)).toContain('"reason":"storage_failed"');
+  });
+
+  it('redacts upload failures and classifies them as storage failures', async () => {
+    mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      for await (const _chunk of stream) {
+        // Consume the derivative so conversion is proven before storage fails.
+      }
+      throw new Error('https://private.example/preview.wav?secret=value');
+    });
+    const { tx } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job() as never)
+    ).rejects.toThrow('Audio derivative could not be stored');
+
+    const logged = JSON.stringify(hoisted.warnMock.mock.calls);
+    expect(logged).not.toContain('private.example');
+    expect(logged).not.toContain('secret=value');
+    expect(hoisted.warnMock).toHaveBeenCalledWith(
+      'Audio playback derivative failed',
+      expect.objectContaining({ failureReason: 'storage_failed' })
+    );
+  });
+});

--- a/apps/web/lib/audio/jobs/playback-derivative.ts
+++ b/apps/web/lib/audio/jobs/playback-derivative.ts
@@ -1,0 +1,266 @@
+import type { AudioPlaybackDerivative } from '@jovie/audio-contracts';
+import { del, get, put } from '@vercel/blob';
+import { and, sql as drizzleSql, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { DbOrTransaction } from '@/lib/db';
+import { discogRecordings } from '@/lib/db/schema/content';
+import type { ingestionJobs } from '@/lib/db/schema/ingestion';
+import { env } from '@/lib/env-server';
+import { logger } from '@/lib/utils/logger';
+import {
+  AudioDerivativeConversionError,
+  MAX_AUDIO_DERIVATIVE_BYTES,
+  prepareAiffPlaybackDerivative,
+} from '../aiff-to-wav';
+import { parseAudioPlaybackDerivative } from '../playback-derivative';
+
+const AUDIO_DERIVATIVE_TIMEOUT_MS = 240_000;
+
+export const audioPlaybackDerivativePayloadSchema = z.object({
+  recordingId: z.string().uuid(),
+  creatorProfileId: z.string().uuid(),
+  formatId: z.literal('aiff'),
+  generation: z.number().int().positive(),
+});
+
+class AudioDerivativeJobError extends Error {
+  constructor(
+    readonly reason:
+      | 'invalid_source'
+      | 'conversion_failed'
+      | 'resource_limit'
+      | 'storage_failed',
+    message: string
+  ) {
+    super(message);
+    this.name = 'AudioDerivativeJobError';
+  }
+}
+
+function safeJobError(error: unknown): AudioDerivativeJobError {
+  if (error instanceof AudioDerivativeJobError) return error;
+  if (error instanceof AudioDerivativeConversionError) {
+    return new AudioDerivativeJobError(error.code, error.message);
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return new AudioDerivativeJobError(
+      'resource_limit',
+      'Audio derivative processing timed out'
+    );
+  }
+  return new AudioDerivativeJobError(
+    'conversion_failed',
+    'Audio derivative processing failed'
+  );
+}
+
+function safeStorageError(
+  error: unknown,
+  message: string
+): AudioDerivativeJobError | AudioDerivativeConversionError | Error {
+  if (
+    error instanceof AudioDerivativeConversionError ||
+    (error instanceof Error && error.name === 'AbortError')
+  ) {
+    return error;
+  }
+  return new AudioDerivativeJobError('storage_failed', message);
+}
+
+async function writeDerivativeState(
+  tx: DbOrTransaction,
+  input: {
+    readonly creatorProfileId: string;
+    readonly derivative: AudioPlaybackDerivative;
+    readonly previewUrl?: string;
+    readonly recordingId: string;
+  }
+) {
+  const [updated] = await tx
+    .update(discogRecordings)
+    .set({
+      metadata: drizzleSql`jsonb_set(
+        coalesce(${discogRecordings.metadata}, '{}'::jsonb),
+        '{audioPlaybackDerivative}',
+        ${JSON.stringify(input.derivative)}::jsonb,
+        true
+      )`,
+      ...(input.previewUrl ? { previewUrl: input.previewUrl } : {}),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(discogRecordings.id, input.recordingId),
+        eq(discogRecordings.creatorProfileId, input.creatorProfileId),
+        drizzleSql`${discogRecordings.metadata} -> 'audioPlaybackDerivative' ->> 'generation' = ${String(input.derivative.generation)}`
+      )
+    )
+    .returning({ id: discogRecordings.id });
+  return Boolean(updated);
+}
+
+export async function processAudioPlaybackDerivativeJob(
+  tx: DbOrTransaction,
+  job: typeof ingestionJobs.$inferSelect
+): Promise<void> {
+  const payload = audioPlaybackDerivativePayloadSchema.parse(job.payload);
+  const startedAt = Date.now();
+  const queueDelayMs = Math.max(0, startedAt - job.createdAt.getTime());
+  const [recording] = await tx
+    .select({
+      audioFormat: discogRecordings.audioFormat,
+      audioUrl: discogRecordings.audioUrl,
+      metadata: discogRecordings.metadata,
+    })
+    .from(discogRecordings)
+    .where(
+      and(
+        eq(discogRecordings.id, payload.recordingId),
+        eq(discogRecordings.creatorProfileId, payload.creatorProfileId)
+      )
+    )
+    .limit(1);
+
+  if (!recording) return;
+  const currentDerivative = parseAudioPlaybackDerivative(recording.metadata);
+  if (
+    !currentDerivative ||
+    currentDerivative.generation !== payload.generation ||
+    currentDerivative.sourceFormatId !== payload.formatId ||
+    !['pending', 'retrying'].includes(currentDerivative.status)
+  ) {
+    return;
+  }
+
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    AUDIO_DERIVATIVE_TIMEOUT_MS
+  );
+  let uploadedUrl: string | null = null;
+  let derivativeCommitted = false;
+
+  try {
+    if (!recording.audioUrl || recording.audioFormat !== 'audio/aiff') {
+      throw new AudioDerivativeJobError(
+        'invalid_source',
+        'Audio derivative source is missing or changed'
+      );
+    }
+    if (!token) {
+      throw new AudioDerivativeJobError(
+        'storage_failed',
+        'Audio derivative storage is not configured'
+      );
+    }
+
+    const source = await get(recording.audioUrl, {
+      access: 'public',
+      token,
+      abortSignal: controller.signal,
+    }).catch(error => {
+      throw safeStorageError(
+        error,
+        'Audio derivative source could not be read'
+      );
+    });
+    if (!source || source.statusCode !== 200) {
+      throw new AudioDerivativeJobError(
+        'storage_failed',
+        'Audio derivative source could not be read'
+      );
+    }
+    if (source.blob.size > MAX_AUDIO_DERIVATIVE_BYTES) {
+      throw new AudioDerivativeJobError(
+        'resource_limit',
+        'Audio derivative source exceeds the processing limit'
+      );
+    }
+
+    const prepared = await prepareAiffPlaybackDerivative(source.stream);
+    const pathname = `audio-derivatives/${payload.recordingId}/playback-${payload.generation}.wav`;
+    const uploaded = await put(pathname, prepared.stream, {
+      access: 'public',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+      cacheControlMaxAge: 60 * 60 * 24 * 365,
+      contentType: 'audio/wav',
+      maximumSizeInBytes: MAX_AUDIO_DERIVATIVE_BYTES,
+      multipart: true,
+      token,
+      abortSignal: controller.signal,
+    }).catch(error => {
+      throw safeStorageError(error, 'Audio derivative could not be stored');
+    });
+    uploadedUrl = uploaded.url;
+
+    const ready: AudioPlaybackDerivative = {
+      status: 'ready',
+      generation: payload.generation,
+      sourceFormatId: payload.formatId,
+      url: uploaded.url,
+      mimeType: 'audio/wav',
+      readyAt: new Date().toISOString(),
+      outputBytes: prepared.outputBytes,
+    };
+    derivativeCommitted = await writeDerivativeState(tx, {
+      recordingId: payload.recordingId,
+      creatorProfileId: payload.creatorProfileId,
+      derivative: ready,
+      previewUrl: uploaded.url,
+    });
+    if (!derivativeCommitted) return;
+
+    logger.info('Audio playback derivative completed', {
+      jobId: job.id,
+      recordingId: payload.recordingId,
+      queueDelayMs,
+      conversionDurationMs: Date.now() - startedAt,
+      inputBytes: source.blob.size,
+      outputBytes: prepared.outputBytes,
+      formatId: payload.formatId,
+    });
+  } catch (error) {
+    const safeError = safeJobError(error);
+    const shouldRetry = job.attempts < job.maxAttempts;
+    const derivative: AudioPlaybackDerivative = shouldRetry
+      ? {
+          status: 'retrying',
+          generation: payload.generation,
+          sourceFormatId: payload.formatId,
+          attempt: job.attempts,
+          maxAttempts: job.maxAttempts,
+          retryAt: new Date().toISOString(),
+        }
+      : {
+          status: 'failed',
+          generation: payload.generation,
+          sourceFormatId: payload.formatId,
+          reason: safeError.reason,
+          failedAt: new Date().toISOString(),
+        };
+    await writeDerivativeState(tx, {
+      recordingId: payload.recordingId,
+      creatorProfileId: payload.creatorProfileId,
+      derivative,
+    });
+
+    logger.warn('Audio playback derivative failed', {
+      jobId: job.id,
+      recordingId: payload.recordingId,
+      queueDelayMs,
+      conversionDurationMs: Date.now() - startedAt,
+      formatId: payload.formatId,
+      failureReason: safeError.reason,
+      attempt: job.attempts,
+      maxAttempts: job.maxAttempts,
+    });
+    throw safeError;
+  } finally {
+    clearTimeout(timeoutId);
+    if (token && uploadedUrl && !derivativeCommitted) {
+      await del(uploadedUrl, { token }).catch(() => {});
+    }
+  }
+}

--- a/apps/web/lib/audio/playback-derivative.test.ts
+++ b/apps/web/lib/audio/playback-derivative.test.ts
@@ -1,0 +1,354 @@
+import { AUDIO_FORMAT_IDS } from '@jovie/audio-contracts';
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY,
+  nextAudioDerivativeGeneration,
+  parseAudioPlaybackDerivative,
+  resolveRecordingPlayback,
+  withAudioPlaybackDerivative,
+} from './playback-derivative';
+
+const pending = {
+  status: 'pending',
+  generation: 1,
+  sourceFormatId: 'aiff',
+  requestedAt: '2026-07-26T00:00:00.000Z',
+} as const;
+
+function derivativeMetadata(value: unknown) {
+  return { [AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY]: value };
+}
+
+describe('audio playback derivative metadata', () => {
+  it('keeps one stable metadata key', () => {
+    expect(AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY).toBe(
+      'audioPlaybackDerivative'
+    );
+  });
+
+  it('round-trips a valid derivative without replacing sibling metadata', () => {
+    const metadata = withAudioPlaybackDerivative(
+      { spotifyId: 'track-1' },
+      pending
+    );
+
+    expect(metadata.spotifyId).toBe('track-1');
+    expect(parseAudioPlaybackDerivative(metadata)).toEqual(pending);
+    expect(nextAudioDerivativeGeneration(metadata)).toBe(2);
+  });
+
+  it.each([
+    null,
+    {},
+    { status: 'pending', generation: 0, sourceFormatId: 'aiff' },
+    {
+      status: 'ready',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      url: 'https://blob.example/preview.wav',
+      mimeType: 'audio/wav',
+      readyAt: '2026-07-26T00:00:00.000Z',
+      outputBytes: 0,
+    },
+    {
+      status: 'ready',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      url: 'javascript:alert(1)',
+      mimeType: 'audio/mpeg',
+      readyAt: '2026-07-26T00:00:00.000Z',
+      outputBytes: 88_244,
+    },
+    {
+      status: 'retrying',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      attempt: 3,
+      maxAttempts: 2,
+      retryAt: '2026-07-26T00:01:00.000Z',
+    },
+  ])('rejects malformed derivative metadata %#', value => {
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it.each(
+    AUDIO_FORMAT_IDS
+  )('accepts %s as a typed derivative source format', sourceFormatId => {
+    const value = { ...pending, sourceFormatId };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+      value
+    );
+  });
+
+  it.each([
+    undefined,
+    null,
+    '',
+    [],
+    1,
+    { ...pending, generation: 1.5 },
+    { ...pending, generation: 0 },
+    { ...pending, generation: -1 },
+    { ...pending, sourceFormatId: 'ogg' },
+    { ...pending, sourceFormatId: 1 },
+    { ...pending, requestedAt: null },
+    { ...pending, status: 'unknown' },
+  ])('rejects invalid derivative shape %#', value => {
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it('accepts canonical ready metadata over HTTP and HTTPS', () => {
+    for (const url of [
+      'https://blob.example/preview.wav',
+      'http://localhost/preview.wav',
+    ]) {
+      const value = {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        url,
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      };
+      expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+        value
+      );
+    }
+  });
+
+  it.each([
+    { url: 1 },
+    { url: new URL('https://blob.example/preview.wav') },
+    { url: 'not a URL' },
+    { url: 'ftp://blob.example/preview.wav' },
+    { mimeType: 'audio/mpeg' },
+    { readyAt: null },
+    { outputBytes: 1.5 },
+    { outputBytes: 0 },
+  ])('rejects ready metadata with invalid field %#', override => {
+    const value = {
+      status: 'ready',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      url: 'https://blob.example/preview.wav',
+      mimeType: 'audio/wav',
+      readyAt: '2026-07-26T00:00:01.000Z',
+      outputBytes: 88_244,
+      ...override,
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it.each([
+    'invalid_source',
+    'conversion_failed',
+    'resource_limit',
+    'storage_failed',
+  ] as const)('accepts the %s terminal failure reason', reason => {
+    const value = {
+      status: 'failed',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      reason,
+      failedAt: '2026-07-26T00:00:01.000Z',
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+      value
+    );
+  });
+
+  it.each([
+    { reason: 'unknown' },
+    { failedAt: null },
+  ])('rejects failed metadata with invalid field %#', override => {
+    const value = {
+      status: 'failed',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      reason: 'conversion_failed',
+      failedAt: '2026-07-26T00:00:01.000Z',
+      ...override,
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it.each([
+    'platform_unsupported',
+    'conversion_not_supported',
+  ] as const)('accepts the %s unavailable reason', reason => {
+    const value = {
+      status: 'unavailable',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      reason,
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+      value
+    );
+  });
+
+  it('rejects an unknown unavailable reason', () => {
+    expect(
+      parseAudioPlaybackDerivative(
+        derivativeMetadata({
+          status: 'unavailable',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          reason: 'unknown',
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('accepts retry boundaries and rejects every malformed retry field', () => {
+    const valid = {
+      status: 'retrying',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      attempt: 1,
+      maxAttempts: 1,
+      retryAt: '2026-07-26T00:01:00.000Z',
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(valid))).toEqual(
+      valid
+    );
+
+    for (const override of [
+      { attempt: 0 },
+      { attempt: 1.5 },
+      { maxAttempts: 0 },
+      { maxAttempts: 1.5 },
+      { attempt: 2, maxAttempts: 1 },
+      { retryAt: null },
+    ]) {
+      expect(
+        parseAudioPlaybackDerivative(
+          derivativeMetadata({ ...valid, ...override })
+        )
+      ).toBeNull();
+    }
+  });
+
+  it('accepts only a timestamped superseded state', () => {
+    const valid = {
+      status: 'superseded',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      supersededAt: '2026-07-26T00:01:00.000Z',
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(valid))).toEqual(
+      valid
+    );
+    expect(
+      parseAudioPlaybackDerivative(
+        derivativeMetadata({ ...valid, supersededAt: null })
+      )
+    ).toBeNull();
+  });
+
+  it('starts the derivative generation at one without metadata', () => {
+    expect(nextAudioDerivativeGeneration(undefined)).toBe(1);
+  });
+});
+
+describe('recording playback resolution', () => {
+  it('uses an existing verified preview without falling back to its master', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: null,
+        audioUrl: 'https://blob.example/master.aiff',
+        previewUrl: 'https://blob.example/verified-preview.wav',
+        metadata: {},
+      })
+    ).toEqual({
+      status: 'ready',
+      source: 'derivative',
+      url: 'https://blob.example/verified-preview.wav',
+    });
+  });
+
+  it('uses a directly playable master', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/mpeg',
+        audioUrl: 'https://blob.example/master.mp3',
+        metadata: {},
+      })
+    ).toEqual({
+      status: 'ready',
+      source: 'master',
+      url: 'https://blob.example/master.mp3',
+    });
+  });
+
+  it.each([
+    {
+      audioFormat: 'audio/mpeg',
+      audioUrl: null,
+      metadata: {},
+    },
+    {
+      audioFormat: null,
+      audioUrl: 'https://blob.example/master.mp3',
+      metadata: {},
+    },
+    {
+      audioFormat: 'audio/unknown',
+      audioUrl: 'https://blob.example/master.bin',
+      metadata: {},
+    },
+  ])('fails closed when a master is not fully typed %#', input => {
+    expect(resolveRecordingPlayback(input)).toEqual({
+      status: 'unavailable',
+      source: null,
+      url: null,
+    });
+  });
+
+  it('does not expose an AIFF master while its derivative is pending', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        metadata: withAudioPlaybackDerivative({}, pending),
+      })
+    ).toEqual({ status: 'pending', source: null, url: null });
+  });
+
+  it('fails closed for a legacy AIFF preview that aliases its master', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        previewUrl: 'https://blob.example/master.aiff',
+        metadata: {},
+      })
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+
+  it('uses only a ready derivative for AIFF', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        metadata: withAudioPlaybackDerivative(
+          {},
+          {
+            status: 'ready',
+            generation: 1,
+            sourceFormatId: 'aiff',
+            url: 'https://blob.example/preview.wav',
+            mimeType: 'audio/wav',
+            readyAt: '2026-07-26T00:00:01.000Z',
+            outputBytes: 88_244,
+          }
+        ),
+      })
+    ).toEqual({
+      status: 'ready',
+      source: 'derivative',
+      url: 'https://blob.example/preview.wav',
+    });
+  });
+});

--- a/apps/web/lib/audio/playback-derivative.ts
+++ b/apps/web/lib/audio/playback-derivative.ts
@@ -1,0 +1,139 @@
+import {
+  AUDIO_FORMAT_IDS,
+  type AudioFormatId,
+  type AudioPlaybackAsset,
+  type AudioPlaybackDerivative,
+  getAudioFormatByMimeType,
+  resolveAudioSource,
+} from '@jovie/audio-contracts';
+
+// Stryker disable next-line StringLiteral: module initializer mutations run
+// before the active mutant test and are guarded by an exact-value test.
+export const AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY = 'audioPlaybackDerivative';
+
+function isAudioFormatId(value: unknown): value is AudioFormatId {
+  return AUDIO_FORMAT_IDS.includes(value as AudioFormatId);
+}
+
+function isHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  if (!URL.canParse(value)) return false;
+  const parsed = new URL(value);
+  return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+}
+
+function isBaseDerivative(value: Record<string, unknown>): value is Record<
+  string,
+  unknown
+> & {
+  generation: number;
+  sourceFormatId: AudioFormatId;
+} {
+  return (
+    Number.isInteger(value.generation) &&
+    Number(value.generation) > 0 &&
+    isAudioFormatId(value.sourceFormatId)
+  );
+}
+
+export function parseAudioPlaybackDerivative(
+  metadata: Record<string, unknown> | null | undefined
+): AudioPlaybackDerivative | null {
+  const value = metadata?.[AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY];
+  if (!value || Array.isArray(value)) return null;
+
+  const candidate = value as Record<string, unknown>;
+  if (!isBaseDerivative(candidate)) return null;
+
+  switch (candidate.status) {
+    case 'pending':
+      return typeof candidate.requestedAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'ready':
+      return isHttpUrl(candidate.url) &&
+        candidate.mimeType === 'audio/wav' &&
+        typeof candidate.readyAt === 'string' &&
+        Number.isInteger(candidate.outputBytes) &&
+        Number(candidate.outputBytes) > 0
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'failed':
+      return [
+        'invalid_source',
+        'conversion_failed',
+        'resource_limit',
+        'storage_failed',
+      ].includes(String(candidate.reason)) &&
+        typeof candidate.failedAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'unavailable':
+      return ['platform_unsupported', 'conversion_not_supported'].includes(
+        String(candidate.reason)
+      )
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'retrying':
+      return Number.isInteger(candidate.attempt) &&
+        Number(candidate.attempt) > 0 &&
+        Number.isInteger(candidate.maxAttempts) &&
+        Number(candidate.maxAttempts) >= Number(candidate.attempt) &&
+        typeof candidate.retryAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'superseded':
+      return typeof candidate.supersededAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    default:
+      return null;
+  }
+}
+
+export function nextAudioDerivativeGeneration(
+  metadata: Record<string, unknown> | null | undefined
+): number {
+  return (parseAudioPlaybackDerivative(metadata)?.generation ?? 0) + 1;
+}
+
+export function withAudioPlaybackDerivative(
+  metadata: Record<string, unknown> | null | undefined,
+  derivative: AudioPlaybackDerivative
+): Record<string, unknown> {
+  return {
+    ...(metadata ?? {}),
+    [AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY]: derivative,
+  };
+}
+
+export function resolveRecordingPlayback(input: {
+  readonly audioFormat: string | null;
+  readonly audioUrl: string | null;
+  readonly previewUrl?: string | null;
+  readonly metadata?: Record<string, unknown> | null;
+}) {
+  if (input.previewUrl && input.previewUrl !== input.audioUrl) {
+    return {
+      status: 'ready',
+      source: 'derivative',
+      url: input.previewUrl,
+    } as const;
+  }
+
+  if (!input.audioUrl || !input.audioFormat) {
+    return { status: 'unavailable', source: null, url: null } as const;
+  }
+
+  const format = getAudioFormatByMimeType(input.audioFormat);
+  if (!format) {
+    return { status: 'unavailable', source: null, url: null } as const;
+  }
+
+  const asset: AudioPlaybackAsset = {
+    formatId: format.id,
+    masterUrl: input.audioUrl,
+    derivative: parseAudioPlaybackDerivative(input.metadata),
+  };
+  return resolveAudioSource(asset, 'web_chromium', 'nativePlayback');
+}

--- a/apps/web/lib/audio/resolve-release-recording.ts
+++ b/apps/web/lib/audio/resolve-release-recording.ts
@@ -11,6 +11,7 @@ export type ReleasePrimaryRecording = {
   readonly recordingId: string;
   readonly previewUrl: string | null;
   readonly audioUrl: string | null;
+  readonly audioFormat: string | null;
   readonly durationMs: number | null;
   readonly metadata: Record<string, unknown>;
 };
@@ -24,6 +25,7 @@ export async function resolvePrimaryRecordingForRelease(
       recordingId: discogRecordings.id,
       previewUrl: discogRecordings.previewUrl,
       audioUrl: discogRecordings.audioUrl,
+      audioFormat: discogRecordings.audioFormat,
       durationMs: discogRecordings.durationMs,
       metadata: discogRecordings.metadata,
     })
@@ -51,6 +53,7 @@ export async function resolvePrimaryRecordingForRelease(
     recordingId: row.recordingId,
     previewUrl: row.previewUrl,
     audioUrl: row.audioUrl,
+    audioFormat: row.audioFormat,
     durationMs: row.durationMs,
     metadata: row.metadata ?? {},
   };

--- a/apps/web/lib/discography/adapters.audio-capability.test.ts
+++ b/apps/web/lib/discography/adapters.audio-capability.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { mapTrackToViewModel } from './adapters';
+import type { ProviderKey } from './types';
+
+function track(metadata: Record<string, unknown>, previewUrl: string | null) {
+  return {
+    id: 'recording-1',
+    releaseId: 'release-1',
+    title: 'First Light',
+    slug: 'first-light',
+    trackNumber: 1,
+    discNumber: 1,
+    durationMs: 60_000,
+    isrc: null,
+    isExplicit: false,
+    previewUrl,
+    audioUrl: 'https://blob.example/master.aiff',
+    audioFormat: 'audio/aiff',
+    metadata,
+    providerLinks: [],
+  };
+}
+
+function map(metadata: Record<string, unknown>, previewUrl: string | null) {
+  return mapTrackToViewModel({
+    track: track(metadata, previewUrl),
+    providerLabels: {} as Record<ProviderKey, string>,
+    profileHandle: 'artist',
+    releaseSlug: 'first-light',
+  });
+}
+
+describe('track view-model audio capability', () => {
+  it('does not hand an AIFF master to playback while conversion is pending', () => {
+    const result = map(
+      {
+        audioPlaybackDerivative: {
+          status: 'pending',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          requestedAt: '2026-07-26T00:00:00.000Z',
+        },
+      },
+      null
+    );
+
+    expect(result.previewUrl).toBeNull();
+    expect(result.audioUrl).toBeNull();
+    expect(result.previewSource).toBeNull();
+    expect(result.previewVerification).toBe('missing');
+  });
+
+  it('does not trust a legacy AIFF preview that aliases its master', () => {
+    const result = map({}, 'https://blob.example/master.aiff');
+
+    expect(result.previewUrl).toBeNull();
+    expect(result.audioUrl).toBeNull();
+    expect(result.previewSource).toBeNull();
+    expect(result.previewVerification).toBe('missing');
+  });
+
+  it('hands consumers only the ready AIFF derivative', () => {
+    const result = map(
+      {
+        audioPlaybackDerivative: {
+          status: 'ready',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          url: 'https://blob.example/preview.wav',
+          mimeType: 'audio/wav',
+          readyAt: '2026-07-26T00:00:01.000Z',
+          outputBytes: 88_244,
+        },
+      },
+      'https://blob.example/preview.wav'
+    );
+
+    expect(result.previewUrl).toBe('https://blob.example/preview.wav');
+    expect(result.audioUrl).toBe('https://blob.example/preview.wav');
+    expect(result.previewSource).toBe('audio_url');
+    expect(result.previewVerification).toBe('verified');
+  });
+});

--- a/apps/web/lib/discography/adapters.ts
+++ b/apps/web/lib/discography/adapters.ts
@@ -1,3 +1,4 @@
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import { toISOStringOrFallback } from '@/lib/utils/date';
 import {
   derivePreviewState,
@@ -76,9 +77,11 @@ export function mapTrackToViewModel(params: {
   releaseSlug: string;
 }): TrackViewModel {
   const { track, providerLabels, profileHandle, releaseSlug } = params;
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.url;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -101,8 +104,8 @@ export function mapTrackToViewModel(params: {
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     previewSource: previewState.previewSource,
     previewVerification: previewState.previewVerification,

--- a/apps/web/lib/discography/release-track-loader.ts
+++ b/apps/web/lib/discography/release-track-loader.ts
@@ -1,3 +1,4 @@
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import {
   derivePreviewState,
   getProviderConfidence,
@@ -76,9 +77,11 @@ function mapLegacyTrackToViewModel(
   profileHandle: string,
   releaseSlug: string
 ): TrackViewModel {
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.status === 'ready' ? playback.url : null;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -99,8 +102,8 @@ function mapLegacyTrackToViewModel(
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     lyrics: track.lyrics,
     previewSource: previewState.previewSource,
@@ -122,9 +125,11 @@ function mapReleaseTrackToViewModel(
   profileHandle: string,
   releaseSlug: string
 ): TrackViewModel {
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.status === 'ready' ? playback.url : null;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -147,8 +152,8 @@ function mapReleaseTrackToViewModel(
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     lyrics: track.lyrics,
     previewSource: previewState.previewSource,

--- a/apps/web/lib/ingestion/processor.ts
+++ b/apps/web/lib/ingestion/processor.ts
@@ -11,6 +11,7 @@
  * - Merge logic: import from './merge'
  */
 
+import { processAudioPlaybackDerivativeJob } from '@/lib/audio/jobs/playback-derivative';
 import type { DbOrTransaction } from '@/lib/db';
 import type { ingestionJobs } from '@/lib/db/schema/ingestion';
 import {
@@ -78,6 +79,8 @@ export async function processJob(
   job: typeof ingestionJobs.$inferSelect
 ) {
   switch (job.jobType) {
+    case 'audio_playback_derivative':
+      return processAudioPlaybackDerivativeJob(tx, job);
     case 'import_linktree':
       return processLinktreeJob(tx, job.payload);
     case 'import_laylo':

--- a/apps/web/lib/ingestion/scheduler.ts
+++ b/apps/web/lib/ingestion/scheduler.ts
@@ -85,6 +85,10 @@ export function determineJobFailure(error: unknown): {
  * Extract hostname from a job's payload URL.
  */
 function getJobHost(job: typeof ingestionJobs.$inferSelect): string | null {
+  if (job.jobType === 'audio_playback_derivative') {
+    return 'provider:audio-derivative';
+  }
+
   if (job.jobType === 'musicfetch_enrichment') {
     return 'provider:musicfetch';
   }

--- a/apps/web/lib/library-share/service.ts
+++ b/apps/web/lib/library-share/service.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
 import { BASE_URL } from '@/constants/app';
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import { db } from '@/lib/db';
 import {
   discogRecordings,
@@ -56,6 +57,8 @@ async function loadDropAssets(
       releaseMetadata: discogReleases.metadata,
       previewUrl: discogRecordings.previewUrl,
       audioUrl: discogRecordings.audioUrl,
+      audioFormat: discogRecordings.audioFormat,
+      recordingMetadata: discogRecordings.metadata,
       recordingLyrics: discogRecordings.lyrics,
       slug: discogReleases.slug,
       artistName: creatorProfiles.displayName,
@@ -85,6 +88,12 @@ async function loadDropAssets(
     .orderBy(asc(libraryShareDropItems.position));
 
   return rows.map(row => {
+    const playback = resolveRecordingPlayback({
+      audioFormat: row.audioFormat,
+      audioUrl: row.audioUrl,
+      previewUrl: row.previewUrl,
+      metadata: row.recordingMetadata,
+    });
     const metadataLyrics = (
       row.releaseMetadata as Record<string, unknown> | null
     )?.lyrics;
@@ -99,7 +108,9 @@ async function loadDropAssets(
       title: row.title,
       artistName: row.artistName?.trim() || 'Unknown Artist',
       artworkUrl: normalizeHttpUrl(row.artworkUrl),
-      previewUrl: normalizeHttpUrl(row.previewUrl ?? row.audioUrl),
+      previewUrl: normalizeHttpUrl(
+        playback.status === 'ready' ? playback.url : null
+      ),
       lyrics: row.includeLyrics ? lyrics : null,
       releaseType: row.releaseType,
       releaseDate: row.releaseDate?.toISOString() ?? null,

--- a/apps/web/stryker.audio.config.mjs
+++ b/apps/web/stryker.audio.config.mjs
@@ -18,10 +18,25 @@ const config = {
     // forwards the complete typed source into the singleton.
     'components/organisms/GlobalAudioPreviewAction.tsx:56-65',
     'components/organisms/GlobalAudioPreviewAction.tsx:68-77',
+    // JOV-4393 keeps accepted masters separate from browser playback,
+    // streams the AIFF derivative, and fails closed through every transition.
+    'lib/audio/aiff-to-wav.ts',
+    'lib/audio/playback-derivative.ts',
+    'lib/audio/jobs/playback-derivative.ts:40-68',
+    'lib/audio/jobs/playback-derivative.ts:124-133',
+    'lib/audio/jobs/playback-derivative.ts:144-213',
+    'lib/audio/jobs/playback-derivative.ts:224-265',
+    'lib/discography/adapters.ts:79-112',
+    'components/features/release/ReleaseAudioAssetPanel.tsx:274-329',
   ],
   testFiles: [
     'tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts',
     'tests/components/organisms/GlobalAudioPreviewAction.test.tsx',
+    'lib/audio/aiff-to-wav.test.ts',
+    'lib/audio/playback-derivative.test.ts',
+    'lib/audio/jobs/playback-derivative.test.ts',
+    'lib/discography/adapters.audio-capability.test.ts',
+    'tests/components/features/release/ReleaseAudioAssetPanel.test.tsx',
   ],
   ignorePatterns: [
     '.next',

--- a/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
+++ b/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReleaseAudioAssetPanel } from '@/components/features/release/ReleaseAudioAssetPanel';
 
 const blobUploadMock = vi.fn();
@@ -21,15 +27,23 @@ vi.mock('sonner', () => ({
 }));
 
 describe('ReleaseAudioAssetPanel', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{}', { status: 404 }))
+    );
     decodeWaveformPeaksMock.mockResolvedValue({
       peaks: [0.2, 0.8, 0.5],
       durationMs: 120_000,
     });
   });
 
-  it('renders an upload dropzone when audio is missing', () => {
+  it('renders an upload dropzone when audio is missing', async () => {
     render(
       <ReleaseAudioAssetPanel
         releaseId='release-1'
@@ -37,7 +51,9 @@ describe('ReleaseAudioAssetPanel', () => {
       />
     );
 
-    expect(screen.getByTestId('release-audio-dropzone')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('release-audio-dropzone')).toBeInTheDocument();
+    });
     expect(
       screen.getByLabelText('Upload audio for Take Me Over')
     ).toBeInTheDocument();
@@ -127,6 +143,246 @@ describe('ReleaseAudioAssetPanel', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/library/audio/confirm',
       expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('shows one non-playable preparation state for an AIFF master', async () => {
+    blobUploadMock.mockResolvedValue({
+      url: 'https://cdn.example.com/master.aiff',
+      pathname: 'library/audio/master.aiff',
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                previewUrl: null,
+                hasAudioMaster: true,
+                playbackDerivative: {
+                  status: 'pending',
+                  generation: 1,
+                  sourceFormatId: 'aiff',
+                  requestedAt: '2026-07-26T00:00:00.000Z',
+                },
+              }),
+              { status: 200 }
+            )
+          );
+        }
+        return Promise.resolve(new Response('{}', { status: 404 }));
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Upload audio for Take Me Over'), {
+      target: {
+        files: [
+          new File(['audio'], 'take-me-over.aiff', { type: 'audio/aiff' }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-audio-derivative-status')
+      ).toHaveTextContent('Preparing preview');
+    });
+    expect(
+      screen.queryByRole('button', { name: /play/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('audio-waveform-editor')
+    ).not.toBeInTheDocument();
+  });
+
+  it('announces the initial audio-state check as busy without exposing controls', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {}))
+    );
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    const status = screen.getByTestId('release-audio-derivative-status');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+    expect(status).toHaveTextContent('Preparing preview');
+    expect(status).toHaveTextContent(
+      'Preparing a browser-ready preview and waveform.'
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'pending',
+      false,
+      'Preparing preview',
+      'Preparing a browser-ready preview and waveform.',
+    ],
+    [
+      'retrying',
+      false,
+      'Preparing preview',
+      'Preview preparation is retrying automatically.',
+    ],
+    [
+      'failed',
+      true,
+      'Preview unavailable',
+      'We could not prepare this preview. Your original is preserved.',
+    ],
+    [
+      'unavailable',
+      true,
+      'Preview unavailable',
+      'This format is preserved, but a browser preview is not available.',
+    ],
+    [
+      'superseded',
+      true,
+      'Preview unavailable',
+      'A newer audio upload replaced this preview.',
+    ],
+    [
+      'ready',
+      true,
+      'Preview unavailable',
+      'Preview metadata is ready, but its audio URL is unavailable.',
+    ],
+  ] as const)('keeps the %s derivative state non-playable with one recovery control', async (status, hasRecoveryControl, heading, copy) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            previewUrl: null,
+            hasAudioMaster: true,
+            playbackDerivative: {
+              status,
+              generation: 1,
+              sourceFormatId: 'aiff',
+              requestedAt: '2026-07-26T00:00:00.000Z',
+              retryAt: '2026-07-26T00:01:00.000Z',
+              failedAt: '2026-07-26T00:00:01.000Z',
+              supersededAt: '2026-07-26T00:00:01.000Z',
+              attempt: 1,
+              maxAttempts: 3,
+              reason:
+                status === 'unavailable'
+                  ? 'conversion_not_supported'
+                  : 'conversion_failed',
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-audio-derivative-status')
+      ).toBeInTheDocument();
+    });
+    const statusRegion = screen.getByTestId('release-audio-derivative-status');
+    expect(statusRegion).toHaveTextContent(heading);
+    expect(statusRegion).toHaveTextContent(copy);
+    if (status === 'pending' || status === 'retrying') {
+      expect(statusRegion).toHaveAttribute('aria-busy', 'true');
+    } else {
+      expect(statusRegion).not.toHaveAttribute('aria-busy');
+    }
+    expect(
+      screen.queryByRole('button', { name: /play/i })
+    ).not.toBeInTheDocument();
+    const recoveryControl = screen.queryByRole('button', {
+      name: 'Replace audio',
+    });
+    if (hasRecoveryControl) {
+      expect(recoveryControl).toBeInTheDocument();
+    } else {
+      expect(recoveryControl).not.toBeInTheDocument();
+    }
+  });
+
+  it('moves from pending to ready without remounting or exposing the master', async () => {
+    vi.useFakeTimers();
+    const onUploaded = vi.fn();
+    const pendingBody = {
+      previewUrl: null,
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        requestedAt: '2026-07-26T00:00:00.000Z',
+      },
+    };
+    const readyBody = {
+      previewUrl: 'https://cdn.example.com/preview.wav',
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        url: 'https://cdn.example.com/preview.wav',
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(pendingBody), { status: 200 })
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify(readyBody), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+        onUploaded={onUploaded}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      screen.getByTestId('release-audio-derivative-status')
+    ).toHaveTextContent('Preparing preview');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.getByTestId('audio-waveform-editor')).toBeInTheDocument();
+    expect(onUploaded).toHaveBeenCalledWith(
+      'https://cdn.example.com/preview.wav'
     );
   });
 });

--- a/apps/web/tests/e2e/audio-real-media-decoding.spec.ts
+++ b/apps/web/tests/e2e/audio-real-media-decoding.spec.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
 import { expect, type Page, test } from '@playwright/test';
+import { prepareAiffPlaybackDerivative } from '../../lib/audio/aiff-to-wav';
 import {
   MALFORMED_AUDIO_FIXTURES,
   REAL_AUDIO_FIXTURES,
@@ -85,4 +87,48 @@ test.describe('canonical real audio corpus', () => {
       });
     });
   }
+
+  test('a streamed AIFF derivative becomes real Chromium-decodable WAV audio', async ({
+    page,
+  }) => {
+    const aiff = readFileSync(
+      resolve(process.cwd(), 'tests/fixtures/audio', 'tone.aiff')
+    );
+    const source = Readable.toWeb(
+      Readable.from(
+        (function* chunks() {
+          for (let offset = 0; offset < aiff.length; offset += 17) {
+            yield aiff.subarray(offset, offset + 17);
+          }
+        })()
+      )
+    ) as ReadableStream<Uint8Array>;
+    const prepared = await prepareAiffPlaybackDerivative(source);
+    const outputChunks: Buffer[] = [];
+    for await (const chunk of prepared.stream) {
+      outputChunks.push(Buffer.from(chunk));
+    }
+    const derivative = Buffer.concat(outputChunks);
+
+    expect(derivative.byteLength).toBe(prepared.outputBytes);
+    const result = await page.evaluate(async encodedBytes => {
+      const decodedBytes = Uint8Array.from(atob(encodedBytes), character =>
+        character.charCodeAt(0)
+      );
+      const context = new AudioContext();
+      try {
+        const decoded = await context.decodeAudioData(decodedBytes.buffer);
+        return {
+          channels: decoded.numberOfChannels,
+          duration: decoded.duration,
+        };
+      } finally {
+        await context.close();
+      }
+    }, derivative.toString('base64'));
+
+    expect(result.channels).toBe(1);
+    expect(result.duration).toBeGreaterThanOrEqual(0.99);
+    expect(result.duration).toBeLessThanOrEqual(1.01);
+  });
 });

--- a/apps/web/tests/unit/api/library-audio-snippet.test.ts
+++ b/apps/web/tests/unit/api/library-audio-snippet.test.ts
@@ -77,6 +77,7 @@ describe('library audio snippet API', () => {
       recordingId: 'recording_123',
       previewUrl: 'https://cdn.example.com/preview.mp3',
       audioUrl: 'https://cdn.example.com/preview.mp3',
+      audioFormat: 'audio/mpeg',
       durationMs: 180_000,
       metadata: {
         audioSnippet: { startMs: 10_000, endMs: 40_000 },
@@ -94,6 +95,7 @@ describe('library audio snippet API', () => {
     expect(response.status).toBe(200);
     expect(body.snippet).toEqual({ startMs: 10_000, endMs: 40_000 });
     expect(body.previewUrl).toBe('https://cdn.example.com/preview.mp3');
+    expect(body.playbackStatus).toBe('ready');
   });
 
   it('persists a normalized snippet trim window', async () => {
@@ -101,6 +103,7 @@ describe('library audio snippet API', () => {
       recordingId: 'recording_123',
       previewUrl: 'https://cdn.example.com/preview.mp3',
       audioUrl: 'https://cdn.example.com/preview.mp3',
+      audioFormat: 'audio/mpeg',
       durationMs: 180_000,
       metadata: {},
     });

--- a/apps/web/tests/unit/api/library-audio.test.ts
+++ b/apps/web/tests/unit/api/library-audio.test.ts
@@ -20,6 +20,9 @@ const hoisted = vi.hoisted(() => {
   const updateWhereMock = vi.fn();
   const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
   const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+  const insertValuesMock = vi.fn();
+  const insertMock = vi.fn().mockReturnValue({ values: insertValuesMock });
+  const transactionMock = vi.fn();
 
   return {
     requireAuthMock: vi.fn(),
@@ -31,6 +34,9 @@ const hoisted = vi.hoisted(() => {
     updateMock,
     updateSetMock,
     updateWhereMock,
+    insertMock,
+    insertValuesMock,
+    transactionMock,
     revalidateTagMock: vi.fn(),
     captureErrorMock: vi.fn(),
   };
@@ -66,6 +72,7 @@ vi.mock('@/lib/db', () => ({
   db: {
     select: hoisted.selectMock,
     update: hoisted.updateMock,
+    transaction: hoisted.transactionMock,
   },
 }));
 
@@ -84,12 +91,20 @@ vi.mock('@/lib/db/schema/content', () => ({
     id: 'recording.id',
     creatorProfileId: 'recording.creatorProfileId',
     previewUrl: 'recording.previewUrl',
+    audioUrl: 'recording.audioUrl',
+    audioFormat: 'recording.audioFormat',
+    metadata: 'recording.metadata',
   },
+}));
+
+vi.mock('@/lib/db/schema/ingestion', () => ({
+  ingestionJobs: 'ingestionJobs',
 }));
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn(),
   eq: vi.fn(),
+  sql: vi.fn(),
 }));
 
 vi.mock('@/lib/error-tracking', () => ({
@@ -99,6 +114,15 @@ vi.mock('@/lib/error-tracking', () => ({
 describe('library audio upload API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.updateMock.mockReturnValue({ set: hoisted.updateSetMock });
+    hoisted.updateSetMock.mockReturnValue({ where: hoisted.updateWhereMock });
+    hoisted.insertMock.mockReturnValue({ values: hoisted.insertValuesMock });
+    hoisted.transactionMock.mockImplementation(async callback =>
+      callback({
+        update: hoisted.updateMock,
+        insert: hoisted.insertMock,
+      })
+    );
     hoisted.requireAuthMock.mockResolvedValue({
       userId: 'clerk_user_123',
       error: null,
@@ -134,6 +158,7 @@ describe('library audio upload API', () => {
       recordingId: 'recording_123',
       previewUrl: null,
       audioUrl: null,
+      audioFormat: null,
       durationMs: null,
       metadata: {},
     });
@@ -165,6 +190,61 @@ describe('library audio upload API', () => {
     expect(hoisted.revalidateTagMock).toHaveBeenCalledWith(
       'releases:clerk_user_123:profile_123',
       'max'
+    );
+  });
+
+  it('preserves AIFF as the master and enqueues a typed playable derivative', async () => {
+    hoisted.resolvePrimaryRecordingForReleaseMock.mockResolvedValue({
+      recordingId: 'recording_123',
+      previewUrl: null,
+      audioUrl: null,
+      audioFormat: null,
+      durationMs: null,
+      metadata: {},
+    });
+    hoisted.updateWhereMock.mockResolvedValue({ rowCount: 1 });
+
+    const { POST } = await import('@/app/api/library/audio/confirm/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/confirm', {
+        method: 'POST',
+        body: JSON.stringify({
+          releaseId: '00000000-0000-4000-8000-000000000001',
+          blobUrl: 'https://cdn.example.com/take-me-over.aiff',
+          blobPathname: 'library/audio/take-me-over.aiff',
+          fileName: 'take-me-over.aiff',
+          fileMimeType: 'audio/aiff',
+          fileSizeBytes: 1024,
+        }),
+      }) as never
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      previewUrl: null,
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'aiff',
+      },
+    });
+    expect(hoisted.updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previewUrl: null,
+        audioUrl: 'https://cdn.example.com/take-me-over.aiff',
+        audioFormat: 'audio/aiff',
+      })
+    );
+    expect(hoisted.insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'audio_playback_derivative',
+        payload: expect.objectContaining({
+          formatId: 'aiff',
+          generation: 1,
+        }),
+      })
     );
   });
 

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -910,7 +910,7 @@ describe('LibrarySurface', () => {
     });
   });
 
-  it('renders a right-rail audio dropzone when a release is missing audio', () => {
+  it('renders a right-rail audio dropzone after checking for a missing audio master', async () => {
     renderLibrary([
       buildAsset({
         previewUrl: null,
@@ -920,7 +920,9 @@ describe('LibrarySurface', () => {
 
     fireEvent.click(screen.getByTestId('library-release-row-release-1'));
 
-    expect(screen.getByTestId('library-audio-dropzone')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('library-audio-dropzone')
+    ).toBeInTheDocument();
     expect(
       screen.getByLabelText('Upload audio for Take Me Over')
     ).toHaveAttribute('accept', expect.stringContaining('audio/mpeg'));

--- a/packages/audio-contracts/capabilities.test.ts
+++ b/packages/audio-contracts/capabilities.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_CAPABILITY_PLATFORMS,
+  AUDIO_CAPABILITY_REGISTRY,
+  AUDIO_FORMAT_IDS,
+  type AudioPlaybackAsset,
+  getAudioCapability,
+  resolveAudioSource,
+} from './index';
+
+const AIFF_MASTER = {
+  formatId: 'aiff',
+  masterUrl: 'https://blob.example/master.aiff',
+} as const satisfies AudioPlaybackAsset;
+
+describe('audio capability registry', () => {
+  it('defines every platform and purpose for every accepted format', () => {
+    expect(Object.keys(AUDIO_CAPABILITY_REGISTRY)).toEqual(AUDIO_FORMAT_IDS);
+
+    for (const formatId of AUDIO_FORMAT_IDS) {
+      expect(Object.keys(AUDIO_CAPABILITY_REGISTRY[formatId])).toEqual(
+        AUDIO_CAPABILITY_PLATFORMS
+      );
+      for (const platform of AUDIO_CAPABILITY_PLATFORMS) {
+        expect(
+          Object.keys(AUDIO_CAPABILITY_REGISTRY[formatId][platform])
+        ).toEqual([
+          'uploadAcceptance',
+          'masterPreservation',
+          'nativePlayback',
+          'waveformDecode',
+          'analysisInput',
+        ]);
+      }
+    }
+  });
+
+  it('keeps acceptance separate from real Chromium decode capability', () => {
+    expect(getAudioCapability('aiff', 'web_chromium', 'uploadAcceptance')).toBe(
+      'direct'
+    );
+    expect(
+      getAudioCapability('aiff', 'web_chromium', 'masterPreservation')
+    ).toBe('direct');
+    expect(getAudioCapability('aiff', 'web_chromium', 'nativePlayback')).toBe(
+      'derivative_required'
+    );
+    expect(getAudioCapability('aiff', 'web_chromium', 'waveformDecode')).toBe(
+      'derivative_required'
+    );
+    expect(getAudioCapability('mp3', 'web_chromium', 'nativePlayback')).toBe(
+      'direct'
+    );
+  });
+
+  it('fails closed for unverified iOS capability', () => {
+    expect(
+      getAudioCapability('m4a', 'ios_avfoundation', 'nativePlayback')
+    ).toBe('unverified');
+    expect(
+      resolveAudioSource(
+        { formatId: 'm4a', masterUrl: 'https://blob.example/master.m4a' },
+        'ios_avfoundation',
+        'nativePlayback'
+      )
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+
+  it('never lets a ready derivative override an unverified platform', () => {
+    expect(
+      resolveAudioSource(
+        {
+          formatId: 'aiff',
+          masterUrl: 'https://blob.example/master.aiff',
+          derivative: {
+            generation: 1,
+            sourceFormatId: 'aiff',
+            status: 'ready',
+            url: 'https://blob.example/preview.wav',
+            mimeType: 'audio/wav',
+            readyAt: '2026-07-26T00:00:01.000Z',
+            outputBytes: 88_244,
+          },
+        },
+        'ios_avfoundation',
+        'nativePlayback'
+      )
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+});
+
+describe('audio source resolution', () => {
+  it('returns a directly supported master without requiring a derivative', () => {
+    expect(
+      resolveAudioSource(
+        { formatId: 'flac', masterUrl: 'https://blob.example/master.flac' },
+        'web_chromium',
+        'waveformDecode'
+      )
+    ).toEqual({
+      status: 'ready',
+      source: 'master',
+      url: 'https://blob.example/master.flac',
+    });
+  });
+
+  it('reports a missing required derivative as unavailable', () => {
+    expect(
+      resolveAudioSource(AIFF_MASTER, 'web_chromium', 'nativePlayback')
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+
+  it.each([
+    'pending',
+    'failed',
+    'unavailable',
+    'retrying',
+    'superseded',
+  ] as const)('never exposes an AIFF master while derivative is %s', status => {
+    const common = {
+      generation: 1,
+      sourceFormatId: 'aiff' as const,
+    };
+    const derivative = {
+      pending: {
+        ...common,
+        status: 'pending' as const,
+        requestedAt: '2026-07-26T00:00:00.000Z',
+      },
+      failed: {
+        ...common,
+        status: 'failed' as const,
+        reason: 'conversion_failed' as const,
+        failedAt: '2026-07-26T00:00:00.000Z',
+      },
+      unavailable: {
+        ...common,
+        status: 'unavailable' as const,
+        reason: 'conversion_not_supported' as const,
+      },
+      retrying: {
+        ...common,
+        status: 'retrying' as const,
+        attempt: 1,
+        maxAttempts: 3,
+        retryAt: '2026-07-26T00:01:00.000Z',
+      },
+      superseded: {
+        ...common,
+        status: 'superseded' as const,
+        supersededAt: '2026-07-26T00:00:00.000Z',
+      },
+    }[status];
+
+    expect(
+      resolveAudioSource(
+        { ...AIFF_MASTER, derivative },
+        'web_chromium',
+        'nativePlayback'
+      )
+    ).toEqual({ status, source: null, url: null });
+  });
+
+  it('returns only the ready AIFF derivative for playback and waveform decode', () => {
+    const asset: AudioPlaybackAsset = {
+      ...AIFF_MASTER,
+      derivative: {
+        generation: 1,
+        sourceFormatId: 'aiff',
+        status: 'ready',
+        url: 'https://blob.example/preview.wav',
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      },
+    };
+
+    for (const purpose of ['nativePlayback', 'waveformDecode'] as const) {
+      expect(resolveAudioSource(asset, 'web_chromium', purpose)).toEqual({
+        status: 'ready',
+        source: 'derivative',
+        url: 'https://blob.example/preview.wav',
+      });
+    }
+  });
+});

--- a/packages/audio-contracts/capabilities.ts
+++ b/packages/audio-contracts/capabilities.ts
@@ -1,0 +1,211 @@
+import type { AudioFormatId } from './index';
+
+export const AUDIO_CAPABILITY_PLATFORMS = [
+  'web_chromium',
+  'desktop_chromium',
+  'ios_avfoundation',
+  'server_analysis',
+] as const;
+
+export type AudioCapabilityPlatform =
+  (typeof AUDIO_CAPABILITY_PLATFORMS)[number];
+
+export type AudioCapabilityPurpose =
+  | 'uploadAcceptance'
+  | 'masterPreservation'
+  | 'nativePlayback'
+  | 'waveformDecode'
+  | 'analysisInput';
+
+export type AudioCapabilityStatus =
+  | 'direct'
+  | 'derivative_required'
+  | 'unavailable'
+  | 'unverified'
+  | 'not_applicable';
+
+export interface AudioPlatformCapabilities {
+  readonly uploadAcceptance: AudioCapabilityStatus;
+  readonly masterPreservation: AudioCapabilityStatus;
+  readonly nativePlayback: AudioCapabilityStatus;
+  readonly waveformDecode: AudioCapabilityStatus;
+  readonly analysisInput: AudioCapabilityStatus;
+}
+
+export type AudioCapabilityRegistry = Readonly<
+  Record<
+    AudioFormatId,
+    Readonly<Record<AudioCapabilityPlatform, AudioPlatformCapabilities>>
+  >
+>;
+
+const DIRECT_CHROMIUM_CAPABILITIES = {
+  uploadAcceptance: 'direct',
+  masterPreservation: 'direct',
+  nativePlayback: 'direct',
+  waveformDecode: 'direct',
+  analysisInput: 'not_applicable',
+} as const satisfies AudioPlatformCapabilities;
+
+const AIFF_CHROMIUM_CAPABILITIES = {
+  uploadAcceptance: 'direct',
+  masterPreservation: 'direct',
+  nativePlayback: 'derivative_required',
+  waveformDecode: 'derivative_required',
+  analysisInput: 'not_applicable',
+} as const satisfies AudioPlatformCapabilities;
+
+const UNVERIFIED_IOS_CAPABILITIES = {
+  uploadAcceptance: 'unavailable',
+  masterPreservation: 'unavailable',
+  nativePlayback: 'unverified',
+  waveformDecode: 'unverified',
+  analysisInput: 'not_applicable',
+} as const satisfies AudioPlatformCapabilities;
+
+const DIRECT_SERVER_ANALYSIS_CAPABILITIES = {
+  uploadAcceptance: 'direct',
+  masterPreservation: 'direct',
+  nativePlayback: 'not_applicable',
+  waveformDecode: 'not_applicable',
+  analysisInput: 'direct',
+} as const satisfies AudioPlatformCapabilities;
+
+// Stryker disable next-line BlockStatement: this registry helper executes
+// during module initialization before Stryker can activate body mutants.
+function directFormatCapabilities() {
+  return {
+    web_chromium: DIRECT_CHROMIUM_CAPABILITIES,
+    desktop_chromium: DIRECT_CHROMIUM_CAPABILITIES,
+    ios_avfoundation: UNVERIFIED_IOS_CAPABILITIES,
+    server_analysis: DIRECT_SERVER_ANALYSIS_CAPABILITIES,
+  } as const satisfies Readonly<
+    Record<AudioCapabilityPlatform, AudioPlatformCapabilities>
+  >;
+}
+
+/**
+ * Canonical, evidence-scoped audio capability registry.
+ *
+ * A format being accepted for upload never implies that a runtime can play or
+ * decode it. `unverified` is intentional: consumers must fail closed until a
+ * real platform fixture proves support.
+ */
+export const AUDIO_CAPABILITY_REGISTRY = {
+  mp3: directFormatCapabilities(),
+  wav: directFormatCapabilities(),
+  flac: directFormatCapabilities(),
+  aiff: {
+    web_chromium: AIFF_CHROMIUM_CAPABILITIES,
+    desktop_chromium: AIFF_CHROMIUM_CAPABILITIES,
+    ios_avfoundation: UNVERIFIED_IOS_CAPABILITIES,
+    server_analysis: DIRECT_SERVER_ANALYSIS_CAPABILITIES,
+  },
+  aac: directFormatCapabilities(),
+  m4a: directFormatCapabilities(),
+} as const satisfies AudioCapabilityRegistry;
+
+export type AudioDerivativeStatus =
+  | 'pending'
+  | 'ready'
+  | 'failed'
+  | 'unavailable'
+  | 'retrying'
+  | 'superseded';
+
+interface AudioDerivativeBase {
+  readonly generation: number;
+  readonly sourceFormatId: AudioFormatId;
+}
+
+export type AudioPlaybackDerivative =
+  | (AudioDerivativeBase & {
+      readonly status: 'pending';
+      readonly requestedAt: string;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'ready';
+      readonly url: string;
+      readonly mimeType: 'audio/wav';
+      readonly readyAt: string;
+      readonly outputBytes: number;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'failed';
+      readonly reason:
+        | 'invalid_source'
+        | 'conversion_failed'
+        | 'resource_limit'
+        | 'storage_failed';
+      readonly failedAt: string;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'unavailable';
+      readonly reason: 'platform_unsupported' | 'conversion_not_supported';
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'retrying';
+      readonly attempt: number;
+      readonly maxAttempts: number;
+      readonly retryAt: string;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'superseded';
+      readonly supersededAt: string;
+    });
+
+export interface AudioPlaybackAsset {
+  readonly formatId: AudioFormatId;
+  readonly masterUrl: string;
+  readonly derivative?: AudioPlaybackDerivative | null;
+}
+
+export type AudioSourceResolution =
+  | {
+      readonly status: 'ready';
+      readonly source: 'master' | 'derivative';
+      readonly url: string;
+    }
+  | {
+      readonly status: Exclude<AudioDerivativeStatus, 'ready'>;
+      readonly source: null;
+      readonly url: null;
+    };
+
+export function getAudioCapability(
+  formatId: AudioFormatId,
+  platform: AudioCapabilityPlatform,
+  purpose: AudioCapabilityPurpose
+): AudioCapabilityStatus {
+  return AUDIO_CAPABILITY_REGISTRY[formatId][platform][purpose];
+}
+
+export function resolveAudioSource(
+  asset: AudioPlaybackAsset,
+  platform: AudioCapabilityPlatform,
+  purpose: 'nativePlayback' | 'waveformDecode'
+): AudioSourceResolution {
+  const capability = getAudioCapability(asset.formatId, platform, purpose);
+
+  if (capability === 'direct') {
+    return { status: 'ready', source: 'master', url: asset.masterUrl };
+  }
+
+  if (capability !== 'derivative_required') {
+    return { status: 'unavailable', source: null, url: null };
+  }
+
+  if (asset.derivative?.status === 'ready') {
+    return {
+      status: 'ready',
+      source: 'derivative',
+      url: asset.derivative.url,
+    };
+  }
+
+  return {
+    status: asset.derivative?.status ?? 'unavailable',
+    source: null,
+    url: null,
+  };
+}

--- a/packages/audio-contracts/index.test.ts
+++ b/packages/audio-contracts/index.test.ts
@@ -82,12 +82,6 @@ describe('audio format registry', () => {
       'chat',
       'promo_download',
     ]);
-    expect(format.platforms).toEqual({
-      web: true,
-      desktop: true,
-      ios: false,
-    });
-
     for (const mimeType of format.mimeTypes) {
       expect(getAudioFormatByMimeType(mimeType)?.id).toBe(format.id);
       expect(isSupportedAudioMimeType(mimeType)).toBe(true);

--- a/packages/audio-contracts/index.ts
+++ b/packages/audio-contracts/index.ts
@@ -1,5 +1,6 @@
 export * from './analysis';
 export * from './beat-grid';
+export * from './capabilities';
 export * from './lyrics';
 export * from './performance';
 export * from './playback';
@@ -16,7 +17,6 @@ export const AUDIO_FORMAT_IDS = [
 
 export type AudioFormatId = (typeof AUDIO_FORMAT_IDS)[number];
 export type AudioUploadSurface = 'library' | 'chat' | 'promo_download';
-export type AudioPlatform = 'web' | 'desktop' | 'ios';
 
 export interface AudioFormatDefinition {
   readonly id: AudioFormatId;
@@ -27,7 +27,6 @@ export interface AudioFormatDefinition {
   readonly container: string;
   readonly expectedCodecs: readonly string[];
   readonly uploadSurfaces: readonly AudioUploadSurface[];
-  readonly platforms: Readonly<Record<AudioPlatform, boolean>>;
 }
 
 const ALL_UPLOAD_SURFACES = [
@@ -35,12 +34,6 @@ const ALL_UPLOAD_SURFACES = [
   'chat',
   'promo_download',
 ] as const satisfies readonly AudioUploadSurface[];
-
-const CURRENT_PLATFORMS = {
-  web: true,
-  desktop: true,
-  ios: false,
-} as const satisfies Readonly<Record<AudioPlatform, boolean>>;
 
 /**
  * Canonical contract for formats Jovie currently accepts.
@@ -59,7 +52,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'mpeg-audio',
     expectedCodecs: ['mp3'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'wav',
@@ -70,7 +62,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'wave',
     expectedCodecs: ['pcm', 'ieee-float'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'flac',
@@ -81,7 +72,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'flac',
     expectedCodecs: ['flac'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'aiff',
@@ -92,7 +82,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'aiff',
     expectedCodecs: ['pcm'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'aac',
@@ -103,7 +92,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'adts',
     expectedCodecs: ['aac'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'm4a',
@@ -114,7 +102,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'iso-base-media',
     expectedCodecs: ['aac', 'alac'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
 ] as const satisfies readonly AudioFormatDefinition[];
 

--- a/packages/audio-contracts/stryker.config.mjs
+++ b/packages/audio-contracts/stryker.config.mjs
@@ -11,6 +11,7 @@ const config = {
   reporters: ['progress', 'clear-text', 'json'],
   mutate: [
     'index.ts',
+    'capabilities.ts',
     'units.ts',
     'analysis.ts',
     'beat-grid.ts',
@@ -21,6 +22,7 @@ const config = {
   ],
   testFiles: [
     'index.test.ts',
+    'capabilities.test.ts',
     'analysis.test.ts',
     'beat-grid.test.ts',
     'lyrics.test.ts',


### PR DESCRIPTION
## Summary

- closes the JOV-4393 delivery slice with a canonical typed audio capability registry across web Chromium, desktop Chromium, iOS AVFoundation, and server analysis
- preserves uploaded masters while deriving bounded browser-safe PCM WAV playback assets through the existing ingestion queue and generation-CAS lifecycle
- makes playback consumers, waveform UI, snippet editing, and library/share adapters fail closed until a verified playable URL exists
- adds reserved transition geometry and one recovery action for pending, retrying, failed, unavailable, superseded, and malformed-ready states

## Stack

- stacked on #14922 (`tw/codex/jov-4391-single-playback-adoption`)
- exact parent SHA at implementation start: `536e83dea2318a56463e510125bf8cd3a3f62747`
- Graphite submit was attempted first but the JovieInc Graphite plan is expired; this draft uses the documented GitHub fallback with the parent branch set explicitly

## Verification

- focused web audio tests: 131/131
- audio contracts: 175/175 plus package typecheck
- real Chromium media corpus: 13/13, including decoding the generated AIFF-to-WAV derivative
- web audio mutation suite: 100% mutation score, 550 generated (515 assertion-killed, 21 timeout-killed, zero surviving/uncovered)
- audio-contract mutation suite: 100% mutation score, 839 tested (834 assertion-killed, 5 timeout-killed, zero surviving/uncovered)
- web typecheck, focused Biome, and focused ESLint: green
- normal pre-commit hooks: green
- normal pre-push hook: green, including all 8 Vitest shards / 2,243 discovered files; no hook bypass
- additional affected regressions: library audio snippet API 2/2 and LibrarySurface missing-master transition 1/1
- AIFF conversion benchmark (10 runs): p50 61.342 ms, p95 248.334 ms, peak heap 3,974,560 bytes; 88,254-byte input / 88,244-byte output

## Release posture

Draft only. Native queue remains untouched. This child must be retargeted/rebased appropriately and receive the full required main-target checks before queueing. No production-shipping claim is made here.