### PR TITLE
feat(audio): derive verified browser playback assets

### DIFF
--- a/apps/web/app/api/library/audio/confirm/route.ts
+++ b/apps/web/app/api/library/audio/confirm/route.ts
@@ -6,17 +6,26 @@
  * the catalog is missing audio.
  */
 
-import { and, eq } from 'drizzle-orm';
+import {
+  type AudioPlaybackDerivative,
+  getAudioCapability,
+  getAudioFormat,
+} from '@jovie/audio-contracts';
+import { and, sql as drizzleSql, eq } from 'drizzle-orm';
 import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { ALLOWED_AUDIO_MIME_TYPES } from '@/lib/audio/constants';
+import {
+  nextAudioDerivativeGeneration,
+  parseAudioPlaybackDerivative,
+} from '@/lib/audio/playback-derivative';
 import { resolvePrimaryRecordingForRelease } from '@/lib/audio/resolve-release-recording';
 import { requireAuth } from '@/lib/auth/require-auth';
 import { getSessionContext } from '@/lib/auth/session';
 import { createSmartLinkContentTag } from '@/lib/cache/tags';
 import { db } from '@/lib/db';
 import { discogRecordings } from '@/lib/db/schema/content';
+import { ingestionJobs } from '@/lib/db/schema/ingestion';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 
@@ -44,8 +53,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { releaseId, blobUrl, fileMimeType } = parsed.data;
-    if (!ALLOWED_AUDIO_MIME_TYPES.has(fileMimeType)) {
+    const { releaseId, blobUrl, fileMimeType, fileName } = parsed.data;
+    const format = getAudioFormat({ name: fileName, type: fileMimeType });
+    if (!format) {
       return NextResponse.json(
         { error: 'Unsupported audio file type' },
         { status: 400, headers: NO_STORE_HEADERS }
@@ -84,20 +94,77 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    await db
-      .update(discogRecordings)
-      .set({
-        previewUrl: blobUrl,
-        audioUrl: blobUrl,
-        audioFormat: fileMimeType,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(discogRecordings.id, recording.recordingId),
-          eq(discogRecordings.creatorProfileId, profile.id)
-        )
-      );
+    const playbackCapability = getAudioCapability(
+      format.id,
+      'web_chromium',
+      'nativePlayback'
+    );
+    const now = new Date();
+    const generation = nextAudioDerivativeGeneration(recording.metadata);
+    const derivative: AudioPlaybackDerivative | null =
+      playbackCapability === 'derivative_required'
+        ? {
+            status: 'pending',
+            generation,
+            sourceFormatId: format.id,
+            requestedAt: now.toISOString(),
+          }
+        : null;
+    const previousDerivative = parseAudioPlaybackDerivative(recording.metadata);
+    const metadataDerivative: AudioPlaybackDerivative | null =
+      derivative ??
+      (previousDerivative &&
+      ['pending', 'retrying'].includes(previousDerivative.status)
+        ? {
+            status: 'superseded',
+            generation: previousDerivative.generation,
+            sourceFormatId: previousDerivative.sourceFormatId,
+            supersededAt: now.toISOString(),
+          }
+        : null);
+    const previewUrl = playbackCapability === 'direct' ? blobUrl : null;
+
+    await db.transaction(async tx => {
+      await tx
+        .update(discogRecordings)
+        .set({
+          previewUrl,
+          audioUrl: blobUrl,
+          audioFormat: format.canonicalMimeType,
+          ...(metadataDerivative
+            ? {
+                metadata: drizzleSql`jsonb_set(
+                  coalesce(${discogRecordings.metadata}, '{}'::jsonb),
+                  '{audioPlaybackDerivative}',
+                  ${JSON.stringify(metadataDerivative)}::jsonb,
+                  true
+                )`,
+              }
+            : {}),
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(discogRecordings.id, recording.recordingId),
+            eq(discogRecordings.creatorProfileId, profile.id)
+          )
+        );
+
+      if (derivative) {
+        await tx.insert(ingestionJobs).values({
+          jobType: 'audio_playback_derivative',
+          payload: {
+            recordingId: recording.recordingId,
+            creatorProfileId: profile.id,
+            formatId: format.id,
+            generation,
+          },
+          priority: -10,
+          maxAttempts: 3,
+          dedupKey: `audio_playback_derivative:${recording.recordingId}:${generation}`,
+        });
+      }
+    });
 
     revalidateTag(`releases:${clerkUserId}:${profile.id}`, 'max');
     revalidateTag(createSmartLinkContentTag(profile.id), 'max');
@@ -105,7 +172,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       {
         success: true,
-        previewUrl: blobUrl,
+        previewUrl,
+        hasAudioMaster: true,
+        playbackDerivative: derivative,
         recordingId: recording.recordingId,
       },
       { status: 200, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/library/audio/snippet/route.ts
+++ b/apps/web/app/api/library/audio/snippet/route.ts
@@ -9,6 +9,10 @@ import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
+  parseAudioPlaybackDerivative,
+  resolveRecordingPlayback,
+} from '@/lib/audio/playback-derivative';
+import {
   getSnippetFromRecording,
   resolvePrimaryRecordingForRelease,
 } from '@/lib/audio/resolve-release-recording';
@@ -71,13 +75,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const previewUrl = recording.previewUrl ?? recording.audioUrl;
+    const playback = resolveRecordingPlayback(recording);
     const snippet = getSnippetFromRecording(recording);
 
     return NextResponse.json(
       {
         recordingId: recording.recordingId,
-        previewUrl,
+        previewUrl: playback.url,
+        playbackStatus: playback.status,
+        playbackDerivative: parseAudioPlaybackDerivative(recording.metadata),
+        hasAudioMaster: Boolean(recording.audioUrl),
         durationMs: recording.durationMs,
         snippet,
       },
@@ -130,9 +137,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!recording.previewUrl && !recording.audioUrl) {
+    const playback = resolveRecordingPlayback(recording);
+    if (playback.status !== 'ready') {
       return NextResponse.json(
-        { error: 'Release has no uploaded audio' },
+        { error: 'Release audio preview is not ready' },
         { status: 409, headers: NO_STORE_HEADERS }
       );
     }

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
@@ -95,7 +95,7 @@ export const TrackRow = memo(function TrackRow({
     });
   }, [allProviders, providerMap]);
 
-  const previewUrl = track.previewUrl || track.audioUrl;
+  const previewUrl = track.previewUrl;
   const canPlay = Boolean(previewUrl);
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isPlaying = isActiveTrack && playbackState.isPlaying;
@@ -141,7 +141,7 @@ export const TrackRow = memo(function TrackRow({
     </button>
   ) : (
     <span className='system-b-track-row-preview-unavailable flex h-7 w-7 items-center justify-center rounded-full text-secondary-token/80'>
-      <VolumeX className='h-3.5 w-3.5' aria-label='No preview available' />
+      <VolumeX className='h-3.5 w-3.5' aria-label='No Preview Available' />
     </span>
   );
 
@@ -171,7 +171,7 @@ export const TrackRow = memo(function TrackRow({
             variant='secondary'
             className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
             title='Explicit content'
-            aria-label='Explicit content'
+            aria-label='Explicit Content'
           >
             E
           </Badge>
@@ -299,7 +299,7 @@ export const TrackRow = memo(function TrackRow({
                     variant='secondary'
                     className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
                     title='Explicit content'
-                    aria-label='Explicit content'
+                    aria-label='Explicit Content'
                   >
                     E
                   </Badge>

--- a/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
+++ b/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { AudioPlaybackDerivative } from '@jovie/audio-contracts';
 import { upload } from '@vercel/blob/client';
 import { FileAudio2, Loader2, Upload } from 'lucide-react';
 import {
@@ -54,7 +55,13 @@ export function ReleaseAudioAssetPanel({
   const readyTestId =
     testIdPrefix === 'library' ? 'library-audio-ready' : 'release-audio-ready';
   const inputRef = useRef<HTMLInputElement>(null);
+  const onUploadedRef = useRef(onUploaded);
   const [localPreviewUrl, setLocalPreviewUrl] = useState(previewUrl ?? null);
+  const [hasAudioMaster, setHasAudioMaster] = useState(Boolean(previewUrl));
+  const [playbackDerivative, setPlaybackDerivative] =
+    useState<AudioPlaybackDerivative | null>(null);
+  const [isCheckingAudioState, setIsCheckingAudioState] = useState(!previewUrl);
+  const [audioStateRevision, setAudioStateRevision] = useState(0);
   const [snippet, setSnippet] = useState<AudioSnippet | null>(
     initialSnippet ?? null
   );
@@ -73,28 +80,56 @@ export function ReleaseAudioAssetPanel({
   }, [initialSnippet]);
 
   useEffect(() => {
-    if (initialSnippet || !localPreviewUrl) return;
+    onUploadedRef.current = onUploaded;
+  }, [onUploaded]);
 
+  useEffect(() => {
+    if (initialSnippet && localPreviewUrl) return;
     let cancelled = false;
-    fetch(
-      `/api/library/audio/snippet?releaseId=${encodeURIComponent(releaseId)}`
-    )
-      .then(async response => {
-        if (!response.ok) return null;
-        return (await response.json()) as {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const loadAudioState = async () => {
+      try {
+        const response = await fetch(
+          `/api/library/audio/snippet?releaseId=${encodeURIComponent(releaseId)}`
+        );
+        if (!response.ok) return;
+        const body = (await response.json()) as {
           snippet?: AudioSnippet | null;
+          previewUrl?: string | null;
+          hasAudioMaster?: boolean;
+          playbackDerivative?: AudioPlaybackDerivative | null;
         };
-      })
-      .then(body => {
-        if (cancelled || !body?.snippet) return;
-        setSnippet(body.snippet);
-      })
-      .catch(() => {});
+        if (cancelled) return;
+
+        if (body.snippet) setSnippet(body.snippet);
+        if (body.previewUrl && !localPreviewUrl) {
+          onUploadedRef.current?.(body.previewUrl);
+        }
+        setLocalPreviewUrl(body.previewUrl ?? null);
+        setHasAudioMaster(Boolean(body.hasAudioMaster));
+        setPlaybackDerivative(body.playbackDerivative ?? null);
+
+        if (
+          body.playbackDerivative?.status === 'pending' ||
+          body.playbackDerivative?.status === 'retrying'
+        ) {
+          timeoutId = setTimeout(loadAudioState, 3_000);
+        }
+      } catch {
+        // Preserve the last known state; the next mount or retry will re-read it.
+      } finally {
+        if (!cancelled) setIsCheckingAudioState(false);
+      }
+    };
+
+    loadAudioState().catch(() => {});
 
     return () => {
       cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [initialSnippet, localPreviewUrl, releaseId]);
+  }, [audioStateRevision, initialSnippet, localPreviewUrl, releaseId]);
 
   const openFilePicker = useCallback(() => {
     inputRef.current?.click();
@@ -155,18 +190,27 @@ export function ReleaseAudioAssetPanel({
         });
 
         const body = (await response.json().catch(() => ({}))) as {
-          readonly previewUrl?: string;
+          readonly previewUrl?: string | null;
+          readonly hasAudioMaster?: boolean;
+          readonly playbackDerivative?: AudioPlaybackDerivative | null;
           readonly error?: string;
         };
 
-        if (!response.ok || !body.previewUrl) {
+        if (!response.ok || !body.hasAudioMaster) {
           throw new Error(body.error ?? 'Audio upload failed');
         }
 
-        setLocalPreviewUrl(body.previewUrl);
+        setLocalPreviewUrl(body.previewUrl ?? null);
+        setHasAudioMaster(true);
+        setPlaybackDerivative(body.playbackDerivative ?? null);
+        setAudioStateRevision(revision => revision + 1);
         setSnippet(null);
-        onUploaded?.(body.previewUrl);
-        toast.success('Audio attached to release');
+        if (body.previewUrl) onUploaded?.(body.previewUrl);
+        toast.success(
+          body.previewUrl
+            ? 'Audio attached to release'
+            : 'Audio uploaded — preparing preview'
+        );
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Audio upload failed';
@@ -226,6 +270,76 @@ export function ReleaseAudioAssetPanel({
     },
     [onSnippetSaved, releaseId]
   );
+
+  if (!localPreviewUrl && (isCheckingAudioState || hasAudioMaster)) {
+    const status = playbackDerivative?.status;
+    const isWorking =
+      isCheckingAudioState ||
+      isUploading ||
+      status === 'pending' ||
+      status === 'retrying';
+    const statusCopy = {
+      pending: 'Preparing a browser-ready preview and waveform.',
+      retrying: 'Preview preparation is retrying automatically.',
+      failed: 'We could not prepare this preview. Your original is preserved.',
+      unavailable:
+        'This format is preserved, but a browser preview is not available.',
+      superseded: 'A newer audio upload replaced this preview.',
+      ready: 'Preview metadata is ready, but its audio URL is unavailable.',
+    }[status ?? 'pending'];
+
+    return (
+      <div
+        className='flex min-h-30 w-full items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-3 py-4'
+        data-testid='release-audio-derivative-status'
+        aria-live='polite'
+        aria-busy={isWorking || undefined}
+      >
+        <span className='grid h-8 w-8 shrink-0 place-items-center rounded-md bg-surface-1 text-secondary-token'>
+          {isWorking ? (
+            <Loader2
+              className='h-4 w-4 animate-spin motion-reduce:animate-none'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          ) : (
+            <FileAudio2
+              className='h-4 w-4'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          )}
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='text-xs font-medium text-primary-token'>
+            {isWorking ? 'Preparing preview' : 'Preview unavailable'}
+          </p>
+          <p className='mt-0.5 text-2xs leading-4 text-tertiary-token'>
+            {statusCopy}
+          </p>
+        </div>
+        {!isWorking && isEditable ? (
+          <button
+            type='button'
+            onClick={openFilePicker}
+            className='focus-ring-themed shrink-0 rounded-md border border-subtle bg-surface-1 px-2 py-1 text-2xs font-medium text-primary-token transition-colors duration-subtle hover:bg-surface-0'
+          >
+            Replace audio
+          </button>
+        ) : null}
+        <input
+          ref={inputRef}
+          type='file'
+          accept={AUDIO_ACCEPT}
+          onChange={handleInputChange}
+          disabled={!isEditable || isUploading}
+          tabIndex={disabledTabIndex}
+          className='sr-only'
+          aria-label={`Upload audio for ${releaseTitle}`}
+        />
+      </div>
+    );
+  }
 
   if (!localPreviewUrl) {
     const formats = SUPPORTED_AUDIO_FORMAT_LABELS.join(', ');

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -82,7 +82,7 @@ function buildReleasePlaybackQueue(
   release: Release
 ): TrackControlSource[] {
   return tracks.flatMap(track => {
-    const audioUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+    const audioUrl = track.previewUrl ?? undefined;
     if (!audioUrl) return [];
 
     return [
@@ -249,7 +249,7 @@ function TrackListRow({
   readonly isLastRow: boolean;
   readonly onSelect?: () => void;
 }) {
-  const playableUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+  const playableUrl = track.previewUrl ?? undefined;
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isTrackPlaying = isActiveTrack && playbackState.isPlaying;
   const trackDuration =

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -271,7 +271,7 @@ export function TrackSidebar({
     ];
   }, [track, isSmartLinkCopied, handleCopySmartLink, smartLinkUrl]);
 
-  const playableUrl = track?.audioUrl ?? track?.previewUrl ?? null;
+  const playableUrl = track?.previewUrl ?? null;
   const isThisTrack = playbackState.activeTrackId === track?.id;
   const isPlaying = isThisTrack && playbackState.isPlaying;
   const currentTime = isThisTrack ? playbackState.currentTime : 0;

--- a/apps/web/lib/audio/jobs/playback-derivative.test.ts
+++ b/apps/web/lib/audio/jobs/playback-derivative.test.ts
@@ -1,0 +1,589 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  delMock: vi.fn(),
+  getMock: vi.fn(),
+  infoMock: vi.fn(),
+  putMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock('@vercel/blob', () => ({
+  del: hoisted.delMock,
+  get: hoisted.getMock,
+  put: hoisted.putMock,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    info: hoisted.infoMock,
+    warn: hoisted.warnMock,
+  },
+}));
+
+import {
+  AudioDerivativeConversionError,
+  MAX_AUDIO_DERIVATIVE_BYTES,
+} from '../aiff-to-wav';
+import { processAudioPlaybackDerivativeJob } from './playback-derivative';
+
+const RECORDING_ID = '00000000-0000-4000-8000-000000000001';
+const PROFILE_ID = '00000000-0000-4000-8000-000000000002';
+const JOB_ID = '00000000-0000-4000-8000-000000000003';
+
+function pendingMetadata() {
+  return {
+    audioPlaybackDerivative: {
+      status: 'pending',
+      generation: 1,
+      sourceFormatId: 'aiff',
+      requestedAt: '2026-07-26T00:00:00.000Z',
+    },
+  };
+}
+
+function fakeTransaction(
+  recording: {
+    audioFormat: string | null;
+    audioUrl: string | null;
+    metadata: Record<string, unknown>;
+  },
+  updatedRows: readonly { id: string }[] = [{ id: RECORDING_ID }]
+) {
+  const setMock = vi.fn();
+  const returningMock = vi.fn().mockResolvedValue(updatedRows);
+  const whereUpdateMock = vi.fn().mockReturnValue({
+    returning: returningMock,
+  });
+  const updateMock = vi.fn().mockReturnValue({
+    set: (...args: unknown[]) => {
+      setMock(...args);
+      return { where: whereUpdateMock };
+    },
+  });
+  const limitMock = vi.fn().mockResolvedValue([recording]);
+  const selectMock = vi.fn().mockReturnValue({
+    from: () => ({
+      where: () => ({ limit: limitMock }),
+    }),
+  });
+
+  return {
+    tx: { select: selectMock, update: updateMock },
+    setMock,
+  };
+}
+
+function job(attempts = 1, maxAttempts = 3) {
+  return {
+    id: JOB_ID,
+    jobType: 'audio_playback_derivative',
+    payload: {
+      recordingId: RECORDING_ID,
+      creatorProfileId: PROFILE_ID,
+      formatId: 'aiff',
+      generation: 1,
+    },
+    status: 'processing',
+    error: null,
+    attempts,
+    runAt: new Date('2026-07-26T00:00:00.000Z'),
+    priority: -10,
+    maxAttempts,
+    nextRunAt: null,
+    dedupKey: `audio_playback_derivative:${RECORDING_ID}:1`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as const;
+}
+
+function mockRealAiffSource() {
+  const bytes = readFileSync(
+    resolve(process.cwd(), 'tests/fixtures/audio/tone.aiff')
+  );
+  hoisted.getMock.mockResolvedValue({
+    statusCode: 200,
+    stream: Readable.toWeb(Readable.from([bytes])),
+    blob: { size: bytes.byteLength },
+  });
+  return bytes;
+}
+
+function writtenState(setMock: ReturnType<typeof vi.fn>): string {
+  const metadata = setMock.mock.calls.at(-1)?.[0]?.metadata as
+    | { queryChunks?: unknown[] }
+    | undefined;
+  return (metadata?.queryChunks ?? [])
+    .flatMap(chunk => {
+      if (typeof chunk === 'string') return [chunk];
+      if (
+        chunk &&
+        typeof chunk === 'object' &&
+        'value' in chunk &&
+        Array.isArray(chunk.value)
+      ) {
+        return chunk.value.filter(value => typeof value === 'string');
+      }
+      return [];
+    })
+    .join('');
+}
+
+describe('audio playback derivative job', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.delMock.mockResolvedValue(undefined);
+    process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
+  });
+
+  it('streams a real AIFF to storage and publishes only the ready derivative', async () => {
+    const bytes = mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      let outputBytes = 0;
+      for await (const chunk of stream) outputBytes += chunk.byteLength;
+      expect(outputBytes).toBe(88_244);
+      return { url: 'https://blob.example/preview.wav' };
+    });
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await processAudioPlaybackDerivativeJob(tx as never, job() as never);
+
+    expect(hoisted.putMock).toHaveBeenCalledWith(
+      `audio-derivatives/${RECORDING_ID}/playback-1.wav`,
+      expect.any(Readable),
+      {
+        access: 'public',
+        addRandomSuffix: false,
+        allowOverwrite: true,
+        cacheControlMaxAge: 31_536_000,
+        contentType: 'audio/wav',
+        maximumSizeInBytes: MAX_AUDIO_DERIVATIVE_BYTES,
+        multipart: true,
+        token: 'test-token',
+        abortSignal: expect.any(AbortSignal),
+      }
+    );
+    expect(hoisted.getMock).toHaveBeenCalledWith(
+      'https://blob.example/master.aiff',
+      {
+        access: 'public',
+        token: 'test-token',
+        abortSignal: expect.any(AbortSignal),
+      }
+    );
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previewUrl: 'https://blob.example/preview.wav',
+      })
+    );
+    expect(writtenState(setMock)).toContain('"status":"ready"');
+    expect(writtenState(setMock)).toContain('"mimeType":"audio/wav"');
+    expect(writtenState(setMock)).toContain('"outputBytes":88244');
+    expect(hoisted.infoMock).toHaveBeenCalledWith(
+      'Audio playback derivative completed',
+      expect.objectContaining({
+        inputBytes: bytes.byteLength,
+        outputBytes: 88_244,
+        formatId: 'aiff',
+      })
+    );
+    expect(
+      hoisted.infoMock.mock.calls[0]?.[1]?.conversionDurationMs
+    ).toBeLessThan(10_000);
+  });
+
+  it('deletes its uploaded derivative when the generation loses the commit race', async () => {
+    mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      for await (const _chunk of stream) {
+        // Consume the real conversion stream before simulating the lost race.
+      }
+      return { url: 'https://blob.example/stale-preview.wav' };
+    });
+    const { tx } = fakeTransaction(
+      {
+        audioFormat: 'audio/aiff',
+        audioUrl: 'https://blob.example/master.aiff',
+        metadata: pendingMetadata(),
+      },
+      []
+    );
+
+    await processAudioPlaybackDerivativeJob(tx as never, job() as never);
+
+    expect(hoisted.delMock).toHaveBeenCalledWith(
+      'https://blob.example/stale-preview.wav',
+      { token: 'test-token' }
+    );
+    expect(hoisted.infoMock).not.toHaveBeenCalled();
+  });
+
+  it('resumes a retrying derivative generation', async () => {
+    mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      for await (const _chunk of stream) {
+        // Consume the real derivative before publishing it.
+      }
+      return { url: 'https://blob.example/retried-preview.wav' };
+    });
+    const { tx } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: {
+        audioPlaybackDerivative: {
+          status: 'retrying',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          attempt: 1,
+          maxAttempts: 3,
+          retryAt: '2026-07-26T00:01:00.000Z',
+        },
+      },
+    });
+
+    await processAudioPlaybackDerivativeJob(tx as never, job(2) as never);
+
+    expect(hoisted.putMock).toHaveBeenCalledOnce();
+    expect(hoisted.infoMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [
+      'a superseded generation',
+      {
+        status: 'superseded',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        supersededAt: '2026-07-26T00:01:00.000Z',
+      },
+    ],
+    [
+      'a different generation',
+      {
+        status: 'pending',
+        generation: 2,
+        sourceFormatId: 'aiff',
+        requestedAt: '2026-07-26T00:01:00.000Z',
+      },
+    ],
+    [
+      'a different source format',
+      {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'wav',
+        requestedAt: '2026-07-26T00:01:00.000Z',
+      },
+    ],
+    [
+      'an already ready derivative',
+      {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        readyAt: '2026-07-26T00:01:00.000Z',
+        url: 'https://blob.example/ready.wav',
+        mimeType: 'audio/wav',
+        outputBytes: 44,
+      },
+    ],
+  ])('does not process %s', async (_, derivative) => {
+    const { tx } = fakeTransaction({
+      audioFormat: 'audio/mpeg',
+      audioUrl: 'https://blob.example/new-master.mp3',
+      metadata: {
+        audioPlaybackDerivative: derivative,
+      },
+    });
+
+    await processAudioPlaybackDerivativeJob(tx as never, job() as never);
+
+    expect(hoisted.getMock).not.toHaveBeenCalled();
+    expect(hoisted.putMock).not.toHaveBeenCalled();
+  });
+
+  it('does not process a missing or untyped derivative record', async () => {
+    const { tx } = fakeTransaction(undefined as never);
+
+    await processAudioPlaybackDerivativeJob(tx as never, job(3) as never);
+
+    expect(hoisted.getMock).not.toHaveBeenCalled();
+    expect(hoisted.putMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'a missing master URL',
+      {
+        audioFormat: 'audio/aiff',
+        audioUrl: null,
+        metadata: pendingMetadata(),
+      },
+    ],
+    [
+      'a changed source format',
+      {
+        audioFormat: 'audio/mpeg',
+        audioUrl: 'https://blob.example/master.mp3',
+        metadata: pendingMetadata(),
+      },
+    ],
+  ])('fails closed for %s', async (_, recording) => {
+    const { tx, setMock } = fakeTransaction(recording as never);
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeJobError',
+      reason: 'invalid_source',
+      message: 'Audio derivative source is missing or changed',
+    });
+
+    expect(writtenState(setMock)).toContain('"status":"failed"');
+    expect(writtenState(setMock)).toContain('"reason":"invalid_source"');
+    expect(hoisted.getMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'a missing storage token',
+      () => {
+        delete process.env.BLOB_READ_WRITE_TOKEN;
+      },
+      'Audio derivative storage is not configured',
+      'storage_failed',
+    ],
+    [
+      'a missing blob response',
+      () => {
+        hoisted.getMock.mockResolvedValue(null);
+      },
+      'Audio derivative source could not be read',
+      'storage_failed',
+    ],
+    [
+      'a non-success blob response',
+      () => {
+        hoisted.getMock.mockResolvedValue({
+          statusCode: 404,
+          stream: new ReadableStream(),
+          blob: { size: 0 },
+        });
+      },
+      'Audio derivative source could not be read',
+      'storage_failed',
+    ],
+    [
+      'an oversized master',
+      () => {
+        hoisted.getMock.mockResolvedValue({
+          statusCode: 200,
+          stream: new ReadableStream(),
+          blob: { size: MAX_AUDIO_DERIVATIVE_BYTES + 1 },
+        });
+      },
+      'Audio derivative source exceeds the processing limit',
+      'resource_limit',
+    ],
+  ])('classifies %s without exposing storage input', async (_, setup, message, reason) => {
+    setup();
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      name: 'AudioDerivativeJobError',
+      message,
+      reason,
+    });
+
+    expect(writtenState(setMock)).toContain('"status":"failed"');
+    expect(writtenState(setMock)).toContain(`"reason":"${reason}"`);
+    expect(hoisted.putMock).not.toHaveBeenCalled();
+    expect(hoisted.delMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves conversion and timeout classifications through storage wrappers', async () => {
+    const invalidAiff = Buffer.from('not an aiff');
+    hoisted.getMock.mockResolvedValueOnce({
+      statusCode: 200,
+      stream: Readable.toWeb(Readable.from([invalidAiff])),
+      blob: { size: invalidAiff.byteLength },
+    });
+    const first = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+    await expect(
+      processAudioPlaybackDerivativeJob(first.tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'invalid_source',
+    });
+    expect(writtenState(first.setMock)).toContain('"reason":"invalid_source"');
+
+    const abortError = new Error('private abort detail');
+    abortError.name = 'AbortError';
+    hoisted.getMock.mockRejectedValueOnce(abortError);
+    const second = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+    await expect(
+      processAudioPlaybackDerivativeJob(second.tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'resource_limit',
+      message: 'Audio derivative processing timed out',
+    });
+    expect(writtenState(second.setMock)).toContain('"reason":"resource_limit"');
+
+    hoisted.getMock.mockRejectedValueOnce(
+      new AudioDerivativeConversionError(
+        'invalid_source',
+        'Typed conversion failure'
+      )
+    );
+    const third = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+    await expect(
+      processAudioPlaybackDerivativeJob(third.tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'invalid_source',
+      message: 'Typed conversion failure',
+    });
+  });
+
+  it('allows a source exactly at the processing-size boundary', async () => {
+    hoisted.getMock.mockResolvedValue({
+      statusCode: 200,
+      stream: null,
+      blob: { size: MAX_AUDIO_DERIVATIVE_BYTES },
+    });
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({ reason: 'conversion_failed' });
+    expect(writtenState(setMock)).toContain('"reason":"conversion_failed"');
+  });
+
+  it('classifies an unexpected conversion exception without logging its value', async () => {
+    hoisted.getMock.mockResolvedValue({
+      statusCode: 200,
+      stream: null,
+      blob: { size: 10 },
+    });
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3) as never)
+    ).rejects.toMatchObject({
+      reason: 'conversion_failed',
+      message: 'Audio derivative processing failed',
+    });
+    expect(writtenState(setMock)).toContain('"reason":"conversion_failed"');
+    expect(JSON.stringify(hoisted.warnMock.mock.calls)).not.toContain(
+      'getReader'
+    );
+  });
+
+  it('redacts storage failures and transitions to retrying', async () => {
+    hoisted.getMock.mockRejectedValue(
+      new Error('https://private.example/master.aiff?secret=value')
+    );
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job() as never)
+    ).rejects.toThrow('Audio derivative source could not be read');
+
+    const logged = JSON.stringify(hoisted.warnMock.mock.calls);
+    expect(logged).not.toContain('private.example');
+    expect(logged).not.toContain('secret=value');
+    expect(setMock).toHaveBeenCalled();
+    expect(writtenState(setMock)).toContain('"status":"retrying"');
+    expect(writtenState(setMock)).toContain('"attempt":1');
+    expect(writtenState(setMock)).toContain('"maxAttempts":3');
+    expect(hoisted.warnMock).toHaveBeenCalledWith(
+      'Audio playback derivative failed',
+      expect.objectContaining({
+        failureReason: 'storage_failed',
+        attempt: 1,
+        maxAttempts: 3,
+      })
+    );
+    expect(
+      hoisted.warnMock.mock.calls[0]?.[1]?.conversionDurationMs
+    ).toBeLessThan(10_000);
+  });
+
+  it('moves the last failed attempt to a terminal failed state', async () => {
+    hoisted.getMock.mockRejectedValue(new Error('private storage detail'));
+    const { tx, setMock } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job(3, 3) as never)
+    ).rejects.toMatchObject({ reason: 'storage_failed' });
+
+    expect(writtenState(setMock)).toContain('"status":"failed"');
+    expect(writtenState(setMock)).toContain('"reason":"storage_failed"');
+  });
+
+  it('redacts upload failures and classifies them as storage failures', async () => {
+    mockRealAiffSource();
+    hoisted.putMock.mockImplementation(async (_path, stream: Readable) => {
+      for await (const _chunk of stream) {
+        // Consume the derivative so conversion is proven before storage fails.
+      }
+      throw new Error('https://private.example/preview.wav?secret=value');
+    });
+    const { tx } = fakeTransaction({
+      audioFormat: 'audio/aiff',
+      audioUrl: 'https://blob.example/master.aiff',
+      metadata: pendingMetadata(),
+    });
+
+    await expect(
+      processAudioPlaybackDerivativeJob(tx as never, job() as never)
+    ).rejects.toThrow('Audio derivative could not be stored');
+
+    const logged = JSON.stringify(hoisted.warnMock.mock.calls);
+    expect(logged).not.toContain('private.example');
+    expect(logged).not.toContain('secret=value');
+    expect(hoisted.warnMock).toHaveBeenCalledWith(
+      'Audio playback derivative failed',
+      expect.objectContaining({ failureReason: 'storage_failed' })
+    );
+  });
+});

--- a/apps/web/lib/audio/jobs/playback-derivative.ts
+++ b/apps/web/lib/audio/jobs/playback-derivative.ts
@@ -1,0 +1,266 @@
+import type { AudioPlaybackDerivative } from '@jovie/audio-contracts';
+import { del, get, put } from '@vercel/blob';
+import { and, sql as drizzleSql, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { DbOrTransaction } from '@/lib/db';
+import { discogRecordings } from '@/lib/db/schema/content';
+import type { ingestionJobs } from '@/lib/db/schema/ingestion';
+import { env } from '@/lib/env-server';
+import { logger } from '@/lib/utils/logger';
+import {
+  AudioDerivativeConversionError,
+  MAX_AUDIO_DERIVATIVE_BYTES,
+  prepareAiffPlaybackDerivative,
+} from '../aiff-to-wav';
+import { parseAudioPlaybackDerivative } from '../playback-derivative';
+
+const AUDIO_DERIVATIVE_TIMEOUT_MS = 240_000;
+
+export const audioPlaybackDerivativePayloadSchema = z.object({
+  recordingId: z.string().uuid(),
+  creatorProfileId: z.string().uuid(),
+  formatId: z.literal('aiff'),
+  generation: z.number().int().positive(),
+});
+
+class AudioDerivativeJobError extends Error {
+  constructor(
+    readonly reason:
+      | 'invalid_source'
+      | 'conversion_failed'
+      | 'resource_limit'
+      | 'storage_failed',
+    message: string
+  ) {
+    super(message);
+    this.name = 'AudioDerivativeJobError';
+  }
+}
+
+function safeJobError(error: unknown): AudioDerivativeJobError {
+  if (error instanceof AudioDerivativeJobError) return error;
+  if (error instanceof AudioDerivativeConversionError) {
+    return new AudioDerivativeJobError(error.code, error.message);
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return new AudioDerivativeJobError(
+      'resource_limit',
+      'Audio derivative processing timed out'
+    );
+  }
+  return new AudioDerivativeJobError(
+    'conversion_failed',
+    'Audio derivative processing failed'
+  );
+}
+
+function safeStorageError(
+  error: unknown,
+  message: string
+): AudioDerivativeJobError | AudioDerivativeConversionError | Error {
+  if (
+    error instanceof AudioDerivativeConversionError ||
+    (error instanceof Error && error.name === 'AbortError')
+  ) {
+    return error;
+  }
+  return new AudioDerivativeJobError('storage_failed', message);
+}
+
+async function writeDerivativeState(
+  tx: DbOrTransaction,
+  input: {
+    readonly creatorProfileId: string;
+    readonly derivative: AudioPlaybackDerivative;
+    readonly previewUrl?: string;
+    readonly recordingId: string;
+  }
+) {
+  const [updated] = await tx
+    .update(discogRecordings)
+    .set({
+      metadata: drizzleSql`jsonb_set(
+        coalesce(${discogRecordings.metadata}, '{}'::jsonb),
+        '{audioPlaybackDerivative}',
+        ${JSON.stringify(input.derivative)}::jsonb,
+        true
+      )`,
+      ...(input.previewUrl ? { previewUrl: input.previewUrl } : {}),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(discogRecordings.id, input.recordingId),
+        eq(discogRecordings.creatorProfileId, input.creatorProfileId),
+        drizzleSql`${discogRecordings.metadata} -> 'audioPlaybackDerivative' ->> 'generation' = ${String(input.derivative.generation)}`
+      )
+    )
+    .returning({ id: discogRecordings.id });
+  return Boolean(updated);
+}
+
+export async function processAudioPlaybackDerivativeJob(
+  tx: DbOrTransaction,
+  job: typeof ingestionJobs.$inferSelect
+): Promise<void> {
+  const payload = audioPlaybackDerivativePayloadSchema.parse(job.payload);
+  const startedAt = Date.now();
+  const queueDelayMs = Math.max(0, startedAt - job.createdAt.getTime());
+  const [recording] = await tx
+    .select({
+      audioFormat: discogRecordings.audioFormat,
+      audioUrl: discogRecordings.audioUrl,
+      metadata: discogRecordings.metadata,
+    })
+    .from(discogRecordings)
+    .where(
+      and(
+        eq(discogRecordings.id, payload.recordingId),
+        eq(discogRecordings.creatorProfileId, payload.creatorProfileId)
+      )
+    )
+    .limit(1);
+
+  if (!recording) return;
+  const currentDerivative = parseAudioPlaybackDerivative(recording.metadata);
+  if (
+    !currentDerivative ||
+    currentDerivative.generation !== payload.generation ||
+    currentDerivative.sourceFormatId !== payload.formatId ||
+    !['pending', 'retrying'].includes(currentDerivative.status)
+  ) {
+    return;
+  }
+
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    AUDIO_DERIVATIVE_TIMEOUT_MS
+  );
+  let uploadedUrl: string | null = null;
+  let derivativeCommitted = false;
+
+  try {
+    if (!recording.audioUrl || recording.audioFormat !== 'audio/aiff') {
+      throw new AudioDerivativeJobError(
+        'invalid_source',
+        'Audio derivative source is missing or changed'
+      );
+    }
+    if (!token) {
+      throw new AudioDerivativeJobError(
+        'storage_failed',
+        'Audio derivative storage is not configured'
+      );
+    }
+
+    const source = await get(recording.audioUrl, {
+      access: 'public',
+      token,
+      abortSignal: controller.signal,
+    }).catch(error => {
+      throw safeStorageError(
+        error,
+        'Audio derivative source could not be read'
+      );
+    });
+    if (!source || source.statusCode !== 200) {
+      throw new AudioDerivativeJobError(
+        'storage_failed',
+        'Audio derivative source could not be read'
+      );
+    }
+    if (source.blob.size > MAX_AUDIO_DERIVATIVE_BYTES) {
+      throw new AudioDerivativeJobError(
+        'resource_limit',
+        'Audio derivative source exceeds the processing limit'
+      );
+    }
+
+    const prepared = await prepareAiffPlaybackDerivative(source.stream);
+    const pathname = `audio-derivatives/${payload.recordingId}/playback-${payload.generation}.wav`;
+    const uploaded = await put(pathname, prepared.stream, {
+      access: 'public',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+      cacheControlMaxAge: 60 * 60 * 24 * 365,
+      contentType: 'audio/wav',
+      maximumSizeInBytes: MAX_AUDIO_DERIVATIVE_BYTES,
+      multipart: true,
+      token,
+      abortSignal: controller.signal,
+    }).catch(error => {
+      throw safeStorageError(error, 'Audio derivative could not be stored');
+    });
+    uploadedUrl = uploaded.url;
+
+    const ready: AudioPlaybackDerivative = {
+      status: 'ready',
+      generation: payload.generation,
+      sourceFormatId: payload.formatId,
+      url: uploaded.url,
+      mimeType: 'audio/wav',
+      readyAt: new Date().toISOString(),
+      outputBytes: prepared.outputBytes,
+    };
+    derivativeCommitted = await writeDerivativeState(tx, {
+      recordingId: payload.recordingId,
+      creatorProfileId: payload.creatorProfileId,
+      derivative: ready,
+      previewUrl: uploaded.url,
+    });
+    if (!derivativeCommitted) return;
+
+    logger.info('Audio playback derivative completed', {
+      jobId: job.id,
+      recordingId: payload.recordingId,
+      queueDelayMs,
+      conversionDurationMs: Date.now() - startedAt,
+      inputBytes: source.blob.size,
+      outputBytes: prepared.outputBytes,
+      formatId: payload.formatId,
+    });
+  } catch (error) {
+    const safeError = safeJobError(error);
+    const shouldRetry = job.attempts < job.maxAttempts;
+    const derivative: AudioPlaybackDerivative = shouldRetry
+      ? {
+          status: 'retrying',
+          generation: payload.generation,
+          sourceFormatId: payload.formatId,
+          attempt: job.attempts,
+          maxAttempts: job.maxAttempts,
+          retryAt: new Date().toISOString(),
+        }
+      : {
+          status: 'failed',
+          generation: payload.generation,
+          sourceFormatId: payload.formatId,
+          reason: safeError.reason,
+          failedAt: new Date().toISOString(),
+        };
+    await writeDerivativeState(tx, {
+      recordingId: payload.recordingId,
+      creatorProfileId: payload.creatorProfileId,
+      derivative,
+    });
+
+    logger.warn('Audio playback derivative failed', {
+      jobId: job.id,
+      recordingId: payload.recordingId,
+      queueDelayMs,
+      conversionDurationMs: Date.now() - startedAt,
+      formatId: payload.formatId,
+      failureReason: safeError.reason,
+      attempt: job.attempts,
+      maxAttempts: job.maxAttempts,
+    });
+    throw safeError;
+  } finally {
+    clearTimeout(timeoutId);
+    if (token && uploadedUrl && !derivativeCommitted) {
+      await del(uploadedUrl, { token }).catch(() => {});
+    }
+  }
+}

--- a/apps/web/lib/audio/resolve-release-recording.ts
+++ b/apps/web/lib/audio/resolve-release-recording.ts
@@ -11,6 +11,7 @@ export type ReleasePrimaryRecording = {
   readonly recordingId: string;
   readonly previewUrl: string | null;
   readonly audioUrl: string | null;
+  readonly audioFormat: string | null;
   readonly durationMs: number | null;
   readonly metadata: Record<string, unknown>;
 };
@@ -24,6 +25,7 @@ export async function resolvePrimaryRecordingForRelease(
       recordingId: discogRecordings.id,
       previewUrl: discogRecordings.previewUrl,
       audioUrl: discogRecordings.audioUrl,
+      audioFormat: discogRecordings.audioFormat,
       durationMs: discogRecordings.durationMs,
       metadata: discogRecordings.metadata,
     })
@@ -51,6 +53,7 @@ export async function resolvePrimaryRecordingForRelease(
     recordingId: row.recordingId,
     previewUrl: row.previewUrl,
     audioUrl: row.audioUrl,
+    audioFormat: row.audioFormat,
     durationMs: row.durationMs,
     metadata: row.metadata ?? {},
   };

--- a/apps/web/lib/discography/adapters.audio-capability.test.ts
+++ b/apps/web/lib/discography/adapters.audio-capability.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { mapTrackToViewModel } from './adapters';
+import type { ProviderKey } from './types';
+
+function track(metadata: Record<string, unknown>, previewUrl: string | null) {
+  return {
+    id: 'recording-1',
+    releaseId: 'release-1',
+    title: 'First Light',
+    slug: 'first-light',
+    trackNumber: 1,
+    discNumber: 1,
+    durationMs: 60_000,
+    isrc: null,
+    isExplicit: false,
+    previewUrl,
+    audioUrl: 'https://blob.example/master.aiff',
+    audioFormat: 'audio/aiff',
+    metadata,
+    providerLinks: [],
+  };
+}
+
+function map(metadata: Record<string, unknown>, previewUrl: string | null) {
+  return mapTrackToViewModel({
+    track: track(metadata, previewUrl),
+    providerLabels: {} as Record<ProviderKey, string>,
+    profileHandle: 'artist',
+    releaseSlug: 'first-light',
+  });
+}
+
+describe('track view-model audio capability', () => {
+  it('does not hand an AIFF master to playback while conversion is pending', () => {
+    const result = map(
+      {
+        audioPlaybackDerivative: {
+          status: 'pending',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          requestedAt: '2026-07-26T00:00:00.000Z',
+        },
+      },
+      null
+    );
+
+    expect(result.previewUrl).toBeNull();
+    expect(result.audioUrl).toBeNull();
+    expect(result.previewSource).toBeNull();
+    expect(result.previewVerification).toBe('missing');
+  });
+
+  it('does not trust a legacy AIFF preview that aliases its master', () => {
+    const result = map({}, 'https://blob.example/master.aiff');
+
+    expect(result.previewUrl).toBeNull();
+    expect(result.audioUrl).toBeNull();
+    expect(result.previewSource).toBeNull();
+    expect(result.previewVerification).toBe('missing');
+  });
+
+  it('hands consumers only the ready AIFF derivative', () => {
+    const result = map(
+      {
+        audioPlaybackDerivative: {
+          status: 'ready',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          url: 'https://blob.example/preview.wav',
+          mimeType: 'audio/wav',
+          readyAt: '2026-07-26T00:00:01.000Z',
+          outputBytes: 88_244,
+        },
+      },
+      'https://blob.example/preview.wav'
+    );
+
+    expect(result.previewUrl).toBe('https://blob.example/preview.wav');
+    expect(result.audioUrl).toBe('https://blob.example/preview.wav');
+    expect(result.previewSource).toBe('audio_url');
+    expect(result.previewVerification).toBe('verified');
+  });
+});

--- a/apps/web/lib/discography/adapters.ts
+++ b/apps/web/lib/discography/adapters.ts
@@ -1,3 +1,4 @@
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import { toISOStringOrFallback } from '@/lib/utils/date';
 import {
   derivePreviewState,
@@ -76,9 +77,11 @@ export function mapTrackToViewModel(params: {
   releaseSlug: string;
 }): TrackViewModel {
   const { track, providerLabels, profileHandle, releaseSlug } = params;
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.url;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -101,8 +104,8 @@ export function mapTrackToViewModel(params: {
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     previewSource: previewState.previewSource,
     previewVerification: previewState.previewVerification,

--- a/apps/web/lib/discography/release-track-loader.ts
+++ b/apps/web/lib/discography/release-track-loader.ts
@@ -1,3 +1,4 @@
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import {
   derivePreviewState,
   getProviderConfidence,
@@ -76,9 +77,11 @@ function mapLegacyTrackToViewModel(
   profileHandle: string,
   releaseSlug: string
 ): TrackViewModel {
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.status === 'ready' ? playback.url : null;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -99,8 +102,8 @@ function mapLegacyTrackToViewModel(
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     lyrics: track.lyrics,
     previewSource: previewState.previewSource,
@@ -122,9 +125,11 @@ function mapReleaseTrackToViewModel(
   profileHandle: string,
   releaseSlug: string
 ): TrackViewModel {
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.status === 'ready' ? playback.url : null;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -147,8 +152,8 @@ function mapReleaseTrackToViewModel(
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     lyrics: track.lyrics,
     previewSource: previewState.previewSource,

--- a/apps/web/lib/ingestion/processor.ts
+++ b/apps/web/lib/ingestion/processor.ts
@@ -11,6 +11,7 @@
  * - Merge logic: import from './merge'
  */
 
+import { processAudioPlaybackDerivativeJob } from '@/lib/audio/jobs/playback-derivative';
 import type { DbOrTransaction } from '@/lib/db';
 import type { ingestionJobs } from '@/lib/db/schema/ingestion';
 import {
@@ -78,6 +79,8 @@ export async function processJob(
   job: typeof ingestionJobs.$inferSelect
 ) {
   switch (job.jobType) {
+    case 'audio_playback_derivative':
+      return processAudioPlaybackDerivativeJob(tx, job);
     case 'import_linktree':
       return processLinktreeJob(tx, job.payload);
     case 'import_laylo':

--- a/apps/web/lib/ingestion/scheduler.ts
+++ b/apps/web/lib/ingestion/scheduler.ts
@@ -85,6 +85,10 @@ export function determineJobFailure(error: unknown): {
  * Extract hostname from a job's payload URL.
  */
 function getJobHost(job: typeof ingestionJobs.$inferSelect): string | null {
+  if (job.jobType === 'audio_playback_derivative') {
+    return 'provider:audio-derivative';
+  }
+
   if (job.jobType === 'musicfetch_enrichment') {
     return 'provider:musicfetch';
   }

--- a/apps/web/lib/library-share/service.ts
+++ b/apps/web/lib/library-share/service.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
 import { BASE_URL } from '@/constants/app';
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import { db } from '@/lib/db';
 import {
   discogRecordings,
@@ -56,6 +57,8 @@ async function loadDropAssets(
       releaseMetadata: discogReleases.metadata,
       previewUrl: discogRecordings.previewUrl,
       audioUrl: discogRecordings.audioUrl,
+      audioFormat: discogRecordings.audioFormat,
+      recordingMetadata: discogRecordings.metadata,
       recordingLyrics: discogRecordings.lyrics,
       slug: discogReleases.slug,
       artistName: creatorProfiles.displayName,
@@ -85,6 +88,12 @@ async function loadDropAssets(
     .orderBy(asc(libraryShareDropItems.position));
 
   return rows.map(row => {
+    const playback = resolveRecordingPlayback({
+      audioFormat: row.audioFormat,
+      audioUrl: row.audioUrl,
+      previewUrl: row.previewUrl,
+      metadata: row.recordingMetadata,
+    });
     const metadataLyrics = (
       row.releaseMetadata as Record<string, unknown> | null
     )?.lyrics;
@@ -99,7 +108,9 @@ async function loadDropAssets(
       title: row.title,
       artistName: row.artistName?.trim() || 'Unknown Artist',
       artworkUrl: normalizeHttpUrl(row.artworkUrl),
-      previewUrl: normalizeHttpUrl(row.previewUrl ?? row.audioUrl),
+      previewUrl: normalizeHttpUrl(
+        playback.status === 'ready' ? playback.url : null
+      ),
       lyrics: row.includeLyrics ? lyrics : null,
       releaseType: row.releaseType,
       releaseDate: row.releaseDate?.toISOString() ?? null,

--- a/apps/web/stryker.audio.config.mjs
+++ b/apps/web/stryker.audio.config.mjs
@@ -18,10 +18,25 @@ const config = {
     // forwards the complete typed source into the singleton.
     'components/organisms/GlobalAudioPreviewAction.tsx:56-65',
     'components/organisms/GlobalAudioPreviewAction.tsx:68-77',
+    // JOV-4393 keeps accepted masters separate from browser playback,
+    // streams the AIFF derivative, and fails closed through every transition.
+    'lib/audio/aiff-to-wav.ts',
+    'lib/audio/playback-derivative.ts',
+    'lib/audio/jobs/playback-derivative.ts:40-68',
+    'lib/audio/jobs/playback-derivative.ts:124-133',
+    'lib/audio/jobs/playback-derivative.ts:144-213',
+    'lib/audio/jobs/playback-derivative.ts:224-265',
+    'lib/discography/adapters.ts:79-112',
+    'components/features/release/ReleaseAudioAssetPanel.tsx:274-329',
   ],
   testFiles: [
     'tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts',
     'tests/components/organisms/GlobalAudioPreviewAction.test.tsx',
+    'lib/audio/aiff-to-wav.test.ts',
+    'lib/audio/playback-derivative.test.ts',
+    'lib/audio/jobs/playback-derivative.test.ts',
+    'lib/discography/adapters.audio-capability.test.ts',
+    'tests/components/features/release/ReleaseAudioAssetPanel.test.tsx',
   ],
   ignorePatterns: [
     '.next',

--- a/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
+++ b/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReleaseAudioAssetPanel } from '@/components/features/release/ReleaseAudioAssetPanel';
 
 const blobUploadMock = vi.fn();
@@ -21,15 +27,23 @@ vi.mock('sonner', () => ({
 }));
 
 describe('ReleaseAudioAssetPanel', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{}', { status: 404 }))
+    );
     decodeWaveformPeaksMock.mockResolvedValue({
       peaks: [0.2, 0.8, 0.5],
       durationMs: 120_000,
     });
   });
 
-  it('renders an upload dropzone when audio is missing', () => {
+  it('renders an upload dropzone when audio is missing', async () => {
     render(
       <ReleaseAudioAssetPanel
         releaseId='release-1'
@@ -37,7 +51,9 @@ describe('ReleaseAudioAssetPanel', () => {
       />
     );
 
-    expect(screen.getByTestId('release-audio-dropzone')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('release-audio-dropzone')).toBeInTheDocument();
+    });
     expect(
       screen.getByLabelText('Upload audio for Take Me Over')
     ).toBeInTheDocument();
@@ -127,6 +143,246 @@ describe('ReleaseAudioAssetPanel', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/library/audio/confirm',
       expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('shows one non-playable preparation state for an AIFF master', async () => {
+    blobUploadMock.mockResolvedValue({
+      url: 'https://cdn.example.com/master.aiff',
+      pathname: 'library/audio/master.aiff',
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                previewUrl: null,
+                hasAudioMaster: true,
+                playbackDerivative: {
+                  status: 'pending',
+                  generation: 1,
+                  sourceFormatId: 'aiff',
+                  requestedAt: '2026-07-26T00:00:00.000Z',
+                },
+              }),
+              { status: 200 }
+            )
+          );
+        }
+        return Promise.resolve(new Response('{}', { status: 404 }));
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Upload audio for Take Me Over'), {
+      target: {
+        files: [
+          new File(['audio'], 'take-me-over.aiff', { type: 'audio/aiff' }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-audio-derivative-status')
+      ).toHaveTextContent('Preparing preview');
+    });
+    expect(
+      screen.queryByRole('button', { name: /play/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('audio-waveform-editor')
+    ).not.toBeInTheDocument();
+  });
+
+  it('announces the initial audio-state check as busy without exposing controls', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {}))
+    );
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    const status = screen.getByTestId('release-audio-derivative-status');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+    expect(status).toHaveTextContent('Preparing preview');
+    expect(status).toHaveTextContent(
+      'Preparing a browser-ready preview and waveform.'
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'pending',
+      false,
+      'Preparing preview',
+      'Preparing a browser-ready preview and waveform.',
+    ],
+    [
+      'retrying',
+      false,
+      'Preparing preview',
+      'Preview preparation is retrying automatically.',
+    ],
+    [
+      'failed',
+      true,
+      'Preview unavailable',
+      'We could not prepare this preview. Your original is preserved.',
+    ],
+    [
+      'unavailable',
+      true,
+      'Preview unavailable',
+      'This format is preserved, but a browser preview is not available.',
+    ],
+    [
+      'superseded',
+      true,
+      'Preview unavailable',
+      'A newer audio upload replaced this preview.',
+    ],
+    [
+      'ready',
+      true,
+      'Preview unavailable',
+      'Preview metadata is ready, but its audio URL is unavailable.',
+    ],
+  ] as const)('keeps the %s derivative state non-playable with one recovery control', async (status, hasRecoveryControl, heading, copy) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            previewUrl: null,
+            hasAudioMaster: true,
+            playbackDerivative: {
+              status,
+              generation: 1,
+              sourceFormatId: 'aiff',
+              requestedAt: '2026-07-26T00:00:00.000Z',
+              retryAt: '2026-07-26T00:01:00.000Z',
+              failedAt: '2026-07-26T00:00:01.000Z',
+              supersededAt: '2026-07-26T00:00:01.000Z',
+              attempt: 1,
+              maxAttempts: 3,
+              reason:
+                status === 'unavailable'
+                  ? 'conversion_not_supported'
+                  : 'conversion_failed',
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-audio-derivative-status')
+      ).toBeInTheDocument();
+    });
+    const statusRegion = screen.getByTestId('release-audio-derivative-status');
+    expect(statusRegion).toHaveTextContent(heading);
+    expect(statusRegion).toHaveTextContent(copy);
+    if (status === 'pending' || status === 'retrying') {
+      expect(statusRegion).toHaveAttribute('aria-busy', 'true');
+    } else {
+      expect(statusRegion).not.toHaveAttribute('aria-busy');
+    }
+    expect(
+      screen.queryByRole('button', { name: /play/i })
+    ).not.toBeInTheDocument();
+    const recoveryControl = screen.queryByRole('button', {
+      name: 'Replace audio',
+    });
+    if (hasRecoveryControl) {
+      expect(recoveryControl).toBeInTheDocument();
+    } else {
+      expect(recoveryControl).not.toBeInTheDocument();
+    }
+  });
+
+  it('moves from pending to ready without remounting or exposing the master', async () => {
+    vi.useFakeTimers();
+    const onUploaded = vi.fn();
+    const pendingBody = {
+      previewUrl: null,
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        requestedAt: '2026-07-26T00:00:00.000Z',
+      },
+    };
+    const readyBody = {
+      previewUrl: 'https://cdn.example.com/preview.wav',
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        url: 'https://cdn.example.com/preview.wav',
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(pendingBody), { status: 200 })
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify(readyBody), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+        onUploaded={onUploaded}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      screen.getByTestId('release-audio-derivative-status')
+    ).toHaveTextContent('Preparing preview');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.getByTestId('audio-waveform-editor')).toBeInTheDocument();
+    expect(onUploaded).toHaveBeenCalledWith(
+      'https://cdn.example.com/preview.wav'
     );
   });
 });

--- a/apps/web/tests/unit/api/library-audio-snippet.test.ts
+++ b/apps/web/tests/unit/api/library-audio-snippet.test.ts
@@ -77,6 +77,7 @@ describe('library audio snippet API', () => {
       recordingId: 'recording_123',
       previewUrl: 'https://cdn.example.com/preview.mp3',
       audioUrl: 'https://cdn.example.com/preview.mp3',
+      audioFormat: 'audio/mpeg',
       durationMs: 180_000,
       metadata: {
         audioSnippet: { startMs: 10_000, endMs: 40_000 },
@@ -94,6 +95,7 @@ describe('library audio snippet API', () => {
     expect(response.status).toBe(200);
     expect(body.snippet).toEqual({ startMs: 10_000, endMs: 40_000 });
     expect(body.previewUrl).toBe('https://cdn.example.com/preview.mp3');
+    expect(body.playbackStatus).toBe('ready');
   });
 
   it('persists a normalized snippet trim window', async () => {
@@ -101,6 +103,7 @@ describe('library audio snippet API', () => {
       recordingId: 'recording_123',
       previewUrl: 'https://cdn.example.com/preview.mp3',
       audioUrl: 'https://cdn.example.com/preview.mp3',
+      audioFormat: 'audio/mpeg',
       durationMs: 180_000,
       metadata: {},
     });

--- a/apps/web/tests/unit/api/library-audio.test.ts
+++ b/apps/web/tests/unit/api/library-audio.test.ts
@@ -20,6 +20,9 @@ const hoisted = vi.hoisted(() => {
   const updateWhereMock = vi.fn();
   const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
   const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+  const insertValuesMock = vi.fn();
+  const insertMock = vi.fn().mockReturnValue({ values: insertValuesMock });
+  const transactionMock = vi.fn();
 
   return {
     requireAuthMock: vi.fn(),
@@ -31,6 +34,9 @@ const hoisted = vi.hoisted(() => {
     updateMock,
     updateSetMock,
     updateWhereMock,
+    insertMock,
+    insertValuesMock,
+    transactionMock,
     revalidateTagMock: vi.fn(),
     captureErrorMock: vi.fn(),
   };
@@ -66,6 +72,7 @@ vi.mock('@/lib/db', () => ({
   db: {
     select: hoisted.selectMock,
     update: hoisted.updateMock,
+    transaction: hoisted.transactionMock,
   },
 }));
 
@@ -84,12 +91,20 @@ vi.mock('@/lib/db/schema/content', () => ({
     id: 'recording.id',
     creatorProfileId: 'recording.creatorProfileId',
     previewUrl: 'recording.previewUrl',
+    audioUrl: 'recording.audioUrl',
+    audioFormat: 'recording.audioFormat',
+    metadata: 'recording.metadata',
   },
+}));
+
+vi.mock('@/lib/db/schema/ingestion', () => ({
+  ingestionJobs: 'ingestionJobs',
 }));
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn(),
   eq: vi.fn(),
+  sql: vi.fn(),
 }));
 
 vi.mock('@/lib/error-tracking', () => ({
@@ -99,6 +114,15 @@ vi.mock('@/lib/error-tracking', () => ({
 describe('library audio upload API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.updateMock.mockReturnValue({ set: hoisted.updateSetMock });
+    hoisted.updateSetMock.mockReturnValue({ where: hoisted.updateWhereMock });
+    hoisted.insertMock.mockReturnValue({ values: hoisted.insertValuesMock });
+    hoisted.transactionMock.mockImplementation(async callback =>
+      callback({
+        update: hoisted.updateMock,
+        insert: hoisted.insertMock,
+      })
+    );
     hoisted.requireAuthMock.mockResolvedValue({
       userId: 'clerk_user_123',
       error: null,
@@ -134,6 +158,7 @@ describe('library audio upload API', () => {
       recordingId: 'recording_123',
       previewUrl: null,
       audioUrl: null,
+      audioFormat: null,
       durationMs: null,
       metadata: {},
     });
@@ -165,6 +190,61 @@ describe('library audio upload API', () => {
     expect(hoisted.revalidateTagMock).toHaveBeenCalledWith(
       'releases:clerk_user_123:profile_123',
       'max'
+    );
+  });
+
+  it('preserves AIFF as the master and enqueues a typed playable derivative', async () => {
+    hoisted.resolvePrimaryRecordingForReleaseMock.mockResolvedValue({
+      recordingId: 'recording_123',
+      previewUrl: null,
+      audioUrl: null,
+      audioFormat: null,
+      durationMs: null,
+      metadata: {},
+    });
+    hoisted.updateWhereMock.mockResolvedValue({ rowCount: 1 });
+
+    const { POST } = await import('@/app/api/library/audio/confirm/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/confirm', {
+        method: 'POST',
+        body: JSON.stringify({
+          releaseId: '00000000-0000-4000-8000-000000000001',
+          blobUrl: 'https://cdn.example.com/take-me-over.aiff',
+          blobPathname: 'library/audio/take-me-over.aiff',
+          fileName: 'take-me-over.aiff',
+          fileMimeType: 'audio/aiff',
+          fileSizeBytes: 1024,
+        }),
+      }) as never
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      previewUrl: null,
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'aiff',
+      },
+    });
+    expect(hoisted.updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previewUrl: null,
+        audioUrl: 'https://cdn.example.com/take-me-over.aiff',
+        audioFormat: 'audio/aiff',
+      })
+    );
+    expect(hoisted.insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'audio_playback_derivative',
+        payload: expect.objectContaining({
+          formatId: 'aiff',
+          generation: 1,
+        }),
+      })
     );
   });
 

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -910,7 +910,7 @@ describe('LibrarySurface', () => {
     });
   });
 
-  it('renders a right-rail audio dropzone when a release is missing audio', () => {
+  it('renders a right-rail audio dropzone after checking for a missing audio master', async () => {
     renderLibrary([
       buildAsset({
         previewUrl: null,
@@ -920,7 +920,9 @@ describe('LibrarySurface', () => {
 
     fireEvent.click(screen.getByTestId('library-release-row-release-1'));
 
-    expect(screen.getByTestId('library-audio-dropzone')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('library-audio-dropzone')
+    ).toBeInTheDocument();
     expect(
       screen.getByLabelText('Upload audio for Take Me Over')
     ).toHaveAttribute('accept', expect.stringContaining('audio/mpeg'));

--- a/packages/audio-contracts/index.ts
+++ b/packages/audio-contracts/index.ts
@@ -4,6 +4,7 @@ export * from './capabilities';
 export * from './lyrics';
 export * from './performance';
 export * from './playback';
+export * from './transcription';
 export * from './units';
 
 export const AUDIO_FORMAT_IDS = [

--- a/packages/audio-contracts/stryker.config.mjs
+++ b/packages/audio-contracts/stryker.config.mjs
@@ -18,6 +18,7 @@ const config = {
     'lyrics.ts',
     'performance.ts',
     'playback.ts',
+    'transcription.ts',
     '!**/*.test.ts',
   ],
   testFiles: [
@@ -28,6 +29,7 @@ const config = {
     'lyrics.test.ts',
     'performance.test.ts',
     'playback.test.ts',
+    'transcription.test.ts',
   ],
   vitest: {
     configFile: 'vitest.config.mts',

--- a/packages/audio-contracts/transcription.test.ts
+++ b/packages/audio-contracts/transcription.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_TRANSCRIPTION_ERROR_CODES,
+  AUDIO_TRANSCRIPTION_EVENTS,
+  AUDIO_TRANSCRIPTION_EXECUTIONS,
+  AUDIO_TRANSCRIPTION_PROVIDER_IDS,
+  AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY,
+  AUDIO_TRANSCRIPTION_SOURCES,
+  AUDIO_TRANSCRIPTION_STATUSES,
+  type AudioTranscriptionEvent,
+  type AudioTranscriptionStatus,
+  createAudioTranscriptionProvenance,
+  createAudioTranscriptionSegment,
+  getNextAudioTranscriptionStatus,
+} from './transcription';
+
+describe('audio transcription registries', () => {
+  it('keeps every cross-platform identifier unique and provider-complete', () => {
+    for (const registry of [
+      AUDIO_TRANSCRIPTION_STATUSES,
+      AUDIO_TRANSCRIPTION_EVENTS,
+      AUDIO_TRANSCRIPTION_SOURCES,
+      AUDIO_TRANSCRIPTION_EXECUTIONS,
+      AUDIO_TRANSCRIPTION_ERROR_CODES,
+      AUDIO_TRANSCRIPTION_PROVIDER_IDS,
+    ]) {
+      expect(new Set(registry).size).toBe(registry.length);
+    }
+    expect(Object.keys(AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY)).toEqual(
+      AUDIO_TRANSCRIPTION_PROVIDER_IDS
+    );
+    for (const providerId of AUDIO_TRANSCRIPTION_PROVIDER_IDS) {
+      expect(AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY[providerId].id).toBe(
+        providerId
+      );
+    }
+  });
+
+  it('models the complete successful lifecycle', () => {
+    const events: readonly AudioTranscriptionEvent[] = [
+      'permission-requested',
+      'capture-started',
+      'partial-result',
+      'capture-stopped',
+      'final-result',
+    ];
+    const statuses: AudioTranscriptionStatus[] = [];
+    let status: AudioTranscriptionStatus = 'idle';
+    for (const event of events) {
+      status = getNextAudioTranscriptionStatus(status, event);
+      statuses.push(status);
+    }
+    expect(statuses).toEqual([
+      'requesting-permission',
+      'listening',
+      'partial',
+      'processing',
+      'completed',
+    ]);
+  });
+
+  it('models empty, cancelled, failed, unsupported, reset, and invalid transitions', () => {
+    expect(getNextAudioTranscriptionStatus('processing', 'empty-result')).toBe(
+      'empty'
+    );
+    expect(getNextAudioTranscriptionStatus('listening', 'cancel')).toBe(
+      'cancelled'
+    );
+    expect(getNextAudioTranscriptionStatus('partial', 'fail')).toBe('failed');
+    expect(getNextAudioTranscriptionStatus('idle', 'unsupported')).toBe(
+      'unsupported'
+    );
+    expect(getNextAudioTranscriptionStatus('failed', 'reset')).toBe('idle');
+    expect(
+      getNextAudioTranscriptionStatus('completed', 'capture-started')
+    ).toBe('completed');
+    expect(getNextAudioTranscriptionStatus('completed', 'cancel')).toBe(
+      'completed'
+    );
+    expect(getNextAudioTranscriptionStatus('empty', 'fail')).toBe('empty');
+    expect(getNextAudioTranscriptionStatus('listening', 'unsupported')).toBe(
+      'listening'
+    );
+    expect(
+      getNextAudioTranscriptionStatus(
+        'listening',
+        'unknown' as AudioTranscriptionEvent
+      )
+    ).toBe('listening');
+  });
+
+  it('matches the exact transition contract for every status-event pair', () => {
+    const expectedByEvent: Readonly<
+      Record<AudioTranscriptionEvent, readonly AudioTranscriptionStatus[]>
+    > = {
+      'permission-requested': [
+        'requesting-permission',
+        'requesting-permission',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'capture-started': [
+        'listening',
+        'listening',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'partial-result': [
+        'idle',
+        'requesting-permission',
+        'partial',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'capture-stopped': [
+        'idle',
+        'requesting-permission',
+        'processing',
+        'processing',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'final-result': [
+        'idle',
+        'requesting-permission',
+        'completed',
+        'completed',
+        'completed',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'empty-result': [
+        'idle',
+        'requesting-permission',
+        'empty',
+        'empty',
+        'empty',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      cancel: [
+        'idle',
+        'cancelled',
+        'cancelled',
+        'cancelled',
+        'cancelled',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      fail: [
+        'idle',
+        'failed',
+        'failed',
+        'failed',
+        'failed',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      unsupported: [
+        'unsupported',
+        'unsupported',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      reset: [
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+      ],
+    };
+
+    for (const event of AUDIO_TRANSCRIPTION_EVENTS) {
+      expect(
+        AUDIO_TRANSCRIPTION_STATUSES.map(status =>
+          getNextAudioTranscriptionStatus(status, event)
+        )
+      ).toEqual(expectedByEvent[event]);
+    }
+  });
+
+  it('creates provider-derived provenance and rejects mismatched execution', () => {
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'apple-speech',
+        execution: 'on-device',
+        locale: ' en-US ',
+      })
+    ).toEqual({
+      source: 'speech-recognition',
+      provider: 'apple-speech',
+      execution: 'on-device',
+      locale: 'en-US',
+      modelId: undefined,
+    });
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'youtube-captions',
+        execution: 'network',
+        modelId: ' captions-v1 ',
+      })
+    ).toEqual({
+      source: 'captions',
+      provider: 'youtube-captions',
+      execution: 'network',
+      locale: undefined,
+      modelId: 'captions-v1',
+    });
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'web-speech',
+        execution: 'on-device',
+      })
+    ).toThrow(
+      'Execution on-device is invalid for transcription provider web-speech'
+    );
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        modelId: ' ',
+      })
+    ).toThrow('modelId must not be empty');
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        locale: ' ',
+      })
+    ).toThrow('locale must not be empty');
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        locale: null,
+      }).locale
+    ).toBeUndefined();
+  });
+
+  it('normalizes valid segments and rejects ambiguous media coordinates', () => {
+    expect(
+      createAudioTranscriptionSegment({
+        startSeconds: 1.25,
+        durationSeconds: 0.5,
+        text: ' hello ',
+        confidence: 0.9,
+        isFinal: true,
+      })
+    ).toEqual({
+      startSeconds: 1.25,
+      durationSeconds: 0.5,
+      text: 'hello',
+      confidence: 0.9,
+      isFinal: true,
+    });
+
+    for (const [input, message] of [
+      [
+        { startSeconds: -1, durationSeconds: 0, text: 'x' },
+        'startSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: Number.NaN, text: 'x' },
+        'durationSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: -1, text: 'x' },
+        'durationSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: ' ' },
+        'transcription segment text must not be empty',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: 'x', confidence: 1.1 },
+        'confidence must be between 0 and 1',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: 'x', confidence: -0.1 },
+        'confidence must be between 0 and 1',
+      ],
+      [
+        {
+          startSeconds: 0,
+          durationSeconds: 0,
+          text: 'x',
+          confidence: Number.NaN,
+        },
+        'confidence must be between 0 and 1',
+      ],
+    ] as const) {
+      expect(() => createAudioTranscriptionSegment(input)).toThrow(message);
+    }
+
+    for (const confidence of [0, 1, undefined]) {
+      expect(
+        createAudioTranscriptionSegment({
+          startSeconds: 0,
+          durationSeconds: 0,
+          text: 'x',
+          confidence,
+        }).confidence
+      ).toBe(confidence);
+    }
+  });
+});

--- a/packages/audio-contracts/transcription.ts
+++ b/packages/audio-contracts/transcription.ts
@@ -1,0 +1,285 @@
+export const AUDIO_TRANSCRIPTION_STATUSES = [
+  'idle',
+  'requesting-permission',
+  'listening',
+  'partial',
+  'processing',
+  'completed',
+  'empty',
+  'cancelled',
+  'failed',
+  'unsupported',
+] as const;
+
+export type AudioTranscriptionStatus =
+  (typeof AUDIO_TRANSCRIPTION_STATUSES)[number];
+
+export const AUDIO_TRANSCRIPTION_EVENTS = [
+  'permission-requested',
+  'capture-started',
+  'partial-result',
+  'capture-stopped',
+  'final-result',
+  'empty-result',
+  'cancel',
+  'fail',
+  'unsupported',
+  'reset',
+] as const;
+
+export type AudioTranscriptionEvent =
+  (typeof AUDIO_TRANSCRIPTION_EVENTS)[number];
+
+export const AUDIO_TRANSCRIPTION_SOURCES = [
+  'provided',
+  'captions',
+  'speech-recognition',
+  'none',
+] as const;
+
+export type AudioTranscriptionSource =
+  (typeof AUDIO_TRANSCRIPTION_SOURCES)[number];
+
+export const AUDIO_TRANSCRIPTION_EXECUTIONS = [
+  'provided',
+  'on-device',
+  'network',
+  'provider-managed',
+  'unavailable',
+] as const;
+
+export type AudioTranscriptionExecution =
+  (typeof AUDIO_TRANSCRIPTION_EXECUTIONS)[number];
+
+export const AUDIO_TRANSCRIPTION_ERROR_CODES = [
+  'permission-denied',
+  'service-not-allowed',
+  'audio-capture',
+  'no-speech',
+  'network',
+  'aborted',
+  'unavailable',
+  'empty-transcript',
+  'unknown',
+] as const;
+
+export type AudioTranscriptionErrorCode =
+  (typeof AUDIO_TRANSCRIPTION_ERROR_CODES)[number];
+
+export const AUDIO_TRANSCRIPTION_PROVIDER_IDS = [
+  'user',
+  'youtube-captions',
+  'web-speech',
+  'apple-speech',
+  'server-asr',
+  'none',
+] as const;
+
+export type AudioTranscriptionProviderId =
+  (typeof AUDIO_TRANSCRIPTION_PROVIDER_IDS)[number];
+
+export interface AudioTranscriptionProviderDefinition {
+  readonly id: AudioTranscriptionProviderId;
+  readonly label: string;
+  readonly source: AudioTranscriptionSource;
+  readonly executions: readonly AudioTranscriptionExecution[];
+  readonly supportsInterimResults: boolean;
+  readonly supportsTimedSegments: boolean;
+}
+
+export const AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY = {
+  user: {
+    id: 'user',
+    label: 'User provided',
+    source: 'provided',
+    executions: ['provided'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  'youtube-captions': {
+    id: 'youtube-captions',
+    label: 'YouTube captions',
+    source: 'captions',
+    executions: ['network'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  'web-speech': {
+    id: 'web-speech',
+    label: 'Browser speech recognition',
+    source: 'speech-recognition',
+    executions: ['provider-managed'],
+    supportsInterimResults: true,
+    supportsTimedSegments: false,
+  },
+  'apple-speech': {
+    id: 'apple-speech',
+    label: 'Apple Speech',
+    source: 'speech-recognition',
+    executions: ['on-device', 'network'],
+    supportsInterimResults: true,
+    supportsTimedSegments: false,
+  },
+  'server-asr': {
+    id: 'server-asr',
+    label: 'Server speech recognition',
+    source: 'speech-recognition',
+    executions: ['network'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  none: {
+    id: 'none',
+    label: 'Unavailable',
+    source: 'none',
+    executions: ['unavailable'],
+    supportsInterimResults: false,
+    supportsTimedSegments: false,
+  },
+} as const satisfies Readonly<
+  Record<AudioTranscriptionProviderId, AudioTranscriptionProviderDefinition>
+>;
+
+export interface AudioTranscriptionProvenance {
+  readonly source: AudioTranscriptionSource;
+  readonly provider: AudioTranscriptionProviderId;
+  readonly execution: AudioTranscriptionExecution;
+  readonly locale?: string;
+  readonly modelId?: string;
+}
+
+export interface AudioTranscriptionSegment {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+  readonly text: string;
+  readonly confidence?: number;
+  readonly isFinal?: boolean;
+}
+
+export interface AudioTranscriptionResult {
+  readonly status: 'completed';
+  readonly text: string;
+  readonly segments: readonly AudioTranscriptionSegment[];
+  readonly provenance: AudioTranscriptionProvenance;
+  readonly latencyMilliseconds: number;
+}
+
+export function getNextAudioTranscriptionStatus(
+  current: AudioTranscriptionStatus,
+  event: AudioTranscriptionEvent
+): AudioTranscriptionStatus {
+  if (event === 'reset') return 'idle';
+
+  switch (event) {
+    case 'permission-requested':
+      return current === 'idle' ? 'requesting-permission' : current;
+    case 'capture-started':
+      return current === 'idle' || current === 'requesting-permission'
+        ? 'listening'
+        : current;
+    case 'partial-result':
+      return current === 'listening' ? 'partial' : current;
+    case 'capture-stopped':
+      return current === 'listening' || current === 'partial'
+        ? 'processing'
+        : current;
+    case 'final-result':
+      return current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'completed'
+        : current;
+    case 'empty-result':
+      return current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'empty'
+        : current;
+    case 'cancel':
+      return current === 'requesting-permission' ||
+        current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'cancelled'
+        : current;
+    case 'fail':
+      return current === 'requesting-permission' ||
+        current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'failed'
+        : current;
+    case 'unsupported':
+      return current === 'idle' || current === 'requesting-permission'
+        ? 'unsupported'
+        : current;
+    default:
+      return current;
+  }
+}
+
+function normalizeOptionalIdentifier(
+  value: string | null | undefined,
+  label: string
+): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${label} must not be empty`);
+  return normalized;
+}
+
+export function createAudioTranscriptionProvenance(input: {
+  readonly provider: AudioTranscriptionProviderId;
+  readonly execution: AudioTranscriptionExecution;
+  readonly locale?: string | null;
+  readonly modelId?: string | null;
+}): AudioTranscriptionProvenance {
+  const provider = AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY[input.provider];
+  if (!(provider.executions as readonly string[]).includes(input.execution)) {
+    throw new TypeError(
+      `Execution ${input.execution} is invalid for transcription provider ${input.provider}`
+    );
+  }
+
+  return {
+    source: provider.source,
+    provider: provider.id,
+    execution: input.execution,
+    locale: normalizeOptionalIdentifier(input.locale, 'locale'),
+    modelId: normalizeOptionalIdentifier(input.modelId, 'modelId'),
+  };
+}
+
+export function createAudioTranscriptionSegment(input: {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+  readonly text: string;
+  readonly confidence?: number;
+  readonly isFinal?: boolean;
+}): AudioTranscriptionSegment {
+  if (!Number.isFinite(input.startSeconds) || input.startSeconds < 0) {
+    throw new RangeError('startSeconds must be finite and non-negative');
+  }
+  if (!Number.isFinite(input.durationSeconds) || input.durationSeconds < 0) {
+    throw new RangeError('durationSeconds must be finite and non-negative');
+  }
+  const text = input.text.trim();
+  if (!text)
+    throw new TypeError('transcription segment text must not be empty');
+  if (
+    input.confidence !== undefined &&
+    (!Number.isFinite(input.confidence) ||
+      input.confidence < 0 ||
+      input.confidence > 1)
+  ) {
+    throw new RangeError('confidence must be between 0 and 1');
+  }
+
+  return {
+    startSeconds: input.startSeconds,
+    durationSeconds: input.durationSeconds,
+    text,
+    confidence: input.confidence,
+    isFinal: input.isFinal,
+  };
+}


### PR DESCRIPTION
## Summary
- adds the generation-aware playback derivative job and API scheduling/confirmation flow
- uses compare-and-swap publication, bounded download/conversion/upload, retry classification, cleanup, and redacted failures
- keeps master values private and never exposes an unverified AIFF source to playback consumers

Linear: JOV-4393

## Stack
1. capability registry
2. playback core
3. **This PR — derivative pipeline**
4. UI adoption

This is a real locally tracked Graphite stack. Graphite submission was attempted first, but the JovieInc Graphite plan is expired, so publication uses the documented GitHub fallback with the exact Graphite parent chain.

## Verification
- job + API focused: 28/28
- web typecheck
- web audio mutation on exact top-of-stack tree: 100% (536 tested; 514 assertion-killed, 22 timeout-killed, 0 survived, 0 uncovered)
- real Chromium corpus: 14/14 Playwright tests
- full normal pre-push gate on top-of-stack: 8/8 Vitest shards, typecheck, lint, guards, CI harness

## Release
Draft only. Do not queue from reduced child checks; retarget to main and obtain full required main-target checks before queueing.