### PR TITLE
feat(audio): define canonical capability registry

### DIFF
--- a/apps/web/lib/audio/aiff-to-wav.test.ts
+++ b/apps/web/lib/audio/aiff-to-wav.test.ts
@@ -1,0 +1,412 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_AUDIO_DERIVATIVE_BYTES,
+  prepareAiffPlaybackDerivative,
+} from './aiff-to-wav';
+
+function fixture(fileName: string): Buffer {
+  return readFileSync(resolve(process.cwd(), 'tests/fixtures/audio', fileName));
+}
+
+function chunkedWebStream(
+  bytes: Buffer,
+  chunkSize: number
+): ReadableStream<Uint8Array> {
+  return Readable.toWeb(
+    Readable.from(
+      (function* chunks() {
+        for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+          yield bytes.subarray(offset, offset + chunkSize);
+        }
+      })()
+    )
+  ) as ReadableStream<Uint8Array>;
+}
+
+async function collect(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+function extended80(value: number): Buffer {
+  const output = Buffer.alloc(10);
+  if (Number.isNaN(value)) {
+    output.writeUInt16BE(0x7fff, 0);
+    return output;
+  }
+  if (value === 0) return output;
+
+  const power = Math.floor(Math.log2(Math.abs(value)));
+  const exponent = power + 16_383;
+  const fraction = Math.abs(value) / 2 ** power;
+  const mantissa = BigInt(Math.round(fraction * 2 ** 31)) << 32n;
+  output.writeUInt16BE(exponent | (value < 0 ? 0x8000 : 0), 0);
+  output.writeBigUInt64BE(mantissa, 2);
+  return output;
+}
+
+function makeChunk(id: string, body: Buffer, declaredSize = body.length) {
+  const header = Buffer.alloc(8);
+  header.write(id, 0, 'ascii');
+  header.writeUInt32BE(declaredSize, 4);
+  return Buffer.concat([
+    header,
+    body,
+    ...(body.length % 2 === 1 ? [Buffer.alloc(1)] : []),
+  ]);
+}
+
+function syntheticAiff(options?: {
+  bitsPerSample?: number;
+  channels?: number;
+  commFirst?: boolean;
+  declaredDataBytes?: number;
+  includeOddJunk?: boolean;
+  pcm?: Buffer;
+  sampleRate?: number;
+  soundOffset?: number;
+}) {
+  const bitsPerSample = options?.bitsPerSample ?? 16;
+  const channels = options?.channels ?? 1;
+  const pcm = options?.pcm ?? Buffer.from([0x12, 0x34, 0xfe, 0xdc]);
+  const soundOffset = options?.soundOffset ?? 0;
+  const declaredDataBytes = options?.declaredDataBytes ?? pcm.length;
+
+  const commBody = Buffer.alloc(18);
+  commBody.writeUInt16BE(channels, 0);
+  const bytesPerFrame = Math.max(1, channels * (bitsPerSample / 8));
+  commBody.writeUInt32BE(
+    Math.max(0, Math.floor(declaredDataBytes / bytesPerFrame)),
+    2
+  );
+  commBody.writeUInt16BE(bitsPerSample, 6);
+  extended80(options?.sampleRate ?? 44_100).copy(commBody, 8);
+  const comm = makeChunk('COMM', commBody);
+
+  const soundBody = Buffer.concat([
+    Buffer.alloc(8),
+    Buffer.alloc(soundOffset),
+    pcm,
+  ]);
+  soundBody.writeUInt32BE(soundOffset, 0);
+  const sound = makeChunk(
+    'SSND',
+    soundBody,
+    8 + soundOffset + declaredDataBytes
+  );
+  const chunks = options?.commFirst === false ? [sound, comm] : [comm, sound];
+  if (options?.includeOddJunk) {
+    chunks.unshift(makeChunk('JUNK', Buffer.from([0x7f])));
+  }
+
+  const formBody = Buffer.concat([Buffer.from('AIFF', 'ascii'), ...chunks]);
+  const formHeader = Buffer.alloc(8);
+  formHeader.write('FORM', 0, 'ascii');
+  formHeader.writeUInt32BE(formBody.length, 4);
+  return Buffer.concat([formHeader, formBody]);
+}
+
+async function convert(bytes: Buffer, chunkSize = 7): Promise<Buffer> {
+  const prepared = await prepareAiffPlaybackDerivative(
+    chunkedWebStream(bytes, chunkSize)
+  );
+  return collect(prepared.stream);
+}
+
+describe('AIFF playback derivative conversion', () => {
+  it('streams a real AIFF into a bounded canonical PCM WAV', async () => {
+    const source = fixture('tone.aiff');
+    const prepared = await prepareAiffPlaybackDerivative(
+      chunkedWebStream(source, 7)
+    );
+    const output = await collect(prepared.stream);
+
+    expect(output.byteLength).toBe(prepared.outputBytes);
+    expect(output).toEqual(fixture('tone.wav'));
+    expect(output.toString('ascii', 0, 4)).toBe('RIFF');
+    expect(output.toString('ascii', 8, 12)).toBe('WAVE');
+    expect(output.toString('ascii', 36, 40)).toBe('data');
+    expect(output.readUInt16LE(20)).toBe(1);
+    expect(output.readUInt16LE(22)).toBe(1);
+    expect(output.readUInt32LE(24)).toBe(44_100);
+    expect(output.readUInt16LE(34)).toBe(16);
+    expect(output.readUInt32LE(40)).toBe(88_200);
+  }, 15_000);
+
+  it('fails closed for a truncated AIFF before emitting a derivative', async () => {
+    await expect(
+      prepareAiffPlaybackDerivative(
+        chunkedWebStream(fixture('truncated.aiff'), 13)
+      )
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF ended before sound data was found',
+    });
+  });
+
+  it.each([
+    ['FORM', 0],
+    ['AIFF', 8],
+  ])('rejects an invalid %s container signature', async (_, offset) => {
+    const source = Buffer.from(fixture('tone.aiff'));
+    source.write('NOPE', offset, 'ascii');
+
+    await expect(
+      prepareAiffPlaybackDerivative(chunkedWebStream(source, 13))
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'Expected an uncompressed AIFF container',
+    });
+  });
+
+  it('rejects inconsistent declared sound data during stream consumption', async () => {
+    const source = fixture('tone.aiff');
+    const truncated = source.subarray(0, source.length - 17);
+    const prepared = await prepareAiffPlaybackDerivative(
+      chunkedWebStream(truncated, 31)
+    );
+
+    await expect(collect(prepared.stream)).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF sound data is truncated',
+    });
+  });
+
+  it.each([
+    [8, Buffer.from([0x80, 0x00, 0x7f]), Buffer.from([0x00, 0x80, 0xff])],
+    [
+      16,
+      Buffer.from([0x12, 0x34, 0xfe, 0xdc]),
+      Buffer.from([0x34, 0x12, 0xdc, 0xfe]),
+    ],
+    [
+      24,
+      Buffer.from([0x12, 0x34, 0x56, 0xfe, 0xdc, 0xba]),
+      Buffer.from([0x56, 0x34, 0x12, 0xba, 0xdc, 0xfe]),
+    ],
+    [
+      32,
+      Buffer.from([0x12, 0x34, 0x56, 0x78, 0xfe, 0xdc, 0xba, 0x98]),
+      Buffer.from([0x78, 0x56, 0x34, 0x12, 0x98, 0xba, 0xdc, 0xfe]),
+    ],
+  ] as const)('converts %i-bit PCM samples exactly across stream boundaries', async (bitsPerSample, pcm, expectedPcm) => {
+    const output = await convert(
+      syntheticAiff({ bitsPerSample, pcm }),
+      bitsPerSample === 24 ? 5 : 3
+    );
+    const bytesPerSample = bitsPerSample / 8;
+
+    expect(output.readUInt16LE(22)).toBe(1);
+    expect(output.readUInt32LE(24)).toBe(44_100);
+    expect(output.readUInt32LE(28)).toBe(44_100 * bytesPerSample);
+    expect(output.readUInt16LE(32)).toBe(bytesPerSample);
+    expect(output.readUInt16LE(34)).toBe(bitsPerSample);
+    expect(output.readUInt32LE(40)).toBe(expectedPcm.length);
+    expect(output.subarray(44)).toEqual(expectedPcm);
+  });
+
+  it.each([
+    8_000, 384_000,
+  ])('preserves the supported %i Hz sample-rate boundary', async sampleRate => {
+    const output = await convert(syntheticAiff({ sampleRate }));
+    expect(output.readUInt32LE(24)).toBe(sampleRate);
+    expect(output.readUInt32LE(28)).toBe(sampleRate * 2);
+  });
+
+  it('preserves stereo block alignment and skips padded odd chunks', async () => {
+    const output = await convert(
+      syntheticAiff({
+        channels: 2,
+        includeOddJunk: true,
+        pcm: Buffer.from([0x12, 0x34, 0x56, 0x78]),
+      })
+    );
+    expect(output.readUInt16LE(22)).toBe(2);
+    expect(output.readUInt16LE(32)).toBe(4);
+    expect(output.subarray(44)).toEqual(Buffer.from([0x34, 0x12, 0x78, 0x56]));
+  });
+
+  it('accepts the eight-channel boundary with aligned PCM', async () => {
+    const output = await convert(
+      syntheticAiff({ channels: 8, pcm: Buffer.alloc(16) })
+    );
+    expect(output.readUInt16LE(22)).toBe(8);
+    expect(output.readUInt16LE(32)).toBe(16);
+  });
+
+  it('skips a positive SSND offset before converting PCM', async () => {
+    const output = await convert(
+      syntheticAiff({
+        soundOffset: 4,
+        pcm: Buffer.from([0x12, 0x34, 0xfe, 0xdc]),
+      })
+    );
+    expect(output.subarray(44)).toEqual(Buffer.from([0x34, 0x12, 0xdc, 0xfe]));
+  });
+
+  it.each([
+    [
+      'unsupported bit depth',
+      { bitsPerSample: 12 },
+      'AIFF PCM bit depth is unsupported',
+    ],
+    ['zero channels', { channels: 0 }, 'AIFF channel count is unsupported'],
+    ['too many channels', { channels: 9 }, 'AIFF channel count is unsupported'],
+    [
+      'sample rate below range',
+      { sampleRate: 7_999 },
+      'AIFF sample rate is unsupported',
+    ],
+    [
+      'sample rate above range',
+      { sampleRate: 384_001 },
+      'AIFF sample rate is unsupported',
+    ],
+    [
+      'fractional sample rate',
+      { sampleRate: 44_100.5 },
+      'AIFF sample rate is unsupported',
+    ],
+    [
+      'negative sample rate',
+      { sampleRate: -44_100 },
+      'AIFF sample rate is unsupported',
+    ],
+    ['zero sample rate', { sampleRate: 0 }, 'AIFF sample rate is unsupported'],
+    [
+      'non-finite sample rate',
+      { sampleRate: Number.NaN },
+      'AIFF sample rate is unsupported',
+    ],
+    ['empty sound data', { pcm: Buffer.alloc(0) }, 'AIFF sound data is empty'],
+    [
+      'misaligned sound data',
+      { channels: 2, pcm: Buffer.from([0x12, 0x34]) },
+      'AIFF sound data is not sample-aligned',
+    ],
+    [
+      'sound offset beyond chunk',
+      { soundOffset: 8, declaredDataBytes: -4 },
+      'AIFF sound data is empty',
+    ],
+  ] as const)('rejects %s', async (_, options, message) => {
+    await expect(
+      convert(syntheticAiff(options as Parameters<typeof syntheticAiff>[0]))
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message,
+    });
+  });
+
+  it('rejects sound data before the format declaration', async () => {
+    await expect(
+      convert(syntheticAiff({ commFirst: false }))
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF sound data appeared before its format declaration',
+    });
+  });
+
+  it.each([
+    ['COMM', 16, 17],
+    ['SSND', 42, 7],
+  ])('rejects a %s chunk whose declared body is shorter than its fixed fields', async (_, sizeOffset, declaredSize) => {
+    const source = syntheticAiff();
+    source.writeUInt32BE(declaredSize, sizeOffset);
+
+    await expect(convert(source, source.length)).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'invalid_source',
+      message: 'AIFF ended before sound data was found',
+    });
+  });
+
+  it('enforces the derivative output limit from header metadata', async () => {
+    await expect(
+      convert(
+        syntheticAiff({
+          declaredDataBytes: MAX_AUDIO_DERIVATIVE_BYTES,
+          pcm: Buffer.alloc(0),
+        })
+      )
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'resource_limit',
+      message: 'Playback derivative exceeds the output size limit',
+    });
+  });
+
+  it('allows an output exactly at the derivative size limit', async () => {
+    const prepared = await prepareAiffPlaybackDerivative(
+      chunkedWebStream(
+        syntheticAiff({
+          declaredDataBytes: MAX_AUDIO_DERIVATIVE_BYTES - 44,
+          pcm: Buffer.alloc(0),
+        }),
+        64
+      )
+    );
+    expect(prepared.outputBytes).toBe(MAX_AUDIO_DERIVATIVE_BYTES);
+    prepared.stream.destroy();
+  });
+
+  it('enforces the bounded header scan before buffering an unbounded chunk', async () => {
+    const junk = makeChunk('JUNK', Buffer.alloc(1024 * 1024));
+    const formBody = Buffer.concat([Buffer.from('AIFF', 'ascii'), junk]);
+    const header = Buffer.alloc(8);
+    header.write('FORM', 0, 'ascii');
+    header.writeUInt32BE(formBody.length, 4);
+
+    await expect(
+      prepareAiffPlaybackDerivative(
+        chunkedWebStream(Buffer.concat([header, formBody]), formBody.length + 8)
+      )
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeConversionError',
+      code: 'resource_limit',
+      message: 'AIFF header exceeds the scan limit',
+    });
+  });
+
+  it('allows exactly one MiB of header data before failing as incomplete', async () => {
+    const junk = makeChunk('JUNK', Buffer.alloc(1024 * 1024 - 20));
+    const formBody = Buffer.concat([Buffer.from('AIFF', 'ascii'), junk]);
+    const header = Buffer.alloc(8);
+    header.write('FORM', 0, 'ascii');
+    header.writeUInt32BE(formBody.length, 4);
+    const source = Buffer.concat([header, formBody]);
+    expect(source.length).toBe(1024 * 1024);
+
+    await expect(
+      prepareAiffPlaybackDerivative(chunkedWebStream(source, source.length))
+    ).rejects.toMatchObject({
+      code: 'invalid_source',
+      message: 'AIFF ended before sound data was found',
+    });
+  });
+
+  it('cancels the source reader after the declared PCM is complete', async () => {
+    let cancelled = false;
+    const bytes = syntheticAiff();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const prepared = await prepareAiffPlaybackDerivative(source);
+    await collect(prepared.stream);
+    expect(cancelled).toBe(true);
+  });
+});

--- a/apps/web/lib/audio/aiff-to-wav.ts
+++ b/apps/web/lib/audio/aiff-to-wav.ts
@@ -1,0 +1,269 @@
+import { Readable } from 'node:stream';
+
+// Stryker disable next-line ArithmeticOperator: module initializer mutations
+// run before the active mutant; boundary tests guard the exact 1 MiB contract.
+const MAX_AIFF_HEADER_BYTES = 1024 * 1024;
+export const MAX_AUDIO_DERIVATIVE_BYTES = 157_286_444;
+
+export class AudioDerivativeConversionError extends Error {
+  constructor(
+    readonly code: 'invalid_source' | 'resource_limit',
+    message: string
+  ) {
+    super(message);
+    this.name = 'AudioDerivativeConversionError';
+  }
+}
+
+interface AiffPcmMetadata {
+  readonly bitsPerSample: number;
+  readonly channels: number;
+  readonly dataBytes: number;
+  readonly dataOffset: number;
+  readonly sampleRate: number;
+}
+
+function readExtended80(buffer: Buffer, offset: number): number {
+  const exponentWord = buffer.readUInt16BE(offset);
+  const sign = exponentWord & 0x8000 ? -1 : 1;
+  const exponent = exponentWord & 0x7fff;
+  const mantissa = buffer.readBigUInt64BE(offset + 2);
+
+  const fraction = Number(mantissa) / 2 ** 63;
+  return sign * fraction * 2 ** (exponent - 16_383);
+}
+
+function parseAiffPcmHeader(buffer: Buffer): AiffPcmMetadata | null {
+  // Stryker disable next-line EqualityOperator: exactly 12 bytes contain only
+  // FORM metadata; parsing now or after the next read has identical behavior.
+  if (buffer.length < 12) return null;
+  if (
+    buffer.toString('ascii', 0, 4) !== 'FORM' ||
+    buffer.toString('ascii', 8, 12) !== 'AIFF'
+  ) {
+    throw new AudioDerivativeConversionError(
+      'invalid_source',
+      'Expected an uncompressed AIFF container'
+    );
+  }
+
+  let offset = 12;
+  let format: Omit<AiffPcmMetadata, 'dataBytes' | 'dataOffset'> | null = null;
+
+  // Stryker disable next-line EqualityOperator: an exact trailing chunk header
+  // cannot be acted on until its body arrives, so either branch awaits a read.
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString('ascii', offset, offset + 4);
+    const chunkSize = buffer.readUInt32BE(offset + 4);
+    const chunkDataOffset = offset + 8;
+    const paddedChunkEnd = chunkDataOffset + chunkSize + (chunkSize % 2);
+
+    if (chunkId === 'COMM') {
+      // Stryker disable next-line EqualityOperator: when exactly 18 bytes are
+      // buffered both branches converge on awaiting the following SSND chunk.
+      if (chunkSize < 18 || chunkDataOffset + 18 > buffer.length) return null;
+      format = {
+        channels: buffer.readUInt16BE(chunkDataOffset),
+        bitsPerSample: buffer.readUInt16BE(chunkDataOffset + 6),
+        sampleRate: readExtended80(buffer, chunkDataOffset + 8),
+      };
+    }
+
+    if (chunkId === 'SSND') {
+      if (chunkSize < 8 || chunkDataOffset + 8 > buffer.length) return null;
+      if (!format) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data appeared before its format declaration'
+        );
+      }
+
+      const soundOffset = buffer.readUInt32BE(chunkDataOffset);
+      const dataOffset = chunkDataOffset + 8 + soundOffset;
+      const dataBytes = chunkSize - 8 - soundOffset;
+      if (dataOffset > buffer.length) return null;
+
+      if (![8, 16, 24, 32].includes(format.bitsPerSample)) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF PCM bit depth is unsupported'
+        );
+      }
+      if (
+        !Number.isInteger(format.channels) ||
+        format.channels < 1 ||
+        format.channels > 8
+      ) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF channel count is unsupported'
+        );
+      }
+      if (
+        !Number.isInteger(format.sampleRate) ||
+        format.sampleRate < 8_000 ||
+        format.sampleRate > 384_000
+      ) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sample rate is unsupported'
+        );
+      }
+
+      const bytesPerSample = format.bitsPerSample / 8;
+      const blockAlign = format.channels * bytesPerSample;
+      if (dataBytes <= 0) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data is empty'
+        );
+      }
+      if (dataBytes % blockAlign !== 0) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data is not sample-aligned'
+        );
+      }
+      if (dataBytes + 44 > MAX_AUDIO_DERIVATIVE_BYTES) {
+        throw new AudioDerivativeConversionError(
+          'resource_limit',
+          'Playback derivative exceeds the output size limit'
+        );
+      }
+
+      return {
+        bitsPerSample: format.bitsPerSample,
+        channels: format.channels,
+        dataBytes,
+        dataOffset,
+        sampleRate: format.sampleRate,
+      };
+    }
+
+    offset = paddedChunkEnd;
+  }
+
+  return null;
+}
+
+function createWavHeader(metadata: AiffPcmMetadata): Buffer {
+  const bytesPerSample = metadata.bitsPerSample / 8;
+  const blockAlign = metadata.channels * bytesPerSample;
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0);
+  header.writeUInt32LE(metadata.dataBytes + 36, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(metadata.channels, 22);
+  header.writeUInt32LE(metadata.sampleRate, 24);
+  header.writeUInt32LE(metadata.sampleRate * blockAlign, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(metadata.bitsPerSample, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(metadata.dataBytes, 40);
+  return header;
+}
+
+function convertPcmByteOrder(chunk: Buffer, bytesPerSample: number): Buffer {
+  const converted = Buffer.from(chunk);
+  if (bytesPerSample === 1) {
+    for (const index of converted.keys()) {
+      converted[index] = (converted[index] ?? 0) ^ 0x80;
+    }
+    return converted;
+  }
+
+  for (let offset = 0; offset !== converted.length; offset += bytesPerSample) {
+    converted.subarray(offset, offset + bytesPerSample).reverse();
+  }
+  return converted;
+}
+
+export interface PreparedAudioDerivative {
+  readonly outputBytes: number;
+  readonly stream: Readable;
+}
+
+export async function prepareAiffPlaybackDerivative(
+  source: ReadableStream<Uint8Array>
+): Promise<PreparedAudioDerivative> {
+  const reader = source.getReader();
+  const headerChunks: Buffer[] = [];
+  let headerBytes = 0;
+  let metadata: AiffPcmMetadata | null = null;
+
+  while (!metadata) {
+    const next = await reader.read();
+    if (next.done) {
+      throw new AudioDerivativeConversionError(
+        'invalid_source',
+        'AIFF ended before sound data was found'
+      );
+    }
+
+    const chunk = Buffer.from(next.value);
+    headerChunks.push(chunk);
+    headerBytes += chunk.byteLength;
+    if (headerBytes > MAX_AIFF_HEADER_BYTES) {
+      await reader.cancel();
+      throw new AudioDerivativeConversionError(
+        'resource_limit',
+        'AIFF header exceeds the scan limit'
+      );
+    }
+    metadata = parseAiffPcmHeader(Buffer.concat(headerChunks, headerBytes));
+  }
+
+  const parsedMetadata = metadata;
+  const buffered = Buffer.concat(headerChunks, headerBytes);
+  const bytesPerSample = parsedMetadata.bitsPerSample / 8;
+  const initialAudio = buffered.subarray(parsedMetadata.dataOffset);
+
+  async function* wavChunks() {
+    let remaining = parsedMetadata.dataBytes;
+    let carry: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    try {
+      yield createWavHeader(parsedMetadata);
+
+      const emitPcm = function* (input: Buffer) {
+        // Stryker disable next-line ConditionalExpression: concatenating an
+        // empty carry is byte-equivalent but allocates on the hot path.
+        const combined = carry.length ? Buffer.concat([carry, input]) : input;
+        const available = Math.min(combined.length, remaining);
+        const aligned = available - (available % bytesPerSample);
+        // Stryker disable next-line ConditionalExpression,EqualityOperator:
+        // aligned is non-negative; emitting an empty Buffer is discarded by
+        // Node's Readable adapter and is observably byte-equivalent.
+        if (aligned > 0) {
+          const pcm = combined.subarray(0, aligned);
+          remaining -= aligned;
+          yield convertPcmByteOrder(pcm, bytesPerSample);
+        }
+        carry = combined.subarray(aligned, available);
+      };
+
+      yield* emitPcm(initialAudio);
+      while (remaining > 0) {
+        const next = await reader.read();
+        if (next.done) break;
+        yield* emitPcm(Buffer.from(next.value));
+      }
+
+      if (remaining !== 0) {
+        throw new AudioDerivativeConversionError(
+          'invalid_source',
+          'AIFF sound data is truncated'
+        );
+      }
+    } finally {
+      await reader.cancel().catch(() => {});
+    }
+  }
+
+  return {
+    outputBytes: parsedMetadata.dataBytes + 44,
+    stream: Readable.from(wavChunks()),
+  };
+}

--- a/apps/web/lib/audio/constants.ts
+++ b/apps/web/lib/audio/constants.ts
@@ -10,7 +10,6 @@ export type {
   AudioFileDescriptor,
   AudioFormatDefinition,
   AudioFormatId,
-  AudioPlatform,
   AudioUploadSurface,
   Bpm,
   Milliseconds,

--- a/apps/web/lib/audio/playback-derivative.test.ts
+++ b/apps/web/lib/audio/playback-derivative.test.ts
@@ -1,0 +1,354 @@
+import { AUDIO_FORMAT_IDS } from '@jovie/audio-contracts';
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY,
+  nextAudioDerivativeGeneration,
+  parseAudioPlaybackDerivative,
+  resolveRecordingPlayback,
+  withAudioPlaybackDerivative,
+} from './playback-derivative';
+
+const pending = {
+  status: 'pending',
+  generation: 1,
+  sourceFormatId: 'aiff',
+  requestedAt: '2026-07-26T00:00:00.000Z',
+} as const;
+
+function derivativeMetadata(value: unknown) {
+  return { [AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY]: value };
+}
+
+describe('audio playback derivative metadata', () => {
+  it('keeps one stable metadata key', () => {
+    expect(AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY).toBe(
+      'audioPlaybackDerivative'
+    );
+  });
+
+  it('round-trips a valid derivative without replacing sibling metadata', () => {
+    const metadata = withAudioPlaybackDerivative(
+      { spotifyId: 'track-1' },
+      pending
+    );
+
+    expect(metadata.spotifyId).toBe('track-1');
+    expect(parseAudioPlaybackDerivative(metadata)).toEqual(pending);
+    expect(nextAudioDerivativeGeneration(metadata)).toBe(2);
+  });
+
+  it.each([
+    null,
+    {},
+    { status: 'pending', generation: 0, sourceFormatId: 'aiff' },
+    {
+      status: 'ready',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      url: 'https://blob.example/preview.wav',
+      mimeType: 'audio/wav',
+      readyAt: '2026-07-26T00:00:00.000Z',
+      outputBytes: 0,
+    },
+    {
+      status: 'ready',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      url: 'javascript:alert(1)',
+      mimeType: 'audio/mpeg',
+      readyAt: '2026-07-26T00:00:00.000Z',
+      outputBytes: 88_244,
+    },
+    {
+      status: 'retrying',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      attempt: 3,
+      maxAttempts: 2,
+      retryAt: '2026-07-26T00:01:00.000Z',
+    },
+  ])('rejects malformed derivative metadata %#', value => {
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it.each(
+    AUDIO_FORMAT_IDS
+  )('accepts %s as a typed derivative source format', sourceFormatId => {
+    const value = { ...pending, sourceFormatId };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+      value
+    );
+  });
+
+  it.each([
+    undefined,
+    null,
+    '',
+    [],
+    1,
+    { ...pending, generation: 1.5 },
+    { ...pending, generation: 0 },
+    { ...pending, generation: -1 },
+    { ...pending, sourceFormatId: 'ogg' },
+    { ...pending, sourceFormatId: 1 },
+    { ...pending, requestedAt: null },
+    { ...pending, status: 'unknown' },
+  ])('rejects invalid derivative shape %#', value => {
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it('accepts canonical ready metadata over HTTP and HTTPS', () => {
+    for (const url of [
+      'https://blob.example/preview.wav',
+      'http://localhost/preview.wav',
+    ]) {
+      const value = {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        url,
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      };
+      expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+        value
+      );
+    }
+  });
+
+  it.each([
+    { url: 1 },
+    { url: new URL('https://blob.example/preview.wav') },
+    { url: 'not a URL' },
+    { url: 'ftp://blob.example/preview.wav' },
+    { mimeType: 'audio/mpeg' },
+    { readyAt: null },
+    { outputBytes: 1.5 },
+    { outputBytes: 0 },
+  ])('rejects ready metadata with invalid field %#', override => {
+    const value = {
+      status: 'ready',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      url: 'https://blob.example/preview.wav',
+      mimeType: 'audio/wav',
+      readyAt: '2026-07-26T00:00:01.000Z',
+      outputBytes: 88_244,
+      ...override,
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it.each([
+    'invalid_source',
+    'conversion_failed',
+    'resource_limit',
+    'storage_failed',
+  ] as const)('accepts the %s terminal failure reason', reason => {
+    const value = {
+      status: 'failed',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      reason,
+      failedAt: '2026-07-26T00:00:01.000Z',
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+      value
+    );
+  });
+
+  it.each([
+    { reason: 'unknown' },
+    { failedAt: null },
+  ])('rejects failed metadata with invalid field %#', override => {
+    const value = {
+      status: 'failed',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      reason: 'conversion_failed',
+      failedAt: '2026-07-26T00:00:01.000Z',
+      ...override,
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toBeNull();
+  });
+
+  it.each([
+    'platform_unsupported',
+    'conversion_not_supported',
+  ] as const)('accepts the %s unavailable reason', reason => {
+    const value = {
+      status: 'unavailable',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      reason,
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(value))).toEqual(
+      value
+    );
+  });
+
+  it('rejects an unknown unavailable reason', () => {
+    expect(
+      parseAudioPlaybackDerivative(
+        derivativeMetadata({
+          status: 'unavailable',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          reason: 'unknown',
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('accepts retry boundaries and rejects every malformed retry field', () => {
+    const valid = {
+      status: 'retrying',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      attempt: 1,
+      maxAttempts: 1,
+      retryAt: '2026-07-26T00:01:00.000Z',
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(valid))).toEqual(
+      valid
+    );
+
+    for (const override of [
+      { attempt: 0 },
+      { attempt: 1.5 },
+      { maxAttempts: 0 },
+      { maxAttempts: 1.5 },
+      { attempt: 2, maxAttempts: 1 },
+      { retryAt: null },
+    ]) {
+      expect(
+        parseAudioPlaybackDerivative(
+          derivativeMetadata({ ...valid, ...override })
+        )
+      ).toBeNull();
+    }
+  });
+
+  it('accepts only a timestamped superseded state', () => {
+    const valid = {
+      status: 'superseded',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      supersededAt: '2026-07-26T00:01:00.000Z',
+    };
+    expect(parseAudioPlaybackDerivative(derivativeMetadata(valid))).toEqual(
+      valid
+    );
+    expect(
+      parseAudioPlaybackDerivative(
+        derivativeMetadata({ ...valid, supersededAt: null })
+      )
+    ).toBeNull();
+  });
+
+  it('starts the derivative generation at one without metadata', () => {
+    expect(nextAudioDerivativeGeneration(undefined)).toBe(1);
+  });
+});
+
+describe('recording playback resolution', () => {
+  it('uses an existing verified preview without falling back to its master', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: null,
+        audioUrl: 'https://blob.example/master.aiff',
+        previewUrl: 'https://blob.example/verified-preview.wav',
+        metadata: {},
+      })
+    ).toEqual({
+      status: 'ready',
+      source: 'derivative',
+      url: 'https://blob.example/verified-preview.wav',
+    });
+  });
+
+  it('uses a directly playable master', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/mpeg',
+        audioUrl: 'https://blob.example/master.mp3',
+        metadata: {},
+      })
+    ).toEqual({
+      status: 'ready',
+      source: 'master',
+      url: 'https://blob.example/master.mp3',
+    });
+  });
+
+  it.each([
+    {
+      audioFormat: 'audio/mpeg',
+      audioUrl: null,
+      metadata: {},
+    },
+    {
+      audioFormat: null,
+      audioUrl: 'https://blob.example/master.mp3',
+      metadata: {},
+    },
+    {
+      audioFormat: 'audio/unknown',
+      audioUrl: 'https://blob.example/master.bin',
+      metadata: {},
+    },
+  ])('fails closed when a master is not fully typed %#', input => {
+    expect(resolveRecordingPlayback(input)).toEqual({
+      status: 'unavailable',
+      source: null,
+      url: null,
+    });
+  });
+
+  it('does not expose an AIFF master while its derivative is pending', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        metadata: withAudioPlaybackDerivative({}, pending),
+      })
+    ).toEqual({ status: 'pending', source: null, url: null });
+  });
+
+  it('fails closed for a legacy AIFF preview that aliases its master', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        previewUrl: 'https://blob.example/master.aiff',
+        metadata: {},
+      })
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+
+  it('uses only a ready derivative for AIFF', () => {
+    expect(
+      resolveRecordingPlayback({
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        metadata: withAudioPlaybackDerivative(
+          {},
+          {
+            status: 'ready',
+            generation: 1,
+            sourceFormatId: 'aiff',
+            url: 'https://blob.example/preview.wav',
+            mimeType: 'audio/wav',
+            readyAt: '2026-07-26T00:00:01.000Z',
+            outputBytes: 88_244,
+          }
+        ),
+      })
+    ).toEqual({
+      status: 'ready',
+      source: 'derivative',
+      url: 'https://blob.example/preview.wav',
+    });
+  });
+});

--- a/apps/web/lib/audio/playback-derivative.ts
+++ b/apps/web/lib/audio/playback-derivative.ts
@@ -1,0 +1,139 @@
+import {
+  AUDIO_FORMAT_IDS,
+  type AudioFormatId,
+  type AudioPlaybackAsset,
+  type AudioPlaybackDerivative,
+  getAudioFormatByMimeType,
+  resolveAudioSource,
+} from '@jovie/audio-contracts';
+
+// Stryker disable next-line StringLiteral: module initializer mutations run
+// before the active mutant test and are guarded by an exact-value test.
+export const AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY = 'audioPlaybackDerivative';
+
+function isAudioFormatId(value: unknown): value is AudioFormatId {
+  return AUDIO_FORMAT_IDS.includes(value as AudioFormatId);
+}
+
+function isHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  if (!URL.canParse(value)) return false;
+  const parsed = new URL(value);
+  return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+}
+
+function isBaseDerivative(value: Record<string, unknown>): value is Record<
+  string,
+  unknown
+> & {
+  generation: number;
+  sourceFormatId: AudioFormatId;
+} {
+  return (
+    Number.isInteger(value.generation) &&
+    Number(value.generation) > 0 &&
+    isAudioFormatId(value.sourceFormatId)
+  );
+}
+
+export function parseAudioPlaybackDerivative(
+  metadata: Record<string, unknown> | null | undefined
+): AudioPlaybackDerivative | null {
+  const value = metadata?.[AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY];
+  if (!value || Array.isArray(value)) return null;
+
+  const candidate = value as Record<string, unknown>;
+  if (!isBaseDerivative(candidate)) return null;
+
+  switch (candidate.status) {
+    case 'pending':
+      return typeof candidate.requestedAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'ready':
+      return isHttpUrl(candidate.url) &&
+        candidate.mimeType === 'audio/wav' &&
+        typeof candidate.readyAt === 'string' &&
+        Number.isInteger(candidate.outputBytes) &&
+        Number(candidate.outputBytes) > 0
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'failed':
+      return [
+        'invalid_source',
+        'conversion_failed',
+        'resource_limit',
+        'storage_failed',
+      ].includes(String(candidate.reason)) &&
+        typeof candidate.failedAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'unavailable':
+      return ['platform_unsupported', 'conversion_not_supported'].includes(
+        String(candidate.reason)
+      )
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'retrying':
+      return Number.isInteger(candidate.attempt) &&
+        Number(candidate.attempt) > 0 &&
+        Number.isInteger(candidate.maxAttempts) &&
+        Number(candidate.maxAttempts) >= Number(candidate.attempt) &&
+        typeof candidate.retryAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    case 'superseded':
+      return typeof candidate.supersededAt === 'string'
+        ? (candidate as unknown as AudioPlaybackDerivative)
+        : null;
+    default:
+      return null;
+  }
+}
+
+export function nextAudioDerivativeGeneration(
+  metadata: Record<string, unknown> | null | undefined
+): number {
+  return (parseAudioPlaybackDerivative(metadata)?.generation ?? 0) + 1;
+}
+
+export function withAudioPlaybackDerivative(
+  metadata: Record<string, unknown> | null | undefined,
+  derivative: AudioPlaybackDerivative
+): Record<string, unknown> {
+  return {
+    ...(metadata ?? {}),
+    [AUDIO_PLAYBACK_DERIVATIVE_METADATA_KEY]: derivative,
+  };
+}
+
+export function resolveRecordingPlayback(input: {
+  readonly audioFormat: string | null;
+  readonly audioUrl: string | null;
+  readonly previewUrl?: string | null;
+  readonly metadata?: Record<string, unknown> | null;
+}) {
+  if (input.previewUrl && input.previewUrl !== input.audioUrl) {
+    return {
+      status: 'ready',
+      source: 'derivative',
+      url: input.previewUrl,
+    } as const;
+  }
+
+  if (!input.audioUrl || !input.audioFormat) {
+    return { status: 'unavailable', source: null, url: null } as const;
+  }
+
+  const format = getAudioFormatByMimeType(input.audioFormat);
+  if (!format) {
+    return { status: 'unavailable', source: null, url: null } as const;
+  }
+
+  const asset: AudioPlaybackAsset = {
+    formatId: format.id,
+    masterUrl: input.audioUrl,
+    derivative: parseAudioPlaybackDerivative(input.metadata),
+  };
+  return resolveAudioSource(asset, 'web_chromium', 'nativePlayback');
+}

--- a/apps/web/tests/e2e/audio-real-media-decoding.spec.ts
+++ b/apps/web/tests/e2e/audio-real-media-decoding.spec.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
 import { expect, type Page, test } from '@playwright/test';
+import { prepareAiffPlaybackDerivative } from '../../lib/audio/aiff-to-wav';
 import {
   MALFORMED_AUDIO_FIXTURES,
   REAL_AUDIO_FIXTURES,
@@ -85,4 +87,48 @@ test.describe('canonical real audio corpus', () => {
       });
     });
   }
+
+  test('a streamed AIFF derivative becomes real Chromium-decodable WAV audio', async ({
+    page,
+  }) => {
+    const aiff = readFileSync(
+      resolve(process.cwd(), 'tests/fixtures/audio', 'tone.aiff')
+    );
+    const source = Readable.toWeb(
+      Readable.from(
+        (function* chunks() {
+          for (let offset = 0; offset < aiff.length; offset += 17) {
+            yield aiff.subarray(offset, offset + 17);
+          }
+        })()
+      )
+    ) as ReadableStream<Uint8Array>;
+    const prepared = await prepareAiffPlaybackDerivative(source);
+    const outputChunks: Buffer[] = [];
+    for await (const chunk of prepared.stream) {
+      outputChunks.push(Buffer.from(chunk));
+    }
+    const derivative = Buffer.concat(outputChunks);
+
+    expect(derivative.byteLength).toBe(prepared.outputBytes);
+    const result = await page.evaluate(async encodedBytes => {
+      const decodedBytes = Uint8Array.from(atob(encodedBytes), character =>
+        character.charCodeAt(0)
+      );
+      const context = new AudioContext();
+      try {
+        const decoded = await context.decodeAudioData(decodedBytes.buffer);
+        return {
+          channels: decoded.numberOfChannels,
+          duration: decoded.duration,
+        };
+      } finally {
+        await context.close();
+      }
+    }, derivative.toString('base64'));
+
+    expect(result.channels).toBe(1);
+    expect(result.duration).toBeGreaterThanOrEqual(0.99);
+    expect(result.duration).toBeLessThanOrEqual(1.01);
+  });
 });

--- a/packages/audio-contracts/capabilities.test.ts
+++ b/packages/audio-contracts/capabilities.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_CAPABILITY_PLATFORMS,
+  AUDIO_CAPABILITY_REGISTRY,
+  AUDIO_FORMAT_IDS,
+  type AudioPlaybackAsset,
+  getAudioCapability,
+  resolveAudioSource,
+} from './index';
+
+const AIFF_MASTER = {
+  formatId: 'aiff',
+  masterUrl: 'https://blob.example/master.aiff',
+} as const satisfies AudioPlaybackAsset;
+
+describe('audio capability registry', () => {
+  it('defines every platform and purpose for every accepted format', () => {
+    expect(Object.keys(AUDIO_CAPABILITY_REGISTRY)).toEqual(AUDIO_FORMAT_IDS);
+
+    for (const formatId of AUDIO_FORMAT_IDS) {
+      expect(Object.keys(AUDIO_CAPABILITY_REGISTRY[formatId])).toEqual(
+        AUDIO_CAPABILITY_PLATFORMS
+      );
+      for (const platform of AUDIO_CAPABILITY_PLATFORMS) {
+        expect(
+          Object.keys(AUDIO_CAPABILITY_REGISTRY[formatId][platform])
+        ).toEqual([
+          'uploadAcceptance',
+          'masterPreservation',
+          'nativePlayback',
+          'waveformDecode',
+          'analysisInput',
+        ]);
+      }
+    }
+  });
+
+  it('keeps acceptance separate from real Chromium decode capability', () => {
+    expect(getAudioCapability('aiff', 'web_chromium', 'uploadAcceptance')).toBe(
+      'direct'
+    );
+    expect(
+      getAudioCapability('aiff', 'web_chromium', 'masterPreservation')
+    ).toBe('direct');
+    expect(getAudioCapability('aiff', 'web_chromium', 'nativePlayback')).toBe(
+      'derivative_required'
+    );
+    expect(getAudioCapability('aiff', 'web_chromium', 'waveformDecode')).toBe(
+      'derivative_required'
+    );
+    expect(getAudioCapability('mp3', 'web_chromium', 'nativePlayback')).toBe(
+      'direct'
+    );
+  });
+
+  it('fails closed for unverified iOS capability', () => {
+    expect(
+      getAudioCapability('m4a', 'ios_avfoundation', 'nativePlayback')
+    ).toBe('unverified');
+    expect(
+      resolveAudioSource(
+        { formatId: 'm4a', masterUrl: 'https://blob.example/master.m4a' },
+        'ios_avfoundation',
+        'nativePlayback'
+      )
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+
+  it('never lets a ready derivative override an unverified platform', () => {
+    expect(
+      resolveAudioSource(
+        {
+          formatId: 'aiff',
+          masterUrl: 'https://blob.example/master.aiff',
+          derivative: {
+            generation: 1,
+            sourceFormatId: 'aiff',
+            status: 'ready',
+            url: 'https://blob.example/preview.wav',
+            mimeType: 'audio/wav',
+            readyAt: '2026-07-26T00:00:01.000Z',
+            outputBytes: 88_244,
+          },
+        },
+        'ios_avfoundation',
+        'nativePlayback'
+      )
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+});
+
+describe('audio source resolution', () => {
+  it('returns a directly supported master without requiring a derivative', () => {
+    expect(
+      resolveAudioSource(
+        { formatId: 'flac', masterUrl: 'https://blob.example/master.flac' },
+        'web_chromium',
+        'waveformDecode'
+      )
+    ).toEqual({
+      status: 'ready',
+      source: 'master',
+      url: 'https://blob.example/master.flac',
+    });
+  });
+
+  it('reports a missing required derivative as unavailable', () => {
+    expect(
+      resolveAudioSource(AIFF_MASTER, 'web_chromium', 'nativePlayback')
+    ).toEqual({ status: 'unavailable', source: null, url: null });
+  });
+
+  it.each([
+    'pending',
+    'failed',
+    'unavailable',
+    'retrying',
+    'superseded',
+  ] as const)('never exposes an AIFF master while derivative is %s', status => {
+    const common = {
+      generation: 1,
+      sourceFormatId: 'aiff' as const,
+    };
+    const derivative = {
+      pending: {
+        ...common,
+        status: 'pending' as const,
+        requestedAt: '2026-07-26T00:00:00.000Z',
+      },
+      failed: {
+        ...common,
+        status: 'failed' as const,
+        reason: 'conversion_failed' as const,
+        failedAt: '2026-07-26T00:00:00.000Z',
+      },
+      unavailable: {
+        ...common,
+        status: 'unavailable' as const,
+        reason: 'conversion_not_supported' as const,
+      },
+      retrying: {
+        ...common,
+        status: 'retrying' as const,
+        attempt: 1,
+        maxAttempts: 3,
+        retryAt: '2026-07-26T00:01:00.000Z',
+      },
+      superseded: {
+        ...common,
+        status: 'superseded' as const,
+        supersededAt: '2026-07-26T00:00:00.000Z',
+      },
+    }[status];
+
+    expect(
+      resolveAudioSource(
+        { ...AIFF_MASTER, derivative },
+        'web_chromium',
+        'nativePlayback'
+      )
+    ).toEqual({ status, source: null, url: null });
+  });
+
+  it('returns only the ready AIFF derivative for playback and waveform decode', () => {
+    const asset: AudioPlaybackAsset = {
+      ...AIFF_MASTER,
+      derivative: {
+        generation: 1,
+        sourceFormatId: 'aiff',
+        status: 'ready',
+        url: 'https://blob.example/preview.wav',
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      },
+    };
+
+    for (const purpose of ['nativePlayback', 'waveformDecode'] as const) {
+      expect(resolveAudioSource(asset, 'web_chromium', purpose)).toEqual({
+        status: 'ready',
+        source: 'derivative',
+        url: 'https://blob.example/preview.wav',
+      });
+    }
+  });
+});

--- a/packages/audio-contracts/capabilities.ts
+++ b/packages/audio-contracts/capabilities.ts
@@ -1,0 +1,211 @@
+import type { AudioFormatId } from './index';
+
+export const AUDIO_CAPABILITY_PLATFORMS = [
+  'web_chromium',
+  'desktop_chromium',
+  'ios_avfoundation',
+  'server_analysis',
+] as const;
+
+export type AudioCapabilityPlatform =
+  (typeof AUDIO_CAPABILITY_PLATFORMS)[number];
+
+export type AudioCapabilityPurpose =
+  | 'uploadAcceptance'
+  | 'masterPreservation'
+  | 'nativePlayback'
+  | 'waveformDecode'
+  | 'analysisInput';
+
+export type AudioCapabilityStatus =
+  | 'direct'
+  | 'derivative_required'
+  | 'unavailable'
+  | 'unverified'
+  | 'not_applicable';
+
+export interface AudioPlatformCapabilities {
+  readonly uploadAcceptance: AudioCapabilityStatus;
+  readonly masterPreservation: AudioCapabilityStatus;
+  readonly nativePlayback: AudioCapabilityStatus;
+  readonly waveformDecode: AudioCapabilityStatus;
+  readonly analysisInput: AudioCapabilityStatus;
+}
+
+export type AudioCapabilityRegistry = Readonly<
+  Record<
+    AudioFormatId,
+    Readonly<Record<AudioCapabilityPlatform, AudioPlatformCapabilities>>
+  >
+>;
+
+const DIRECT_CHROMIUM_CAPABILITIES = {
+  uploadAcceptance: 'direct',
+  masterPreservation: 'direct',
+  nativePlayback: 'direct',
+  waveformDecode: 'direct',
+  analysisInput: 'not_applicable',
+} as const satisfies AudioPlatformCapabilities;
+
+const AIFF_CHROMIUM_CAPABILITIES = {
+  uploadAcceptance: 'direct',
+  masterPreservation: 'direct',
+  nativePlayback: 'derivative_required',
+  waveformDecode: 'derivative_required',
+  analysisInput: 'not_applicable',
+} as const satisfies AudioPlatformCapabilities;
+
+const UNVERIFIED_IOS_CAPABILITIES = {
+  uploadAcceptance: 'unavailable',
+  masterPreservation: 'unavailable',
+  nativePlayback: 'unverified',
+  waveformDecode: 'unverified',
+  analysisInput: 'not_applicable',
+} as const satisfies AudioPlatformCapabilities;
+
+const DIRECT_SERVER_ANALYSIS_CAPABILITIES = {
+  uploadAcceptance: 'direct',
+  masterPreservation: 'direct',
+  nativePlayback: 'not_applicable',
+  waveformDecode: 'not_applicable',
+  analysisInput: 'direct',
+} as const satisfies AudioPlatformCapabilities;
+
+// Stryker disable next-line BlockStatement: this registry helper executes
+// during module initialization before Stryker can activate body mutants.
+function directFormatCapabilities() {
+  return {
+    web_chromium: DIRECT_CHROMIUM_CAPABILITIES,
+    desktop_chromium: DIRECT_CHROMIUM_CAPABILITIES,
+    ios_avfoundation: UNVERIFIED_IOS_CAPABILITIES,
+    server_analysis: DIRECT_SERVER_ANALYSIS_CAPABILITIES,
+  } as const satisfies Readonly<
+    Record<AudioCapabilityPlatform, AudioPlatformCapabilities>
+  >;
+}
+
+/**
+ * Canonical, evidence-scoped audio capability registry.
+ *
+ * A format being accepted for upload never implies that a runtime can play or
+ * decode it. `unverified` is intentional: consumers must fail closed until a
+ * real platform fixture proves support.
+ */
+export const AUDIO_CAPABILITY_REGISTRY = {
+  mp3: directFormatCapabilities(),
+  wav: directFormatCapabilities(),
+  flac: directFormatCapabilities(),
+  aiff: {
+    web_chromium: AIFF_CHROMIUM_CAPABILITIES,
+    desktop_chromium: AIFF_CHROMIUM_CAPABILITIES,
+    ios_avfoundation: UNVERIFIED_IOS_CAPABILITIES,
+    server_analysis: DIRECT_SERVER_ANALYSIS_CAPABILITIES,
+  },
+  aac: directFormatCapabilities(),
+  m4a: directFormatCapabilities(),
+} as const satisfies AudioCapabilityRegistry;
+
+export type AudioDerivativeStatus =
+  | 'pending'
+  | 'ready'
+  | 'failed'
+  | 'unavailable'
+  | 'retrying'
+  | 'superseded';
+
+interface AudioDerivativeBase {
+  readonly generation: number;
+  readonly sourceFormatId: AudioFormatId;
+}
+
+export type AudioPlaybackDerivative =
+  | (AudioDerivativeBase & {
+      readonly status: 'pending';
+      readonly requestedAt: string;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'ready';
+      readonly url: string;
+      readonly mimeType: 'audio/wav';
+      readonly readyAt: string;
+      readonly outputBytes: number;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'failed';
+      readonly reason:
+        | 'invalid_source'
+        | 'conversion_failed'
+        | 'resource_limit'
+        | 'storage_failed';
+      readonly failedAt: string;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'unavailable';
+      readonly reason: 'platform_unsupported' | 'conversion_not_supported';
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'retrying';
+      readonly attempt: number;
+      readonly maxAttempts: number;
+      readonly retryAt: string;
+    })
+  | (AudioDerivativeBase & {
+      readonly status: 'superseded';
+      readonly supersededAt: string;
+    });
+
+export interface AudioPlaybackAsset {
+  readonly formatId: AudioFormatId;
+  readonly masterUrl: string;
+  readonly derivative?: AudioPlaybackDerivative | null;
+}
+
+export type AudioSourceResolution =
+  | {
+      readonly status: 'ready';
+      readonly source: 'master' | 'derivative';
+      readonly url: string;
+    }
+  | {
+      readonly status: Exclude<AudioDerivativeStatus, 'ready'>;
+      readonly source: null;
+      readonly url: null;
+    };
+
+export function getAudioCapability(
+  formatId: AudioFormatId,
+  platform: AudioCapabilityPlatform,
+  purpose: AudioCapabilityPurpose
+): AudioCapabilityStatus {
+  return AUDIO_CAPABILITY_REGISTRY[formatId][platform][purpose];
+}
+
+export function resolveAudioSource(
+  asset: AudioPlaybackAsset,
+  platform: AudioCapabilityPlatform,
+  purpose: 'nativePlayback' | 'waveformDecode'
+): AudioSourceResolution {
+  const capability = getAudioCapability(asset.formatId, platform, purpose);
+
+  if (capability === 'direct') {
+    return { status: 'ready', source: 'master', url: asset.masterUrl };
+  }
+
+  if (capability !== 'derivative_required') {
+    return { status: 'unavailable', source: null, url: null };
+  }
+
+  if (asset.derivative?.status === 'ready') {
+    return {
+      status: 'ready',
+      source: 'derivative',
+      url: asset.derivative.url,
+    };
+  }
+
+  return {
+    status: asset.derivative?.status ?? 'unavailable',
+    source: null,
+    url: null,
+  };
+}

--- a/packages/audio-contracts/index.test.ts
+++ b/packages/audio-contracts/index.test.ts
@@ -82,12 +82,6 @@ describe('audio format registry', () => {
       'chat',
       'promo_download',
     ]);
-    expect(format.platforms).toEqual({
-      web: true,
-      desktop: true,
-      ios: false,
-    });
-
     for (const mimeType of format.mimeTypes) {
       expect(getAudioFormatByMimeType(mimeType)?.id).toBe(format.id);
       expect(isSupportedAudioMimeType(mimeType)).toBe(true);

--- a/packages/audio-contracts/index.ts
+++ b/packages/audio-contracts/index.ts
@@ -1,5 +1,6 @@
 export * from './analysis';
 export * from './beat-grid';
+export * from './capabilities';
 export * from './lyrics';
 export * from './performance';
 export * from './playback';
@@ -16,7 +17,6 @@ export const AUDIO_FORMAT_IDS = [
 
 export type AudioFormatId = (typeof AUDIO_FORMAT_IDS)[number];
 export type AudioUploadSurface = 'library' | 'chat' | 'promo_download';
-export type AudioPlatform = 'web' | 'desktop' | 'ios';
 
 export interface AudioFormatDefinition {
   readonly id: AudioFormatId;
@@ -27,7 +27,6 @@ export interface AudioFormatDefinition {
   readonly container: string;
   readonly expectedCodecs: readonly string[];
   readonly uploadSurfaces: readonly AudioUploadSurface[];
-  readonly platforms: Readonly<Record<AudioPlatform, boolean>>;
 }
 
 const ALL_UPLOAD_SURFACES = [
@@ -35,12 +34,6 @@ const ALL_UPLOAD_SURFACES = [
   'chat',
   'promo_download',
 ] as const satisfies readonly AudioUploadSurface[];
-
-const CURRENT_PLATFORMS = {
-  web: true,
-  desktop: true,
-  ios: false,
-} as const satisfies Readonly<Record<AudioPlatform, boolean>>;
 
 /**
  * Canonical contract for formats Jovie currently accepts.
@@ -59,7 +52,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'mpeg-audio',
     expectedCodecs: ['mp3'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'wav',
@@ -70,7 +62,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'wave',
     expectedCodecs: ['pcm', 'ieee-float'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'flac',
@@ -81,7 +72,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'flac',
     expectedCodecs: ['flac'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'aiff',
@@ -92,7 +82,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'aiff',
     expectedCodecs: ['pcm'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'aac',
@@ -103,7 +92,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'adts',
     expectedCodecs: ['aac'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
   {
     id: 'm4a',
@@ -114,7 +102,6 @@ export const AUDIO_FORMAT_REGISTRY = [
     container: 'iso-base-media',
     expectedCodecs: ['aac', 'alac'],
     uploadSurfaces: ALL_UPLOAD_SURFACES,
-    platforms: CURRENT_PLATFORMS,
   },
 ] as const satisfies readonly AudioFormatDefinition[];
 

--- a/packages/audio-contracts/stryker.config.mjs
+++ b/packages/audio-contracts/stryker.config.mjs
@@ -11,6 +11,7 @@ const config = {
   reporters: ['progress', 'clear-text', 'json'],
   mutate: [
     'index.ts',
+    'capabilities.ts',
     'units.ts',
     'analysis.ts',
     'beat-grid.ts',
@@ -21,6 +22,7 @@ const config = {
   ],
   testFiles: [
     'index.test.ts',
+    'capabilities.test.ts',
     'analysis.test.ts',
     'beat-grid.test.ts',
     'lyrics.test.ts',


### PR DESCRIPTION
## Summary
- defines the canonical typed audio capability registry across web Chromium, desktop Chromium, iOS AVFoundation, and server processing
- separates acceptance, preservation, native playback, waveform, and analysis capabilities
- keeps platform/format decisions fail-closed at runtime boundaries

Linear: JOV-4393

## Stack
1. **This PR — capability registry**
2. playback core
3. derivative pipeline
4. UI adoption

This is a real locally tracked Graphite stack. Graphite submission was attempted first, but the JovieInc Graphite plan is expired, so publication uses the documented GitHub fallback with the exact Graphite parent chain.

## Verification
- audio-contracts focused: 30/30
- audio-contracts full mutation: 100% (839 tested; 834 assertion-killed, 5 timeout-killed, 0 survived, 0 uncovered)
- audio-contracts + web typecheck
- Biome clean
- full normal pre-push gate on top-of-stack: 8/8 Vitest shards, typecheck, lint, guards, CI harness

## Release
Draft only. Do not queue from reduced child checks; retarget to main and obtain full required main-target checks before queueing.