### PR TITLE
docs(ci): make native merge queue canonical

### DIFF
--- a/.claude/commands/clean.md
+++ b/.claude/commands/clean.md
@@ -125,7 +125,7 @@ gh pr create \
 EOF
 )"
 
-# Add the PR to the Graphite merge queue (enqueues by label)
+# Request GitHub native merge-queue enrollment
 gh pr edit --add-label merge-queue
 
 # Return to develop for next batch

--- a/.claude/commands/drain.md
+++ b/.claude/commands/drain.md
@@ -1,29 +1,30 @@
 ---
-description: Graphite-native PR drain — enroll clean PRs into the merge queue, fan out worktree fix agents for the rest, never go red
+description: GitHub-native PR drain — enroll clean PRs into the merge queue, fan out worktree fix agents for the rest, never go red
 allowed-tools: Bash(gh:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*), Bash(bash:*), Bash(chmod:*)
 ---
 
-# Drain — Graphite merge queue to zero
+# Drain — GitHub native merge queue to zero
 
-Clears the open-PR backlog the way the repo actually ships now: agents open PRs
-straight to `main`, the **Graphite merge queue** rebase-merges them server-side,
-and the queue **re-tests each PR against latest `main` before landing** — so the
-queue, not this command, is what keeps `main` green.
+Clears the open-PR backlog through GitHub's **native merge queue**. Agents open
+PRs to `main`; the controller enrolls exact heads; GitHub creates combined
+`merge_group` heads and **re-tests each entry against latest `main` before
+landing**. The queue, not this command, keeps `main` green.
 
 ## Hard rules (current CI — do not violate)
 
-- **Never `gh pr merge` / `--auto` / `--admin`.** Branch protection lets only the
-  Graphite app push to `main`; those calls fail and bypass the queue.
-- **Enroll = add the `merge-queue` label.** That is the only way a PR enters the queue.
+- **Never manually run `gh pr merge` / `--auto` / `--admin`.** The authorized
+  native controller owns queue mutation and postcondition checks.
+- **Enrollment intent = add `merge-queue`.** The label wakes the native
+  controller; GitHub's authoritative queue state determines membership.
 - **`fast` is emergency/hotfix-only.** Ordinary generated PRs on `codex/*`,
   `claude/*`, `agent/*`, or similar branches must not use `fast` unless the PR
   is explicitly classified as emergency/hotfix/incident; otherwise the guard
   removes `fast` and gates the PR for human review.
-- **Dequeue hard gates = remove only the `merge-queue` label.** A PR with
-  `needs-human`, `hold`, or `gated` must not keep occupying Graphite MQ slots.
+- **Dequeue hard gates through the controller.** A PR with `needs-human`,
+  `hold`, or `gated` must not occupy native queue slots; remove the intent label
+  only after authoritative dequeue succeeds.
 - **Never retarget to `integration/loop-*`.** That model is dormant; agents go to `main`.
 - **Never close a PR you didn't open.** Surface superseded/stale ones to the human.
-- **Never touch `gtmq_*` draft PRs** (author `app/graphite-app`) — that's the queue working.
 - **Opt-outs:** `needs-human`, `hold`, `gated` → leave the PR for a human after
   removing `merge-queue` if it was already enrolled.
 
@@ -41,16 +42,15 @@ budget; the next operation is deferred to the next tick.
 
 The script enrolls every non-draft, `MERGEABLE`, green, non-opted-out PR and
 prints five work buckets: **DEQUEUE**, **CONFLICT**, **BLOCKED**, **SURFACE**,
-**GRAPHITE MQ**.
+and **NATIVE QUEUE**.
 
 ## Phase 1 — Kill systemic blockers first
 
 If the same required check fails on **3+ PRs**, it's broken on `main`, not in the
 branches. Fix it once on `main` via a single PR, then add `merge-queue` so
-Graphite retests and lands it ahead of downstream work. Add `fast` only when
-the PR is explicitly emergency/hotfix/incident-classified; otherwise use the
-Graphite dashboard's merge-now path for human-approved emergency bypass. Don't
-fix the same thing on N branches.
+the native controller can enroll it ahead of downstream work. Add `fast` only
+when the PR is explicitly emergency/hotfix/incident-classified. Do not use an
+alternate merge path or fix the same thing on N branches.
 
 ```bash
 # failing-check histogram across open PRs
@@ -113,16 +113,12 @@ gh pr list --state open --json number,title --limit 100 \
 - Enrolled into queue: <n> (#…)
 - Fix agents dispatched: <n> (DONE: …, still blocked: …)
 - Surfaced for human: <n> (#… — recommend close/keep + why)
-- Graphite MQ in-flight: <n> groups
+- Native queue in-flight: <n> entries/groups
 - Systemic blockers fixed on main: <…/none>
 - Last merge: <ts>  | Open PRs: <n>
 ```
 
 Flow-health targets: nothing non-draft sits unenrolled; no agent PR open >24h
-without a push; if a labeled PR isn't entering the queue, the `merge-queue` →
-Graphite enrollment wiring is broken — flag it.
-
-If a Graphite draft gets stale after a downstack MQ draft closes, first resubmit
-the source PR with `gt submit --always --update-only --no-edit --no-interactive
---no-verify`. If the stale `gtmq_*` draft remains, use the Graphite dashboard
-to cancel/retry the queue entry. Do not close `gtmq_*` PRs from GitHub.
+without a push; if a labeled PR isn't entering the queue, the intent-label →
+native-controller wiring is broken. Inspect authoritative GitHub queue state
+before retrying or changing labels.

--- a/.claude/commands/sonar-fix.md
+++ b/.claude/commands/sonar-fix.md
@@ -112,7 +112,7 @@ For each COMMENTS_TO_ADDRESS PR, follow this cycle:
 For every open sonar-fix PR (including ones just fixed):
 
 ```bash
-# Add to Graphite merge queue (enqueues by label; native auto-merge retired)
+# Request GitHub native merge-queue enrollment
 gh pr edit <NUMBER> --add-label merge-queue
 
 # Update branch with latest base
@@ -252,7 +252,7 @@ Fixes {N} SonarCloud issues ({severity} priority):
 EOF
 )"
 
-# Add the PR to the Graphite merge queue (enqueues by label)
+# Request GitHub native merge-queue enrollment
 gh pr edit --add-label merge-queue
 ```
 

--- a/.claude/rules/hermes-air.md
+++ b/.claude/rules/hermes-air.md
@@ -66,7 +66,7 @@ The legacy `scripts/hermes/jobs/voice-memo-ingest.ts` watcher is not the activat
 2. Hermes-Air files a GitHub issue using the canonical follow-up shape from `.claude/rules/linear.md` (Source / Follow-up / Why it matters / Classification / Acceptance criteria). A voice-derived issue references only the sanitized private proposal receipt, never the raw memo or transcript.
 3. Optional: add the `agent-ready` label when the issue should enter the GitHub-native orchestrator immediately.
 4. The Pro codex issue shipper or `.github/workflows/github-ai-orchestrator.yml` discovers labeled/ready work — no Air-side `repository_dispatch`, no SSH.
-5. PR opens with `Fixes #N` in the body; merge to `main` closes the GitHub issue (Graphite queue-land safe). `linear-sync-on-merge.yml` still mirrors to Linear until `TRACKER_GITHUB_ONLY=1`.
+5. PR opens with `Fixes #N` in the body; GitHub native queue landing on `main` closes the GitHub issue. `linear-sync-on-merge.yml` still mirrors to Linear until `TRACKER_GITHUB_ONLY=1`.
 
 If the Air cannot file the GitHub issue (network down, `gh` outage), queue a Telegram-derived or already-sanitized intent in `~/.hermes/state/linear-queue.jsonl` for operator inspection. A voice-derived proposal remains only in the private voice store and may be retried after service recovery without copying its raw memo or transcript into shared gbrain or the queue.
 

--- a/.claude/rules/pr-stacking.md
+++ b/.claude/rules/pr-stacking.md
@@ -5,9 +5,9 @@
 > as one `big-pr` PR — **never** N base-on-base micro-PRs (that collapsed the queue
 > on 2026-06-22, #11689).
 
-Small, reviewable PRs that move through the Graphite merge queue fast. Big PRs
-clog the queue, recursively rebase, and can't be reviewed for taste — so we cap
-size and stack instead.
+Small, reviewable PRs that move through GitHub's native merge queue quickly.
+Big PRs clog the queue, recursively rebase, and can't be reviewed for taste —
+so we cap size and stack instead.
 
 ## Size cap (enforced — `.github/workflows/pr-size-guard.yml`)
 
@@ -26,21 +26,22 @@ few **sibling** PRs off `main` split by top-level domain. **Never** as a deep
 base-on-base stack of one-PR-per-file/component.
 
 Why: `ci.yml` only triggers on PRs to `main`/`integration/**`, so a stack of N
-agent PRs based on each other runs *no* heavy CI on the PR itself — then Graphite
-lands the stack bottom-up, rebasing each member onto main and running the **full**
-pipeline (build + 4× Lighthouse + tests) **per member**. A 63-deep token-drift
-stack = 63 sequential full-CI runs for one mechanical diff, and any one
-slow/failing/conflicted member stalls the whole chain. (This happened — June 2026,
-collapsed in #11689.) One `big-pr` PR = one CI run.
+agent PRs based on each other runs *no* heavy CI on the PR itself. Native queue
+landing still requires each child to be retargeted/rebased onto `main` after its
+parent lands, then to run the **full** source and combined-head pipeline. A
+63-deep token-drift stack = 63 sequential full-CI runs for one mechanical diff,
+and any one slow/failing/conflicted member stalls the whole chain. (This
+happened — June 2026, collapsed in #11689.) One `big-pr` PR = one CI run.
 
 Agents generating drift/token sweeps: emit a single PR per sweep. Do not call
 `gt create` once per component.
 
 ## Stack, don't pile
 
-- **Dependent work** (B needs A) → a **Graphite stack**: `gt create` per logical
-  step. The stack restacks once and lands bottom-up through the queue; children
-  auto-retarget to `main` as their base merges.
+- **Dependent work** (B needs A) → a **PR stack managed with the Graphite CLI**:
+  `gt create` per logical step, then `gt restack`/`gt submit`. Graphite manages
+  branch relationships and PR submission only; GitHub's native queue lands
+  each PR after its parent is on `main` and the child is retargeted/rebased.
 - **Independent work** in the same area → **sibling PRs** off `main`. They land
   in parallel and don't trigger each other's rebases.
 - **One PR = one logical change.** No drive-by refactors — pull them into their
@@ -61,5 +62,6 @@ gt create -m "feat(x): step 2"     # stacked on step 1
 gt submit --stack                  # opens/updates the whole stack
 ```
 
-Enroll each PR with the `merge-queue` label; Graphite merges the stack
-bottom-up. See also [`ci-branching.md`](ci-branching.md).
+After a parent lands, retarget/rebase the next child onto `main`, push its exact
+head, then apply `merge-queue`. The native controller owns enrollment and
+combined-head validation. See also [`ci-branching.md`](ci-branching.md).

--- a/.claude/rules/swarm.md
+++ b/.claude/rules/swarm.md
@@ -203,7 +203,7 @@ gh pr create --draft --base main --title "fix(design-system): <title>" --body "<
 # Invoke /ship
 # /ship detects the draft PR, promotes it, runs typecheck + lint + tests
 
-# 8. Add to Graphite merge queue
+# 8. Request GitHub native merge-queue enrollment
 PR_NUM=$(gh pr view --json number --jq '.number')
 gh pr edit $PR_NUM --add-label merge-queue
 

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -3,7 +3,8 @@
 `main` merges through GitHub's native merge queue. The live repository variable
 is `MERGE_QUEUE_BACKEND=native`, and ruleset `Main Branch Protection`
 (`10512119`) owns queue admission and combined-head validation. Graphite is a
-rollback transport only; never run both transports concurrently.
+stack-construction CLI only: use `gt` to create, restack, and submit dependent
+PRs, never to enroll, validate, or land them.
 
 ## How a PR lands
 
@@ -89,7 +90,7 @@ It fails closed if an open PR is missing from that authoritative snapshot.
   cancellation churn from becoming a dequeue/re-enroll loop.
 - Main movement triggers event-driven reconciliation and bounded mechanical
   update-branch/rebase repair for agent branches. There is no polling watchdog
-  or Graphite label-cycle loop in the native path.
+  or legacy vendor label-cycle loop in the native path.
 - Queue enrollment is serialized by `merge-queue-drain-mutex`; it does not
   race another controller instance.
 
@@ -135,9 +136,9 @@ and broad refactors fail closed out of this lane. The policy lives in
   combined head through production.
 - Queue controller refuses mutation: confirm the repository variable is exactly
   `native`; a missing/non-native value intentionally fails the workflow closed.
-- Emergency rollback: first drain native entries, explicitly set the backend to
-  `graphite`, restore the reviewed Graphite bypass/config, and prove a canary.
-  This is an incident procedure, not a normal throughput lever.
+- Emergency response: pause auto-enrollment, drain or dequeue native entries
+  through the controller, repair the native ruleset/workflow, and prove one
+  canary before resuming. Do not introduce a second landing transport.
 
 ## Signed commits
 

--- a/.github/workflows/agent-landing-sweep.yml
+++ b/.github/workflows/agent-landing-sweep.yml
@@ -20,7 +20,7 @@
 # 5. Scope judge = success
 # 6. CodeRabbit not blocking (no CHANGES_REQUESTED)
 # 7. CI harness risk classifier does not block unattended auto-merge
-# 8. Queue pressure guard: defers when merge-queue depth hits GRAPHITE_QUEUE_POLICY.maxQueueDepth
+# 8. Queue pressure guard: defers when native merge-queue depth hits the configured cap
 #
 # RELATIONSHIP TO agent-pipeline.yml:
 # This workflow is idempotent. Enabling auto-merge on an already-queued PR is
@@ -147,9 +147,9 @@ jobs:
             echo "Labels: ${LABELS:-none}"
             echo "Already in merge queue: $PR_QUEUED"
 
-            # Skip if already enqueued in Graphite (idempotency guard)
+            # Skip if native queue intent is already recorded (idempotency guard)
             if [[ "$PR_QUEUED" == "true" ]]; then
-              echo "Already in Graphite merge queue. Skipping."
+              echo "Native merge-queue enrollment already requested. Skipping."
               SKIPPED=$((SKIPPED + 1))
               continue
             fi
@@ -241,9 +241,9 @@ jobs:
               continue
             fi
 
-            # Graphite enqueues by label; native auto-merge retired
+            # The label records intent; the native auto-enroll controller owns admission.
             if gh pr edit "$PR_NUMBER" --add-label "merge-queue"; then
-              echo "Added PR #$PR_NUMBER to the Graphite merge queue."
+              echo "Requested native merge-queue enrollment for PR #$PR_NUMBER."
               LANDED=$((LANDED + 1))
             else
               echo "::warning::Failed to add merge-queue label to PR #$PR_NUMBER — not enqueued."

--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -163,7 +163,7 @@ jobs:
               echo "Queue pressure threshold reached. Stopping."; break
             fi
 
-            echo "All gates passed for PR #$PR_NUMBER. Adding to Graphite merge queue..."
+            echo "All gates passed for PR #$PR_NUMBER. Requesting native merge-queue enrollment..."
             if gh pr edit "$PR_NUMBER" --add-label "merge-queue"; then
               echo "Added PR #$PR_NUMBER to merge queue."; LANDED=$((LANDED + 1))
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
 
   # ── Centralized deterministic path-change detection ────────────────────
   # Source and combined heads compute their own exact diff. The former
-  # Graphite reuse action is intentionally absent: native queue provenance
+  # Vendor queue reuse actions are intentionally absent: native queue provenance
   # cannot rely on an external source-branch skip decision.
   ci-path-changes:
     name: Path Changes

--- a/.github/workflows/main-autofix.yml
+++ b/.github/workflows/main-autofix.yml
@@ -656,13 +656,13 @@ jobs:
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
-      - name: Add to Graphite merge queue
+      - name: Request native merge-queue enrollment
         if: steps.create-pr.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
-          # Graphite enqueues by label; native auto-merge retired
+          # The label records intent; the native auto-enroll controller owns admission.
           gh pr edit "$PR_URL" --add-label "merge-queue" || { echo "::error::Failed to add merge-queue label to $PR_URL"; exit 1; }
 
       - name: Slack — PR opened

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -1,7 +1,7 @@
 name: PR Size Guard
 
 # Forces small, reviewable PRs — which forces stacking. A change too big to
-# review as one PR must be split into a Graphite stack of dependent PRs
+# review as one PR must be split into dependent PRs managed with the `gt` CLI
 # (`gt create` per logical step) or independent sibling PRs. Opt out for
 # approved mechanical codemods (token sweeps, renames, generated output) with
 # the `big-pr` label. Thresholds tunable via repo vars PR_MAX_LINES / PR_MAX_FILES.
@@ -127,23 +127,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           MAX_LINES: ${{ vars.PR_MAX_LINES || '800' }}
           MAX_FILES: ${{ vars.PR_MAX_FILES || '40' }}
         run: |
           set -euo pipefail
-
-          # Graphite merge-queue group drafts don't inherit member labels, so a
-          # `big-pr`-bypassed member would fail size guard on the synthetic draft and
-          # abort the whole merge group. Members were already size-checked individually.
-          # Exit 0 (not skip) so the required "PR Size Guard" context reports success.
-          title="$PR_TITLE"
-          case "$title" in
-            '[Graphite MQ]'*)
-              echo "✅ Graphite merge-queue group draft — size guard not applicable (members checked individually)"; exit 0;;
-          esac
 
           labels="$PR_LABELS"
           case ",$labels," in

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -204,13 +204,13 @@ jobs:
 
           if [ -n "$EXISTING_PR" ]; then
             echo "Updated existing PR #$EXISTING_PR via force-push"
-            # Re-apply merge-queue label (idempotent; Graphite enqueues by label)
-            # Graphite enqueues by label; native auto-merge retired
+            # Re-apply native queue intent after the screenshot update.
+            # The native auto-enroll controller owns authoritative admission.
             gh pr edit --add-label "merge-queue" "$EXISTING_PR" || { echo "::error::Failed to add merge-queue label to $EXISTING_PR"; exit 1; }
           else
             PR_URL=$(gh pr create \
               --title "chore: update product screenshots" \
               --body "Auto-generated screenshot update triggered by ${GITHUB_SHA::8}.")
-            # Graphite enqueues by label; native auto-merge retired
+            # The label records intent; the native auto-enroll controller owns admission.
             gh pr edit --add-label "merge-queue" "$PR_URL" || { echo "::error::Failed to add merge-queue label to $PR_URL"; exit 1; }
           fi

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -198,13 +198,13 @@ jobs:
 
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
 
-      - name: Add to Graphite merge queue
+      - name: Request native merge-queue enrollment
         if: steps.create-pr.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
-          # Graphite enqueues by label; native auto-merge retired
+          # The label records intent; the native auto-enroll controller owns admission.
           gh pr edit "$PR_URL" --add-label "merge-queue" || { echo "::error::Failed to add merge-queue label to $PR_URL"; exit 1; }
 
       - name: Fallback — convert to draft if validation failed

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -224,7 +224,7 @@ guarded so mutable upstream instructions cannot be installed silently:
 test "$(git ls-remote https://github.com/Leonxlnx/taste-skill.git HEAD | awk '{print $1}')" = "06d6028b5c623016c59ce8536f578e5a1127b499" && DISABLE_TELEMETRY=1 DO_NOT_TRACK=1 npx --yes skills add https://github.com/Leonxlnx/taste-skill --skill "design-taste-frontend" -y
 ```
 
-Safe UI-only fixes can use the guarded Graphite UI fast lane from JOV-3895 only when the diff stays inside the allowed visual UI paths in `.github/MERGE_QUEUE.md`. The PR must carry `ui`, `fast-track-ui`, `fast`, and `merge-queue`, plus a `## Fast-track UI eligibility` section with `Why eligible`, `Before`, `After`, and `Checks run` evidence. The merge-queue guard fails closed for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, and broad refactors.
+Safe UI-only fixes can use the guarded native-queue UI fast lane from JOV-3895 only when the diff stays inside the allowed visual UI paths in `.github/MERGE_QUEUE.md`. The PR must carry `ui`, `fast-track-ui`, `fast`, and `merge-queue`, plus a `## Fast-track UI eligibility` section with `Why eligible`, `Before`, `After`, and `Checks run` evidence. The merge-queue guard fails closed for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, and broad refactors.
 
 Config variables:
 

--- a/docs/company/autonomous-shipping-doctrine.md
+++ b/docs/company/autonomous-shipping-doctrine.md
@@ -41,7 +41,8 @@ Jovie is a **100% autonomous shipping** company during development.
 - `CI / PR Ready`, `CI / Migration Guard`, security jobs (Trivy, Gitleaks, Sonar, etc.) — **strict**: every check that ran must succeed
 - `lib/pr_gates.taste_surface` — taste-touching diffs → label `needs-human-taste`, not generic `needs-human`
 - `scripts/taste-label-guard.mjs` (workflow: `Taste Label Guard`) — backstop that auto-clears mis-applied taste labels per the rule below
-- Graphite merge queue (`merge-queue` label), squash, signed commits per ruleset
+- GitHub native merge queue (`merge-queue` intent label), squash, and the
+  repository ruleset
 - Hermes `pr-autofix`, `drain-pr-queue`, `pr-merge-queue` (when `HERMES_AUTOMERGE=1`)
 
 ## What counts as a taste call (canonical, 2026-06-26)
@@ -76,7 +77,7 @@ flip a dashboard toggle).
 | `approved:taste` / `tim-approved` | Taste override — does not bypass CI |
 | `hold` / `gated` | Explicit pause (incident, experiment) |
 | `needs-agent-fix` | Machine second-opinion/spec failed — **agent** fixes, not human review queue |
-| `merge-queue` | Enrolled in Graphite MQ |
+| `merge-queue` | Requests native queue enrollment; authoritative membership lives in GitHub's queue |
 
 **Deprecated for dev-loop gating:** `needs-human` as a generic blocker; `blocked:migration`, `blocked:auth`, `blocked:payments` as human-merge gates (use CI instead).
 

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -727,7 +727,7 @@ export function buildAgentPrompt(input: BuildPromptInput): string {
       '    * Narrow lint and typecheck results (e.g., output of `pnpm biome check --changed` and `pnpm typecheck --noEmit` on changed files).',
       '    * Explicit pass/fail of the design-taste-frontend checklist (state which checks passed/failed).',
       '- For existing Jovie product/dashboard UI, use the audit/checklist parts of the skill only. Do not force landing-page hero, bento, or marketing patterns into product UI.',
-      `- Safe UI-only fast-track lane: if and only if the final diff is limited to visual UI paths allowed by \`.github/MERGE_QUEUE.md\`, add PR labels \`ui\`, \`${UI_FAST_TRACK_LABEL}\`, \`fast\`, and \`merge-queue\` so Graphite can bypass unrelated backend trains after evidence.`,
+      `- Safe UI-only fast-track lane: if and only if the final diff is limited to visual UI paths allowed by \`.github/MERGE_QUEUE.md\`, add PR labels \`ui\`, \`${UI_FAST_TRACK_LABEL}\`, \`fast\`, and \`merge-queue\` so the native queue controller can prioritize eligible UI work after evidence.`,
       '- When requesting UI fast-track, include a PR section titled `## Fast-track UI eligibility` with `Why eligible`, `Before`, `After`, and `Checks run` lines. Evidence must include before/after screenshots or component evidence, narrow typecheck output, narrow lint/Biome output, and affected component/test output or an explicit explanation when none exists. Do not request fast-track for API routes, auth, billing, DB/migrations, security/CSP, infra/cron, routing behavior, package manifests, CI, or broad refactors.',
       '- If the issue is not UI-focused, do not enforce this skill.',
     ]);

--- a/scripts/loop-train-drain.sh
+++ b/scripts/loop-train-drain.sh
@@ -19,8 +19,8 @@ for num in "${TRAIN_PRS[@]}"; do
       echo "  (update-branch skipped — may be in merge queue)"
   fi
   if [[ "$state" == "CLEAN" ]]; then
-    # Graphite enqueues by label; native auto-merge retired
-    gh pr edit "$num" --add-label "merge-queue" || echo "WARN: failed to enqueue #$num into Graphite merge queue" >&2
+    # The label records intent; the native auto-enroll controller owns admission.
+    gh pr edit "$num" --add-label "merge-queue" || echo "WARN: failed to request native queue enrollment for #$num" >&2
   fi
 done
 


### PR DESCRIPTION
## Summary
- make GitHub native merge queue the only documented landing and combined-head validation transport
- scope Graphite explicitly to `gt` CLI stack construction, restacking, and submission
- update agent/workflow queue language and remove the obsolete `[Graphite MQ]` PR-size exemption

## Verification
- `pnpm vitest run scripts/lib/__tests__/merge-queue-backend.test.mjs scripts/lib/__tests__/merge-group-workflow-contract.test.mjs` (51 passed)
- `python3 -m pytest -q scripts/tests/test_agent_workflow_hygiene.py` (34 passed)
- repository pre-push gate: typecheck, lint, affected Vitest shards, CI harness validation (green)
- `git diff --check`

## Follow-on boundaries
This policy/workflow slice intentionally does not mix in the executable legacy-backend removal. The native-only backend/drain cleanup and retired GTMQ guard deletion will follow as separate focused sibling PRs.