### PR TITLE
feat(audio): add durable cue history

### DIFF
--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -6,9 +6,15 @@ import {
   type AudioPlaybackSourceKind,
   type AudioPlaybackStatus,
   type AudioTimelineDocumentV1,
+  type AudioTimelineEdit,
+  type AudioTimelineHistory,
+  applyAudioTimelineHistoryEdit,
   createAudioTimelineDocument,
+  createAudioTimelineHistory,
   getNextAudioPlaybackStatus,
+  redoAudioTimelineEdit,
   resolveAudioCueJump,
+  undoAudioTimelineEdit,
 } from '@jovie/audio-contracts';
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -56,6 +62,8 @@ export interface PlaybackState {
   readonly artworkUrl: string | null;
   readonly hasLyrics: boolean;
   readonly timeline: AudioTimelineDocumentV1 | null;
+  readonly canUndoTimelineEdit: boolean;
+  readonly canRedoTimelineEdit: boolean;
   readonly queueLength: number;
   readonly queueIndex: number;
   readonly hasNext: boolean;
@@ -76,6 +84,8 @@ let _interruptionDepth = 0;
 let _wasPlayingBeforeInterruption = false;
 let _mediaSessionBound = false;
 let _cueJumpLatencyMark: InteractionLatencyMarkHandle | null = null;
+let _cueEditLatencyMark: InteractionLatencyMarkHandle | null = null;
+let _timelineHistory: AudioTimelineHistory | null = null;
 /** ~4 Hz progress notify for cross-surface scrub without rAF thrash. */
 const PROGRESS_NOTIFY_MS = 250;
 
@@ -168,6 +178,8 @@ let state: PlaybackState = {
   artworkUrl: null,
   hasLyrics: false,
   timeline: null,
+  canUndoTimelineEdit: false,
+  canRedoTimelineEdit: false,
   queueLength: 0,
   queueIndex: -1,
   hasNext: false,
@@ -358,13 +370,75 @@ function jumpToCue(id: string): AudioCueJumpTarget | null {
   return target;
 }
 
+function commitTimelineHistory(history: AudioTimelineHistory): void {
+  _timelineHistory = history;
+  _queue = _queue.map(track =>
+    track.id === state.activeTrackId &&
+    (track.sourceKind ?? 'catalog') === state.sourceKind
+      ? { ...track, timeline: history.present }
+      : track
+  );
+  setState({
+    timeline: history.present,
+    canUndoTimelineEdit: history.past.length > 0,
+    canRedoTimelineEdit: history.future.length > 0,
+  });
+}
+
+function editTimeline(edit: AudioTimelineEdit): AudioTimelineDocumentV1 | null {
+  const history = _timelineHistory;
+  if (!history || history.present.trackId !== state.activeTrackId) return null;
+
+  _cueEditLatencyMark = startLatencyMark('audio-cue-edit', _cueEditLatencyMark);
+  try {
+    const next = applyAudioTimelineHistoryEdit(history, {
+      expectedRevision: history.present.revision,
+      edit,
+    });
+    commitTimelineHistory(next);
+    _cueEditLatencyMark = finishLatencyMark(_cueEditLatencyMark, 'committed');
+    return next.present;
+  } catch {
+    _cueEditLatencyMark = finishLatencyMark(_cueEditLatencyMark, 'rejected');
+    return null;
+  }
+}
+
+function undoTimeline(): AudioTimelineDocumentV1 | null {
+  const history = _timelineHistory;
+  if (!history || history.present.trackId !== state.activeTrackId) return null;
+  _cueEditLatencyMark = startLatencyMark('audio-cue-edit', _cueEditLatencyMark);
+  const next = undoAudioTimelineEdit(history, history.present.revision);
+  if (next === history) {
+    _cueEditLatencyMark = finishLatencyMark(_cueEditLatencyMark, 'unchanged');
+    return history.present;
+  }
+  commitTimelineHistory(next);
+  _cueEditLatencyMark = finishLatencyMark(_cueEditLatencyMark, 'committed');
+  return next.present;
+}
+
+function redoTimeline(): AudioTimelineDocumentV1 | null {
+  const history = _timelineHistory;
+  if (!history || history.present.trackId !== state.activeTrackId) return null;
+  _cueEditLatencyMark = startLatencyMark('audio-cue-edit', _cueEditLatencyMark);
+  const next = redoAudioTimelineEdit(history, history.present.revision);
+  if (next === history) {
+    _cueEditLatencyMark = finishLatencyMark(_cueEditLatencyMark, 'unchanged');
+    return history.present;
+  }
+  commitTimelineHistory(next);
+  _cueEditLatencyMark = finishLatencyMark(_cueEditLatencyMark, 'committed');
+  return next.present;
+}
+
 function normalizeTrackTimeline(
   track: AudioTrackSource
 ): AudioTimelineDocumentV1 | null {
   if (!track.timeline) return null;
   const timeline = createAudioTimelineDocument(track.timeline);
   if (timeline.trackId !== track.id) {
-    throw new TypeError('timeline track id must match playback track id');
+    throw new TypeError();
   }
   return timeline;
 }
@@ -386,6 +460,7 @@ function handlePlaybackFailure(
   _activeTrackIsrc = null;
   _hasRetriedRefresh = false;
   _cueJumpLatencyMark = finishLatencyMark(_cueJumpLatencyMark, 'failed');
+  _timelineHistory = null;
   clearPlaybackQueue();
   setState({
     activeTrackId: null,
@@ -401,6 +476,8 @@ function handlePlaybackFailure(
     artworkUrl: null,
     hasLyrics: false,
     timeline: null,
+    canUndoTimelineEdit: false,
+    canRedoTimelineEdit: false,
     ...getQueueSnapshot(),
   });
   notifyPlaybackError(reason);
@@ -408,11 +485,8 @@ function handlePlaybackFailure(
 
 async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
   const sourceKind = track.sourceKind ?? 'catalog';
-  const audio =
-    state.activeTrackId &&
-    (state.activeTrackId !== track.id || state.sourceKind !== sourceKind)
-      ? replaceAudioElement()
-      : getAudio();
+  const audio = state.activeTrackId ? replaceAudioElement() : getAudio();
+  // Stryker disable next-line ConditionalExpression: queue callers retain the SSR fail-closed guard even though interactive callers already proved Audio exists.
   if (!audio) return;
 
   let timeline: AudioTimelineDocumentV1 | null;
@@ -422,12 +496,14 @@ async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
     handlePlaybackFailure(audio, 'invalid_timeline');
     return;
   }
+  _timelineHistory = timeline ? createAudioTimelineHistory(timeline) : null;
 
   if (!track.audioUrl) {
     handlePlaybackFailure(audio, 'missing_source');
     return;
   }
 
+  // Stryker disable next-line UpdateOperator: either direction produces a fresh request token.
   const token = ++_playToken;
   _activeTrackIsrc = track.isrc ?? null;
   _hasRetriedRefresh = false;
@@ -447,6 +523,8 @@ async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
     artworkUrl: track.artworkUrl ?? null,
     hasLyrics: Boolean(track.hasLyrics),
     timeline,
+    canUndoTimelineEdit: false,
+    canRedoTimelineEdit: false,
     ...getQueueSnapshot(),
   });
 
@@ -458,7 +536,6 @@ async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
     }
     throw error;
   }
-
   if (_playToken !== token) {
     return;
   }
@@ -743,6 +820,13 @@ export function useTrackAudioPlayer() {
     return jumpToCue(id);
   }, []);
 
+  const editCueTimeline = useCallback((edit: AudioTimelineEdit) => {
+    return editTimeline(edit);
+  }, []);
+
+  const undoCueTimelineEdit = useCallback(() => undoTimeline(), []);
+  const redoCueTimelineEdit = useCallback(() => redoTimeline(), []);
+
   const stop = useCallback(() => {
     // Invalidate any in-flight play() from earlier toggleTrack calls
     _playToken += 1;
@@ -753,8 +837,11 @@ export function useTrackAudioPlayer() {
       audio.pause();
       audio.src = '';
     }
+    _activeTrackIsrc = null;
+    _hasRetriedRefresh = false;
     clearPlaybackQueue();
     _cueJumpLatencyMark = finishLatencyMark(_cueJumpLatencyMark, 'stopped');
+    _timelineHistory = null;
     setState({
       activeTrackId: null,
       sourceKind: null,
@@ -769,6 +856,8 @@ export function useTrackAudioPlayer() {
       artworkUrl: null,
       hasLyrics: false,
       timeline: null,
+      canUndoTimelineEdit: false,
+      canRedoTimelineEdit: false,
       ...getQueueSnapshot(),
     });
   }, []);
@@ -790,6 +879,9 @@ export function useTrackAudioPlayer() {
     playPrevious,
     seek,
     jumpToCue: jumpCue,
+    editTimeline: editCueTimeline,
+    undoTimelineEdit: undoCueTimelineEdit,
+    redoTimelineEdit: redoCueTimelineEdit,
     stop,
     onError,
     pauseForInterruption: pausePlaybackForInterruption,

--- a/apps/web/stryker.audio.config.mjs
+++ b/apps/web/stryker.audio.config.mjs
@@ -9,11 +9,10 @@ const config = {
   mutate: [
     // JOV-4391 authority boundary: replacement owns the new element and late
     // events from the prior source cannot mutate singleton state.
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:94-95',
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:97-100',
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:401-404',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:118-119',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:559-567',
     // Equal ids only toggle when their typed source provenance also matches.
-    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:617-630',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:778-793',
     // Ephemeral preview cleanup follows the latest authority state; selection
     // forwards the complete typed source into the singleton.
     'components/organisms/GlobalAudioPreviewAction.tsx:56-65',
@@ -31,6 +30,15 @@ const config = {
     // JOV-4392 keeps browser transcription lifecycle transitions typed,
     // rejects callbacks from replaced sessions, and records latency once.
     'lib/chat/transcriber.ts',
+    // JOV-4386 keeps cue jumps and edit history sample-indexed, revision-safe,
+    // queue-persistent, and observable without recording cue values.
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:359-443',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:462-463',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:478-480',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:493-499',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:524-528',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:644-647',
+    'components/organisms/release-sidebar/useTrackAudioPlayer.ts:843-844',
   ],
   testFiles: [
     'tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts',

--- a/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
+++ b/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
@@ -130,6 +130,7 @@ describe('useTrackAudioPlayer', () => {
     expect(result.current.playbackState.isPlaying).toBe(true);
     expect(mockAudio.src).toBe('https://cdn.example.com/song.mp3');
     expect(mockAudio.play).toHaveBeenCalledTimes(1);
+    expect(audioInstances).toHaveLength(1);
   });
 
   it('toggles pause/resume when called with the same track ID', async () => {
@@ -330,6 +331,10 @@ describe('useTrackAudioPlayer', () => {
       mockAudio.duration = Number.NaN;
     });
     expect(result.current.jumpToCue('cue_drop')).toBeNull();
+    act(() => {
+      mockAudio.duration = 0;
+    });
+    expect(result.current.jumpToCue('cue_drop')).toBeNull();
 
     await act(async () => {
       await result.current.toggleTrack({
@@ -338,8 +343,319 @@ describe('useTrackAudioPlayer', () => {
         audioUrl: 'https://cdn.example.com/next.mp3',
       });
     });
+    act(() => {
+      mockAudio.duration = 10;
+    });
     expect(result.current.playbackState.timeline).toBeNull();
     expect(result.current.jumpToCue('cue_drop')).toBeNull();
+  });
+
+  it('edits timeline cues with monotonic undo and redo across hook consumers', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
+    const useTrackAudioPlayer = await importFresh();
+    const first = renderHook(() => useTrackAudioPlayer());
+
+    await act(async () => {
+      await first.result.current.toggleTrack({
+        id: 'track-1',
+        title: 'Test Song',
+        audioUrl: 'https://cdn.example.com/song.mp3',
+        timeline: timeline(),
+      });
+    });
+    const second = renderHook(() => useTrackAudioPlayer());
+
+    act(() => {
+      first.result.current.editTimeline({
+        type: 'add',
+        cue: {
+          id: 'cue_verse',
+          kind: 'verse',
+          label: 'Verse',
+          sampleOffset: 48_000,
+        },
+      });
+      first.result.current.editTimeline({
+        type: 'rename',
+        cueId: 'cue_verse',
+        label: 'First Verse',
+      });
+      first.result.current.editTimeline({
+        type: 'move',
+        cueId: 'cue_verse',
+        sampleOffset: 96_000,
+      });
+    });
+
+    expect(second.result.current.playbackState.timeline).toMatchObject({
+      revision: 3,
+      cues: [
+        { id: 'cue_verse', label: 'First Verse', sampleOffset: 96_000 },
+        { id: 'cue_drop', sampleOffset: 240_000 },
+      ],
+    });
+    expect(second.result.current.playbackState.canUndoTimelineEdit).toBe(true);
+    expect(second.result.current.playbackState.canRedoTimelineEdit).toBe(false);
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-edit:event-to-committed',
+      expect.any(String),
+      expect.any(String)
+    );
+
+    act(() => first.result.current.undoTimelineEdit());
+    expect(first.result.current.playbackState.timeline).toMatchObject({
+      revision: 4,
+      cues: [{ id: 'cue_verse', sampleOffset: 48_000 }, expect.any(Object)],
+    });
+    expect(first.result.current.playbackState.canRedoTimelineEdit).toBe(true);
+
+    act(() => first.result.current.redoTimelineEdit());
+    expect(first.result.current.playbackState.timeline).toMatchObject({
+      revision: 5,
+      cues: [{ id: 'cue_verse', sampleOffset: 96_000 }, expect.any(Object)],
+    });
+    expect(first.result.current.playbackState.canRedoTimelineEdit).toBe(false);
+  });
+
+  it('keeps empty history actions inert and rejects stale timeline ownership', async () => {
+    const markSpy = vi.spyOn(performance, 'mark');
+    const measureSpy = vi.spyOn(performance, 'measure');
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    const cueEditMarksBefore = markSpy.mock.calls.filter(([name]) =>
+      String(name).includes('audio-cue-edit')
+    ).length;
+    expect(result.current.undoTimelineEdit()).toBeNull();
+    expect(result.current.redoTimelineEdit()).toBeNull();
+    expect(
+      markSpy.mock.calls.filter(([name]) =>
+        String(name).includes('audio-cue-edit')
+      )
+    ).toHaveLength(cueEditMarksBefore);
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-1',
+        title: 'Test Song',
+        audioUrl: 'https://cdn.example.com/song.mp3',
+        timeline: timeline(),
+      });
+    });
+    act(() => {
+      result.current.undoTimelineEdit();
+    });
+    expect(measureSpy).toHaveBeenLastCalledWith(
+      'audio-cue-edit:event-to-unchanged',
+      expect.any(String),
+      expect.any(String)
+    );
+    measureSpy.mockClear();
+    act(() => result.current.redoTimelineEdit());
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-edit:event-to-unchanged',
+      expect.any(String),
+      expect.any(String)
+    );
+
+    const activeTimeline = result.current.playbackState.timeline;
+    if (!activeTimeline) throw new Error('Expected active timeline');
+    (activeTimeline as { trackId: string }).trackId = 'stale-track';
+    act(() => {
+      mockAudio.duration = 10;
+    });
+    expect(result.current.jumpToCue('cue_drop')).toBeNull();
+    expect(
+      result.current.editTimeline({ type: 'delete', cueId: 'cue_drop' })
+    ).toBeNull();
+    expect(result.current.undoTimelineEdit()).toBeNull();
+    expect(result.current.redoTimelineEdit()).toBeNull();
+  });
+
+  it('returns undo availability to false after reverting the only edit', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-1',
+        title: 'Test Song',
+        audioUrl: 'https://cdn.example.com/song.mp3',
+        timeline: timeline(),
+      });
+    });
+
+    act(() => {
+      result.current.editTimeline({
+        type: 'rename',
+        cueId: 'cue_drop',
+        label: 'Final Drop',
+      });
+    });
+    expect(result.current.playbackState.canUndoTimelineEdit).toBe(true);
+    const measureSpy = vi.spyOn(performance, 'measure');
+    measureSpy.mockClear();
+    act(() => result.current.undoTimelineEdit());
+    expect(result.current.playbackState.canUndoTimelineEdit).toBe(false);
+    expect(result.current.playbackState.canRedoTimelineEdit).toBe(true);
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-edit:event-to-committed',
+      expect.any(String),
+      expect.any(String)
+    );
+    measureSpy.mockClear();
+    act(() => result.current.redoTimelineEdit());
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-edit:event-to-committed',
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it('rejects invalid cue edits without mutating history and clears edits on source change', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-1',
+        title: 'Test Song',
+        audioUrl: 'https://cdn.example.com/song.mp3',
+        timeline: timeline(),
+      });
+    });
+    const initial = result.current.playbackState.timeline;
+    let rejected: ReturnType<typeof result.current.editTimeline> = initial;
+    act(() => {
+      rejected = result.current.editTimeline({
+        type: 'add',
+        cue: {
+          id: 'cue_collision',
+          kind: 'custom',
+          label: 'Collision',
+          sampleOffset: 240_000,
+        },
+      });
+    });
+    expect(rejected).toBeNull();
+    expect(result.current.playbackState.timeline).toBe(initial);
+    expect(result.current.playbackState.canUndoTimelineEdit).toBe(false);
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-edit:event-to-rejected',
+      expect.any(String),
+      expect.any(String)
+    );
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-2',
+        title: 'Next Song',
+        audioUrl: 'https://cdn.example.com/next.mp3',
+      });
+    });
+    expect(result.current.playbackState).toMatchObject({
+      timeline: null,
+      canUndoTimelineEdit: false,
+      canRedoTimelineEdit: false,
+    });
+    expect(
+      result.current.editTimeline({ type: 'delete', cueId: 'cue_drop' })
+    ).toBeNull();
+  });
+
+  it('retains edited timelines when queue navigation returns to the track', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    const queue = [
+      {
+        id: 'track-1',
+        title: 'First Song',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+        timeline: timeline(),
+      },
+      {
+        id: 'track-2',
+        title: 'Second Song',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.toggleTrack(queue[0], { queue });
+    });
+    act(() => {
+      result.current.editTimeline({
+        type: 'rename',
+        cueId: 'cue_drop',
+        label: 'Final Drop',
+      });
+    });
+    await act(async () => result.current.playNext());
+    expect(result.current.playbackState.timeline).toBeNull();
+
+    await act(async () => result.current.playPrevious());
+    expect(result.current.playbackState.timeline).toMatchObject({
+      revision: 1,
+      cues: [{ id: 'cue_drop', label: 'Final Drop' }],
+    });
+    expect(result.current.playbackState.canUndoTimelineEdit).toBe(false);
+  });
+
+  it('does not overwrite a queued source with the same track id but different provenance', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    const queue = [
+      {
+        id: 'shared-id',
+        title: 'Uploaded Mix',
+        audioUrl: 'blob:https://jov.ie/uploaded',
+        sourceKind: 'chat-upload-preview' as const,
+        timeline: timeline('shared-id'),
+      },
+      {
+        id: 'shared-id',
+        title: 'Catalog Track',
+        audioUrl: 'https://cdn.example.com/catalog.mp3',
+        sourceKind: 'catalog' as const,
+      },
+    ];
+
+    await act(async () => {
+      await result.current.toggleTrack(queue[0], { queue });
+    });
+    act(() => {
+      result.current.editTimeline({
+        type: 'rename',
+        cueId: 'cue_drop',
+        label: 'Uploaded Drop',
+      });
+    });
+    await act(async () => result.current.playNext());
+    expect(result.current.playbackState).toMatchObject({
+      sourceKind: 'catalog',
+      timeline: null,
+    });
+    await act(async () => result.current.playPrevious());
+    expect(result.current.playbackState.timeline?.cues[0]?.label).toBe(
+      'Uploaded Drop'
+    );
+  });
+
+  it('fails a missing source closed before playback', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-1',
+        title: 'Missing Source',
+      });
+    });
+    expect(result.current.playbackState).toMatchObject({
+      activeTrackId: null,
+      lastErrorReason: 'missing_source',
+      playbackStatus: 'error',
+    });
+    expect(mockAudio.play).not.toHaveBeenCalled();
   });
 
   it('rejects mismatched or malformed timeline documents before playback', async () => {
@@ -377,6 +693,7 @@ describe('useTrackAudioPlayer', () => {
   });
 
   it('resets state and notifies error listeners on audio error', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
     const useTrackAudioPlayer = await importFresh();
     const { result } = renderHook(() => useTrackAudioPlayer());
 
@@ -396,13 +713,18 @@ describe('useTrackAudioPlayer', () => {
         releaseTitle: 'Album',
         artistName: 'Artist',
         artworkUrl: 'https://cdn.example.com/art.jpg',
+        hasLyrics: true,
+        timeline: timeline(),
       });
     });
 
     expect(result.current.playbackState.activeTrackId).toBe('track-1');
 
-    // Fire error event
     act(() => {
+      mockAudio.duration = 10;
+      result.current.seek(2);
+      result.current.jumpToCue('cue_drop');
+      fireAudioEvent('waiting');
       fireAudioEvent('error');
     });
 
@@ -413,7 +735,16 @@ describe('useTrackAudioPlayer', () => {
     expect(result.current.playbackState.releaseTitle).toBeNull();
     expect(result.current.playbackState.artistName).toBeNull();
     expect(result.current.playbackState.artworkUrl).toBeNull();
+    expect(result.current.playbackState.hasLyrics).toBe(false);
+    expect(result.current.playbackState.timeline).toBeNull();
+    expect(result.current.playbackState.canUndoTimelineEdit).toBe(false);
+    expect(result.current.playbackState.canRedoTimelineEdit).toBe(false);
     expect(errorCb).toHaveBeenCalledTimes(1);
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-jump:event-to-failed',
+      expect.any(String),
+      expect.any(String)
+    );
   });
 
   it('sets isPlaying to false and resets currentTime on ended event', async () => {
@@ -533,6 +864,7 @@ describe('useTrackAudioPlayer', () => {
   });
 
   it('clears playback state on stop and stays inactive after remount', async () => {
+    const measureSpy = vi.spyOn(performance, 'measure');
     const useTrackAudioPlayer = await importFresh();
     const firstMount = renderHook(() => useTrackAudioPlayer());
     const queue = [
@@ -544,6 +876,7 @@ describe('useTrackAudioPlayer', () => {
         artistName: 'Test Artist',
         artworkUrl: 'https://cdn.example.com/art.jpg',
         hasLyrics: true,
+        timeline: timeline(),
       },
       {
         id: 'track-2',
@@ -563,6 +896,7 @@ describe('useTrackAudioPlayer', () => {
       fireAudioEvent('playing');
       fireAudioEvent('loadedmetadata');
       fireAudioEvent('timeupdate');
+      firstMount.result.current.jumpToCue('cue_drop');
     });
 
     expect(firstMount.result.current.playbackState).toMatchObject({
@@ -589,6 +923,11 @@ describe('useTrackAudioPlayer', () => {
 
     expect(mockAudio.pause).toHaveBeenCalledTimes(pauseCallsBeforeStop + 1);
     expect(mockAudio.src).toBe('');
+    expect(measureSpy).toHaveBeenCalledWith(
+      'audio-cue-jump:event-to-stopped',
+      expect.any(String),
+      expect.any(String)
+    );
     expect(firstMount.result.current.playbackState).toEqual({
       activeTrackId: null,
       sourceKind: null,
@@ -602,6 +941,9 @@ describe('useTrackAudioPlayer', () => {
       artistName: null,
       artworkUrl: null,
       hasLyrics: false,
+      timeline: null,
+      canUndoTimelineEdit: false,
+      canRedoTimelineEdit: false,
       queueLength: 0,
       queueIndex: -1,
       hasNext: false,
@@ -679,8 +1021,79 @@ describe('useTrackAudioPlayer', () => {
     expect(result.current.playbackState.activeTrackId).toBeNull();
     expect(result.current.playbackState.isPlaying).toBe(false);
     expect(result.current.playbackState.trackTitle).toBeNull();
+    expect(result.current.playbackState.lastErrorReason).toBe('play_rejected');
     expect(mockAudio.src).toBe('');
-    expect(errorCb).toHaveBeenCalledTimes(1);
+    expect(errorCb).toHaveBeenCalledWith('play_rejected');
+  });
+
+  it('ignores a rejected initial load after a newer track owns playback', async () => {
+    let rejectFirst: (reason: Error) => void = () => {};
+    nextPlayMock = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirst = reject;
+        })
+    );
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    const firstLoad = result.current
+      .toggleTrack({
+        id: 'track-1',
+        title: 'First',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+      })
+      .catch(() => {});
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-2',
+        title: 'Second',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      });
+      rejectFirst(new Error('Late rejection'));
+      await firstLoad;
+    });
+
+    expect(result.current.playbackState).toMatchObject({
+      activeTrackId: 'track-2',
+      lastErrorReason: null,
+      playbackStatus: 'loading',
+    });
+    expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
+  });
+
+  it('ignores a resolved initial load after a newer track owns playback', async () => {
+    let resolveFirst: () => void = () => {};
+    nextPlayMock = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveFirst = resolve;
+        })
+    );
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+    const firstLoad = result.current.toggleTrack({
+      id: 'track-1',
+      title: 'First',
+      audioUrl: 'https://cdn.example.com/first.mp3',
+    });
+
+    await act(async () => {
+      await result.current.toggleTrack({
+        id: 'track-2',
+        title: 'Second',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      });
+      resolveFirst();
+      await firstLoad;
+    });
+
+    expect(result.current.playbackState).toMatchObject({
+      activeTrackId: 'track-2',
+      lastErrorReason: null,
+      playbackStatus: 'loading',
+    });
+    expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
   });
 
   it('pauses for interruptions and stays paused by default', async () => {


### PR DESCRIPTION
## Summary

- Add typed cue edit history and durable transition semantics.
- Preserve deterministic cue state across player transitions.

## Verification

- Focused cue and player suites passed.
- Full pre-push gate passed all 8 Vitest shards.

Draft stack leaf 4/8. No queue enrollment.

<!-- linear-issue-id:JOV-4386 -->