### PR TITLE
feat(audio): define transcription lifecycle contracts

### DIFF
--- a/packages/audio-contracts/index.ts
+++ b/packages/audio-contracts/index.ts
@@ -4,6 +4,7 @@ export * from './capabilities';
 export * from './lyrics';
 export * from './performance';
 export * from './playback';
+export * from './transcription';
 export * from './units';
 
 export const AUDIO_FORMAT_IDS = [

--- a/packages/audio-contracts/stryker.config.mjs
+++ b/packages/audio-contracts/stryker.config.mjs
@@ -18,6 +18,7 @@ const config = {
     'lyrics.ts',
     'performance.ts',
     'playback.ts',
+    'transcription.ts',
     '!**/*.test.ts',
   ],
   testFiles: [
@@ -28,6 +29,7 @@ const config = {
     'lyrics.test.ts',
     'performance.test.ts',
     'playback.test.ts',
+    'transcription.test.ts',
   ],
   vitest: {
     configFile: 'vitest.config.mts',

--- a/packages/audio-contracts/transcription.test.ts
+++ b/packages/audio-contracts/transcription.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIO_TRANSCRIPTION_ERROR_CODES,
+  AUDIO_TRANSCRIPTION_EVENTS,
+  AUDIO_TRANSCRIPTION_EXECUTIONS,
+  AUDIO_TRANSCRIPTION_PROVIDER_IDS,
+  AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY,
+  AUDIO_TRANSCRIPTION_SOURCES,
+  AUDIO_TRANSCRIPTION_STATUSES,
+  type AudioTranscriptionEvent,
+  type AudioTranscriptionStatus,
+  createAudioTranscriptionProvenance,
+  createAudioTranscriptionSegment,
+  getNextAudioTranscriptionStatus,
+} from './transcription';
+
+describe('audio transcription registries', () => {
+  it('keeps every cross-platform identifier unique and provider-complete', () => {
+    for (const registry of [
+      AUDIO_TRANSCRIPTION_STATUSES,
+      AUDIO_TRANSCRIPTION_EVENTS,
+      AUDIO_TRANSCRIPTION_SOURCES,
+      AUDIO_TRANSCRIPTION_EXECUTIONS,
+      AUDIO_TRANSCRIPTION_ERROR_CODES,
+      AUDIO_TRANSCRIPTION_PROVIDER_IDS,
+    ]) {
+      expect(new Set(registry).size).toBe(registry.length);
+    }
+    expect(Object.keys(AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY)).toEqual(
+      AUDIO_TRANSCRIPTION_PROVIDER_IDS
+    );
+    for (const providerId of AUDIO_TRANSCRIPTION_PROVIDER_IDS) {
+      expect(AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY[providerId].id).toBe(
+        providerId
+      );
+    }
+  });
+
+  it('models the complete successful lifecycle', () => {
+    const events: readonly AudioTranscriptionEvent[] = [
+      'permission-requested',
+      'capture-started',
+      'partial-result',
+      'capture-stopped',
+      'final-result',
+    ];
+    const statuses: AudioTranscriptionStatus[] = [];
+    let status: AudioTranscriptionStatus = 'idle';
+    for (const event of events) {
+      status = getNextAudioTranscriptionStatus(status, event);
+      statuses.push(status);
+    }
+    expect(statuses).toEqual([
+      'requesting-permission',
+      'listening',
+      'partial',
+      'processing',
+      'completed',
+    ]);
+  });
+
+  it('models empty, cancelled, failed, unsupported, reset, and invalid transitions', () => {
+    expect(getNextAudioTranscriptionStatus('processing', 'empty-result')).toBe(
+      'empty'
+    );
+    expect(getNextAudioTranscriptionStatus('listening', 'cancel')).toBe(
+      'cancelled'
+    );
+    expect(getNextAudioTranscriptionStatus('partial', 'fail')).toBe('failed');
+    expect(getNextAudioTranscriptionStatus('idle', 'unsupported')).toBe(
+      'unsupported'
+    );
+    expect(getNextAudioTranscriptionStatus('failed', 'reset')).toBe('idle');
+    expect(
+      getNextAudioTranscriptionStatus('completed', 'capture-started')
+    ).toBe('completed');
+    expect(getNextAudioTranscriptionStatus('completed', 'cancel')).toBe(
+      'completed'
+    );
+    expect(getNextAudioTranscriptionStatus('empty', 'fail')).toBe('empty');
+    expect(getNextAudioTranscriptionStatus('listening', 'unsupported')).toBe(
+      'listening'
+    );
+    expect(
+      getNextAudioTranscriptionStatus(
+        'listening',
+        'unknown' as AudioTranscriptionEvent
+      )
+    ).toBe('listening');
+  });
+
+  it('matches the exact transition contract for every status-event pair', () => {
+    const expectedByEvent: Readonly<
+      Record<AudioTranscriptionEvent, readonly AudioTranscriptionStatus[]>
+    > = {
+      'permission-requested': [
+        'requesting-permission',
+        'requesting-permission',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'capture-started': [
+        'listening',
+        'listening',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'partial-result': [
+        'idle',
+        'requesting-permission',
+        'partial',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'capture-stopped': [
+        'idle',
+        'requesting-permission',
+        'processing',
+        'processing',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'final-result': [
+        'idle',
+        'requesting-permission',
+        'completed',
+        'completed',
+        'completed',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      'empty-result': [
+        'idle',
+        'requesting-permission',
+        'empty',
+        'empty',
+        'empty',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      cancel: [
+        'idle',
+        'cancelled',
+        'cancelled',
+        'cancelled',
+        'cancelled',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      fail: [
+        'idle',
+        'failed',
+        'failed',
+        'failed',
+        'failed',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      unsupported: [
+        'unsupported',
+        'unsupported',
+        'listening',
+        'partial',
+        'processing',
+        'completed',
+        'empty',
+        'cancelled',
+        'failed',
+        'unsupported',
+      ],
+      reset: [
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+        'idle',
+      ],
+    };
+
+    for (const event of AUDIO_TRANSCRIPTION_EVENTS) {
+      expect(
+        AUDIO_TRANSCRIPTION_STATUSES.map(status =>
+          getNextAudioTranscriptionStatus(status, event)
+        )
+      ).toEqual(expectedByEvent[event]);
+    }
+  });
+
+  it('creates provider-derived provenance and rejects mismatched execution', () => {
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'apple-speech',
+        execution: 'on-device',
+        locale: ' en-US ',
+      })
+    ).toEqual({
+      source: 'speech-recognition',
+      provider: 'apple-speech',
+      execution: 'on-device',
+      locale: 'en-US',
+      modelId: undefined,
+    });
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'youtube-captions',
+        execution: 'network',
+        modelId: ' captions-v1 ',
+      })
+    ).toEqual({
+      source: 'captions',
+      provider: 'youtube-captions',
+      execution: 'network',
+      locale: undefined,
+      modelId: 'captions-v1',
+    });
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'web-speech',
+        execution: 'on-device',
+      })
+    ).toThrow(
+      'Execution on-device is invalid for transcription provider web-speech'
+    );
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        modelId: ' ',
+      })
+    ).toThrow('modelId must not be empty');
+    expect(() =>
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        locale: ' ',
+      })
+    ).toThrow('locale must not be empty');
+    expect(
+      createAudioTranscriptionProvenance({
+        provider: 'server-asr',
+        execution: 'network',
+        locale: null,
+      }).locale
+    ).toBeUndefined();
+  });
+
+  it('normalizes valid segments and rejects ambiguous media coordinates', () => {
+    expect(
+      createAudioTranscriptionSegment({
+        startSeconds: 1.25,
+        durationSeconds: 0.5,
+        text: ' hello ',
+        confidence: 0.9,
+        isFinal: true,
+      })
+    ).toEqual({
+      startSeconds: 1.25,
+      durationSeconds: 0.5,
+      text: 'hello',
+      confidence: 0.9,
+      isFinal: true,
+    });
+
+    for (const [input, message] of [
+      [
+        { startSeconds: -1, durationSeconds: 0, text: 'x' },
+        'startSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: Number.NaN, text: 'x' },
+        'durationSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: -1, text: 'x' },
+        'durationSeconds must be finite and non-negative',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: ' ' },
+        'transcription segment text must not be empty',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: 'x', confidence: 1.1 },
+        'confidence must be between 0 and 1',
+      ],
+      [
+        { startSeconds: 0, durationSeconds: 0, text: 'x', confidence: -0.1 },
+        'confidence must be between 0 and 1',
+      ],
+      [
+        {
+          startSeconds: 0,
+          durationSeconds: 0,
+          text: 'x',
+          confidence: Number.NaN,
+        },
+        'confidence must be between 0 and 1',
+      ],
+    ] as const) {
+      expect(() => createAudioTranscriptionSegment(input)).toThrow(message);
+    }
+
+    for (const confidence of [0, 1, undefined]) {
+      expect(
+        createAudioTranscriptionSegment({
+          startSeconds: 0,
+          durationSeconds: 0,
+          text: 'x',
+          confidence,
+        }).confidence
+      ).toBe(confidence);
+    }
+  });
+});

--- a/packages/audio-contracts/transcription.ts
+++ b/packages/audio-contracts/transcription.ts
@@ -1,0 +1,285 @@
+export const AUDIO_TRANSCRIPTION_STATUSES = [
+  'idle',
+  'requesting-permission',
+  'listening',
+  'partial',
+  'processing',
+  'completed',
+  'empty',
+  'cancelled',
+  'failed',
+  'unsupported',
+] as const;
+
+export type AudioTranscriptionStatus =
+  (typeof AUDIO_TRANSCRIPTION_STATUSES)[number];
+
+export const AUDIO_TRANSCRIPTION_EVENTS = [
+  'permission-requested',
+  'capture-started',
+  'partial-result',
+  'capture-stopped',
+  'final-result',
+  'empty-result',
+  'cancel',
+  'fail',
+  'unsupported',
+  'reset',
+] as const;
+
+export type AudioTranscriptionEvent =
+  (typeof AUDIO_TRANSCRIPTION_EVENTS)[number];
+
+export const AUDIO_TRANSCRIPTION_SOURCES = [
+  'provided',
+  'captions',
+  'speech-recognition',
+  'none',
+] as const;
+
+export type AudioTranscriptionSource =
+  (typeof AUDIO_TRANSCRIPTION_SOURCES)[number];
+
+export const AUDIO_TRANSCRIPTION_EXECUTIONS = [
+  'provided',
+  'on-device',
+  'network',
+  'provider-managed',
+  'unavailable',
+] as const;
+
+export type AudioTranscriptionExecution =
+  (typeof AUDIO_TRANSCRIPTION_EXECUTIONS)[number];
+
+export const AUDIO_TRANSCRIPTION_ERROR_CODES = [
+  'permission-denied',
+  'service-not-allowed',
+  'audio-capture',
+  'no-speech',
+  'network',
+  'aborted',
+  'unavailable',
+  'empty-transcript',
+  'unknown',
+] as const;
+
+export type AudioTranscriptionErrorCode =
+  (typeof AUDIO_TRANSCRIPTION_ERROR_CODES)[number];
+
+export const AUDIO_TRANSCRIPTION_PROVIDER_IDS = [
+  'user',
+  'youtube-captions',
+  'web-speech',
+  'apple-speech',
+  'server-asr',
+  'none',
+] as const;
+
+export type AudioTranscriptionProviderId =
+  (typeof AUDIO_TRANSCRIPTION_PROVIDER_IDS)[number];
+
+export interface AudioTranscriptionProviderDefinition {
+  readonly id: AudioTranscriptionProviderId;
+  readonly label: string;
+  readonly source: AudioTranscriptionSource;
+  readonly executions: readonly AudioTranscriptionExecution[];
+  readonly supportsInterimResults: boolean;
+  readonly supportsTimedSegments: boolean;
+}
+
+export const AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY = {
+  user: {
+    id: 'user',
+    label: 'User provided',
+    source: 'provided',
+    executions: ['provided'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  'youtube-captions': {
+    id: 'youtube-captions',
+    label: 'YouTube captions',
+    source: 'captions',
+    executions: ['network'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  'web-speech': {
+    id: 'web-speech',
+    label: 'Browser speech recognition',
+    source: 'speech-recognition',
+    executions: ['provider-managed'],
+    supportsInterimResults: true,
+    supportsTimedSegments: false,
+  },
+  'apple-speech': {
+    id: 'apple-speech',
+    label: 'Apple Speech',
+    source: 'speech-recognition',
+    executions: ['on-device', 'network'],
+    supportsInterimResults: true,
+    supportsTimedSegments: false,
+  },
+  'server-asr': {
+    id: 'server-asr',
+    label: 'Server speech recognition',
+    source: 'speech-recognition',
+    executions: ['network'],
+    supportsInterimResults: false,
+    supportsTimedSegments: true,
+  },
+  none: {
+    id: 'none',
+    label: 'Unavailable',
+    source: 'none',
+    executions: ['unavailable'],
+    supportsInterimResults: false,
+    supportsTimedSegments: false,
+  },
+} as const satisfies Readonly<
+  Record<AudioTranscriptionProviderId, AudioTranscriptionProviderDefinition>
+>;
+
+export interface AudioTranscriptionProvenance {
+  readonly source: AudioTranscriptionSource;
+  readonly provider: AudioTranscriptionProviderId;
+  readonly execution: AudioTranscriptionExecution;
+  readonly locale?: string;
+  readonly modelId?: string;
+}
+
+export interface AudioTranscriptionSegment {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+  readonly text: string;
+  readonly confidence?: number;
+  readonly isFinal?: boolean;
+}
+
+export interface AudioTranscriptionResult {
+  readonly status: 'completed';
+  readonly text: string;
+  readonly segments: readonly AudioTranscriptionSegment[];
+  readonly provenance: AudioTranscriptionProvenance;
+  readonly latencyMilliseconds: number;
+}
+
+export function getNextAudioTranscriptionStatus(
+  current: AudioTranscriptionStatus,
+  event: AudioTranscriptionEvent
+): AudioTranscriptionStatus {
+  if (event === 'reset') return 'idle';
+
+  switch (event) {
+    case 'permission-requested':
+      return current === 'idle' ? 'requesting-permission' : current;
+    case 'capture-started':
+      return current === 'idle' || current === 'requesting-permission'
+        ? 'listening'
+        : current;
+    case 'partial-result':
+      return current === 'listening' ? 'partial' : current;
+    case 'capture-stopped':
+      return current === 'listening' || current === 'partial'
+        ? 'processing'
+        : current;
+    case 'final-result':
+      return current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'completed'
+        : current;
+    case 'empty-result':
+      return current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'empty'
+        : current;
+    case 'cancel':
+      return current === 'requesting-permission' ||
+        current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'cancelled'
+        : current;
+    case 'fail':
+      return current === 'requesting-permission' ||
+        current === 'listening' ||
+        current === 'partial' ||
+        current === 'processing'
+        ? 'failed'
+        : current;
+    case 'unsupported':
+      return current === 'idle' || current === 'requesting-permission'
+        ? 'unsupported'
+        : current;
+    default:
+      return current;
+  }
+}
+
+function normalizeOptionalIdentifier(
+  value: string | null | undefined,
+  label: string
+): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${label} must not be empty`);
+  return normalized;
+}
+
+export function createAudioTranscriptionProvenance(input: {
+  readonly provider: AudioTranscriptionProviderId;
+  readonly execution: AudioTranscriptionExecution;
+  readonly locale?: string | null;
+  readonly modelId?: string | null;
+}): AudioTranscriptionProvenance {
+  const provider = AUDIO_TRANSCRIPTION_PROVIDER_REGISTRY[input.provider];
+  if (!(provider.executions as readonly string[]).includes(input.execution)) {
+    throw new TypeError(
+      `Execution ${input.execution} is invalid for transcription provider ${input.provider}`
+    );
+  }
+
+  return {
+    source: provider.source,
+    provider: provider.id,
+    execution: input.execution,
+    locale: normalizeOptionalIdentifier(input.locale, 'locale'),
+    modelId: normalizeOptionalIdentifier(input.modelId, 'modelId'),
+  };
+}
+
+export function createAudioTranscriptionSegment(input: {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+  readonly text: string;
+  readonly confidence?: number;
+  readonly isFinal?: boolean;
+}): AudioTranscriptionSegment {
+  if (!Number.isFinite(input.startSeconds) || input.startSeconds < 0) {
+    throw new RangeError('startSeconds must be finite and non-negative');
+  }
+  if (!Number.isFinite(input.durationSeconds) || input.durationSeconds < 0) {
+    throw new RangeError('durationSeconds must be finite and non-negative');
+  }
+  const text = input.text.trim();
+  if (!text)
+    throw new TypeError('transcription segment text must not be empty');
+  if (
+    input.confidence !== undefined &&
+    (!Number.isFinite(input.confidence) ||
+      input.confidence < 0 ||
+      input.confidence > 1)
+  ) {
+    throw new RangeError('confidence must be between 0 and 1');
+  }
+
+  return {
+    startSeconds: input.startSeconds,
+    durationSeconds: input.durationSeconds,
+    text,
+    confidence: input.confidence,
+    isFinal: input.isFinal,
+  };
+}


### PR DESCRIPTION
## Summary
- define canonical typed transcription statuses, events, providers, provenance, segments, and results
- enforce the exhaustive status-event transition matrix across platforms
- add mutation coverage for the pure transcription contract

## Verification
- audio contracts: 181 tests passed
- audio contracts mutation: 1,034 killed, 5 timed out, 0 survived, 100% score
- typecheck and Biome passed
- full normal pre-push gate passed all 8 Vitest shards

## Stack
Parent: #14936
Child: transcription web adoption

Draft only. Before queueing, retarget to main and obtain every required main-target check. Native queue is intentionally untouched.

Linear: JOV-4392