### PR TITLE
fix(ci): run Fork PR Gate on pull_request events

### DIFF
--- a/.github/workflows/fork-pr-gate.yml
+++ b/.github/workflows/fork-pr-gate.yml
@@ -124,6 +124,7 @@ jobs:
     # through the API and sets a commit status; it never checks out head code.
     # It gives fork PRs the bot credential required to update the required gate.
     if: >-
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]') ||
       (github.event_name == 'pull_request_review' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

PRs from `tw/codex/*` branches (codex CLI agent) never triggered `pull_request_target` events, so Fork PR Gate never ran. The drain/autoenroll classifier saw `Fork PR Gate (missing)` and refused to enroll perfectly clean, MERGEABLE PRs into the native merge queue.

## Fix

Added `(github.event_name == 'pull_request')` to the `fork-gate` job condition. The job already handles `pull_request_review` events; this adds the standard PR event that fires reliably on every push/open/reopen/synchronize.

## Impact

Without this fix, the autoenroll controller cannot admit any PR lacking Fork PR Gate check runs — 17+ CLEAN PRs have been stuck outside the MQ for 6-10+ hours.