### PR TITLE
fix(ci): sync fixed-runner action contracts

### DIFF
--- a/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
+++ b/apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts
@@ -48,7 +48,7 @@ describe('fixed runner canary workflow', () => {
 
   it('pins checkout and does not persist credentials', () => {
     expect(workflow).toContain(
-      'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'
+      'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
     );
     expect(workflow).toContain('ref: main');
     expect(workflow).toContain('persist-credentials: false');

--- a/apps/web/tests/unit/ci/runner-setup-action.test.ts
+++ b/apps/web/tests/unit/ci/runner-setup-action.test.ts
@@ -427,7 +427,7 @@ describe('baked runner prerequisite contract', () => {
       '.github/runner-image/build-context.sh "$EXPECTED_SHA"'
     );
     expect(runnerImageOfflineProof).toContain(
-      'uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124'
+      'uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487'
     );
     expect(runnerImageOfflineProof).toContain(
       "runner-image-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-"


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4485 -->

## Summary
- JOV-4485 / #14964: sync the fixed-runner canary contract test with the existing `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` workflow pin.
- JOV-4486 / #14974: sync the runner-setup contract test with the existing `crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487` workflow pin.
- No workflow behavior, runner routing, queue state, or deployment behavior changed.

## Tracking
- [JOV-4485](https://linear.app/jovie/issue/JOV-4485) / [#14964](https://github.com/JovieInc/Jovie/issues/14964)
- [JOV-4486](https://linear.app/jovie/issue/JOV-4486) / [#14974](https://github.com/JovieInc/Jovie/issues/14974)

## Bug-to-Test
bug-to-test: satisfied
Regression tests:
- `apps/web/tests/unit/ci/fixed-runner-canary-workflow.test.ts`
- `apps/web/tests/unit/ci/runner-setup-action.test.ts`

## Test Coverage
- Focused Vitest: 2 files, 29 tests passed.
- Web typecheck passed.
- Biome check passed on both changed test files.
- `git diff --check` passed.

## Pre-Landing Review
No issues found. The combined diff is two one-line contract assertion repairs; workflow behavior is unchanged.

## Verification Results
- Exact base: `origin/main@fd9c64062f0a747e23f4e513d2b9138536459608`.
- Published commits: `7f4fd8675f26142d6d0c2dd140d8dec791c4232c`, then `7f7989c98bc722f381640d651da74b802a7fa72b`.
- Normal pre-commit and protected pre-push hooks passed.
- No changelog adjustment was required for this internal contract-only repair.

## Linear follow-ups
Linear follow-ups: none.