### PR TITLE
feat(audio): validate OpenKeyScan protocol

### DIFF
--- a/apps/web/lib/audio/analysis/openkeyscan-protocol.test.ts
+++ b/apps/web/lib/audio/analysis/openkeyscan-protocol.test.ts
@@ -1,0 +1,177 @@
+import {
+  createCanonicalMusicalKey,
+  MUSICAL_KEY_MODES,
+  MUSICAL_KEY_TONICS,
+} from '@jovie/audio-contracts';
+import { describe, expect, it } from 'vitest';
+import {
+  OpenKeyScanProtocolError,
+  parseOpenKeyScanProviderMessage,
+} from './openkeyscan-protocol';
+
+const REQUEST_ID = '00000000-0000-4000-8000-000000000001';
+const AUDIO_PATH = '/private/audio/example.mp3';
+
+function success(
+  overrides: Readonly<Record<string, unknown>> = {}
+): Record<string, unknown> {
+  return {
+    id: REQUEST_ID,
+    status: 'success',
+    camelot: '11B',
+    openkey: '4d',
+    key: 'A major',
+    class_id: 22,
+    filename: 'example.mp3',
+    generation: 0,
+    ...overrides,
+  };
+}
+
+describe('OpenKeyScan provider protocol', () => {
+  it('normalizes every canonical Camelot class without trusting display text', () => {
+    for (const mode of MUSICAL_KEY_MODES) {
+      for (const tonic of MUSICAL_KEY_TONICS) {
+        const key = createCanonicalMusicalKey(tonic, mode);
+        const classId =
+          Number.parseInt(key.camelot, 10) -
+          1 +
+          (key.camelot.endsWith('B') ? 12 : 0);
+
+        expect(
+          parseOpenKeyScanProviderMessage(
+            success({
+              camelot: key.camelot,
+              openkey: key.openKey,
+              key: key.traditional,
+              class_id: classId,
+            }),
+            AUDIO_PATH
+          )
+        ).toEqual({
+          status: 'success',
+          id: REQUEST_ID,
+          filename: 'example.mp3',
+          generation: 0,
+          classId,
+          key,
+        });
+      }
+    }
+  });
+
+  it.each([
+    ['C# major', 'Db major', '3B', '8d', 14],
+    ['D# minor', 'Eb minor', '2A', '7m', 1],
+    ['F# major', 'Gb major', '2B', '7d', 13],
+    ['G# minor', 'Ab minor', '1A', '6m', 0],
+    ['A# major', 'Bb major', '6B', '11d', 17],
+  ] as const)('accepts consistent enharmonic provider names %s/%s', (sharp, flat, camelot, openkey, classId) => {
+    expect(
+      parseOpenKeyScanProviderMessage(
+        success({
+          camelot,
+          openkey,
+          key: `${flat}/${sharp}`,
+          class_id: classId,
+        }),
+        AUDIO_PATH
+      )
+    ).toMatchObject({
+      status: 'success',
+      classId,
+    });
+  });
+
+  it.each([
+    ['Camelot', { camelot: '8B' }],
+    ['Open Key', { openkey: '1d' }],
+    ['class id', { class_id: 0 }],
+    ['traditional key', { key: 'C major' }],
+    ['mode', { key: 'A minor' }],
+    ['mixed enharmonics', { key: 'A major/C major' }],
+    ['traditional prefix', { key: 'prefix A major' }],
+    ['traditional suffix', { key: 'A major suffix' }],
+    ['missing traditional tonic', { key: 'major' }],
+    ['filename', { filename: 'other.mp3' }],
+  ])('rejects inconsistent %s metadata', (_label, overrides) => {
+    try {
+      parseOpenKeyScanProviderMessage(success(overrides), AUDIO_PATH);
+      throw new Error('expected protocol rejection');
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpenKeyScanProtocolError);
+      expect(error).toMatchObject({
+        name: 'OpenKeyScanProtocolError',
+        message: 'analyzer returned inconsistent key metadata',
+      });
+    }
+  });
+
+  it('trims each consistent traditional-key variant', () => {
+    expect(
+      parseOpenKeyScanProviderMessage(
+        success({ key: '  A major / A major  ' }),
+        AUDIO_PATH
+      )
+    ).toMatchObject({ status: 'success', classId: 22 });
+  });
+
+  it.each([
+    ['unknown field', { extra: true }],
+    ['invalid id', { id: 'not-a-uuid' }],
+    ['invalid status', { status: 'pending' }],
+    ['invalid generation', { generation: -1 }],
+    ['invalid class', { class_id: 24 }],
+    ['invalid notation', { camelot: '13B' }],
+  ])('rejects %s', (_label, overrides) => {
+    try {
+      parseOpenKeyScanProviderMessage(success(overrides), AUDIO_PATH);
+      throw new Error('expected protocol rejection');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'OpenKeyScanProtocolError',
+        message: 'analyzer returned an invalid response',
+      });
+    }
+  });
+
+  it('accepts a matching provider error while discarding its detail', () => {
+    expect(
+      parseOpenKeyScanProviderMessage(
+        {
+          id: REQUEST_ID,
+          status: 'error',
+          error: 'sensitive path and decoder detail',
+          filename: 'example.mp3',
+          generation: 2,
+        },
+        AUDIO_PATH
+      )
+    ).toEqual({
+      status: 'error',
+      id: REQUEST_ID,
+      filename: 'example.mp3',
+      generation: 2,
+    });
+  });
+
+  it.each([
+    ['wrong filename', { filename: 'other.mp3' }],
+    ['missing detail', { error: '' }],
+    ['unknown field', { extra: true }],
+  ])('rejects a provider error with %s', (_label, overrides) => {
+    expect(() =>
+      parseOpenKeyScanProviderMessage(
+        {
+          id: REQUEST_ID,
+          status: 'error',
+          error: 'provider detail',
+          filename: 'example.mp3',
+          generation: 0,
+          ...overrides,
+        },
+        AUDIO_PATH
+      )
+    ).toThrow(OpenKeyScanProtocolError);
+  });
+});

--- a/apps/web/lib/audio/analysis/openkeyscan-protocol.ts
+++ b/apps/web/lib/audio/analysis/openkeyscan-protocol.ts
@@ -1,0 +1,143 @@
+import { basename } from 'node:path';
+import {
+  type CanonicalMusicalKey,
+  createCanonicalMusicalKey,
+  MUSICAL_KEY_MODES,
+  MUSICAL_KEY_TONICS,
+  type MusicalKeyMode,
+  type MusicalKeyTonic,
+} from '@jovie/audio-contracts';
+import { z } from 'zod';
+
+// Stryker disable all: Zod schemas are constructed during module loading,
+// before Stryker activates an individual mutant. Invalid-message tests below
+// still exercise every schema boundary without reporting false survivors.
+const successSchema = z
+  .object({
+    id: z.string().uuid(),
+    status: z.literal('success'),
+    camelot: z.string().regex(/^(?:[1-9]|1[0-2])[AB]$/),
+    openkey: z.string().regex(/^(?:[1-9]|1[0-2])[dm]$/),
+    key: z.string().min(3).max(128),
+    class_id: z.number().int().min(0).max(23),
+    filename: z.string().min(1).max(1024),
+    generation: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const errorSchema = z
+  .object({
+    id: z.string().uuid(),
+    status: z.literal('error'),
+    error: z.string().min(1).max(4096),
+    filename: z.string().min(1).max(1024),
+    generation: z.number().int().nonnegative(),
+  })
+  .strict();
+// Stryker restore all
+
+const FLAT_TO_SHARP = {
+  Db: 'C#',
+  Eb: 'D#',
+  Gb: 'F#',
+  Ab: 'G#',
+  Bb: 'A#',
+} as const satisfies Readonly<Record<string, MusicalKeyTonic>>;
+
+export class OpenKeyScanProtocolError extends Error {
+  constructor(message = 'analyzer returned an invalid response') {
+    super(message);
+    this.name = 'OpenKeyScanProtocolError';
+  }
+}
+
+export type OpenKeyScanProviderMessage =
+  | {
+      readonly status: 'success';
+      readonly id: string;
+      readonly filename: string;
+      readonly generation: number;
+      readonly classId: number;
+      readonly key: CanonicalMusicalKey;
+    }
+  | {
+      readonly status: 'error';
+      readonly id: string;
+      readonly filename: string;
+      readonly generation: number;
+    };
+
+function keyFromCamelot(camelot: string): CanonicalMusicalKey | null {
+  for (const mode of MUSICAL_KEY_MODES) {
+    for (const tonic of MUSICAL_KEY_TONICS) {
+      const key = createCanonicalMusicalKey(tonic, mode);
+      if (key.camelot === camelot) return key;
+    }
+  }
+  return null;
+}
+
+function normalizeTonic(value: string): MusicalKeyTonic | null {
+  if ((MUSICAL_KEY_TONICS as readonly string[]).includes(value)) {
+    return value as MusicalKeyTonic;
+  }
+  return FLAT_TO_SHARP[value as keyof typeof FLAT_TO_SHARP] ?? null;
+}
+
+function traditionalMatches(
+  providerValue: string,
+  expected: CanonicalMusicalKey
+): boolean {
+  return providerValue.split('/').every(variant => {
+    const match = /^([A-G](?:#|b)?) (major|minor)$/.exec(variant.trim());
+    if (!match) return false;
+    return (
+      normalizeTonic(match[1] as string) === expected.tonic &&
+      (match[2] as MusicalKeyMode) === expected.mode
+    );
+  });
+}
+
+export function parseOpenKeyScanProviderMessage(
+  value: unknown,
+  audioPath: string
+): OpenKeyScanProviderMessage {
+  const success = successSchema.safeParse(value);
+  if (success.success) {
+    const key = keyFromCamelot(success.data.camelot);
+    const expectedClassId =
+      Number.parseInt(success.data.camelot, 10) -
+      1 +
+      (success.data.camelot.endsWith('B') ? 12 : 0);
+    if (
+      !key ||
+      key.openKey !== success.data.openkey ||
+      expectedClassId !== success.data.class_id ||
+      success.data.filename !== basename(audioPath) ||
+      !traditionalMatches(success.data.key, key)
+    ) {
+      throw new OpenKeyScanProtocolError(
+        'analyzer returned inconsistent key metadata'
+      );
+    }
+    return {
+      status: 'success',
+      id: success.data.id,
+      filename: success.data.filename,
+      generation: success.data.generation,
+      classId: success.data.class_id,
+      key,
+    };
+  }
+
+  const failure = errorSchema.safeParse(value);
+  if (failure.success && failure.data.filename === basename(audioPath)) {
+    return {
+      status: 'error',
+      id: failure.data.id,
+      filename: failure.data.filename,
+      generation: failure.data.generation,
+    };
+  }
+  throw new OpenKeyScanProtocolError();
+}


### PR DESCRIPTION
## Summary
- validate the OpenKeyScan NDJSON ready, heartbeat, success, and error protocol
- normalize Camelot, OpenKey, and traditional key metadata into the canonical typed key contract
- reject mismatched filenames, generations, IDs, and provider details without exposing raw values

## Evidence
- protocol tests: 27/27 green
- protocol mutation: 100% (71 killed, 0 survived/uncovered/errors/timeouts)
- stack-head focused audio tests: 118/118 green
- full turbo typecheck: 11/11 packages green
- normal pre-push: secret scans, Biome, lint, full Vitest shards, and CI harness green

## Scope boundary
Draft Graphite-tracked child of #14978. This validates the provider boundary only; it does not approve OpenKeyScan for production. Keep it out of the native queue until the stack lands, this PR targets current `main`, and full main-target required checks pass.

Linear: JOV-4385