### PR TITLE
fix(ci): bound staged performance timing confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Bounded staged performance confirmation (JOV-4484):** an isolated timing outlier may receive one same-route confirmation batch while resource failures, persistent violations, and execution errors remain fail-closed with raw evidence preserved.
 - [internal] **Merge-group visual CI harness repair:** the filtered web workspace can resolve the repository Chromatic config again, DB-free mobile overflow excludes only explicitly database-backed redirects, and a forward-only Storybook audit now requires five clean runs before newly opened UI PRs can be gated.
 - [internal] **Bounded `ci-fast` lane groups (JOV-4477):** independent typecheck and remaining fast-gate checks now run in two hosted groups while preserving the single required `ci-fast` result and complete lane diagnostics.
 - **Unified app shell migration:** the authenticated app now uses one canonical customer/OV navigation model, header search, route-shaped loading states, chat home, Library filters, release/tour-date/profile rails, audio controls, and privacy-safe navigation telemetry. Better Auth production-artifact tests, route-specific readiness contracts, optimistic profile edit concurrency, and a 21-route performance matrix cover the migration end to end.

--- a/apps/web/scripts/performance-budgets-guard.test.ts
+++ b/apps/web/scripts/performance-budgets-guard.test.ts
@@ -12,7 +12,16 @@ vi.mock('@playwright/test', () => ({
   },
 }));
 
+import type {
+  GuardSample,
+  MetricResult,
+  PageResult,
+  ViolationResult,
+} from './performance-budgets-guard';
 import {
+  buildConfirmedPageResult,
+  confirmTimingViolations,
+  evaluateTimingConfirmation,
   loadGuardManifestRoutes,
   measureSameRouteInteraction,
   measureWarmNavigationRoute,
@@ -21,7 +30,148 @@ import {
   selectGuardRoutes,
   waitForWarmDestinationReady,
 } from './performance-budgets-guard';
-import type { PerfRouteDefinition } from './performance-route-manifest';
+import type {
+  PerfResourceMetricName,
+  PerfRouteDefinition,
+  PerfTimingMetricName,
+} from './performance-route-manifest';
+
+function createConfirmationSample(
+  metric: PerfTimingMetricName,
+  measured: number,
+  resourceMeasured = 0
+): GuardSample {
+  return {
+    finalUrl: 'http://127.0.0.1:4100/app/confirmed',
+    resolvedPath: '/app/confirmed',
+    resourceValues: {
+      font: 0,
+      image: 0,
+      script: resourceMeasured,
+      stylesheet: 0,
+      total: resourceMeasured,
+    } satisfies Record<PerfResourceMetricName, number>,
+    timingValues: {
+      'cumulative-layout-shift': 0,
+      'first-contentful-paint': 0,
+      'first-input-delay': 0,
+      'interactive-shell-ready': 0,
+      'largest-contentful-paint': 0,
+      'redirect-complete': 0,
+      'skeleton-to-content': 0,
+      'time-to-first-byte': 0,
+      'warm-shell-response': 0,
+      [metric]: measured,
+    } satisfies Record<PerfTimingMetricName, number>,
+  };
+}
+
+function createMetric(
+  name: string,
+  measured: number,
+  budget: number,
+  unit: 'KB' | 'ms' = 'ms'
+): MetricResult {
+  return {
+    budget,
+    measured,
+    name,
+    overshootPct: measured > budget ? ((measured - budget) / budget) * 100 : 0,
+    passed: measured <= budget,
+    unit,
+  };
+}
+
+function createTimingViolation(
+  routeId = 'creator-library',
+  metric = 'warm-shell-response' as PerfTimingMetricName
+): ViolationResult {
+  return {
+    ...createMetric(metric, 210, 100),
+    kind: 'timing',
+    routeId,
+  };
+}
+
+function createConfirmationPage(options: {
+  readonly id: string;
+  readonly metric?: PerfTimingMetricName;
+  readonly measured?: number;
+  readonly resourceMeasured?: number;
+  readonly includeMetric?: boolean;
+}) {
+  const metric = options.metric ?? 'warm-shell-response';
+  const measured = options.measured ?? 65;
+  const resourceMeasured = options.resourceMeasured ?? 0;
+  return {
+    id: options.id,
+    resourceSizes: [createMetric('script', resourceMeasured, 100, 'KB')],
+    samples: [createConfirmationSample(metric, measured, resourceMeasured)],
+    timings:
+      options.includeMetric === false
+        ? []
+        : [createMetric(metric, measured, 100)],
+  };
+}
+
+function createPageResultFixture(options: {
+  readonly id?: string;
+  readonly primaryMeasured?: number;
+  readonly primaryMetric?: PerfTimingMetricName;
+  readonly rawTimings?: Partial<Record<PerfTimingMetricName, number>>;
+  readonly samples?: readonly GuardSample[];
+  readonly timings?: readonly MetricResult[];
+  readonly violations?: readonly ViolationResult[];
+}): PageResult {
+  const id = options.id ?? 'creator-library';
+  const primaryMetric = options.primaryMetric ?? 'warm-shell-response';
+  const primaryMeasured = options.primaryMeasured ?? 65;
+  const samples = options.samples ?? [
+    createConfirmationSample(primaryMetric, primaryMeasured),
+  ];
+  const rawTimings = {
+    ...samples[0]!.timingValues,
+    ...options.rawTimings,
+  } satisfies Record<PerfTimingMetricName, number>;
+  const timings = options.timings ?? [
+    createMetric(primaryMetric, primaryMeasured, 100),
+  ];
+  const violations =
+    options.violations ??
+    timings
+      .filter(metric => !metric.passed)
+      .map(metric => ({
+        ...metric,
+        kind: 'timing' as const,
+        routeId: id,
+      }));
+
+  return {
+    auth: true,
+    configuredPath: '/app/library',
+    group: 'creator-shell',
+    id,
+    initialViolations: violations,
+    primaryMetric,
+    rawResourceSizes: {
+      font: 0,
+      image: 0,
+      script: 0,
+      stylesheet: 0,
+      total: 0,
+    },
+    rawTimings,
+    resolvedPath: '/app/library',
+    resourceSizes: [createMetric('script', 0, 100, 'KB')],
+    routeSurface: 'creator-app',
+    samples,
+    timingConfirmations: [],
+    timings,
+    terminalStatus: violations.length > 0 ? 'fail' : 'pass',
+    url: samples[0]!.finalUrl,
+    violations,
+  };
+}
 
 function createInteractivePage({
   contentSelector,
@@ -101,6 +251,196 @@ describe('performance budgets guard', () => {
     playwrightMocks.chromiumLaunch.mockResolvedValue({
       close: playwrightMocks.browserClose,
     });
+  });
+
+  it('passes an isolated timing outlier after a clean same-route confirmation', async () => {
+    const initialViolation = createTimingViolation();
+    const confirmationPage = createConfirmationPage({
+      id: 'creator-library',
+      measured: 65,
+    });
+    const measureConfirmation = vi.fn().mockResolvedValue(confirmationPage);
+
+    const confirmations = await confirmTimingViolations({
+      initialViolations: [initialViolation],
+      measureConfirmation,
+    });
+
+    expect(measureConfirmation).toHaveBeenCalledOnce();
+    expect(confirmations).toHaveLength(1);
+    expect(confirmations[0]).toMatchObject({
+      reason: 'clean-confirmation',
+      routeId: 'creator-library',
+      terminalStatus: 'pass',
+    });
+    expect(
+      confirmations[0]?.samples[0]?.timingValues['warm-shell-response']
+    ).toBe(65);
+  });
+
+  it('fails when the same route and metric remain over budget', async () => {
+    const confirmations = await confirmTimingViolations({
+      initialViolations: [createTimingViolation()],
+      measureConfirmation: async () =>
+        createConfirmationPage({
+          id: 'creator-library',
+          measured: 210,
+        }),
+    });
+
+    expect(confirmations[0]).toMatchObject({
+      reason: 'persistent-timing-violation',
+      terminalStatus: 'fail',
+    });
+  });
+
+  it('uses confirmation measurements for terminal fields and preserves initial evidence', async () => {
+    const initialPage = createPageResultFixture({ primaryMeasured: 210 });
+    const confirmationPage = createPageResultFixture({ primaryMeasured: 65 });
+    const timingConfirmations = await confirmTimingViolations({
+      initialViolations: initialPage.violations,
+      measureConfirmation: async () => confirmationPage,
+    });
+
+    const terminalPage = buildConfirmedPageResult(
+      initialPage,
+      confirmationPage,
+      timingConfirmations
+    );
+
+    expect(terminalPage.terminalStatus).toBe('pass');
+    expect(terminalPage.rawTimings['warm-shell-response']).toBe(65);
+    expect(terminalPage.timings[0]?.measured).toBe(65);
+    expect(terminalPage.samples[0]?.timingValues['warm-shell-response']).toBe(
+      65
+    );
+    expect(
+      terminalPage.initialMeasurement?.rawTimings['warm-shell-response']
+    ).toBe(210);
+    expect(terminalPage.initialMeasurement?.timings[0]?.measured).toBe(210);
+    expect(
+      terminalPage.initialMeasurement?.samples[0]?.timingValues[
+        'warm-shell-response'
+      ]
+    ).toBe(210);
+  });
+
+  it('keeps terminal failure when a different confirmation timing metric fails', async () => {
+    const initialPage = createPageResultFixture({ primaryMeasured: 210 });
+    const confirmationSample = createConfirmationSample(
+      'warm-shell-response',
+      65
+    );
+    const confirmationPage = createPageResultFixture({
+      rawTimings: {
+        'skeleton-to-content': 210,
+      },
+      samples: [
+        {
+          ...confirmationSample,
+          timingValues: {
+            ...confirmationSample.timingValues,
+            'skeleton-to-content': 210,
+          },
+        },
+      ],
+      timings: [
+        createMetric('warm-shell-response', 65, 100),
+        createMetric('skeleton-to-content', 210, 100),
+      ],
+    });
+    const timingConfirmations = await confirmTimingViolations({
+      initialViolations: initialPage.violations,
+      measureConfirmation: async () => confirmationPage,
+    });
+
+    const terminalPage = buildConfirmedPageResult(
+      initialPage,
+      confirmationPage,
+      timingConfirmations
+    );
+
+    expect(timingConfirmations[0]?.terminalStatus).toBe('pass');
+    expect(terminalPage.terminalStatus).toBe('fail');
+    expect(terminalPage.violations).toEqual(confirmationPage.violations);
+    expect(terminalPage.rawTimings['skeleton-to-content']).toBe(210);
+  });
+
+  it('fails on resource evidence and refuses to confirm an initial resource violation', async () => {
+    const confirmationPage = createConfirmationPage({
+      id: 'creator-library',
+      measured: 65,
+      resourceMeasured: 101,
+    });
+    const confirmations = await confirmTimingViolations({
+      initialViolations: [createTimingViolation()],
+      measureConfirmation: async () => confirmationPage,
+    });
+
+    expect(confirmations[0]).toMatchObject({
+      reason: 'resource-violation',
+      terminalStatus: 'fail',
+    });
+
+    await expect(
+      confirmTimingViolations({
+        initialViolations: [
+          {
+            ...createMetric('script', 101, 100, 'KB'),
+            kind: 'resource',
+            routeId: 'creator-library',
+          },
+        ],
+        measureConfirmation: async () => confirmationPage,
+      })
+    ).rejects.toThrow('cannot launder resource violations');
+  });
+
+  it('fails closed for thrown execution and missing metric inspection errors', async () => {
+    await expect(
+      confirmTimingViolations({
+        initialViolations: [createTimingViolation()],
+        measureConfirmation: async () => {
+          throw new Error('inspection failed');
+        },
+      })
+    ).rejects.toThrow('inspection failed');
+
+    await expect(
+      confirmTimingViolations({
+        initialViolations: [createTimingViolation()],
+        measureConfirmation: async () =>
+          createConfirmationPage({
+            id: 'creator-library',
+            includeMetric: false,
+          }),
+      })
+    ).rejects.toThrow('metric mismatch');
+  });
+
+  it('does not replace a route or metric violation with another route or metric success', () => {
+    const initialViolation = createTimingViolation();
+
+    expect(() =>
+      evaluateTimingConfirmation(
+        initialViolation,
+        createConfirmationPage({
+          id: 'creator-chat-nav',
+          measured: 65,
+        })
+      )
+    ).toThrow('route mismatch');
+
+    expect(() =>
+      evaluateTimingConfirmation(
+        initialViolation,
+        createConfirmationPage({
+          id: 'creator-library',
+          metric: 'skeleton-to-content',
+          measured: 65,
+        })
+      )
+    ).toThrow('metric mismatch');
   });
 
   it('parses group and route-id selectors from the CLI', () => {

--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -53,14 +53,14 @@ export interface GuardCliOptions {
   readonly runs: number;
 }
 
-interface GuardSample {
+export interface GuardSample {
   readonly finalUrl: string;
   readonly resolvedPath: string;
   readonly timingValues: Record<PerfTimingMetricName, number>;
   readonly resourceValues: Record<PerfResourceMetricName, number>;
 }
 
-interface MetricResult {
+export interface MetricResult {
   readonly name: string;
   readonly measured: number;
   readonly budget: number;
@@ -69,25 +69,47 @@ interface MetricResult {
   readonly overshootPct: number;
 }
 
-interface ViolationResult extends MetricResult {
+export interface ViolationResult extends MetricResult {
   readonly kind: 'timing' | 'resource';
+  readonly routeId: string;
 }
 
-export interface PageResult {
+export type TimingConfirmationReason =
+  | 'clean-confirmation'
+  | 'persistent-timing-violation'
+  | 'resource-violation';
+
+export interface TimingConfirmation {
+  readonly confirmation: MetricResult;
+  readonly initial: ViolationResult;
+  readonly reason: TimingConfirmationReason;
+  readonly routeId: string;
+  readonly samples: readonly GuardSample[];
+  readonly terminalStatus: 'fail' | 'pass';
+}
+
+export interface PageMeasurement {
+  readonly rawResourceSizes: Record<PerfResourceMetricName, number>;
+  readonly rawTimings: Record<PerfTimingMetricName, number>;
+  readonly resourceSizes: readonly MetricResult[];
+  readonly samples: readonly GuardSample[];
+  readonly timings: readonly MetricResult[];
+  readonly url: string;
+}
+
+export interface PageResult extends PageMeasurement {
   readonly auth: boolean;
   readonly configuredPath: string;
   readonly group: string;
   readonly id: string;
+  readonly initialMeasurement?: PageMeasurement;
+  readonly initialViolations: readonly ViolationResult[];
   readonly primaryMetric: PerfTimingMetricName;
   readonly resolvedPath: string;
-  readonly resourceSizes: readonly MetricResult[];
   readonly routeSurface: string;
-  readonly samples: readonly GuardSample[];
-  readonly timings: readonly MetricResult[];
-  readonly url: string;
+  readonly timingConfirmations: readonly TimingConfirmation[];
+  readonly terminalStatus: 'fail' | 'pass';
   readonly violations: readonly ViolationResult[];
-  readonly rawResourceSizes: Record<PerfResourceMetricName, number>;
-  readonly rawTimings: Record<PerfTimingMetricName, number>;
 }
 
 export interface GuardSummary {
@@ -118,6 +140,7 @@ const DEFAULT_AUTH_STATE_PATHS = [
   resolve(webRoot, '.auth', 'session.json'),
 ] as const;
 const DEFAULT_RUNS = 3;
+const TIMING_CONFIRMATION_RUNS = 3;
 const NAVIGATION_TIMEOUT_MS = 60_000;
 const READY_TIMEOUT_MS = 15_000;
 const PERF_INIT_SCRIPT = `
@@ -1118,10 +1141,18 @@ function createPageResult(
   const violations: ViolationResult[] = [
     ...timings
       .filter(metric => !metric.passed)
-      .map(metric => ({ ...metric, kind: 'timing' as const })),
+      .map(metric => ({
+        ...metric,
+        kind: 'timing' as const,
+        routeId: route.id,
+      })),
     ...resourceSizes
       .filter(metric => !metric.passed)
-      .map(metric => ({ ...metric, kind: 'resource' as const })),
+      .map(metric => ({
+        ...metric,
+        kind: 'resource' as const,
+        routeId: route.id,
+      })),
   ];
 
   return {
@@ -1129,6 +1160,7 @@ function createPageResult(
     configuredPath: route.path,
     group: route.group,
     id: route.id,
+    initialViolations: violations,
     primaryMetric,
     rawResourceSizes,
     rawTimings,
@@ -1137,9 +1169,108 @@ function createPageResult(
     routeSurface: route.surface,
     samples,
     timings,
+    timingConfirmations: [],
+    terminalStatus: violations.length > 0 ? 'fail' : 'pass',
     url: medianSample.finalUrl,
     violations,
   };
+}
+
+type TimingConfirmationPage = Pick<
+  PageResult,
+  'id' | 'resourceSizes' | 'samples' | 'timings'
+>;
+
+export function evaluateTimingConfirmation(
+  initialViolation: ViolationResult,
+  confirmationPage: TimingConfirmationPage
+): TimingConfirmation {
+  if (initialViolation.kind !== 'timing') {
+    throw new TypeError(
+      `Only timing violations may be confirmed; ${initialViolation.name} is ${initialViolation.kind}.`
+    );
+  }
+
+  if (confirmationPage.id !== initialViolation.routeId) {
+    throw new Error(
+      `Timing confirmation route mismatch: expected ${initialViolation.routeId}, received ${confirmationPage.id}.`
+    );
+  }
+
+  const confirmation = confirmationPage.timings.find(
+    metric => metric.name === initialViolation.name
+  );
+  if (!confirmation) {
+    throw new Error(
+      `Timing confirmation metric mismatch for ${initialViolation.routeId}: expected ${initialViolation.name}.`
+    );
+  }
+
+  const resourceViolations = confirmationPage.resourceSizes.filter(
+    metric => !metric.passed
+  );
+  const reason: TimingConfirmationReason =
+    resourceViolations.length > 0
+      ? 'resource-violation'
+      : confirmation.passed
+        ? 'clean-confirmation'
+        : 'persistent-timing-violation';
+
+  return {
+    confirmation,
+    initial: initialViolation,
+    reason,
+    routeId: initialViolation.routeId,
+    samples: confirmationPage.samples,
+    terminalStatus: reason === 'clean-confirmation' ? 'pass' : 'fail',
+  };
+}
+
+function pageMeasurement(page: PageResult): PageMeasurement {
+  return {
+    rawResourceSizes: page.rawResourceSizes,
+    rawTimings: page.rawTimings,
+    resourceSizes: page.resourceSizes,
+    samples: page.samples,
+    timings: page.timings,
+    url: page.url,
+  };
+}
+
+export function buildConfirmedPageResult(
+  initialPage: PageResult,
+  confirmationPage: PageResult,
+  timingConfirmations: readonly TimingConfirmation[]
+): PageResult {
+  return {
+    ...confirmationPage,
+    initialMeasurement: pageMeasurement(initialPage),
+    initialViolations: initialPage.initialViolations,
+    terminalStatus: confirmationPage.violations.length > 0 ? 'fail' : 'pass',
+    timingConfirmations,
+  };
+}
+
+export async function confirmTimingViolations(options: {
+  readonly initialViolations: readonly ViolationResult[];
+  readonly measureConfirmation: () => Promise<TimingConfirmationPage>;
+}) {
+  if (options.initialViolations.length === 0) {
+    throw new TypeError('Timing confirmation requires at least one violation.');
+  }
+
+  if (
+    options.initialViolations.some(violation => violation.kind !== 'timing')
+  ) {
+    throw new TypeError(
+      'Timing confirmation cannot launder resource violations or other terminal failures.'
+    );
+  }
+
+  const confirmationPage = await options.measureConfirmation();
+  return options.initialViolations.map(initialViolation =>
+    evaluateTimingConfirmation(initialViolation, confirmationPage)
+  );
 }
 
 function sortRoutesForExecution(routes: readonly PerfRouteDefinition[]) {
@@ -1303,7 +1434,64 @@ async function measureRoutesAgainstBudgets(
         );
       }
 
-      results.push(createPageResult(route, resolvedPath, samples, devMode));
+      const initialPage = createPageResult(
+        route,
+        resolvedPath,
+        samples,
+        devMode
+      );
+      const initialTimingViolations = initialPage.violations.filter(
+        violation => violation.kind === 'timing'
+      );
+      const hasResourceViolation = initialPage.violations.some(
+        violation => violation.kind === 'resource'
+      );
+
+      if (initialTimingViolations.length === 0 || hasResourceViolation) {
+        results.push(initialPage);
+        continue;
+      }
+
+      logInfo(
+        `  timing violation on ${route.id}; running ${TIMING_CONFIRMATION_RUNS}-sample same-route confirmation`,
+        options
+      );
+      const confirmationSamples: GuardSample[] = [];
+      for (let index = 0; index < TIMING_CONFIRMATION_RUNS; index += 1) {
+        const sample = await measureRouteSample(
+          browser,
+          route,
+          options.baseUrl,
+          url,
+          resolvedPath,
+          authCookies,
+          devMode
+        );
+        confirmationSamples.push(sample);
+        logInfo(
+          `  confirmation ${index + 1}/${TIMING_CONFIRMATION_RUNS}: ${formatMetric(sample.timingValues[getPrimaryTimingMetricName(route)], 'ms')}`,
+          options
+        );
+      }
+
+      const confirmationPage = createPageResult(
+        route,
+        resolvedPath,
+        confirmationSamples,
+        devMode
+      );
+      const timingConfirmations = await confirmTimingViolations({
+        initialViolations: initialTimingViolations,
+        measureConfirmation: async () => confirmationPage,
+      });
+
+      results.push(
+        buildConfirmedPageResult(
+          initialPage,
+          confirmationPage,
+          timingConfirmations
+        )
+      );
     }
 
     return results;
@@ -1320,13 +1508,26 @@ function printHumanSummary(summary: GuardSummary) {
       `${page.id} (${page.resolvedPath}) primary=${page.primaryMetric}=${formatMetric(
         page.rawTimings[page.primaryMetric],
         page.primaryMetric === 'cumulative-layout-shift' ? '' : 'ms'
-      )}`
+      )}${page.timingConfirmations.length > 0 ? ' (confirmation evidence)' : ''}`
     );
 
     for (const metric of [...page.timings, ...page.resourceSizes]) {
-      const status = metric.passed ? 'PASS' : 'FAIL';
+      const confirmation = page.timingConfirmations.find(
+        candidate => candidate.confirmation.name === metric.name
+      );
+      const status = metric.passed
+        ? 'PASS'
+        : confirmation?.terminalStatus === 'pass'
+          ? 'CONFIRMED'
+          : 'FAIL';
       console.log(
         `  ${status} ${metric.name}: ${formatMetric(metric.measured, metric.unit)} / ${formatMetric(metric.budget, metric.unit)}`
+      );
+    }
+
+    for (const confirmation of page.timingConfirmations) {
+      console.log(
+        `  ${confirmation.terminalStatus.toUpperCase()} confirmation ${confirmation.routeId}/${confirmation.confirmation.name}: ${formatMetric(confirmation.confirmation.measured, confirmation.confirmation.unit)} / ${formatMetric(confirmation.confirmation.budget, confirmation.confirmation.unit)} (${confirmation.reason})`
       );
     }
   }


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4484 -->

Refs #14963

## Summary

Bound staged warm-navigation performance confirmation to one same-route, three-sample confirmation batch only after an initial timing-budget violation. Resource violations, persistent timing violations, and inspection errors remain fail-closed, with initial and confirmation evidence preserved separately.

## Verification

- Focused staged-performance guard suite: 42 tests passed
- Web typecheck: passed
- Bug-to-test gate: satisfied
- Biome on changed TypeScript files: passed
- Protected pre-push verification: passed
- git diff --check: passed
- Workflow syntax validation: not applicable, no workflow files changed

## Scope

No performance budgets changed. No audio, dependency, credential, queue, merge, or deployment mutations.

Linear: JOV-4484