### PR TITLE
feat(audio): isolate OpenKeyScan worker

### DIFF
--- a/apps/web/lib/audio/analysis/openkeyscan-worker.test.ts
+++ b/apps/web/lib/audio/analysis/openkeyscan-worker.test.ts
@@ -1,0 +1,262 @@
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  OpenKeyScanWorker,
+  OpenKeyScanWorkerError,
+  type OpenKeyScanWorkerLaunch,
+} from './openkeyscan-worker';
+
+const REAL_MP3_PATH = resolve(
+  process.cwd(),
+  'tests/fixtures/audio/long-vbr-tone.mp3'
+);
+
+const FAKE_WORKER_SOURCE = String.raw`
+const readline = require('node:readline');
+const path = require('node:path');
+const mode = process.argv[1];
+process.on('SIGTERM', () => process.exit(0));
+if (mode === 'never-ready') {
+  setInterval(() => {}, 1000);
+} else if (mode === 'invalid-ready') {
+  process.stdout.write(JSON.stringify({ type: 'ready', extra: true }) + '\n');
+} else if (mode === 'stderr-overflow') {
+  process.stderr.write('x'.repeat(256));
+  setInterval(() => {}, 1000);
+} else {
+  process.stdout.write(JSON.stringify({ type: 'ready' }) + '\n');
+  const lines = readline.createInterface({ input: process.stdin });
+  lines.on('line', line => {
+    const request = JSON.parse(line);
+    if (mode === 'analysis-timeout') return;
+    if (mode === 'exit') process.exit(7);
+    if (mode === 'provider-error') {
+      process.stdout.write(JSON.stringify({
+        id: request.id,
+        status: 'error',
+        error: 'sensitive provider detail',
+        filename: path.basename(request.path),
+        generation: 0,
+      }) + '\n');
+      return;
+    }
+    process.stdout.write(JSON.stringify({
+      id: mode === 'wrong-id'
+        ? '00000000-0000-4000-8000-000000000000'
+        : request.id,
+      status: 'success',
+      camelot: mode === 'inconsistent' ? '8B' : '11B',
+      openkey: '4d',
+      key: 'A major',
+      class_id: 22,
+      filename: path.basename(request.path),
+      generation: 0,
+    }) + '\n');
+  });
+}
+`;
+
+const workers = new Set<OpenKeyScanWorker>();
+
+function launch(mode = 'success'): OpenKeyScanWorkerLaunch {
+  return {
+    executable: process.execPath,
+    args: ['-e', FAKE_WORKER_SOURCE, mode],
+    environment: {},
+  };
+}
+
+async function start(
+  mode = 'success',
+  limits: Parameters<typeof OpenKeyScanWorker.start>[1] = {}
+): Promise<OpenKeyScanWorker> {
+  const worker = await OpenKeyScanWorker.start(launch(mode), {
+    startupTimeoutMs: 1_000,
+    analysisTimeoutMs: 1_000,
+    shutdownGraceMs: 50,
+    ...limits,
+  });
+  workers.add(worker);
+  return worker;
+}
+
+function expectWorkerError(
+  promise: Promise<unknown>,
+  code: OpenKeyScanWorkerError['code']
+): Promise<void> {
+  return expect(promise).rejects.toMatchObject({
+    name: 'OpenKeyScanWorkerError',
+    code,
+  });
+}
+
+afterEach(async () => {
+  await Promise.all([...workers].map(worker => worker.close()));
+  workers.clear();
+});
+
+describe('OpenKeyScanWorker', () => {
+  it('normalizes a real audio path through an actual NDJSON subprocess', async () => {
+    const worker = await start();
+
+    const result = await worker.analyze(REAL_MP3_PATH);
+
+    expect(result).toEqual({
+      providerId: 'openkeyscan',
+      key: {
+        tonic: 'A',
+        mode: 'major',
+        traditional: 'A major',
+        camelot: '11B',
+        openKey: '4d',
+      },
+      providerClassId: 22,
+      providerGeneration: 0,
+      startupLatencyMs: expect.any(Number),
+      analysisLatencyMs: expect.any(Number),
+    });
+    expect(result.startupLatencyMs).toBeLessThan(1_000);
+    expect(result.analysisLatencyMs).toBeLessThan(1_000);
+  });
+
+  it('keeps one worker alive for sequential analysis', async () => {
+    const worker = await start();
+
+    await expect(worker.analyze(REAL_MP3_PATH)).resolves.toMatchObject({
+      providerId: 'openkeyscan',
+    });
+    await expect(worker.analyze(REAL_MP3_PATH)).resolves.toMatchObject({
+      providerId: 'openkeyscan',
+    });
+  });
+
+  it('rejects relative executables, working directories, audio paths, and unsafe arguments', async () => {
+    await expectWorkerError(
+      OpenKeyScanWorker.start({ executable: 'python', args: [] }),
+      'invalid_configuration'
+    );
+    await expectWorkerError(
+      OpenKeyScanWorker.start({
+        executable: process.execPath,
+        args: ['-e'],
+        cwd: 'relative',
+      }),
+      'invalid_configuration'
+    );
+    await expectWorkerError(
+      OpenKeyScanWorker.start({
+        executable: process.execPath,
+        args: ['bad\0argument'],
+      }),
+      'invalid_configuration'
+    );
+
+    const worker = await start();
+    await expectWorkerError(
+      worker.analyze('relative.mp3'),
+      'invalid_configuration'
+    );
+  });
+
+  it('does not allow concurrent requests to multiply worker memory', async () => {
+    const worker = await start('analysis-timeout', {
+      analysisTimeoutMs: 500,
+    });
+    const active = worker.analyze(REAL_MP3_PATH);
+
+    await expectWorkerError(
+      worker.analyze(REAL_MP3_PATH),
+      'invalid_configuration'
+    );
+    const activeError = expectWorkerError(active, 'aborted');
+    await worker.close();
+    await activeError;
+  });
+
+  it('cancels analysis and closes the worker', async () => {
+    const worker = await start('analysis-timeout');
+    const controller = new AbortController();
+    const result = worker.analyze(REAL_MP3_PATH, {
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    await expectWorkerError(result, 'aborted');
+    await expectWorkerError(worker.analyze(REAL_MP3_PATH), 'worker_exited');
+  });
+
+  it('enforces startup and analysis timeouts', async () => {
+    await expectWorkerError(
+      OpenKeyScanWorker.start(launch('never-ready'), {
+        startupTimeoutMs: 30,
+        analysisTimeoutMs: 100,
+        shutdownGraceMs: 25,
+      }),
+      'startup_timeout'
+    );
+
+    const worker = await start('analysis-timeout', {
+      analysisTimeoutMs: 30,
+    });
+    await expectWorkerError(worker.analyze(REAL_MP3_PATH), 'analysis_timeout');
+  });
+
+  it.each([
+    ['invalid-ready', 'protocol_error'],
+    ['stderr-overflow', 'protocol_error'],
+  ] as const)('fails closed when startup mode %s violates the protocol', async (mode, code) => {
+    await expectWorkerError(
+      OpenKeyScanWorker.start(launch(mode), {
+        startupTimeoutMs: 1_000,
+        analysisTimeoutMs: 1_000,
+        shutdownGraceMs: 25,
+        maxStderrBytes: 64,
+      }),
+      code
+    );
+  });
+
+  it.each([
+    'wrong-id',
+    'inconsistent',
+  ] as const)('fails closed when a %s response contradicts canonical metadata', async mode => {
+    const worker = await start(mode);
+    await expectWorkerError(worker.analyze(REAL_MP3_PATH), 'protocol_error');
+  });
+
+  it('redacts provider failures at the adapter boundary', async () => {
+    const worker = await start('provider-error');
+
+    const result = worker.analyze(REAL_MP3_PATH);
+
+    await expectWorkerError(result, 'provider_error');
+    await expect(result).rejects.not.toThrow('sensitive provider detail');
+  });
+
+  it('reports unexpected worker exit without leaking process output', async () => {
+    const worker = await start('exit');
+    await expectWorkerError(worker.analyze(REAL_MP3_PATH), 'worker_exited');
+  });
+
+  it('rejects already-aborted startup and analysis signals', async () => {
+    const startupController = new AbortController();
+    startupController.abort();
+    await expectWorkerError(
+      OpenKeyScanWorker.start(launch(), {
+        signal: startupController.signal,
+      }),
+      'aborted'
+    );
+
+    const worker = await start();
+    const analysisController = new AbortController();
+    analysisController.abort();
+    await expectWorkerError(
+      worker.analyze(REAL_MP3_PATH, {
+        signal: analysisController.signal,
+      }),
+      'aborted'
+    );
+  });
+});

--- a/apps/web/lib/audio/analysis/openkeyscan-worker.ts
+++ b/apps/web/lib/audio/analysis/openkeyscan-worker.ts
@@ -1,0 +1,507 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { isAbsolute } from 'node:path';
+import type { CanonicalMusicalKey } from '@jovie/audio-contracts';
+import {
+  OpenKeyScanProtocolError,
+  parseOpenKeyScanProviderMessage,
+} from './openkeyscan-protocol';
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
+const DEFAULT_ANALYSIS_TIMEOUT_MS = 240_000;
+const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
+const DEFAULT_MAX_LINE_BYTES = 64 * 1024;
+const DEFAULT_MAX_STDERR_BYTES = 64 * 1024;
+
+export const OPENKEYSCAN_WORKER_ERROR_CODES = [
+  'invalid_configuration',
+  'startup_timeout',
+  'analysis_timeout',
+  'aborted',
+  'protocol_error',
+  'provider_error',
+  'worker_exited',
+] as const;
+
+export type OpenKeyScanWorkerErrorCode =
+  (typeof OPENKEYSCAN_WORKER_ERROR_CODES)[number];
+
+export class OpenKeyScanWorkerError extends Error {
+  constructor(
+    readonly code: OpenKeyScanWorkerErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'OpenKeyScanWorkerError';
+  }
+}
+
+export interface OpenKeyScanWorkerLaunch {
+  /** Absolute path to a pinned OpenKeyScan executable or Python interpreter. */
+  readonly executable: string;
+  /** Explicit arguments, including the server script when using Python. */
+  readonly args: readonly string[];
+  /** Optional absolute working directory. */
+  readonly cwd?: string;
+  /**
+   * Complete child environment except for the adapter's fixed production
+   * NODE_ENV. Parent variables are intentionally not inherited so application
+   * secrets cannot leak into the analyzer process.
+   */
+  readonly environment?: Readonly<Record<string, string>>;
+}
+
+export interface OpenKeyScanWorkerLimits {
+  readonly startupTimeoutMs?: number;
+  readonly analysisTimeoutMs?: number;
+  readonly shutdownGraceMs?: number;
+  readonly maxLineBytes?: number;
+  readonly maxStderrBytes?: number;
+}
+
+export interface OpenKeyScanAnalysis {
+  readonly providerId: 'openkeyscan';
+  readonly key: CanonicalMusicalKey;
+  readonly providerClassId: number;
+  readonly providerGeneration: number;
+  readonly startupLatencyMs: number;
+  readonly analysisLatencyMs: number;
+}
+
+interface PendingRequest {
+  readonly id: string;
+  readonly audioPath: string;
+  readonly startedAt: number;
+  readonly resolve: (result: OpenKeyScanAnalysis) => void;
+  readonly reject: (error: OpenKeyScanWorkerError) => void;
+  readonly timeoutId: ReturnType<typeof setTimeout>;
+  readonly removeAbortListener: () => void;
+}
+
+interface ResolvedLimits {
+  readonly startupTimeoutMs: number;
+  readonly analysisTimeoutMs: number;
+  readonly shutdownGraceMs: number;
+  readonly maxLineBytes: number;
+  readonly maxStderrBytes: number;
+}
+
+function positiveInteger(
+  value: number | undefined,
+  fallback: number,
+  label: string
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new OpenKeyScanWorkerError(
+      'invalid_configuration',
+      `${label} must be a positive integer`
+    );
+  }
+  return resolved;
+}
+
+function resolveLimits(input: OpenKeyScanWorkerLimits): ResolvedLimits {
+  return {
+    startupTimeoutMs: positiveInteger(
+      input.startupTimeoutMs,
+      DEFAULT_STARTUP_TIMEOUT_MS,
+      'startup timeout'
+    ),
+    analysisTimeoutMs: positiveInteger(
+      input.analysisTimeoutMs,
+      DEFAULT_ANALYSIS_TIMEOUT_MS,
+      'analysis timeout'
+    ),
+    shutdownGraceMs: positiveInteger(
+      input.shutdownGraceMs,
+      DEFAULT_SHUTDOWN_GRACE_MS,
+      'shutdown grace'
+    ),
+    maxLineBytes: positiveInteger(
+      input.maxLineBytes,
+      DEFAULT_MAX_LINE_BYTES,
+      'line limit'
+    ),
+    maxStderrBytes: positiveInteger(
+      input.maxStderrBytes,
+      DEFAULT_MAX_STDERR_BYTES,
+      'stderr limit'
+    ),
+  };
+}
+
+function validateLaunch(launch: OpenKeyScanWorkerLaunch): void {
+  if (!isAbsolute(launch.executable)) {
+    throw new OpenKeyScanWorkerError(
+      'invalid_configuration',
+      'analyzer executable must be absolute'
+    );
+  }
+  if (launch.cwd !== undefined && !isAbsolute(launch.cwd)) {
+    throw new OpenKeyScanWorkerError(
+      'invalid_configuration',
+      'analyzer working directory must be absolute'
+    );
+  }
+  if (
+    launch.args.some(
+      argument => argument.length === 0 || argument.includes('\0')
+    )
+  ) {
+    throw new OpenKeyScanWorkerError(
+      'invalid_configuration',
+      'analyzer arguments must be nonempty and contain no null bytes'
+    );
+  }
+  if (
+    Object.entries(launch.environment ?? {}).some(
+      ([key, value]) =>
+        key.length === 0 ||
+        key.includes('=') ||
+        key.includes('\0') ||
+        value.includes('\0')
+    )
+  ) {
+    throw new OpenKeyScanWorkerError(
+      'invalid_configuration',
+      'analyzer environment is invalid'
+    );
+  }
+}
+
+/**
+ * One bounded OpenKeyScan NDJSON session.
+ *
+ * The adapter deliberately allows one in-flight analysis. This matches the
+ * canonical provider registry's single offline-worker boundary and prevents
+ * application concurrency from multiplying PyTorch memory usage.
+ */
+export class OpenKeyScanWorker {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly limits: ResolvedLimits;
+  private readonly startedAt = Date.now();
+  private readonly readyPromise: Promise<void>;
+  private resolveReady!: () => void;
+  private rejectReady!: (error: OpenKeyScanWorkerError) => void;
+  private startupTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private pending: PendingRequest | null = null;
+  private stdoutBuffer = '';
+  private stderrBytes = 0;
+  private startupLatencyMs = 0;
+  private ready = false;
+  private closing = false;
+  private closed = false;
+
+  private constructor(launch: OpenKeyScanWorkerLaunch, limits: ResolvedLimits) {
+    this.limits = limits;
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+    this.child = spawn(launch.executable, [...launch.args], {
+      cwd: launch.cwd,
+      env: { ...(launch.environment ?? {}), NODE_ENV: 'production' },
+      shell: false,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', chunk => this.handleStdout(String(chunk)));
+    this.child.stderr.on('data', chunk => this.handleStderr(chunk as Buffer));
+    this.child.once('error', () => {
+      this.failWorker(
+        new OpenKeyScanWorkerError(
+          'worker_exited',
+          'analyzer process could not start'
+        )
+      );
+    });
+    this.child.once('close', () => {
+      this.closed = true;
+      if (!this.closing) {
+        this.failWorker(
+          new OpenKeyScanWorkerError(
+            'worker_exited',
+            'analyzer process exited unexpectedly'
+          )
+        );
+      }
+    });
+  }
+
+  static async start(
+    launch: OpenKeyScanWorkerLaunch,
+    options: OpenKeyScanWorkerLimits & { readonly signal?: AbortSignal } = {}
+  ): Promise<OpenKeyScanWorker> {
+    validateLaunch(launch);
+    const limits = resolveLimits(options);
+    if (options.signal?.aborted) {
+      throw new OpenKeyScanWorkerError(
+        'aborted',
+        'analyzer startup was cancelled'
+      );
+    }
+
+    const worker = new OpenKeyScanWorker(launch, limits);
+    const onAbort = () => {
+      worker.failWorker(
+        new OpenKeyScanWorkerError('aborted', 'analyzer startup was cancelled')
+      );
+      void worker.close();
+    };
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    worker.startupTimeoutId = setTimeout(() => {
+      worker.failWorker(
+        new OpenKeyScanWorkerError(
+          'startup_timeout',
+          'analyzer did not become ready in time'
+        )
+      );
+      void worker.close();
+    }, limits.startupTimeoutMs);
+
+    try {
+      await worker.readyPromise;
+      return worker;
+    } finally {
+      options.signal?.removeEventListener('abort', onAbort);
+      if (worker.startupTimeoutId) {
+        clearTimeout(worker.startupTimeoutId);
+        worker.startupTimeoutId = null;
+      }
+    }
+  }
+
+  async analyze(
+    audioPath: string,
+    options: { readonly signal?: AbortSignal } = {}
+  ): Promise<OpenKeyScanAnalysis> {
+    if (!isAbsolute(audioPath)) {
+      throw new OpenKeyScanWorkerError(
+        'invalid_configuration',
+        'audio path must be absolute'
+      );
+    }
+    if (!this.ready || this.closed || this.closing) {
+      throw new OpenKeyScanWorkerError(
+        'worker_exited',
+        'analyzer worker is not available'
+      );
+    }
+    if (this.pending) {
+      throw new OpenKeyScanWorkerError(
+        'invalid_configuration',
+        'analyzer worker already has an active request'
+      );
+    }
+    if (options.signal?.aborted) {
+      throw new OpenKeyScanWorkerError(
+        'aborted',
+        'audio analysis was cancelled'
+      );
+    }
+
+    const id = randomUUID();
+    return new Promise<OpenKeyScanAnalysis>((resolve, reject) => {
+      const onAbort = () => {
+        this.rejectPending(
+          new OpenKeyScanWorkerError('aborted', 'audio analysis was cancelled')
+        );
+        void this.close();
+      };
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+      const timeoutId = setTimeout(() => {
+        this.rejectPending(
+          new OpenKeyScanWorkerError(
+            'analysis_timeout',
+            'audio analysis exceeded its time budget'
+          )
+        );
+        void this.close();
+      }, this.limits.analysisTimeoutMs);
+      this.pending = {
+        id,
+        audioPath,
+        startedAt: Date.now(),
+        resolve,
+        reject,
+        timeoutId,
+        removeAbortListener: () =>
+          options.signal?.removeEventListener('abort', onAbort),
+      };
+
+      this.child.stdin.write(
+        `${JSON.stringify({ id, path: audioPath })}\n`,
+        error => {
+          if (!error) return;
+          this.rejectPending(
+            new OpenKeyScanWorkerError(
+              'worker_exited',
+              'analyzer request could not be written'
+            )
+          );
+          void this.close();
+        }
+      );
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closing || this.closed) return;
+    this.closing = true;
+    this.rejectPending(
+      new OpenKeyScanWorkerError('aborted', 'analyzer worker was closed')
+    );
+    this.child.stdin.end();
+    if (this.child.exitCode !== null || this.child.signalCode !== null) {
+      this.closed = true;
+      return;
+    }
+
+    this.child.kill('SIGTERM');
+    await new Promise<void>(resolve => {
+      const timeoutId = setTimeout(() => {
+        if (this.child.exitCode === null && this.child.signalCode === null) {
+          this.child.kill('SIGKILL');
+        }
+        resolve();
+      }, this.limits.shutdownGraceMs);
+      this.child.once('close', () => {
+        clearTimeout(timeoutId);
+        resolve();
+      });
+    });
+  }
+
+  private handleStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    if (Buffer.byteLength(this.stdoutBuffer) > this.limits.maxLineBytes) {
+      this.protocolFailure('analyzer output exceeded the line limit');
+      return;
+    }
+
+    let newlineIndex = this.stdoutBuffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line) this.handleLine(line);
+      if (Buffer.byteLength(this.stdoutBuffer) > this.limits.maxLineBytes) {
+        this.protocolFailure('analyzer output exceeded the line limit');
+        return;
+      }
+      newlineIndex = this.stdoutBuffer.indexOf('\n');
+    }
+  }
+
+  private handleStderr(chunk: Buffer): void {
+    this.stderrBytes += chunk.byteLength;
+    if (this.stderrBytes > this.limits.maxStderrBytes) {
+      this.protocolFailure('analyzer diagnostic output exceeded its limit');
+    }
+  }
+
+  private handleLine(line: string): void {
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      this.protocolFailure('analyzer returned invalid JSON');
+      return;
+    }
+
+    if (
+      value &&
+      typeof value === 'object' &&
+      'type' in value &&
+      value.type === 'heartbeat' &&
+      this.ready
+    ) {
+      return;
+    }
+    if (
+      value &&
+      typeof value === 'object' &&
+      'type' in value &&
+      value.type === 'ready'
+    ) {
+      if (this.ready || Object.keys(value).length !== 1) {
+        this.protocolFailure('analyzer returned an invalid ready message');
+        return;
+      }
+      this.ready = true;
+      this.startupLatencyMs = Math.max(0, Date.now() - this.startedAt);
+      this.resolveReady();
+      return;
+    }
+
+    if (!this.ready || !this.pending) {
+      this.protocolFailure('analyzer returned an unexpected message');
+      return;
+    }
+
+    try {
+      const message = parseOpenKeyScanProviderMessage(
+        value,
+        this.pending.audioPath
+      );
+      if (message.id !== this.pending.id) {
+        this.protocolFailure('analyzer response id did not match the request');
+        return;
+      }
+      if (message.status === 'success') {
+        const pending = this.takePending();
+        pending?.resolve({
+          providerId: 'openkeyscan',
+          key: message.key,
+          providerClassId: message.classId,
+          providerGeneration: message.generation,
+          startupLatencyMs: this.startupLatencyMs,
+          analysisLatencyMs: Math.max(
+            0,
+            Date.now() - (pending?.startedAt ?? 0)
+          ),
+        });
+      } else {
+        this.rejectPending(
+          new OpenKeyScanWorkerError(
+            'provider_error',
+            'analyzer could not analyze the audio'
+          )
+        );
+      }
+    } catch (error) {
+      this.protocolFailure(
+        error instanceof OpenKeyScanProtocolError
+          ? error.message
+          : 'analyzer returned an invalid response'
+      );
+    }
+  }
+
+  private takePending(): PendingRequest | null {
+    const pending = this.pending;
+    this.pending = null;
+    if (pending) {
+      clearTimeout(pending.timeoutId);
+      pending.removeAbortListener();
+    }
+    return pending;
+  }
+
+  private rejectPending(error: OpenKeyScanWorkerError): void {
+    this.takePending()?.reject(error);
+  }
+
+  private protocolFailure(message: string): void {
+    const error = new OpenKeyScanWorkerError('protocol_error', message);
+    this.failWorker(error);
+    void this.close();
+  }
+
+  private failWorker(error: OpenKeyScanWorkerError): void {
+    if (!this.ready) this.rejectReady(error);
+    this.rejectPending(error);
+  }
+}


### PR DESCRIPTION
## Summary
- isolate OpenKeyScan behind a secret-free, shell-disabled long-lived subprocess boundary
- enforce one in-flight analysis, bounded startup/analysis/shutdown, strict stdout/stderr limits, and typed cancellation
- report canonical key output with startup and analysis latency while redacting provider failures

## Evidence
- worker integration tests use real Node child processes
- stack-head worker tests: 44/44 green
- stack-head focused audio tests: 118/118 green
- full turbo typecheck: 11/11 packages green
- normal pre-push: secret scans, Biome, lint, full Vitest shards, and CI harness green

## Scope boundary
Draft Graphite-tracked child of the protocol PR. OpenKeyScan remains a key-only benchmark candidate, not a production-selected BPM/grid provider. Keep it out of the native queue until the stack lands, this PR targets current `main`, and full main-target required checks pass.

Linear: JOV-4385