### PR TITLE
fix(onboarding): send verified Turnstile token

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -3,7 +3,14 @@
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   consumeHomepageIntent,
   readHomepageIntent,
@@ -42,6 +49,7 @@ import {
   OnboardingChatEmptyIntro,
   type OnboardingEntryMode,
 } from './OnboardingChatEmptyIntro';
+import { OnboardingMessageRecoveryRow } from './OnboardingMessageRecoveryRow';
 import type { OnboardingProfileBuilderState } from './OnboardingProfileRail';
 import { OnboardingProfileRail } from './OnboardingProfileRail';
 import {
@@ -76,9 +84,8 @@ import {
  * Anonymous onboarding chat client (JOV-2132 PR 3).
  *
  * Streams against `/api/chat` in `mode='onboarding'`. The first request also
- * carries the Cloudflare Turnstile token; subsequent requests in the same
- * session do not (the signed cookie + session-lifetime rate limit carry
- * trust forward).
+ * carries the Cloudflare Turnstile token; the signed cookie +
+ * session-lifetime rate limit carry trust forward after that request.
  */
 
 interface OnboardingChatProps {
@@ -104,6 +111,32 @@ interface OnboardingChatProps {
   ) => void;
   /** Validated URL-provided context for an automatic first message. */
   readonly starterHandoff?: StartEntryHandoff | null;
+}
+
+class OnboardingChatTransport extends DefaultChatTransport<UIMessage> {
+  private readonly turnstileState: { token: string | null };
+
+  constructor() {
+    const turnstileState = { token: null as string | null };
+    super({
+      api: '/api/chat',
+      prepareSendMessagesRequest: ({ messages, body }) => ({
+        body: {
+          ...body,
+          mode: 'onboarding' as const,
+          messages,
+          ...(turnstileState.token
+            ? { turnstileToken: turnstileState.token }
+            : {}),
+        },
+      }),
+    });
+    this.turnstileState = turnstileState;
+  }
+
+  setTurnstileToken(token: string | null): void {
+    this.turnstileState.token = token;
+  }
 }
 
 const BLOCKED_TURNSTILE_TOKEN_STATUSES: ReadonlySet<
@@ -443,76 +476,25 @@ function getDisplayMessages(
   ];
 }
 
-interface ChatErrorStatusBannerProps {
-  readonly chatError: ChatError | null;
-  readonly handleRetry: () => void;
-  readonly isBusy: boolean;
-  readonly isSubmitted: boolean;
-}
-
-function ChatErrorStatusBanner({
-  chatError,
-  handleRetry,
-  isBusy,
-  isSubmitted,
-}: ChatErrorStatusBannerProps) {
-  if (!chatError) return null;
-
-  const canRetry = Boolean(chatError.failedMessage) && !chatError.retryAfter;
-
-  return (
-    <div className='px-3 py-2.5 text-xs leading-5'>
-      <div role='alert' aria-live='assertive' aria-atomic='true'>
-        <p className='font-medium text-primary-token'>Message paused</p>
-        <p className='mt-0.5 text-secondary-token'>{chatError.message}</p>
-        {canRetry ? (
-          <button
-            type='button'
-            onClick={handleRetry}
-            disabled={isBusy || isSubmitted}
-            className='mt-2 inline-flex h-7 items-center rounded-lg border border-subtle px-2.5 text-2xs font-medium text-secondary-token transition-colors duration-fast hover:border-white/15 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 disabled:opacity-50'
-          >
-            Retry message
-          </button>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-interface ComposerStatusBannerProps extends ChatErrorStatusBannerProps {
+interface ComposerStatusBannerProps {
   readonly reserveTurnstileSpace?: boolean;
   readonly shouldShowTurnstileBanner: boolean;
   readonly turnstilePanel: ReactNode;
 }
 
 function ComposerStatusBanner({
-  chatError,
-  handleRetry,
-  isBusy,
-  isSubmitted,
   reserveTurnstileSpace = false,
   shouldShowTurnstileBanner,
   turnstilePanel,
 }: ComposerStatusBannerProps) {
-  if (!shouldShowTurnstileBanner && !chatError) return null;
+  if (!shouldShowTurnstileBanner) return null;
 
   return (
-    <div className='divide-y divide-white/[0.065]'>
-      {shouldShowTurnstileBanner ? (
-        <div
-          className={reserveTurnstileSpace ? 'min-h-[10rem]' : undefined}
-          data-testid='onboarding-turnstile-slot'
-        >
-          {turnstilePanel}
-        </div>
-      ) : null}
-      <ChatErrorStatusBanner
-        chatError={chatError}
-        handleRetry={handleRetry}
-        isBusy={isBusy}
-        isSubmitted={isSubmitted}
-      />
+    <div
+      className={reserveTurnstileSpace ? 'min-h-[10rem]' : undefined}
+      data-testid='onboarding-turnstile-slot'
+    >
+      {turnstilePanel}
     </div>
   );
 }
@@ -637,6 +619,7 @@ export function OnboardingChat({
     return 'blank';
   });
   const latestInputRef = useRef(initialStarterPrompt);
+  const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
   const [hasSentFirst, setHasSentFirst] = useState(false);
   const [verificationRequested, setVerificationRequested] = useState(false);
   const [chatError, setChatError] = useState<ChatError | null>(null);
@@ -676,23 +659,12 @@ export function OnboardingChat({
     }
   }, [turnstileStatus, turnstileToken]);
 
-  const transport = useMemo(
-    () =>
-      new DefaultChatTransport({
-        api: '/api/chat',
-        // `prepareSendMessagesRequest` lets us mutate the body per-request so
-        // the first POST carries the Turnstile token; subsequent POSTs skip it.
-        prepareSendMessagesRequest: ({ messages, body }) => ({
-          body: {
-            ...body,
-            mode: 'onboarding' as const,
-            messages,
-            ...(turnstileToken ? { turnstileToken } : {}),
-          },
-        }),
-      }),
-    [turnstileToken]
-  );
+  // AI SDK's useChat captures its transport when the Chat instance is created.
+  // Keep it stable and update its request state before any passive send effect.
+  const transport = useMemo(() => new OnboardingChatTransport(), []);
+  useLayoutEffect(() => {
+    transport.setTurnstileToken(turnstileToken);
+  }, [transport, turnstileToken]);
 
   const { messages, sendMessage, setMessages, status, stop } = useChat({
     id: 'onboarding',
@@ -704,7 +676,7 @@ export function OnboardingChat({
       const failedMessage = lastAttemptedMessageRef.current ?? undefined;
       setChatError({
         type,
-        message: getOnboardingErrorMessage(message),
+        message: getOnboardingErrorMessage(message, metadata.errorCode, type),
         retryAfter: metadata.retryAfter,
         errorCode: metadata.errorCode,
         requestId: metadata.requestId,
@@ -726,6 +698,11 @@ export function OnboardingChat({
   const isSubmitted = status === 'submitted';
   const isStreaming = status === 'streaming';
   const isBusy = isSubmitted || isStreaming;
+  useLayoutEffect(() => {
+    if (!chatError) return;
+    composerInputRef.current?.focus({ preventScroll: true });
+  }, [chatError]);
+
   const requiresTurnstile =
     process.env.NODE_ENV !== 'development' && localAutomationBypass !== true;
   const isAwaitingFirstToken =
@@ -985,14 +962,8 @@ export function OnboardingChat({
     (isAwaitingFirstToken ||
       shouldReserveStarterVerification ||
       verificationRequested);
-  const hasComposerStatusBanner =
-    shouldShowTurnstileBanner || chatError !== null;
-  const composerStatusBanner = hasComposerStatusBanner ? (
+  const composerStatusBanner = shouldShowTurnstileBanner ? (
     <ComposerStatusBanner
-      chatError={chatError}
-      handleRetry={handleRetry}
-      isBusy={isBusy}
-      isSubmitted={isSubmitted}
       reserveTurnstileSpace={shouldReserveStarterVerification}
       shouldShowTurnstileBanner={shouldShowTurnstileBanner}
       turnstilePanel={turnstilePanel}
@@ -1040,7 +1011,15 @@ export function OnboardingChat({
   } as const;
   const onboardingComposerSurface = (
     <div className='mx-auto w-full max-w-[45rem]'>
-      <ChatInput {...onboardingChatInputProps} />
+      {chatError ? (
+        <OnboardingMessageRecoveryRow
+          chatError={chatError}
+          handleRetry={handleRetry}
+          isBusy={isBusy}
+          isSubmitted={isSubmitted}
+        />
+      ) : null}
+      <ChatInput ref={composerInputRef} {...onboardingChatInputProps} />
     </div>
   );
 

--- a/apps/web/components/features/onboarding/OnboardingMessageRecoveryRow.tsx
+++ b/apps/web/components/features/onboarding/OnboardingMessageRecoveryRow.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { RefreshCw, WifiOff } from 'lucide-react';
+import type { ChatError } from '@/components/jovie/types';
+
+interface OnboardingMessageRecoveryRowProps {
+  readonly chatError: ChatError;
+  readonly handleRetry: () => void;
+  readonly isBusy: boolean;
+  readonly isSubmitted: boolean;
+}
+
+export function OnboardingMessageRecoveryRow({
+  chatError,
+  handleRetry,
+  isBusy,
+  isSubmitted,
+}: OnboardingMessageRecoveryRowProps) {
+  const canRetry = Boolean(chatError.failedMessage) && !chatError.retryAfter;
+
+  return (
+    <div
+      className='mb-2 flex w-full items-start gap-3 border-y border-subtle px-1 py-3 text-xs leading-5'
+      data-testid='onboarding-message-recovery'
+      role='alert'
+      aria-live='assertive'
+      aria-atomic='true'
+    >
+      <WifiOff
+        className='mt-0.5 size-4 shrink-0 text-tertiary-token'
+        aria-hidden='true'
+      />
+      <div className='min-w-0 flex-1'>
+        <p className='text-app font-medium text-primary-token'>
+          Message paused
+        </p>
+        <p className='text-secondary-token'>{chatError.message}</p>
+        {canRetry ? (
+          <button
+            type='button'
+            onClick={handleRetry}
+            disabled={isBusy || isSubmitted}
+            className='mt-1.5 inline-flex items-center gap-1.5 text-2xs font-medium text-secondary-token underline-offset-4 transition-colors duration-fast hover:text-primary-token hover:underline focus-visible:text-primary-token focus-visible:underline focus-visible:outline-none disabled:opacity-50'
+          >
+            <RefreshCw className='size-3.5' aria-hidden='true' />
+            Retry message
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/features/onboarding/onboardingChatHelpers.ts
+++ b/apps/web/components/features/onboarding/onboardingChatHelpers.ts
@@ -2,7 +2,7 @@
 // Type guards + transforms, no JSX/hooks -- a testable logic module.
 
 import { type UIMessage } from 'ai';
-import type { MessagePart } from '@/components/jovie/types';
+import type { ChatErrorType, MessagePart } from '@/components/jovie/types';
 import { type CheckoutCardPayload } from './ChatProposeCheckoutCard';
 import { type NextStepCardPayload } from './ChatProposeNextStepCard';
 import type {
@@ -138,11 +138,38 @@ export function findLastAssistantMessageId(messages: readonly UIMessage[]) {
   return null;
 }
 
-export function getOnboardingErrorMessage(message: string): string {
+export function getOnboardingErrorMessage(
+  message: string,
+  errorCode?: string,
+  type: ChatErrorType = 'unknown'
+): string {
+  switch (errorCode) {
+    case 'TURNSTILE_REQUIRED':
+      return 'Complete the security check to send your message.';
+    case 'RATE_LIMITED':
+      return 'Too many messages were sent. Try again in a moment.';
+    case 'INVALID_ONBOARDING_PAYLOAD':
+    case 'INVALID_MESSAGES':
+      return 'Jovie could not send that message. Try again.';
+    case 'SESSION_SECRET_NOT_CONFIGURED':
+    case 'TURNSTILE_NOT_CONFIGURED':
+    case 'ONBOARDING_CHAT_PERSISTENCE_FAILED':
+    case 'INTERNAL_ERROR':
+      return 'Chat is temporarily unavailable. Try again in a moment.';
+    default:
+      break;
+  }
+
   if (/authentication service is initializing/i.test(message)) {
     return 'Jovie is still connecting. Try again in a moment.';
   }
-  return message;
+  if (type === 'network' || /failed to fetch/i.test(message)) {
+    return 'Jovie could not reach the chat service.';
+  }
+  if (type === 'rate_limit') {
+    return 'Too many messages were sent. Try again in a moment.';
+  }
+  return 'Jovie could not send your message. Try again.';
 }
 
 export function artistFromSelection(

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -5,7 +5,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { type FormEvent, type ReactNode, useState } from 'react';
+import { type FormEvent, forwardRef, type ReactNode, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OnboardingChat } from '@/components/features/onboarding/OnboardingChat';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
@@ -36,13 +36,31 @@ const analyticsMocks = vi.hoisted(() => ({
   track: vi.fn(),
 }));
 
+const transportMocks = vi.hoisted(() => ({
+  options: [] as Array<{
+    prepareSendMessagesRequest: (input: {
+      messages: readonly unknown[];
+      body?: Record<string, unknown>;
+    }) => { body: Record<string, unknown> };
+  }>,
+}));
+
 vi.mock('@/lib/analytics', () => ({
   track: analyticsMocks.track,
 }));
 
 vi.mock('ai', () => ({
   DefaultChatTransport: class DefaultChatTransport {
-    constructor(readonly options: unknown) {}
+    constructor(
+      readonly options: {
+        prepareSendMessagesRequest: (input: {
+          messages: readonly unknown[];
+          body?: Record<string, unknown>;
+        }) => { body: Record<string, unknown> };
+      }
+    ) {
+      transportMocks.options.push(options);
+    }
   },
   gateway: vi.fn((model: string) => model),
 }));
@@ -76,31 +94,34 @@ vi.mock('@/components/jovie/components', () => ({
   }: {
     readonly children: ReactNode;
   }) => <div data-testid='chat-empty-state-composer-region'>{children}</div>,
-  ChatInput: ({
-    isSubmitting,
-    onChange,
-    onSubmit,
-    statusBanner,
-    value,
-  }: {
-    readonly isSubmitting: boolean;
-    readonly onChange: (value: string) => void;
-    readonly onSubmit: (event?: FormEvent) => void;
-    readonly statusBanner?: ReactNode;
-    readonly value: string;
-  }) => (
-    <form onSubmit={onSubmit}>
-      <textarea
-        aria-label='Chat Message Input'
-        value={value}
-        onChange={event => onChange(event.currentTarget.value)}
-      />
-      {statusBanner}
-      <button type='submit' aria-label='Send message' disabled={isSubmitting}>
-        Send
-      </button>
-    </form>
-  ),
+  ChatInput: forwardRef<
+    HTMLTextAreaElement,
+    {
+      readonly isSubmitting: boolean;
+      readonly onChange: (value: string) => void;
+      readonly onSubmit: (event?: FormEvent) => void;
+      readonly statusBanner?: ReactNode;
+      readonly value: string;
+    }
+  >(function MockChatInput(
+    { isSubmitting, onChange, onSubmit, statusBanner, value },
+    ref
+  ) {
+    return (
+      <form onSubmit={onSubmit}>
+        <textarea
+          ref={ref}
+          aria-label='Chat Message Input'
+          value={value}
+          onChange={event => onChange(event.currentTarget.value)}
+        />
+        {statusBanner}
+        <button type='submit' aria-label='Send message' disabled={isSubmitting}>
+          Send
+        </button>
+      </form>
+    );
+  }),
   ChatMessage: ({ id }: { readonly id: string }) => (
     <div data-testid='chat-message'>{id}</div>
   ),
@@ -238,6 +259,7 @@ describe('OnboardingChat Turnstile gating', () => {
     chatMocks.stop.mockReset();
     analyticsMocks.track.mockReset();
     errorMocks.metadata = {};
+    transportMocks.options = [];
   });
 
   it('keeps the first turn stable before docking follow-up turns', () => {
@@ -394,6 +416,55 @@ describe('OnboardingChat Turnstile gating', () => {
     });
   });
 
+  it('uses the latest verified token in the stable chat transport', () => {
+    const { rerender } = render(
+      <ControlledStarterHarness
+        starterPrompt='Help me get started'
+        turnstileToken={null}
+      />
+    );
+
+    rerender(
+      <ControlledStarterHarness
+        starterPrompt='Help me get started'
+        turnstileToken='fresh-token'
+      />
+    );
+
+    expect(transportMocks.options).toHaveLength(1);
+    expect(
+      transportMocks.options[0]?.prepareSendMessagesRequest({
+        messages: [{ id: 'message-1', role: 'user', parts: [] }],
+      }).body
+    ).toMatchObject({
+      mode: 'onboarding',
+      turnstileToken: 'fresh-token',
+    });
+  });
+
+  it('renders one semantic recovery row outside the bordered composer', () => {
+    render(<TurnstileHarness initialToken='token-1' />);
+
+    const input = screen.getByLabelText('Chat Message Input');
+    fireEvent.change(input, { target: { value: 'I am Test Artist' } });
+    input.focus();
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    act(() => {
+      chatMocks.onError?.(new TypeError('Failed to fetch'));
+    });
+
+    const recovery = screen.getByTestId('onboarding-message-recovery');
+    expect(recovery).toHaveTextContent('Message paused');
+    expect(recovery).toHaveTextContent(
+      'Jovie could not reach the chat service.'
+    );
+    expect(recovery).not.toHaveTextContent('Failed to fetch');
+    expect(recovery.closest('form')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Retry message' })).toBeVisible();
+    expect(screen.getByLabelText('Chat Message Input')).toHaveFocus();
+  });
+
   it('tracks chat completion once while reporting each completed user turn', () => {
     const onConversationActivity = vi.fn();
     const { rerender } = render(
@@ -524,6 +595,7 @@ describe('OnboardingChat Turnstile gating', () => {
 
     const input = screen.getByLabelText('Chat Message Input');
     fireEvent.change(input, { target: { value: 'I am Test Artist' } });
+    input.focus();
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
 
     errorMocks.metadata = {
@@ -538,9 +610,16 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(chatMocks.setMessages).toHaveBeenCalled();
     expect(chatMocks.messages).toEqual([]);
     expect(onTurnstileRejected).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('onboarding-message-recovery')).toHaveTextContent(
+      'Complete the security check to send your message.'
+    );
+    expect(
+      screen.getByTestId('onboarding-message-recovery')
+    ).not.toHaveTextContent('Bot challenge failed');
     expect(screen.getByLabelText('Chat Message Input')).toHaveValue(
       'I am Test Artist'
     );
+    expect(screen.getByLabelText('Chat Message Input')).toHaveFocus();
   });
 
   it('auto-retries a rejected first turn after fresh Turnstile verification', async () => {

--- a/apps/web/tests/unit/onboarding/onboardingChatHelpers.errors.test.ts
+++ b/apps/web/tests/unit/onboarding/onboardingChatHelpers.errors.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { getOnboardingErrorMessage } from '@/components/features/onboarding/onboardingChatHelpers';
+import {
+  extractErrorMetadata,
+  getErrorType,
+  getPreferredErrorMessage,
+} from '@/components/jovie/utils';
+
+function serializeApiError(
+  status: number,
+  body: Record<string, unknown>
+): {
+  errorCode?: string;
+  message: string;
+  type: ReturnType<typeof getErrorType>;
+} {
+  const error = Object.assign(new Error(JSON.stringify(body)), { status });
+  const type = getErrorType(error);
+  const metadata = extractErrorMetadata(error);
+  return {
+    errorCode: metadata.errorCode,
+    message: getPreferredErrorMessage(error, type, metadata),
+    type,
+  };
+}
+
+describe('getOnboardingErrorMessage', () => {
+  it.each([
+    {
+      status: 403,
+      body: {
+        error: 'Bot challenge failed',
+        errorCode: 'TURNSTILE_REQUIRED',
+      },
+      expected: 'Complete the security check to send your message.',
+    },
+    {
+      status: 429,
+      body: {
+        error: 'Rate limit exceeded',
+        message: 'IP limit exceeded',
+        errorCode: 'RATE_LIMITED',
+      },
+      expected: 'Too many messages were sent. Try again in a moment.',
+    },
+    {
+      status: 503,
+      body: {
+        error: 'Onboarding chat is temporarily unavailable',
+        errorCode: 'TURNSTILE_NOT_CONFIGURED',
+      },
+      expected: 'Chat is temporarily unavailable. Try again in a moment.',
+    },
+    {
+      status: 503,
+      body: {
+        error: 'Onboarding chat is temporarily unavailable',
+        errorCode: 'ONBOARDING_CHAT_PERSISTENCE_FAILED',
+      },
+      expected: 'Chat is temporarily unavailable. Try again in a moment.',
+    },
+    {
+      status: 500,
+      body: {
+        error: 'Onboarding chat failed',
+        errorCode: 'INTERNAL_ERROR',
+      },
+      expected: 'Chat is temporarily unavailable. Try again in a moment.',
+    },
+  ])('maps a $status API response without leaking its body', ({
+    status,
+    body,
+    expected,
+  }) => {
+    const serialized = serializeApiError(status, body);
+
+    expect(
+      getOnboardingErrorMessage(
+        serialized.message,
+        serialized.errorCode,
+        serialized.type
+      )
+    ).toBe(expected);
+  });
+
+  it('uses calm fallback copy for arbitrary plain-text errors', () => {
+    expect(
+      getOnboardingErrorMessage(
+        'upstream socket exploded with tenant 123',
+        undefined,
+        'unknown'
+      )
+    ).toBe('Jovie could not send your message. Try again.');
+  });
+});


### PR DESCRIPTION
Current-main successor to the stale onboarding Turnstile repair. Preserves the verified-token transport and recovery-row scope, reconciles the Start handoff contract, and restores textarea focus after a recoverable send failure. Supersedes #14904 once this exact-head PR is green.