### PR TITLE
chore(ci): remove GTMQ branch exceptions

### DIFF
--- a/scripts/lib/__tests__/agent-branch-pattern.test.mjs
+++ b/scripts/lib/__tests__/agent-branch-pattern.test.mjs
@@ -27,11 +27,10 @@ describe('agent-branch-pattern (open-agent-PR capacity)', () => {
     expect(isOpenAgentPrBranch('Tim/JOV-123_fix')).toBe(true);
   });
 
-  it('rejects non-agent and merge-queue synthetic branches', () => {
+  it('rejects non-agent branches', () => {
     expect(isOpenAgentPrBranch('feature/foo')).toBe(false);
     expect(isOpenAgentPrBranch('hotfix/prod')).toBe(false);
     expect(isOpenAgentPrBranch('main')).toBe(false);
-    expect(isOpenAgentPrBranch('gtmq_14279')).toBe(false);
     expect(isOpenAgentPrBranch('tim/not-a-ticket')).toBe(false);
     expect(isOpenAgentPrBranch('')).toBe(false);
     expect(isOpenAgentPrBranch(null)).toBe(false);
@@ -50,13 +49,11 @@ describe('agent-branch-pattern (open-agent-PR capacity)', () => {
       { headRefName: 'codex/a' },
       { headRefName: 'tim/jov-123_fix' },
       { headRefName: 'feature/human' },
-      { headRefName: 'gtmq_1' },
     ];
     const restShape = [
       { head: { ref: 'codex/a' } },
       { head: { ref: 'tim/jov-123_fix' } },
       { head: { ref: 'feature/human' } },
-      { head: { ref: 'gtmq_1' } },
     ];
     expect(countOpenAgentPrs(prListShape)).toBe(2);
     expect(countOpenAgentPrs(restShape)).toBe(2);

--- a/scripts/lib/__tests__/pr-check-failures.test.mjs
+++ b/scripts/lib/__tests__/pr-check-failures.test.mjs
@@ -381,7 +381,6 @@ describe('pr-check-failures', () => {
     expect(isAgentBranch('codex/gh-12734-fix')).toBe(true);
     expect(isAgentBranch('tim/jov-1234')).toBe(true);
     expect(isAgentBranch('agent/wave-1')).toBe(true);
-    expect(isAgentBranch('gtmq_spec_abc')).toBe(false);
     expect(isAgentBranch('feature/user-auth')).toBe(false);
     expect(AGENT_BRANCH_RE.test('feat/onboarding')).toBe(true);
   });

--- a/scripts/lib/agent-branch-pattern.mjs
+++ b/scripts/lib/agent-branch-pattern.mjs
@@ -38,7 +38,7 @@ export const AGENT_OPEN_PR_JOV_RE = /^[^/]+\/jov-[0-9]+([_-].+)?$/i;
  * behaviorally identical to {@link isOpenAgentPrBranch}.
  */
 export const AGENT_OPEN_PR_BRANCH_JQ_TEST =
-  '(test("^(codex|codegen-bot|linear|claude)/") or test("^[^/]+/jov-[0-9]+([_-].+)?$"; "i")) and (startswith("gtmq_") | not)';
+  '(test("^(codex|codegen-bot|linear|claude)/") or test("^[^/]+/jov-[0-9]+([_-].+)?$"; "i"))';
 
 /**
  * @param {unknown} ref
@@ -46,7 +46,6 @@ export const AGENT_OPEN_PR_BRANCH_JQ_TEST =
  */
 export function isOpenAgentPrBranch(ref) {
   if (typeof ref !== 'string' || ref.length === 0) return false;
-  if (ref.startsWith('gtmq_')) return false;
   return AGENT_OPEN_PR_PREFIX_RE.test(ref) || AGENT_OPEN_PR_JOV_RE.test(ref);
 }
 

--- a/scripts/lib/pr-check-failures.mjs
+++ b/scripts/lib/pr-check-failures.mjs
@@ -14,7 +14,6 @@ export const AGENT_BRANCH_RE_LEGACY = /(^|\/)jov-\d+/i;
 
 export function isAgentBranch(headRefName) {
   if (!headRefName) return false;
-  if (headRefName.startsWith('gtmq_')) return false;
   return (
     AGENT_BRANCH_RE.test(headRefName) ||
     AGENT_BRANCH_RE_LEGACY.test(headRefName)


### PR DESCRIPTION
## Summary
- remove obsolete GTMQ branch exclusions from agent-branch classifiers
- remove the corresponding stale test fixtures

There are no open `gtmq_*` PRs. Graphite remains only as the `gt` CLI for constructing/restacking/submitting PR stacks.

## Verification
- focused script Vitest suites (22 passed)
- Biome and `git diff --check`
- read-only GitHub check found zero open `gtmq_*` PR heads

## Scope
Independent four-file cleanup; no live queue/settings mutation.