### PR TITLE
chore(ci): remove Graphite selector manifests

### DIFF
--- a/scripts/hermes/config/model-registry.json
+++ b/scripts/hermes/config/model-registry.json
@@ -136,13 +136,12 @@
     "mergeability-refresh",
     "focused-tests",
     "main-green",
-    "graphite-label-only"
+    "native-queue-only"
   ],
   "forbidden_actions": [
     "merge",
     "auto-merge",
     "admin",
-    "gtmq-drafts",
     "taste-gates",
     "codex-for-ordinary-remediation"
   ]

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -187,17 +187,6 @@ const PERSISTED_AUTH_FIXTURE_REPAIR_DIFF = [
   ...PERSISTED_AUTH_FIXTURE_REPAIR_CORE,
   ...AFFECTED_TEST_SELECTOR_MANIFEST,
 ];
-const GTMQ_SOURCE_GATE_REAPER_MANIFEST = [
-  '.github/actions/setup-node-pnpm/action.yml',
-  '.github/workflows/gtmq-source-authorization.yml',
-  '.github/workflows/merge-queue-autoenroll.yml',
-  'apps/web/tests/unit/ci/runner-setup-action.test.ts',
-  'scripts/drain-pr-queue.sh',
-  'scripts/guard-gtmq-source-authorization.sh',
-  'scripts/tests/test_gh_retry.py',
-  'scripts/run-affected-tests.mjs',
-  'scripts/lib/__tests__/automation-verify.test.mjs',
-];
 const MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST = [
   'apps/web/tests/e2e/mobile-overflow.spec.ts',
   'apps/web/tests/e2e/utils/mobile-overflow.ts',
@@ -925,48 +914,6 @@ describe('automation-verify affected scope', () => {
     ).toBe('full');
   });
 
-  it('selects the Graphite source-gate regression and selector self-test for the exact repair signature', () => {
-    const plan = buildAffectedTestPlan(GTMQ_SOURCE_GATE_REAPER_MANIFEST);
-
-    expect(plan.mode).toBe('selected');
-    expect(plan.pythonTests).toEqual(['scripts/tests/test_gh_retry.py']);
-    expect(plan.scriptVitestTests).toEqual([
-      'scripts/lib/__tests__/automation-verify.test.mjs',
-    ]);
-    expect(buildSelectedTestCommands(plan, '2')).toEqual([
-      [
-        'pnpm',
-        [
-          'exec',
-          'vitest',
-          '--root',
-          'scripts',
-          '--config',
-          'vitest.config.mts',
-          'run',
-          'lib/__tests__/automation-verify.test.mjs',
-          '--maxWorkers',
-          '2',
-        ],
-      ],
-      ['python3', ['-m', 'pytest', 'scripts/tests/test_gh_retry.py', '-q']],
-      [
-        'pnpm',
-        [
-          '--filter',
-          '@jovie/web',
-          'exec',
-          'vitest',
-          'run',
-          'tests/unit/ci/runner-setup-action.test.ts',
-          '--passWithNoTests',
-          '--maxWorkers',
-          '2',
-        ],
-      ],
-    ]);
-  });
-
   it('keeps Playwright deep and selects deterministic mobile overflow regressions', () => {
     const plan = buildAffectedTestPlan(
       MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST
@@ -1145,16 +1092,6 @@ describe('automation-verify affected scope', () => {
   });
 
   it.each(
-    GTMQ_SOURCE_GATE_REAPER_MANIFEST
-  )('fails closed when the Graphite source-gate repair is missing %s', missingInput => {
-    expect(
-      buildAffectedTestPlan(
-        GTMQ_SOURCE_GATE_REAPER_MANIFEST.filter(file => file !== missingInput)
-      ).mode
-    ).toBe('full');
-  });
-
-  it.each(
     MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST
   )('fails closed when the mobile overflow navigation repair is missing %s', missingInput => {
     expect(
@@ -1209,15 +1146,6 @@ describe('automation-verify affected scope', () => {
       buildAffectedTestPlan([
         ...PERFORMANCE_PROFILER_REPAIR_PRIMARY_MANIFEST,
         'scripts/hermes/lib/unknown-profiler-helper.ts',
-      ]).mode
-    ).toBe('full');
-  });
-
-  it('fails closed when the Graphite source-gate repair includes an unknown peer', () => {
-    expect(
-      buildAffectedTestPlan([
-        ...GTMQ_SOURCE_GATE_REAPER_MANIFEST,
-        'scripts/unknown-graphite-controller.sh',
       ]).mode
     ).toBe('full');
   });

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -249,21 +249,6 @@ const VISUAL_QA_DIFF_ARTIFACTS_MANIFEST = new Set([
   VISUAL_QA_DIFF_ARTIFACTS_SOURCE,
   VISUAL_QA_DIFF_ARTIFACTS_TEST,
 ]);
-const GTMQ_SOURCE_GATE_REAPER_MANIFEST = new Set([
-  '.github/actions/setup-node-pnpm/action.yml',
-  '.github/workflows/gtmq-source-authorization.yml',
-  '.github/workflows/merge-queue-autoenroll.yml',
-  'apps/web/tests/unit/ci/runner-setup-action.test.ts',
-  'scripts/drain-pr-queue.sh',
-  'scripts/guard-gtmq-source-authorization.sh',
-  'scripts/tests/test_gh_retry.py',
-  'scripts/run-affected-tests.mjs',
-  'scripts/lib/__tests__/automation-verify.test.mjs',
-]);
-const GTMQ_SOURCE_GATE_REAPER_PYTHON_TESTS = ['scripts/tests/test_gh_retry.py'];
-const GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS = [
-  'scripts/lib/__tests__/automation-verify.test.mjs',
-];
 const MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST = new Set([
   'apps/web/tests/e2e/mobile-overflow.spec.ts',
   'apps/web/tests/e2e/utils/mobile-overflow.ts',
@@ -493,12 +478,6 @@ export function buildAffectedTestPlan(
     files.length ===
       AFFECTED_TEST_SELECTOR_MANIFEST.size +
         VISUAL_QA_DIFF_ARTIFACTS_MANIFEST.size;
-  const gtmqSourceGateReaperInputCount = files.filter(file =>
-    GTMQ_SOURCE_GATE_REAPER_MANIFEST.has(file)
-  ).length;
-  const isExactGtmqSourceGateReaper =
-    gtmqSourceGateReaperInputCount === GTMQ_SOURCE_GATE_REAPER_MANIFEST.size &&
-    files.length === GTMQ_SOURCE_GATE_REAPER_MANIFEST.size;
   const mobileOverflowNavigationRaceInputCount = files.filter(file =>
     MOBILE_OVERFLOW_NAVIGATION_RACE_MANIFEST.has(file)
   ).length;
@@ -681,9 +660,6 @@ export function buildAffectedTestPlan(
     ...(isExactVercelCongestionControl
       ? VERCEL_CONGESTION_CONTROL_PYTHON_TESTS
       : []),
-    ...(isExactGtmqSourceGateReaper
-      ? GTMQ_SOURCE_GATE_REAPER_PYTHON_TESTS
-      : []),
   ]);
   const scriptVitestTests = unique([
     ...(isExactPerformanceProfilerRepairPrimary ||
@@ -715,9 +691,6 @@ export function buildAffectedTestPlan(
       : []),
     ...(isExactPersistedAuthFixtureRepair
       ? PERSISTED_AUTH_FIXTURE_SCRIPT_TESTS
-      : []),
-    ...(isExactGtmqSourceGateReaper
-      ? GTMQ_SOURCE_GATE_REAPER_SCRIPT_TESTS
       : []),
     ...(isExactMobileOverflowNavigationRace
       ? MOBILE_OVERFLOW_NAVIGATION_RACE_SCRIPT_TESTS
@@ -823,7 +796,6 @@ export function buildAffectedTestPlan(
     !isExactPerformanceProfilerRepairWithSelector &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
-    !isExactGtmqSourceGateReaper &&
     !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
@@ -855,23 +827,6 @@ export function buildAffectedTestPlan(
     !isExactPerformanceProfilerRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
-    !isExactGtmqSourceGateReaper &&
-    !isExactMobileOverflowNavigationRace &&
-    !isExactRunnerIoPressure &&
-    !isExactRunnerPrerequisiteRepair &&
-    !isExactLayoutGuardContract &&
-    !isExactPrSizeGuardWithSelector;
-  const hasIncompleteGtmqSourceGateReaper =
-    hasManifestInputBeyondDirectTests(GTMQ_SOURCE_GATE_REAPER_MANIFEST) &&
-    !isExactGtmqSourceGateReaper &&
-    !isExactAuthenticatedA11yRepair &&
-    !isExactGoldenPathSmokeContractRepair &&
-    !isExactNeonAttemptArtifactRepair &&
-    !isExactPersistedAuthFixtureRepair &&
-    !isExactAffectedTestSelector &&
-    !isExactScannerLoadRepairPrimary &&
-    !isExactVisualQaSelectorRepair &&
-    !isExactPerformanceProfilerRepairWithSelector &&
     !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
@@ -889,7 +844,6 @@ export function buildAffectedTestPlan(
     !isExactPerformanceProfilerRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
-    !isExactGtmqSourceGateReaper &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactLayoutGuardContract &&
@@ -903,7 +857,6 @@ export function buildAffectedTestPlan(
     !isExactPersistedAuthFixtureRepair &&
     !isExactAffectedTestSelector &&
     !isExactVisualQaSelectorRepair &&
-    !isExactGtmqSourceGateReaper &&
     !isExactPerformanceProfilerRepair &&
     !isExactMobileOverflowNavigationRace &&
     !isExactRunnerPrerequisiteRepair &&
@@ -915,7 +868,6 @@ export function buildAffectedTestPlan(
     !isExactAuthenticatedA11yRepair &&
     !isExactAffectedTestSelector &&
     !isExactVisualQaSelectorRepair &&
-    !isExactGtmqSourceGateReaper &&
     !isExactPrerequisiteTrain &&
     !isExactGoldenPathSmokeContractRepair &&
     !isExactNeonAttemptArtifactRepair &&
@@ -934,7 +886,6 @@ export function buildAffectedTestPlan(
     !isExactGoldenPathSmokeContractRepair &&
     !isExactNeonAttemptArtifactRepair &&
     !isExactPersistedAuthFixtureRepair &&
-    !isExactGtmqSourceGateReaper &&
     !isExactVisualQaSelectorRepair &&
     !isExactRunnerPrerequisiteRepair &&
     !isExactPerformanceProfilerRepair &&
@@ -952,7 +903,6 @@ export function buildAffectedTestPlan(
     !isExactPerformanceProfilerRepair &&
     !isExactPersistedAuthFixtureRepair &&
     !isExactVisualQaSelectorRepair &&
-    !isExactGtmqSourceGateReaper &&
     !isExactMobileOverflowNavigationRace &&
     !isExactRunnerIoPressure &&
     !isExactRunnerPrerequisiteRepair &&
@@ -970,7 +920,6 @@ export function buildAffectedTestPlan(
     hasIncompletePrSizeGuard ||
     hasIncompletePerformanceProfilerRepair ||
     hasIncompleteScannerLoadRepair ||
-    hasIncompleteGtmqSourceGateReaper ||
     hasIncompleteMobileOverflowNavigationRace ||
     hasIncompleteRunnerIoPressure ||
     hasIncompleteRunnerPrerequisiteContract ||
@@ -998,7 +947,6 @@ export function buildAffectedTestPlan(
             isExactPerformanceProfilerRepair ||
             isExactPersistedAuthFixtureRepair ||
             isExactVisualQaSelectorRepair ||
-            isExactGtmqSourceGateReaper ||
             isExactMobileOverflowNavigationRace ||
             isExactRunnerIoPressure ||
             isExactRunnerPrerequisiteRepair ||


### PR DESCRIPTION
## Summary
- remove the affected-test selector for the retired Graphite source guard
- remove obsolete Graphite/GTMQ capability entries from the Hermes model registry
- preserve all remaining automation selector coverage

Graphite remains only as the `gt` CLI for PR stack construction/restacking/submission.

## Verification
- script Vitest selector suite (174 passed)
- Biome and `git diff --check`

## Stack
Depends on #14992 -> #14991 -> #14989. Retarget each child to `main` after its parent lands; final landing remains GitHub native merge queue.