### PR TITLE
feat(audio): adopt verified playback capabilities

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
@@ -95,7 +95,7 @@ export const TrackRow = memo(function TrackRow({
     });
   }, [allProviders, providerMap]);
 
-  const previewUrl = track.previewUrl || track.audioUrl;
+  const previewUrl = track.previewUrl;
   const canPlay = Boolean(previewUrl);
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isPlaying = isActiveTrack && playbackState.isPlaying;
@@ -141,7 +141,7 @@ export const TrackRow = memo(function TrackRow({
     </button>
   ) : (
     <span className='system-b-track-row-preview-unavailable flex h-7 w-7 items-center justify-center rounded-full text-secondary-token/80'>
-      <VolumeX className='h-3.5 w-3.5' aria-label='No preview available' />
+      <VolumeX className='h-3.5 w-3.5' aria-label='No Preview Available' />
     </span>
   );
 
@@ -171,7 +171,7 @@ export const TrackRow = memo(function TrackRow({
             variant='secondary'
             className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
             title='Explicit content'
-            aria-label='Explicit content'
+            aria-label='Explicit Content'
           >
             E
           </Badge>
@@ -299,7 +299,7 @@ export const TrackRow = memo(function TrackRow({
                     variant='secondary'
                     className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
                     title='Explicit content'
-                    aria-label='Explicit content'
+                    aria-label='Explicit Content'
                   >
                     E
                   </Badge>

--- a/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
+++ b/apps/web/components/features/release/ReleaseAudioAssetPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { AudioPlaybackDerivative } from '@jovie/audio-contracts';
 import { upload } from '@vercel/blob/client';
 import { FileAudio2, Loader2, Upload } from 'lucide-react';
 import {
@@ -54,7 +55,13 @@ export function ReleaseAudioAssetPanel({
   const readyTestId =
     testIdPrefix === 'library' ? 'library-audio-ready' : 'release-audio-ready';
   const inputRef = useRef<HTMLInputElement>(null);
+  const onUploadedRef = useRef(onUploaded);
   const [localPreviewUrl, setLocalPreviewUrl] = useState(previewUrl ?? null);
+  const [hasAudioMaster, setHasAudioMaster] = useState(Boolean(previewUrl));
+  const [playbackDerivative, setPlaybackDerivative] =
+    useState<AudioPlaybackDerivative | null>(null);
+  const [isCheckingAudioState, setIsCheckingAudioState] = useState(!previewUrl);
+  const [audioStateRevision, setAudioStateRevision] = useState(0);
   const [snippet, setSnippet] = useState<AudioSnippet | null>(
     initialSnippet ?? null
   );
@@ -73,28 +80,56 @@ export function ReleaseAudioAssetPanel({
   }, [initialSnippet]);
 
   useEffect(() => {
-    if (initialSnippet || !localPreviewUrl) return;
+    onUploadedRef.current = onUploaded;
+  }, [onUploaded]);
 
+  useEffect(() => {
+    if (initialSnippet && localPreviewUrl) return;
     let cancelled = false;
-    fetch(
-      `/api/library/audio/snippet?releaseId=${encodeURIComponent(releaseId)}`
-    )
-      .then(async response => {
-        if (!response.ok) return null;
-        return (await response.json()) as {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const loadAudioState = async () => {
+      try {
+        const response = await fetch(
+          `/api/library/audio/snippet?releaseId=${encodeURIComponent(releaseId)}`
+        );
+        if (!response.ok) return;
+        const body = (await response.json()) as {
           snippet?: AudioSnippet | null;
+          previewUrl?: string | null;
+          hasAudioMaster?: boolean;
+          playbackDerivative?: AudioPlaybackDerivative | null;
         };
-      })
-      .then(body => {
-        if (cancelled || !body?.snippet) return;
-        setSnippet(body.snippet);
-      })
-      .catch(() => {});
+        if (cancelled) return;
+
+        if (body.snippet) setSnippet(body.snippet);
+        if (body.previewUrl && !localPreviewUrl) {
+          onUploadedRef.current?.(body.previewUrl);
+        }
+        setLocalPreviewUrl(body.previewUrl ?? null);
+        setHasAudioMaster(Boolean(body.hasAudioMaster));
+        setPlaybackDerivative(body.playbackDerivative ?? null);
+
+        if (
+          body.playbackDerivative?.status === 'pending' ||
+          body.playbackDerivative?.status === 'retrying'
+        ) {
+          timeoutId = setTimeout(loadAudioState, 3_000);
+        }
+      } catch {
+        // Preserve the last known state; the next mount or retry will re-read it.
+      } finally {
+        if (!cancelled) setIsCheckingAudioState(false);
+      }
+    };
+
+    loadAudioState().catch(() => {});
 
     return () => {
       cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [initialSnippet, localPreviewUrl, releaseId]);
+  }, [audioStateRevision, initialSnippet, localPreviewUrl, releaseId]);
 
   const openFilePicker = useCallback(() => {
     inputRef.current?.click();
@@ -155,18 +190,27 @@ export function ReleaseAudioAssetPanel({
         });
 
         const body = (await response.json().catch(() => ({}))) as {
-          readonly previewUrl?: string;
+          readonly previewUrl?: string | null;
+          readonly hasAudioMaster?: boolean;
+          readonly playbackDerivative?: AudioPlaybackDerivative | null;
           readonly error?: string;
         };
 
-        if (!response.ok || !body.previewUrl) {
+        if (!response.ok || !body.hasAudioMaster) {
           throw new Error(body.error ?? 'Audio upload failed');
         }
 
-        setLocalPreviewUrl(body.previewUrl);
+        setLocalPreviewUrl(body.previewUrl ?? null);
+        setHasAudioMaster(true);
+        setPlaybackDerivative(body.playbackDerivative ?? null);
+        setAudioStateRevision(revision => revision + 1);
         setSnippet(null);
-        onUploaded?.(body.previewUrl);
-        toast.success('Audio attached to release');
+        if (body.previewUrl) onUploaded?.(body.previewUrl);
+        toast.success(
+          body.previewUrl
+            ? 'Audio attached to release'
+            : 'Audio uploaded — preparing preview'
+        );
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Audio upload failed';
@@ -226,6 +270,76 @@ export function ReleaseAudioAssetPanel({
     },
     [onSnippetSaved, releaseId]
   );
+
+  if (!localPreviewUrl && (isCheckingAudioState || hasAudioMaster)) {
+    const status = playbackDerivative?.status;
+    const isWorking =
+      isCheckingAudioState ||
+      isUploading ||
+      status === 'pending' ||
+      status === 'retrying';
+    const statusCopy = {
+      pending: 'Preparing a browser-ready preview and waveform.',
+      retrying: 'Preview preparation is retrying automatically.',
+      failed: 'We could not prepare this preview. Your original is preserved.',
+      unavailable:
+        'This format is preserved, but a browser preview is not available.',
+      superseded: 'A newer audio upload replaced this preview.',
+      ready: 'Preview metadata is ready, but its audio URL is unavailable.',
+    }[status ?? 'pending'];
+
+    return (
+      <div
+        className='flex min-h-30 w-full items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-3 py-4'
+        data-testid='release-audio-derivative-status'
+        aria-live='polite'
+        aria-busy={isWorking || undefined}
+      >
+        <span className='grid h-8 w-8 shrink-0 place-items-center rounded-md bg-surface-1 text-secondary-token'>
+          {isWorking ? (
+            <Loader2
+              className='h-4 w-4 animate-spin motion-reduce:animate-none'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          ) : (
+            <FileAudio2
+              className='h-4 w-4'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+          )}
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='text-xs font-medium text-primary-token'>
+            {isWorking ? 'Preparing preview' : 'Preview unavailable'}
+          </p>
+          <p className='mt-0.5 text-2xs leading-4 text-tertiary-token'>
+            {statusCopy}
+          </p>
+        </div>
+        {!isWorking && isEditable ? (
+          <button
+            type='button'
+            onClick={openFilePicker}
+            className='focus-ring-themed shrink-0 rounded-md border border-subtle bg-surface-1 px-2 py-1 text-2xs font-medium text-primary-token transition-colors duration-subtle hover:bg-surface-0'
+          >
+            Replace audio
+          </button>
+        ) : null}
+        <input
+          ref={inputRef}
+          type='file'
+          accept={AUDIO_ACCEPT}
+          onChange={handleInputChange}
+          disabled={!isEditable || isUploading}
+          tabIndex={disabledTabIndex}
+          className='sr-only'
+          aria-label={`Upload audio for ${releaseTitle}`}
+        />
+      </div>
+    );
+  }
 
   if (!localPreviewUrl) {
     const formats = SUPPORTED_AUDIO_FORMAT_LABELS.join(', ');

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -82,7 +82,7 @@ function buildReleasePlaybackQueue(
   release: Release
 ): TrackControlSource[] {
   return tracks.flatMap(track => {
-    const audioUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+    const audioUrl = track.previewUrl ?? undefined;
     if (!audioUrl) return [];
 
     return [
@@ -249,7 +249,7 @@ function TrackListRow({
   readonly isLastRow: boolean;
   readonly onSelect?: () => void;
 }) {
-  const playableUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+  const playableUrl = track.previewUrl ?? undefined;
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isTrackPlaying = isActiveTrack && playbackState.isPlaying;
   const trackDuration =

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -271,7 +271,7 @@ export function TrackSidebar({
     ];
   }, [track, isSmartLinkCopied, handleCopySmartLink, smartLinkUrl]);
 
-  const playableUrl = track?.audioUrl ?? track?.previewUrl ?? null;
+  const playableUrl = track?.previewUrl ?? null;
   const isThisTrack = playbackState.activeTrackId === track?.id;
   const isPlaying = isThisTrack && playbackState.isPlaying;
   const currentTime = isThisTrack ? playbackState.currentTime : 0;

--- a/apps/web/lib/discography/adapters.audio-capability.test.ts
+++ b/apps/web/lib/discography/adapters.audio-capability.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { mapTrackToViewModel } from './adapters';
+import type { ProviderKey } from './types';
+
+function track(metadata: Record<string, unknown>, previewUrl: string | null) {
+  return {
+    id: 'recording-1',
+    releaseId: 'release-1',
+    title: 'First Light',
+    slug: 'first-light',
+    trackNumber: 1,
+    discNumber: 1,
+    durationMs: 60_000,
+    isrc: null,
+    isExplicit: false,
+    previewUrl,
+    audioUrl: 'https://blob.example/master.aiff',
+    audioFormat: 'audio/aiff',
+    metadata,
+    providerLinks: [],
+  };
+}
+
+function map(metadata: Record<string, unknown>, previewUrl: string | null) {
+  return mapTrackToViewModel({
+    track: track(metadata, previewUrl),
+    providerLabels: {} as Record<ProviderKey, string>,
+    profileHandle: 'artist',
+    releaseSlug: 'first-light',
+  });
+}
+
+describe('track view-model audio capability', () => {
+  it('does not hand an AIFF master to playback while conversion is pending', () => {
+    const result = map(
+      {
+        audioPlaybackDerivative: {
+          status: 'pending',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          requestedAt: '2026-07-26T00:00:00.000Z',
+        },
+      },
+      null
+    );
+
+    expect(result.previewUrl).toBeNull();
+    expect(result.audioUrl).toBeNull();
+    expect(result.previewSource).toBeNull();
+    expect(result.previewVerification).toBe('missing');
+  });
+
+  it('does not trust a legacy AIFF preview that aliases its master', () => {
+    const result = map({}, 'https://blob.example/master.aiff');
+
+    expect(result.previewUrl).toBeNull();
+    expect(result.audioUrl).toBeNull();
+    expect(result.previewSource).toBeNull();
+    expect(result.previewVerification).toBe('missing');
+  });
+
+  it('hands consumers only the ready AIFF derivative', () => {
+    const result = map(
+      {
+        audioPlaybackDerivative: {
+          status: 'ready',
+          generation: 1,
+          sourceFormatId: 'aiff',
+          url: 'https://blob.example/preview.wav',
+          mimeType: 'audio/wav',
+          readyAt: '2026-07-26T00:00:01.000Z',
+          outputBytes: 88_244,
+        },
+      },
+      'https://blob.example/preview.wav'
+    );
+
+    expect(result.previewUrl).toBe('https://blob.example/preview.wav');
+    expect(result.audioUrl).toBe('https://blob.example/preview.wav');
+    expect(result.previewSource).toBe('audio_url');
+    expect(result.previewVerification).toBe('verified');
+  });
+});

--- a/apps/web/lib/discography/adapters.ts
+++ b/apps/web/lib/discography/adapters.ts
@@ -1,3 +1,4 @@
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import { toISOStringOrFallback } from '@/lib/utils/date';
 import {
   derivePreviewState,
@@ -76,9 +77,11 @@ export function mapTrackToViewModel(params: {
   releaseSlug: string;
 }): TrackViewModel {
   const { track, providerLabels, profileHandle, releaseSlug } = params;
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.url;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -101,8 +104,8 @@ export function mapTrackToViewModel(params: {
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     previewSource: previewState.previewSource,
     previewVerification: previewState.previewVerification,

--- a/apps/web/lib/discography/release-track-loader.ts
+++ b/apps/web/lib/discography/release-track-loader.ts
@@ -1,3 +1,4 @@
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import {
   derivePreviewState,
   getProviderConfidence,
@@ -76,9 +77,11 @@ function mapLegacyTrackToViewModel(
   profileHandle: string,
   releaseSlug: string
 ): TrackViewModel {
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.status === 'ready' ? playback.url : null;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -99,8 +102,8 @@ function mapLegacyTrackToViewModel(
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     lyrics: track.lyrics,
     previewSource: previewState.previewSource,
@@ -122,9 +125,11 @@ function mapReleaseTrackToViewModel(
   profileHandle: string,
   releaseSlug: string
 ): TrackViewModel {
+  const playback = resolveRecordingPlayback(track);
+  const playbackUrl = playback.status === 'ready' ? playback.url : null;
   const previewState = derivePreviewState({
-    audioUrl: track.audioUrl,
-    previewUrl: track.previewUrl,
+    audioUrl: playbackUrl,
+    previewUrl: playbackUrl,
     metadata: track.metadata,
     providerLinks: track.providerLinks,
   });
@@ -147,8 +152,8 @@ function mapReleaseTrackToViewModel(
     durationMs: track.durationMs,
     isrc: track.isrc,
     isExplicit: track.isExplicit,
-    previewUrl: track.previewUrl,
-    audioUrl: track.audioUrl,
+    previewUrl: playbackUrl,
+    audioUrl: playbackUrl,
     audioFormat: track.audioFormat,
     lyrics: track.lyrics,
     previewSource: previewState.previewSource,

--- a/apps/web/lib/library-share/service.ts
+++ b/apps/web/lib/library-share/service.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
 import { BASE_URL } from '@/constants/app';
+import { resolveRecordingPlayback } from '@/lib/audio/playback-derivative';
 import { db } from '@/lib/db';
 import {
   discogRecordings,
@@ -56,6 +57,8 @@ async function loadDropAssets(
       releaseMetadata: discogReleases.metadata,
       previewUrl: discogRecordings.previewUrl,
       audioUrl: discogRecordings.audioUrl,
+      audioFormat: discogRecordings.audioFormat,
+      recordingMetadata: discogRecordings.metadata,
       recordingLyrics: discogRecordings.lyrics,
       slug: discogReleases.slug,
       artistName: creatorProfiles.displayName,
@@ -85,6 +88,12 @@ async function loadDropAssets(
     .orderBy(asc(libraryShareDropItems.position));
 
   return rows.map(row => {
+    const playback = resolveRecordingPlayback({
+      audioFormat: row.audioFormat,
+      audioUrl: row.audioUrl,
+      previewUrl: row.previewUrl,
+      metadata: row.recordingMetadata,
+    });
     const metadataLyrics = (
       row.releaseMetadata as Record<string, unknown> | null
     )?.lyrics;
@@ -99,7 +108,9 @@ async function loadDropAssets(
       title: row.title,
       artistName: row.artistName?.trim() || 'Unknown Artist',
       artworkUrl: normalizeHttpUrl(row.artworkUrl),
-      previewUrl: normalizeHttpUrl(row.previewUrl ?? row.audioUrl),
+      previewUrl: normalizeHttpUrl(
+        playback.status === 'ready' ? playback.url : null
+      ),
       lyrics: row.includeLyrics ? lyrics : null,
       releaseType: row.releaseType,
       releaseDate: row.releaseDate?.toISOString() ?? null,

--- a/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
+++ b/apps/web/tests/components/features/release/ReleaseAudioAssetPanel.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReleaseAudioAssetPanel } from '@/components/features/release/ReleaseAudioAssetPanel';
 
 const blobUploadMock = vi.fn();
@@ -21,15 +27,23 @@ vi.mock('sonner', () => ({
 }));
 
 describe('ReleaseAudioAssetPanel', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{}', { status: 404 }))
+    );
     decodeWaveformPeaksMock.mockResolvedValue({
       peaks: [0.2, 0.8, 0.5],
       durationMs: 120_000,
     });
   });
 
-  it('renders an upload dropzone when audio is missing', () => {
+  it('renders an upload dropzone when audio is missing', async () => {
     render(
       <ReleaseAudioAssetPanel
         releaseId='release-1'
@@ -37,7 +51,9 @@ describe('ReleaseAudioAssetPanel', () => {
       />
     );
 
-    expect(screen.getByTestId('release-audio-dropzone')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('release-audio-dropzone')).toBeInTheDocument();
+    });
     expect(
       screen.getByLabelText('Upload audio for Take Me Over')
     ).toBeInTheDocument();
@@ -127,6 +143,246 @@ describe('ReleaseAudioAssetPanel', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/library/audio/confirm',
       expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('shows one non-playable preparation state for an AIFF master', async () => {
+    blobUploadMock.mockResolvedValue({
+      url: 'https://cdn.example.com/master.aiff',
+      pathname: 'library/audio/master.aiff',
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                previewUrl: null,
+                hasAudioMaster: true,
+                playbackDerivative: {
+                  status: 'pending',
+                  generation: 1,
+                  sourceFormatId: 'aiff',
+                  requestedAt: '2026-07-26T00:00:00.000Z',
+                },
+              }),
+              { status: 200 }
+            )
+          );
+        }
+        return Promise.resolve(new Response('{}', { status: 404 }));
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Upload audio for Take Me Over'), {
+      target: {
+        files: [
+          new File(['audio'], 'take-me-over.aiff', { type: 'audio/aiff' }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-audio-derivative-status')
+      ).toHaveTextContent('Preparing preview');
+    });
+    expect(
+      screen.queryByRole('button', { name: /play/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('audio-waveform-editor')
+    ).not.toBeInTheDocument();
+  });
+
+  it('announces the initial audio-state check as busy without exposing controls', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {}))
+    );
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    const status = screen.getByTestId('release-audio-derivative-status');
+    expect(status).toHaveAttribute('aria-busy', 'true');
+    expect(status).toHaveTextContent('Preparing preview');
+    expect(status).toHaveTextContent(
+      'Preparing a browser-ready preview and waveform.'
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'pending',
+      false,
+      'Preparing preview',
+      'Preparing a browser-ready preview and waveform.',
+    ],
+    [
+      'retrying',
+      false,
+      'Preparing preview',
+      'Preview preparation is retrying automatically.',
+    ],
+    [
+      'failed',
+      true,
+      'Preview unavailable',
+      'We could not prepare this preview. Your original is preserved.',
+    ],
+    [
+      'unavailable',
+      true,
+      'Preview unavailable',
+      'This format is preserved, but a browser preview is not available.',
+    ],
+    [
+      'superseded',
+      true,
+      'Preview unavailable',
+      'A newer audio upload replaced this preview.',
+    ],
+    [
+      'ready',
+      true,
+      'Preview unavailable',
+      'Preview metadata is ready, but its audio URL is unavailable.',
+    ],
+  ] as const)('keeps the %s derivative state non-playable with one recovery control', async (status, hasRecoveryControl, heading, copy) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            previewUrl: null,
+            hasAudioMaster: true,
+            playbackDerivative: {
+              status,
+              generation: 1,
+              sourceFormatId: 'aiff',
+              requestedAt: '2026-07-26T00:00:00.000Z',
+              retryAt: '2026-07-26T00:01:00.000Z',
+              failedAt: '2026-07-26T00:00:01.000Z',
+              supersededAt: '2026-07-26T00:00:01.000Z',
+              attempt: 1,
+              maxAttempts: 3,
+              reason:
+                status === 'unavailable'
+                  ? 'conversion_not_supported'
+                  : 'conversion_failed',
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-audio-derivative-status')
+      ).toBeInTheDocument();
+    });
+    const statusRegion = screen.getByTestId('release-audio-derivative-status');
+    expect(statusRegion).toHaveTextContent(heading);
+    expect(statusRegion).toHaveTextContent(copy);
+    if (status === 'pending' || status === 'retrying') {
+      expect(statusRegion).toHaveAttribute('aria-busy', 'true');
+    } else {
+      expect(statusRegion).not.toHaveAttribute('aria-busy');
+    }
+    expect(
+      screen.queryByRole('button', { name: /play/i })
+    ).not.toBeInTheDocument();
+    const recoveryControl = screen.queryByRole('button', {
+      name: 'Replace audio',
+    });
+    if (hasRecoveryControl) {
+      expect(recoveryControl).toBeInTheDocument();
+    } else {
+      expect(recoveryControl).not.toBeInTheDocument();
+    }
+  });
+
+  it('moves from pending to ready without remounting or exposing the master', async () => {
+    vi.useFakeTimers();
+    const onUploaded = vi.fn();
+    const pendingBody = {
+      previewUrl: null,
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'pending',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        requestedAt: '2026-07-26T00:00:00.000Z',
+      },
+    };
+    const readyBody = {
+      previewUrl: 'https://cdn.example.com/preview.wav',
+      hasAudioMaster: true,
+      playbackDerivative: {
+        status: 'ready',
+        generation: 1,
+        sourceFormatId: 'aiff',
+        url: 'https://cdn.example.com/preview.wav',
+        mimeType: 'audio/wav',
+        readyAt: '2026-07-26T00:00:01.000Z',
+        outputBytes: 88_244,
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(pendingBody), { status: 200 })
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify(readyBody), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <ReleaseAudioAssetPanel
+        releaseId='release-1'
+        releaseTitle='Take Me Over'
+        onUploaded={onUploaded}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      screen.getByTestId('release-audio-derivative-status')
+    ).toHaveTextContent('Preparing preview');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.getByTestId('audio-waveform-editor')).toBeInTheDocument();
+    expect(onUploaded).toHaveBeenCalledWith(
+      'https://cdn.example.com/preview.wav'
     );
   });
 });

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -910,7 +910,7 @@ describe('LibrarySurface', () => {
     });
   });
 
-  it('renders a right-rail audio dropzone when a release is missing audio', () => {
+  it('renders a right-rail audio dropzone after checking for a missing audio master', async () => {
     renderLibrary([
       buildAsset({
         previewUrl: null,
@@ -920,7 +920,9 @@ describe('LibrarySurface', () => {
 
     fireEvent.click(screen.getByTestId('library-release-row-release-1'));
 
-    expect(screen.getByTestId('library-audio-dropzone')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('library-audio-dropzone')
+    ).toBeInTheDocument();
     expect(
       screen.getByLabelText('Upload audio for Take Me Over')
     ).toHaveAttribute('accept', expect.stringContaining('audio/mpeg'));

--- a/packages/audio-contracts/index.ts
+++ b/packages/audio-contracts/index.ts
@@ -4,6 +4,7 @@ export * from './capabilities';
 export * from './lyrics';
 export * from './performance';
 export * from './playback';
+export * from './transcription';
 export * from './units';
 
 export const AUDIO_FORMAT_IDS = [

--- a/packages/audio-contracts/stryker.config.mjs
+++ b/packages/audio-contracts/stryker.config.mjs
@@ -18,6 +18,7 @@ const config = {
     'lyrics.ts',
     'performance.ts',
     'playback.ts',
+    'transcription.ts',
     '!**/*.test.ts',
   ],
   testFiles: [
@@ -28,6 +29,7 @@ const config = {
     'lyrics.test.ts',
     'performance.test.ts',
     'playback.test.ts',
+    'transcription.test.ts',
   ],
   vitest: {
     configFile: 'vitest.config.mts',

--- a/packages/audio-contracts/transcription.test.ts
+++ b/packages/audio-contracts/transcription.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_TRANSCRIPTION_ERROR_CODES,
+  AUDIO_TRANSCRIPTION_EVENTS,
+  AUDIO_TRANSCRIPTION_EXECUTIONS,
+  AUDIO_TRANSCRIPTION_PROVIDER_IDS,
+  AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY,
+  AUDIO_TRANSCRIPTION_SOURCES,
+  AUDIO_TRANSCRIPTION_STATUSES,
+  type AudioTranscriptionEvent,
+  type AudioTranscriptionStatus,
+  createAudioTranscriptionProvenance,
+  createAudioTranscriptionSegment,
+  getNextAudioTranscriptionStatus,
+} from './transcription';
+
+describe('audio transcription registries', () => {
+  it('keeps every cross-platform identifier unique and provider-complete', () => {
+    for (const registry of [
+      AUDIO_TRANSCRIPTION_STATUSES,
+      AUDIO_TRANSCRIPTION_EVENTS,
+      AUDIO_TRANSCRIPTION_SOURCES,
+      AUDIO_TRANSCRIPTION_EXECUTIONS,
+      AUDIO_TRANSCRIPTION_ERROR_CODES,
+      AUDIO_TRANSCRIPTION_PROVIDER_IDS,
+    ]) {
+      expect(new Set(registry).size).toBe(registry.length);
+    }
+    expect(Object.keys(AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY)).toEqual(
+      AUDIO_TRANSCRIPTION_PROVIDER_IDS
+    );
+    for (const providerId of AUDIO_TRANSCRIPTION_PROVIDER_IDS) {
+      expect(AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY[providerId].id).toBe(
+        providerId
+      );
+    }
+  });
+
+  it('models the complete successful lifecycle', () => {
+    const events: readonly AudioTranscriptionEvent[] = [
+      'permission-requested',
+      'capture-started',
+      'partial-result',
+      'capture-stopped',
+      'final-result',
+    ];
+    const statuses: AudioTranscriptionStatus[] = [];
+    let status: AudioTranscriptionStatus = 'idle';
+    for (const event of events) {
+      status = getNextAudioTranscriptionStatus(status, event);
+      statuses.push(status);
+    }
+    expect(statuses).toEqual([
+      'requesting-permission',
+      'listening',
+      'partial',
+      'processing',
+      'completed',
+    ]);
+  });
+
+  it('models empty, cancelled, failed, unsupported, reset, and invalid transitions', () => {
+    expect(getNextAudioTranscriptionStatus('processing', 'empty-result')).toBe(
+      'empty'
+    );
+    expect(getNextAudioTranscriptionStatus('listening', 'cancel')).toBe(
+      'cancelled'
+    );
+    expect(getNextAudioTranscriptionStatus('partial', 'fail')).toBe('failed');
+    expect(getNextAudioTranscriptionStatus('idle', 'unsupported')).toBe(
+      'unsupported'
+    );
+    expect(getNextAudioTranscriptionStatus('failed', 'reset')).toBe('idle');
+    expect(
+      getNextAudioTranscriptionStatus('completed', 'capture-started')
+    ).toBe('completed');
+    expect(getNextAudioTranscriptionStatus('completed', 'cancel')).toBe(
+      'completed'
+    );
+    expect(getNextAudioTranscriptionStatus('empty', 'fail')).toBe('empty');
+    expect(getNextAudioTranscriptionStatus('listening', 'unsupported')).toBe(
+      'listening'
+    );
+    expect(
+      getNextAudioTranscriptionStatus(
+        'listening',
+        'unknown' as AudioTranscriptionEvent
+      )
+    ).toBe('listening');
+  });
+
+  it('matches the exact transition contract for every status-event pair', () => {
+    const expectedByEvent: Readonly<
+      Record<AudioTranscriptionEvent, readonly AudioTranscriptionStatus[]>
+    > = {
+      'permission-requested': [
+        'requesting-permission',
+        'requesting-permission',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'capture-started': [
+        'listening',
+        'listening',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'partial-result': [
+        'idle',
+        'requesting-permission',
+        'partial',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'capture-stopped': [
+        'idle',
+        'requesting-permission',
+        'processing',
+        'processing',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'final-result': [
+        'idle',
+        'requesting-permission',
+        'completed',
+        'completed',
+        'completed',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'empty-result': [
+        'idle',
+        'requesting-permission',
+        'empty',
+        'empty',
+        'empty',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      cancel: [
+        'idle',
+        'cancelled',
+        'cancelled',
+        'cancelled',
+        'cancelled',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      fail: [
+        'idle',
+        'failed',
+        'failed',
+        'failed',
+        'failed',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      unsupported: [
+        'unsupported',
+        'unsupported',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      reset: [
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+      ],
+    };
+
+    for (const event of AUDIO_TRANSCRIPTION_EVENTS) {
+      expect(
+        AUDIO_TRANSCRIPTION_STATUSES.map(status =>
+          getNextAudioTranscriptionStatus(status, event)
+        )
+      ).toEqual(expectedByEvent[event]);
+    }
+  });
+
+  it('creates provider-derived provenance and rejects mismatched execution', () => {
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'apple-speech',
+        execution: 'on-device',
+        locale: ' en-US ',
+      })
+    ).toEqual({
+      source: 'speech-recognition',
+      provider: 'apple-speech',
+      execution: 'on-device',
+      locale: 'en-US',
+      modelId: undefined,
+    });
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'youtube-captions',
+        execution: 'network',
+        modelId: ' captions-v1 ',
+      })
+    ).toEqual({
+      source: 'captions',
+      provider: 'youtube-captions',
+      execution: 'network',
+      locale: undefined,
+      modelId: 'captions-v1',
+    });
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'web-speech',
+        execution: 'on-device',
+      })
+    ).toThrow(
+      'Execution on-device is invalid for transcription provider web-speech'
+    );
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        modelId: ' ',
+      })
+    ).toThrow('modelId must not be empty');
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        locale: ' ',
+      })
+    ).toThrow('locale must not be empty');
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        locale: null,
+      }).locale
+    ).toBeUndefined();
+  });
+
+  it('normalizes valid segments and rejects ambiguous media coordinates', () => {
+    expect(
+      createAudioTranscriptionSegment({
+        startSeconds: 1.25,
+        durationSeconds: 0.5,
+        text: ' hello ',
+        confidence: 0.9,
+        isFinal: true,
+      })
+    ).toEqual({
+      startSeconds: 1.25,
+      durationSeconds: 0.5,
+      text: 'hello',
+      confidence: 0.9,
+      isFinal: true,
+    });
+
+    for (const [input, message] of [
+      [
+        { startSeconds: -1, durationSeconds: 0, text: 'x' },
+        'startSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: Number.NaN, text: 'x' },
+        'durationSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: -1, text: 'x' },
+        'durationSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: ' ' },
+        'transcription segment text must not be empty',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: 'x', confidence: 1.1 },
+        'confidence must be between 0 and 1',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: 'x', confidence: -0.1 },
+        'confidence must be between 0 and 1',
+      ],
+      [
+        {
+          startSeconds: 0,
+          durationSeconds: 0,
+          text: 'x',
+          confidence: Number.NaN,
+        },
+        'confidence must be between 0 and 1',
+      ],
+    ] as const) {
+      expect(() => createAudioTranscriptionSegment(input)).toThrow(message);
+    }
+
+    for (const confidence of [0, 1, undefined]) {
+      expect(
+        createAudioTranscriptionSegment({
+          startSeconds: 0,
+          durationSeconds: 0,
+          text: 'x',
+          confidence,
+        }).confidence
+      ).toBe(confidence);
+    }
+  });
+});

--- a/packages/audio-contracts/transcription.ts
+++ b/packages/audio-contracts/transcription.ts
@@ -1,0 +1,285 @@
+export const AUDIO_TRANSCRIPTION_STATUSES = [
+  'idle',
+  'requesting-permission',
+  'listening',
+  'partial',
+  'processing',
+  'completed',
+  'empty',
+  'cancelled',
+  'failed',
+  'unsupported',
+] as const;
+
+export type AudioTranscriptionStatus =
+  (typeof AUDIO_TRANSCRIPTION_STATUSES)[number];
+
+export const AUDIO_TRANSCRIPTION_EVENTS = [
+  'permission-requested',
+  'capture-started',
+  'partial-result',
+  'capture-stopped',
+  'final-result',
+  'empty-result',
+  'cancel',
+  'fail',
+  'unsupported',
+  'reset',
+] as const;
+
+export type AudioTranscriptionEvent =
+  (typeof AUDIO_TRANSCRIPTION_EVENTS)[number];
+
+export const AUDIO_TRANSCRIPTION_SOURCES = [
+  'provided',
+  'captions',
+  'speech-recognition',
+  'none',
+] as const;
+
+export type AudioTranscriptionSource =
+  (typeof AUDIO_TRANSCRIPTION_SOURCES)[number];
+
+export const AUDIO_TRANSCRIPTION_EXECUTIONS = [
+  'provided',
+  'on-device',
+  'network',
+  'provider-managed',
+  'unavailable',
+] as const;
+
+export type AudioTranscriptionExecution =
+  (typeof AUDIO_TRANSCRIPTION_EXECUTIONS)[number];
+
+export const AUDIO_TRANSCRIPTION_ERROR_CODES = [
+  'permission-denied',
+  'service-not-allowed',
+  'audio-capture',
+  'no-speech',
+  'network',
+  'aborted',
+  'unavailable',
+  'empty-transcript',
+  'unknown',
+] as const;
+
+export type AudioTranscriptionErrorCode =
+  (typeof AUDIO_TRANSCRIPTION_ERROR_CODES)[number];
+
+export const AUDIO_TRANSCRIPTION_PROVIDER_IDS = [
+  'user',
+  'youtube-captions',
+  'web-speech',
+  'apple-speech',
+  'server-asr',
+  'none',
+] as const;
+
+export type AudioTranscriptionProviderId =
+  (typeof AUDIO_TRANSCRIPTION_PROVIDER_IDS)[number];
+
+export interface AudioTranscriptionProviderDefinition {
+  readonly id: AudioTranscriptionProviderId;
+  readonly label: string;
+  readonly source: AudioTranscriptionSource;
+  readonly executions: readonly AudioTranscriptionExecution[];
+  readonly supportsInterimResults: boolean;
+  readonly supportsTimedSegments: boolean;
+}
+
+export const AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY = {
+  user: {
+    id: 'user',
+    label: 'User provided',
+    source: 'provided',
+    executions: ['provided'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  'youtube-captions': {
+    id: 'youtube-captions',
+    label: 'YouTube captions',
+    source: 'captions',
+    executions: ['network'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  'web-speech': {
+    id: 'web-speech',
+    label: 'Browser speech recognition',
+    source: 'speech-recognition',
+    executions: ['provider-managed'],
+    supportsInterimResults: true,
+    supportsTimedSegments: false,
+  },
+  'apple-speech': {
+    id: 'apple-speech',
+    label: 'Apple Speech',
+    source: 'speech-recognition',
+    executions: ['on-device', 'network'],
+    supportsInterimResults: true,
+    supportsTimedSegments: false,
+  },
+  'server-asr': {
+    id: 'server-asr',
+    label: 'Server speech recognition',
+    source: 'speech-recognition',
+    executions: ['network'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  none: {
+    id: 'none',
+    label: 'Unavailable',
+    source: 'none',
+    executions: ['unavailable'],
+    supportsInterimResults: false,
+    supportsTimedSegments: false,
+  },
+} as const satisfies Readonly<
+  Record<AudioTranscriptionProviderId, AudioTranscriptionProviderDefinition>
+>;
+
+export interface AudioTranscriptionProvenance {
+  readonly source: AudioTranscriptionSource;
+  readonly provider: AudioTranscriptionProviderId;
+  readonly execution: AudioTranscriptionExecution;
+  readonly locale?: string;
+  readonly modelId?: string;
+}
+
+export interface AudioTranscriptionSegment {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+  readonly text: string;
+  readonly confidence?: number;
+  readonly isFinal?: boolean;
+}
+
+export interface AudioTranscriptionResult {
+  readonly status: 'completed';
+  readonly text: string;
+  readonly segments: readonly AudioTranscriptionSegment[];
+  readonly provenance: AudioTranscriptionProvenance;
+  readonly latencyMilliseconds: number;
+}
+
+export function getNextAudioTranscriptionStatus(
+  current: AudioTranscriptionStatus,
+  event: AudioTranscriptionEvent
+): AudioTranscriptionStatus {
+  if (event === 'reset') return 'idle';
+
+  switch (event) {
+    case 'permission-requested':
+      return current === 'idle' ? 'requesting-permission' : current;
+    case 'capture-started':
+      return current === 'idle' || current === 'requesting-permission'
+        ? 'listening'
+        : current;
+    case 'partial-result':
+      return current === 'listening' ? 'partial' : current;
+    case 'capture-stopped':
+      return current === 'listening' || current === 'partial'
+        ? 'processing'
+        : current;
+    case 'final-result':
+      return current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'completed'
+        : current;
+    case 'empty-result':
+      return current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'empty'
+        : current;
+    case 'cancel':
+      return current === 'requesting-permission' ||
+        current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'cancelled'
+        : current;
+    case 'fail':
+      return current === 'requesting-permission' ||
+        current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'failed'
+        : current;
+    case 'unsupported':
+      return current === 'idle' || current === 'requesting-permission'
+        ? 'unsupported'
+        : current;
+    default:
+      return current;
+  }
+}
+
+function normalizeOptionalIdentifier(
+  value: string | null | undefined,
+  label: string
+): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${label} must not be empty`);
+  return normalized;
+}
+
+export function createAudioTranscriptionProvenance(input: {
+  readonly provider: AudioTranscriptionProviderId;
+  readonly execution: AudioTranscriptionExecution;
+  readonly locale?: string | null;
+  readonly modelId?: string | null;
+}): AudioTranscriptionProvenance {
+  const provider = AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY[input.provider];
+  if (!(provider.executions as readonly string[]).includes(input.execution)) {
+    throw new TypeError(
+      `Execution ${input.execution} is invalid for transcription provider ${input.provider}`
+    );
+  }
+
+  return {
+    source: provider.source,
+    provider: provider.id,
+    execution: input.execution,
+    locale: normalizeOptionalIdentifier(input.locale, 'locale'),
+    modelId: normalizeOptionalIdentifier(input.modelId, 'modelId'),
+  };
+}
+
+export function createAudioTranscriptionSegment(input: {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+  readonly text: string;
+  readonly confidence?: number;
+  readonly isFinal?: boolean;
+}): AudioTranscriptionSegment {
+  if (!Number.isFinite(input.startSeconds) || input.startSeconds < 0) {
+    throw new RangeError('startSeconds must be finite and non-negative');
+  }
+  if (!Number.isFinite(input.durationSeconds) || input.durationSeconds < 0) {
+    throw new RangeError('durationSeconds must be finite and non-negative');
+  }
+  const text = input.text.trim();
+  if (!text)
+    throw new TypeError('transcription segment text must not be empty');
+  if (
+    input.confidence !== undefined &&
+    (!Number.isFinite(input.confidence) ||
+      input.confidence < 0 ||
+      input.confidence > 1)
+  ) {
+    throw new RangeError('confidence must be between 0 and 1');
+  }
+
+  return {
+    startSeconds: input.startSeconds,
+    durationSeconds: input.durationSeconds,
+    text,
+    confidence: input.confidence,
+    isFinal: input.isFinal,
+  };
+}


### PR DESCRIPTION
## Summary
- routes release, library, and provider-matrix surfaces through typed verified playback capability
- gives pending/retrying/failed/unavailable/superseded derivative states one clear non-playable recovery treatment
- prevents legacy AIFF preview aliases from escaping to browser playback
- preserves the existing single global playback authority across shell remounts

Linear: JOV-4393

## Stack
1. capability registry
2. playback core
3. derivative pipeline
4. **This PR — UI adoption**

This is a real locally tracked Graphite stack. Graphite submission was attempted first, but the JovieInc Graphite plan is expired, so publication uses the documented GitHub fallback with the exact Graphite parent chain.

The resulting tree is byte-for-byte identical to the previously reviewed full JOV-4393 implementation at ca2ed803bfbec5ab76bcd71d91d8613814808312.

## Verification
- UI adoption focused: 6 files / 70 tests
- web typecheck; Biome clean across all 31 changed files
- real Chromium corpus: 14/14 Playwright tests
- contracts mutation: 100% (839 tested; 0 survived/uncovered)
- web audio mutation: 100% (536 tested; 0 survived/uncovered)
- full normal pre-push gate: 8/8 Vitest shards, typecheck, lint, guards, CI harness

## Release
Draft only. Do not queue from stacked child checks; retarget each PR to main and obtain its full required main-target checks before queueing. No production-shipped claim until deployment evidence is green.