### PR TITLE
perf(ci): run manual E2E shards concurrently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4054,8 +4054,8 @@ jobs:
     env: { PLAYWRIGHT_ARTIFACT_REQUIRE_PRODUCER_STAGE: 'true' }
     strategy:
       fail-fast: true
-      # Cap E2E shard concurrency (preview env + Playwright is heavy).
-      max-parallel: 2
+      # Run all four E2E shards concurrently; each reuses the shared Neon artifact.
+      max-parallel: 4
       matrix:
         shard: [1, 2, 3, 4]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- [internal] **Bounded staged performance confirmation (JOV-4484):** an isolated timing outlier may receive one same-route confirmation batch while resource failures, persistent violations, and execution errors remain fail-closed with raw evidence preserved.
+- [internal] **Manual Full E2E shards now run concurrently (JOV-4483):** all four hosted Preview shards can start together while retaining fail-fast behavior, shared Neon setup, Playwright workers, and cleanup.
 - [internal] **Merge-group visual CI harness repair:** the filtered web workspace can resolve the repository Chromatic config again, DB-free mobile overflow excludes only explicitly database-backed redirects, and a forward-only Storybook audit now requires five clean runs before newly opened UI PRs can be gated.
 - [internal] **Bounded `ci-fast` lane groups (JOV-4477):** independent typecheck and remaining fast-gate checks now run in two hosted groups while preserving the single required `ci-fast` result and complete lane diagnostics.
 - **Unified app shell migration:** the authenticated app now uses one canonical customer/OV navigation model, header search, route-shaped loading states, chat home, Library filters, release/tour-date/profile rails, audio controls, and privacy-safe navigation telemetry. Better Auth production-artifact tests, route-specific readiness contracts, optimistic profile edit concurrency, and a 21-route performance matrix cover the migration end to end.

--- a/scripts/lib/__tests__/ci-harness.test.mjs
+++ b/scripts/lib/__tests__/ci-harness.test.mjs
@@ -284,6 +284,55 @@ describe('ci-harness manifest', () => {
     );
   });
 
+  it('runs manual Full E2E as four concurrent shared-Neon shards', () => {
+    const workflow = readFileSync(
+      resolve(REPO_ROOT, '.github/workflows/ci.yml'),
+      'utf8'
+    );
+    const e2e = extractWorkflowJobBlock(workflow, 'ci-e2e-tests');
+    const neonDb = extractWorkflowJobBlock(workflow, 'neon-db');
+    const playwrightConfig = readFileSync(
+      resolve(REPO_ROOT, 'apps/web/playwright.config.ts'),
+      'utf8'
+    );
+
+    expect(e2e).toContain('name: Full E2E (Preview)');
+    expect(e2e).toContain('environment: Preview – jovie');
+    expect(e2e).toContain(
+      'needs: [ci-path-changes, ci-build-public, neon-db, ci-e2e-migrate]'
+    );
+    expect(e2e).toContain("github.event_name == 'workflow_dispatch'");
+    expect(e2e).toMatch(
+      /strategy:\n\s+fail-fast: true\n\s+# Run all four E2E shards concurrently; each reuses the shared Neon artifact\.\n\s+max-parallel: 4\n\s+matrix:\n\s+shard: \[1, 2, 3, 4\]/
+    );
+    expect(e2e).toContain('echo "SHARD_TOTAL=4" >> "$GITHUB_ENV"');
+    expect(e2e).toContain(
+      'echo "SHARD_INDEX=${{ matrix.shard }}" >> "$GITHUB_ENV"'
+    );
+    expect(e2e).toContain(
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
+    );
+    expect(e2e).toContain(
+      'connection_file: ${{ runner.temp }}/neon-db-connection/connection.json'
+    );
+    expect(e2e).toContain('RESOLVED_DB_SOURCE=neon-artifact');
+    expect(e2e).toContain('guard-playwright-artifacts.mjs');
+    expect(e2e).toContain('--shard=${SHARD_INDEX}/${SHARD_TOTAL}');
+    expect(e2e).toContain(
+      'uses: ./.github/actions/upload-safe-playwright-artifact'
+    );
+    expect(e2e).not.toContain('neon-create-branch-with-retry');
+    expect(neonDb).toContain('uses: ./.github/actions/neon-branch-cleanup');
+    expect(neonDb).toContain(
+      'name: neon-db-connection-${{ github.run_id }}-${{ github.run_attempt }}'
+    );
+
+    // The matrix cap changes process-level fan-out only; full-suite Playwright
+    // workers and the smoke override remain unchanged.
+    expect(playwrightConfig).toContain('return isSmokeOnly ? 8 : 4;');
+    expect(playwrightConfig).toContain('workers: getWorkers(),');
+  });
+
   it('binds the production Sentry gate to its environment before reading secrets', () => {
     const workflow = readFileSync(
       resolve(REPO_ROOT, '.github/workflows/production-release.yml'),


### PR DESCRIPTION
## Summary
- Links: JOV-4483, GitHub issue #14958
- Raises the manual Full E2E (Preview) matrix cap from 2 to 4 so all four shards can start concurrently.
- Expected wall-clock improvement: 11-22% for the manual E2E path, measured against the prior two-shard cap and subject to preview/runner contention.

## Preserved invariants
- `fail-fast: true` remains enabled.
- The shared Neon artifact remains the only database source for the four shards.
- The four-shard matrix remains explicit, with `SHARD_TOTAL=4`, matrix shard indexing, Playwright `--shard=${SHARD_INDEX}/${SHARD_TOTAL}`, full-suite workers at 4, smoke override at 8, artifact guarding/upload, and Neon cleanup unchanged.
- No per-shard Neon branch creation or other release/production behavior was introduced.

## Verification receipts
- Base: exact `origin/main` `27edbcc62678e056a616fe390f4f2e1a888952fe`.
- Focused Vitest: 1 file, 35 passed.
- `pnpm ci:control:test`: 11 files, 216 passed.
- Web typecheck: `pnpm --filter @jovie/web run typecheck -- --pretty false`, passed.
- Runtime: Node v22.23.1, pnpm 9.15.4.
- Biome: changed JavaScript test file, passed.
- actionlint: `.github/actionlint.yaml`, `-shellcheck=`, `-pyflakes=`, changed workflow, passed.
- YAML parse and `git diff --check`: passed.
- Normal commit/pre-push hooks: secret scans, repo hygiene, governance, proxy/Tailwind guards, affected-package typecheck/lint/test bundle, CI harness validation, all passed.

## Scope
Exactly `.github/workflows/ci.yml`, `CHANGELOG.md`, and `scripts/lib/__tests__/ci-harness.test.mjs`.

## Test plan
- [x] Contract test covers four concurrent shared-Neon shards.
- [x] CI control contracts pass.
- [x] Protected push completed with hooks.

No production mutation, workflow dispatch, queue enrollment, merge, or ready transition performed.