### PR TITLE
fix(profile): streamline payment terminal

### DIFF
--- a/apps/web/components/atoms/AmountSelector.tsx
+++ b/apps/web/components/atoms/AmountSelector.tsx
@@ -10,6 +10,7 @@ interface AmountSelectorProps {
   readonly index: number;
   readonly className?: string;
   readonly disabled?: boolean;
+  readonly ariaLabel?: string;
 }
 
 export const AmountSelector = memo(function AmountSelector({
@@ -19,6 +20,7 @@ export const AmountSelector = memo(function AmountSelector({
   index,
   className,
   disabled,
+  ariaLabel,
 }: AmountSelectorProps) {
   const handleClick = useCallback(() => {
     onClick(index);
@@ -29,33 +31,20 @@ export const AmountSelector = memo(function AmountSelector({
       type='button'
       onClick={handleClick}
       aria-pressed={isSelected}
-      aria-label={`Select $${amount} tip amount`}
+      aria-label={ariaLabel ?? `Select $${amount} tip amount`}
       disabled={disabled}
       aria-disabled={disabled}
+      data-selected={isSelected ? 'true' : 'false'}
       className={cn(
-        'group relative flex aspect-square w-full flex-col items-center justify-center gap-0.5 rounded-2xl border text-center transition-[background-color,border-color,box-shadow,color,opacity] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base',
+        'group relative flex h-12 w-full items-center justify-center rounded-full border px-3 text-center tabular-nums transition-[background-color,border-color,box-shadow,color,opacity] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base',
         disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         isSelected
-          ? 'border-(--profile-pearl-primary-bg) bg-(--profile-pearl-primary-bg) text-(--profile-pearl-primary-fg) ring-1 ring-white/10'
-          : 'border-black/6 bg-white text-primary-token ring-1 ring-black/[0.03] hover:border-black/10 hover:bg-(--profile-pearl-bg-hover) hover:ring-black/[0.05] dark:border-white/10 dark:bg-(--color-text-tooltip) dark:ring-white/[0.04] dark:hover:border-white/14 dark:hover:bg-(--profile-pearl-bg-hover) dark:hover:ring-white/[0.06]',
+          ? 'border-(--profile-pearl-primary-bg) bg-(--profile-pearl-primary-bg) text-(--profile-pearl-primary-fg) shadow-[0_0_0_1px_rgba(255,255,255,0.12)]'
+          : 'border-black/8 bg-white text-primary-token hover:border-black/14 hover:bg-(--profile-pearl-bg-hover) dark:border-white/12 dark:bg-white/[0.04] dark:hover:border-white/18 dark:hover:bg-white/[0.07]',
         className
       )}
     >
-      <span
-        className={cn(
-          'text-3xs font-medium tracking-[0.08em]',
-          isSelected
-            ? 'text-(--profile-pearl-primary-fg)/72'
-            : 'text-secondary-token'
-        )}
-        aria-hidden
-      >
-        USD
-      </span>
-      <span
-        className='text-2xl font-semibold tabular-nums tracking-tight'
-        aria-hidden
-      >
+      <span className='text-app font-semibold tracking-[-0.02em]' aria-hidden>
         ${amount}
       </span>
     </button>

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -5,6 +5,7 @@ import { useId } from 'react';
 import { Drawer } from 'vaul';
 import type { ProfileSurfacePresentation } from '@/features/profile/contracts';
 import { PROFILE_Z } from '@/lib/profile/z-index-constants';
+import { cn } from '@/lib/utils';
 
 type ProfileDrawerNavigationLevel = 'root' | 'secondary';
 
@@ -22,6 +23,8 @@ interface ProfileDrawerShellProps {
   readonly bodyClassName?: string;
   readonly dataTestId?: string;
   readonly presentation?: ProfileSurfacePresentation;
+  /** Center short task titles between the existing equal 44px controls. */
+  readonly centerTitle?: boolean;
 }
 
 export function ProfileDrawerShell({
@@ -36,6 +39,7 @@ export function ProfileDrawerShell({
   bodyClassName, // NOSONAR -- deprecated prop kept for backward compat; used internally to apply caller overrides
   dataTestId,
   presentation = 'standalone',
+  centerTitle = false,
 }: ProfileDrawerShellProps) {
   const titleId = useId();
   const subtitleId = useId();
@@ -50,7 +54,7 @@ export function ProfileDrawerShell({
     ['--profile-drawer-height-max' as string]: 'min(472px, 62dvh)',
     ['--profile-drawer-header' as string]: '72px',
   } as React.CSSProperties;
-  const contentClasses = `relative flex max-h-(--profile-drawer-height-max) w-full flex-col overflow-hidden rounded-t-(--profile-drawer-radius-mobile) border-t border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_-8px_40px_rgba(0,0,0,0.4)] backdrop-blur-2xl md:max-w-(--profile-shell-max-width) md:rounded-t-(--profile-drawer-radius-desktop) before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.04),transparent)] ${contentClassName ?? ''}`;
+  const contentClasses = `relative flex max-h-(--profile-drawer-height-max) w-full flex-col overflow-hidden rounded-t-(--profile-drawer-radius-mobile) border-t border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_-8px_40px_rgba(0,0,0,0.4)] md:max-w-(--profile-shell-max-width) md:rounded-t-(--profile-drawer-radius-desktop) before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.04),transparent)] ${contentClassName ?? ''}`;
   // Fixed height (not min-h) so overflow-y-auto activates on overflow; min-h
   // lets the body grow past the parent's max-h and get clipped by overflow-hidden.
   const bodyClasses = `relative z-10 h-[calc(var(--profile-drawer-height-max)_-_var(--profile-drawer-header))] overflow-y-auto overscroll-contain [touch-action:pan-y] [will-change:scroll-position] px-5 pb-[calc(1.25rem_+_env(safe-area-inset-bottom))] pt-3 ${bodyClassName ?? ''}`;
@@ -82,7 +86,10 @@ export function ProfileDrawerShell({
             >
               <h2
                 id={titleId}
-                className='truncate text-mid font-semibold leading-[1.08] tracking-[-0.018em] text-primary-token'
+                className={cn(
+                  'truncate text-mid font-semibold leading-[1.08] tracking-[-0.018em] text-primary-token',
+                  centerTitle && 'text-center'
+                )}
               >
                 {title}
               </h2>
@@ -90,7 +97,10 @@ export function ProfileDrawerShell({
                 {subtitle ? (
                   <p
                     id={subtitleId}
-                    className='truncate text-3xs font-[440] leading-[1.1] tracking-tight text-tertiary-token'
+                    className={cn(
+                      'truncate text-3xs font-[440] leading-[1.1] tracking-tight text-tertiary-token',
+                      centerTitle && 'text-center'
+                    )}
                   >
                     {subtitle}
                   </p>
@@ -157,7 +167,7 @@ export function ProfileDrawerShell({
         <button
           type='button'
           aria-label='Close Drawer Overlay'
-          className={`fixed inset-0 ${PROFILE_Z.LOCAL_CONTENT} bg-black/48 backdrop-blur-sm`}
+          className={`fixed inset-0 ${PROFILE_Z.LOCAL_CONTENT} bg-black/24`}
           onClick={() => onOpenChange(false)}
         />
         <dialog
@@ -169,7 +179,7 @@ export function ProfileDrawerShell({
           open
         >
           <div
-            className={`relative flex max-h-(--profile-drawer-height-max) w-full flex-col overflow-hidden rounded-t-(--profile-drawer-radius-desktop) border-t border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_-16px_52px_rgba(0,0,0,0.5)] backdrop-blur-2xl before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.04),transparent)] ${contentClassName ?? ''}`}
+            className={`relative flex max-h-(--profile-drawer-height-max) w-full flex-col overflow-hidden rounded-t-(--profile-drawer-radius-desktop) border-t border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_-16px_52px_rgba(0,0,0,0.5)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.04),transparent)] ${contentClassName ?? ''}`}
           >
             <span id={accessibleDescriptionId} className='sr-only'>
               {accessibleDescription}
@@ -189,7 +199,7 @@ export function ProfileDrawerShell({
 
     return (
       <div
-        className={`absolute inset-0 ${PROFILE_Z.EMBEDDED_MODAL} flex items-center justify-center bg-black/52 p-6 backdrop-blur-sm`}
+        className={`absolute inset-0 ${PROFILE_Z.EMBEDDED_MODAL} flex items-center justify-center bg-black/24 p-6`}
       >
         <button
           type='button'
@@ -198,7 +208,7 @@ export function ProfileDrawerShell({
           onClick={() => onOpenChange(false)}
         />
         <div
-          className='relative z-10 flex max-h-[min(760px,calc(100%-24px))] w-full max-w-108 flex-col overflow-hidden rounded-(--profile-card-radius) border border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_34px_96px_rgba(0,0,0,0.48)] backdrop-blur-2xl'
+          className='relative z-10 flex max-h-[min(760px,calc(100%-24px))] w-full max-w-108 flex-col overflow-hidden rounded-(--profile-card-radius) border border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_34px_96px_rgba(0,0,0,0.48)]'
           data-testid={dataTestId}
           role='dialog'
           aria-describedby={accessibleDescriptionId}

--- a/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
+++ b/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
@@ -358,6 +358,7 @@ export function ProfileUnifiedDrawer({
       navigationLevel={isSubView ? 'secondary' : 'root'}
       dataTestId='profile-menu-drawer'
       presentation={presentation}
+      centerTitle={renderedView === 'pay'}
     >
       <AnimatePresence mode='wait' initial={false}>
         <motion.div

--- a/apps/web/components/features/profile/drawer-overlay-styles.test.ts
+++ b/apps/web/components/features/profile/drawer-overlay-styles.test.ts
@@ -4,12 +4,13 @@ import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 import { DRAWER_OVERLAY_CLASS } from './drawer-overlay-styles';
 
 describe('drawer-overlay-styles', () => {
-  it('overlay includes 60% black opacity for sufficient backdrop coverage', () => {
-    expect(DRAWER_OVERLAY_CLASS).toContain('bg-black/60');
+  it('uses a light flat dim so the mobile drawer remains crisp', () => {
+    expect(DRAWER_OVERLAY_CLASS).toContain('bg-black/24');
   });
 
-  it('overlay includes backdrop blur', () => {
-    expect(DRAWER_OVERLAY_CLASS).toContain('backdrop-blur-sm');
+  it('does not blur the underlying profile', () => {
+    expect(DRAWER_OVERLAY_CLASS).not.toContain('backdrop-blur');
+    expect(DRAWER_OVERLAY_CLASS).toContain('bg-black/24');
   });
 
   it('overlay sits on the canonical drawer-backdrop layer below drawer content', () => {

--- a/apps/web/components/features/profile/drawer-overlay-styles.ts
+++ b/apps/web/components/features/profile/drawer-overlay-styles.ts
@@ -8,4 +8,4 @@ import { PROFILE_Z } from '@/lib/profile/z-index-constants';
  * Layered at `PROFILE_Z.DRAWER_BACKDROP` (z-40), below drawer content
  * which sits at `PROFILE_Z.DRAWER_CONTENT` (z-50).
  */
-export const DRAWER_OVERLAY_CLASS = `fixed inset-0 ${PROFILE_Z.DRAWER_BACKDROP} bg-black/60 backdrop-blur-sm`;
+export const DRAWER_OVERLAY_CLASS = `fixed inset-0 ${PROFILE_Z.DRAWER_BACKDROP} bg-black/24`;

--- a/apps/web/components/features/release/SmartLinkProviderButton.tsx
+++ b/apps/web/components/features/release/SmartLinkProviderButton.tsx
@@ -1,13 +1,18 @@
+import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 interface SmartLinkProviderButtonProps {
   readonly label: string;
   readonly iconPath?: string;
   /** Custom icon element — used instead of iconPath when provided */
-  readonly icon?: React.ReactNode;
+  readonly icon?: ReactNode;
   readonly href?: string;
   readonly onClick?: () => void;
   readonly className?: string;
+  readonly disabled?: boolean;
+  readonly ariaLabel?: string;
+  /** The canonical full-width primary provider action used by the payment terminal. */
+  readonly primary?: boolean;
 }
 
 /**
@@ -20,6 +25,9 @@ export function SmartLinkProviderButton({
   href,
   onClick,
   className,
+  disabled = false,
+  ariaLabel,
+  primary = false,
 }: Readonly<SmartLinkProviderButtonProps>) {
   const content = (
     <>
@@ -34,24 +42,39 @@ export function SmartLinkProviderButton({
             <path d={iconPath} />
           </svg>
         ) : null)}
-      <span className='text-foreground flex-1 text-base font-semibold'>
+      <span
+        className={cn(
+          primary
+            ? 'text-btn-primary-foreground flex-none'
+            : 'text-foreground flex-1',
+          'text-base font-semibold'
+        )}
+      >
         {label}
       </span>
-      <svg
-        viewBox='0 0 24 24'
-        fill='none'
-        stroke='currentColor'
-        strokeWidth='2'
-        className='h-4 w-4 text-muted-foreground/70'
-        aria-hidden='true'
-      >
-        <path d='m9 18 6-6-6-6' strokeLinecap='round' strokeLinejoin='round' />
-      </svg>
+      {primary ? null : (
+        <svg
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          className='h-4 w-4 text-muted-foreground/70'
+          aria-hidden='true'
+        >
+          <path
+            d='m9 18 6-6-6-6'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+        </svg>
+      )}
     </>
   );
 
   const sharedClassName = cn(
-    'group flex w-full items-center gap-3.5 rounded-full bg-white/10 px-4 py-3 ring-1 ring-inset ring-white/[0.08] backdrop-blur-sm transition-colors duration-fast hover:bg-white/15',
+    primary
+      ? 'group flex min-h-13 w-full items-center justify-center gap-2 rounded-full border border-btn-primary bg-btn-primary px-5 text-btn-primary-foreground shadow-button-inset transition-[background-color,border-color,color,box-shadow,opacity] duration-subtle hover:border-btn-primary-hover hover:bg-btn-primary-hover disabled:pointer-events-none disabled:opacity-[var(--state-disabled-opacity)]'
+      : 'group flex w-full items-center gap-3.5 rounded-full bg-white/10 px-4 py-3 ring-1 ring-inset ring-white/[0.08] backdrop-blur-sm transition-colors duration-fast hover:bg-white/15',
     className
   );
 
@@ -62,7 +85,8 @@ export function SmartLinkProviderButton({
           type='button'
           onClick={onClick}
           className={sharedClassName}
-          aria-label={`Open ${label}`}
+          aria-label={ariaLabel ?? `Open ${label}`}
+          disabled={disabled}
         >
           {content}
         </button>
@@ -79,7 +103,7 @@ export function SmartLinkProviderButton({
       rel='noopener noreferrer'
       onClick={onClick}
       className={sharedClassName}
-      aria-label={`Open ${label}`}
+      aria-label={ariaLabel ?? `Open ${label}`}
     >
       {content}
     </a>

--- a/apps/web/components/molecules/PaySelector.tsx
+++ b/apps/web/components/molecules/PaySelector.tsx
@@ -5,10 +5,17 @@ import { ChevronDown, PencilLine } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AmountSelector } from '@/components/atoms/AmountSelector';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
+import { SmartLinkProviderButton } from '@/features/release/SmartLinkProviderButton';
 import { cn } from '@/lib/utils';
 import { formatDollarAmount } from '@/lib/utils/format-number';
 
 type PaySelectorPresentation = 'default' | 'drawer';
+
+export interface PaymentMethodCapability {
+  readonly id: 'apple-pay' | 'venmo';
+  readonly label: string;
+  readonly availability: 'eligible' | 'available' | 'unavailable';
+}
 
 interface PaySelectorProps {
   readonly amounts?: number[];
@@ -16,6 +23,11 @@ interface PaySelectorProps {
   readonly isLoading?: boolean;
   readonly className?: string;
   readonly paymentLabel?: string;
+  /**
+   * A provider is only rendered when the caller has proven eligibility. The
+   * public profile currently supplies Venmo as the truthful fallback.
+   */
+  readonly paymentMethod?: PaymentMethodCapability;
   readonly presentation?: PaySelectorPresentation;
   readonly primaryLabel?: string;
   readonly otherPaymentOptionsLabel?: string;
@@ -53,6 +65,7 @@ export function PaySelector({
   isLoading = false,
   className = '',
   paymentLabel,
+  paymentMethod,
   presentation = 'default',
   primaryLabel = 'Continue',
   otherPaymentOptionsLabel = 'Other payment methods',
@@ -80,6 +93,19 @@ export function PaySelector({
   }, [amounts, customAmount, customMode, defaultIdx, selectedIdx]);
 
   const canContinue = selectedAmount > 0;
+  const resolvedMethod =
+    paymentMethod ??
+    (paymentLabel === 'Venmo'
+      ? {
+          id: 'venmo' as const,
+          label: paymentLabel,
+          availability: 'available' as const,
+        }
+      : undefined);
+  const isMethodAvailable = resolvedMethod?.availability !== 'unavailable';
+  const paymentActionLabel = resolvedMethod
+    ? `Pay ${formatAmountForScreenReader(selectedAmount)} with ${resolvedMethod.label}`
+    : `${primaryLabel} with ${formatAmountForScreenReader(selectedAmount)}`;
 
   const handleContinue = useCallback(() => {
     if (!canContinue) {
@@ -128,7 +154,7 @@ export function PaySelector({
   if (presentation === 'drawer') {
     return (
       <div
-        className={cn('space-y-4.5', className)}
+        className={cn('w-full space-y-4.5', className)}
         data-presentation='drawer'
         data-test='pay-selector'
       >
@@ -142,14 +168,17 @@ export function PaySelector({
         <div className='sr-only' aria-live='polite' ref={statusRef}></div>
 
         <div className='space-y-4'>
-          <div className='min-h-40' data-testid='pay-selector-amount-slot'>
-            <div className='min-h-23'>
+          <div
+            className='min-h-32 w-full'
+            data-testid='pay-selector-amount-slot'
+          >
+            <div className='min-h-12'>
               {customMode ? (
-                <div className='flex min-h-23 items-center'>
+                <div className='flex min-h-12 items-center'>
                   <label className='w-full'>
                     <span className='sr-only'>Custom Amount</span>
-                    <div className='flex h-23 items-center rounded-3xl border border-white/12 bg-white/[0.03] px-4.5 text-white dark:text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]'>
-                      <span className='mr-3 text-2xl font-medium tracking-[-0.04em] text-tertiary-token'>
+                    <div className='flex h-12 items-center rounded-full border border-white/12 bg-white/[0.03] px-4 text-white dark:text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]'>
+                      <span className='mr-2 text-mid font-medium tracking-[-0.04em] text-tertiary-token'>
                         $
                       </span>
                       <input
@@ -163,7 +192,7 @@ export function PaySelector({
                           );
                         }}
                         placeholder='0.00'
-                        className='h-full w-full bg-transparent text-3xl font-semibold tracking-[-0.05em] text-primary-token outline-none placeholder:text-tertiary-token'
+                        className='h-full w-full bg-transparent text-mid font-semibold tracking-[-0.03em] text-primary-token outline-none placeholder:text-tertiary-token'
                         aria-label='Custom Amount'
                       />
                     </div>
@@ -171,68 +200,59 @@ export function PaySelector({
                 </div>
               ) : (
                 <fieldset
-                  className='m-0 grid grid-cols-3 gap-3 border-0 p-0'
+                  className='m-0 grid grid-cols-3 gap-2 border-0 p-0'
                   aria-label='Amount Options'
                 >
                   {amounts.map((amount, idx) => {
                     const isSelected = idx === selectedIdx;
                     return (
-                      <Button
+                      <AmountSelector
                         key={amount}
-                        type='button'
-                        variant='ghost'
-                        aria-pressed={isSelected}
-                        aria-label={`Select ${formatAmountForScreenReader(amount)} payment amount`}
-                        onClick={() => handleAmountSelect(idx)}
-                        className={cn(
-                          'flex h-23 items-center justify-center rounded-3xl border text-center transition-[border-color,background-color,box-shadow,color,opacity] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
-                          isSelected
-                            ? 'border-white bg-white dark:bg-surface-1 text-(--color-bg-input) shadow-[0_20px_40px_rgba(255,255,255,0.08)]'
-                            : 'border-white/10 bg-white/[0.02] text-white dark:text-white hover:border-white/18 hover:bg-white/[0.04]'
-                        )}
-                      >
-                        <span className='text-lg font-medium tracking-[-0.03em]'>
-                          {formatAmountForScreenReader(amount)}
-                        </span>
-                      </Button>
+                        amount={amount}
+                        isSelected={isSelected}
+                        onClick={handleAmountSelect}
+                        index={idx}
+                        ariaLabel={`Select ${formatAmountForScreenReader(amount)} payment amount`}
+                      />
                     );
                   })}
                 </fieldset>
               )}
             </div>
-
-            <div className='mt-3.5 flex justify-end'>
-              <Button
-                type='button'
-                variant='ghost'
-                onClick={handleCustomToggle}
-                className='inline-flex h-auto items-center gap-1.5 text-app font-medium tracking-[-0.015em] text-secondary-token transition-colors duration-subtle hover:bg-transparent hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
-                aria-pressed={customMode}
-                aria-controls='pay-selector-heading'
-              >
-                <span>Custom Amount</span>
-                <PencilLine className='h-3.5 w-3.5' />
-              </Button>
-            </div>
           </div>
+
+          <SmartLinkProviderButton
+            label={
+              isLoading
+                ? `Opening ${resolvedMethod?.label ?? 'payment'}…`
+                : paymentActionLabel
+            }
+            ariaLabel={paymentActionLabel}
+            primary
+            onClick={handleContinue}
+            disabled={isLoading || !canContinue || !isMethodAvailable}
+            icon={
+              resolvedMethod?.id === 'venmo' ? (
+                <SocialIcon
+                  platform='venmo'
+                  size={20}
+                  className='shrink-0'
+                  aria-hidden
+                />
+              ) : null
+            }
+          />
 
           <Button
             type='button'
-            variant='primary'
-            onClick={handleContinue}
-            disabled={isLoading || !canContinue}
-            className='flex h-13 w-full items-center justify-center gap-2.5 rounded-full border-0 bg-(--profile-pearl-primary-bg) px-5 text-base font-semibold tracking-[-0.025em] text-(--profile-pearl-primary-fg) shadow-none transition-[opacity] duration-subtle hover:opacity-96 disabled:cursor-not-allowed disabled:opacity-50'
-            aria-label={`${primaryLabel} for ${formatAmountForScreenReader(selectedAmount)}`}
+            variant='ghost'
+            onClick={handleCustomToggle}
+            className='inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-4 text-app font-medium tracking-[-0.015em] text-secondary-token transition-[border-color,background-color,color] duration-subtle hover:border-white/16 hover:bg-white/[0.05] hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+            aria-pressed={customMode}
+            aria-controls='pay-selector-heading'
           >
-            {paymentLabel === 'Venmo' ? (
-              <SocialIcon
-                platform='venmo'
-                size={20}
-                className='shrink-0'
-                aria-hidden
-              />
-            ) : null}
-            {isLoading ? 'Processing...' : primaryLabel}
+            <span>Custom Amount</span>
+            <PencilLine className='h-3.5 w-3.5' />
           </Button>
 
           {showOtherPaymentOptions && paymentLabel ? (
@@ -296,8 +316,8 @@ export function PaySelector({
   )}`;
   if (isLoading) {
     continueLabel = 'Processing...';
-  } else if (paymentLabel) {
-    continueLabel = `Continue with ${paymentLabel}`;
+  } else if (resolvedMethod) {
+    continueLabel = paymentActionLabel;
   }
 
   return (
@@ -334,15 +354,15 @@ export function PaySelector({
         onClick={handleContinue}
         className='mt-4 flex w-full items-center justify-center gap-2.5 rounded-full border border-white/8 text-mid font-semibold tracking-[-0.015em] text-btn-primary-foreground shadow-none transition-[opacity,border-color] duration-subtle hover:border-white/14'
         size='lg'
-        disabled={isLoading}
+        disabled={isLoading || !canContinue || !isMethodAvailable}
         variant='primary'
         aria-label={
-          paymentLabel
-            ? `Continue with ${paymentLabel} for ${formatAmountForScreenReader(selectedAmount)}`
+          resolvedMethod
+            ? paymentActionLabel
             : `Continue with ${formatAmountForScreenReader(selectedAmount)}`
         }
       >
-        {paymentLabel ? (
+        {resolvedMethod?.id === 'venmo' ? (
           <SocialIcon
             platform='venmo'
             size={20}

--- a/apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts
@@ -19,6 +19,7 @@ describe('AmountSelector System B style guard', () => {
     );
     expect(source).toContain('duration-subtle');
     expect(source).toContain('ease-subtle');
-    expect(source).toContain('aspect-square');
+    expect(source).toContain('h-12 w-full');
+    expect(source).toContain('rounded-full');
   });
 });

--- a/apps/web/tests/unit/molecules/TipSelector.test.tsx
+++ b/apps/web/tests/unit/molecules/TipSelector.test.tsx
@@ -3,13 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { PaySelector } from '@/components/molecules/PaySelector';
 
 describe('PaySelector', () => {
-  it('uses primary foreground token for the Venmo CTA and icon', () => {
+  it('uses the selected amount in the Venmo CTA and icon', () => {
     const onContinue = vi.fn();
 
     render(<PaySelector onContinue={onContinue} paymentLabel='Venmo' />);
 
     const continueButton = screen.getByRole('button', {
-      name: /Continue with Venmo for \$10/i,
+      name: /Pay \$10 with Venmo/i,
     });
 
     expect(continueButton).toHaveClass('text-btn-primary-foreground');
@@ -27,7 +27,7 @@ describe('PaySelector', () => {
       screen.getByRole('button', { name: /Select \$20 tip amount/i })
     );
     fireEvent.click(
-      screen.getByRole('button', { name: /Continue with Venmo for \$20/i })
+      screen.getByRole('button', { name: /Pay \$20 with Venmo/i })
     );
 
     expect(onContinue).toHaveBeenCalledWith(20);
@@ -46,7 +46,7 @@ describe('PaySelector', () => {
     );
 
     expect(
-      screen.getByRole('button', { name: /Continue with Venmo for \$10/i })
+      screen.getByRole('button', { name: /Pay \$10 with Venmo/i })
     ).toBeInTheDocument();
 
     fireEvent.click(
@@ -56,6 +56,9 @@ describe('PaySelector', () => {
     expect(
       screen.queryByRole('button', { name: /Continue with Venmo for \$10/i })
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Pay \$10 with Venmo/i })
+    ).toBeInTheDocument();
   });
 
   it('swaps preset amounts for a custom input without changing the reserved slot', () => {
@@ -102,9 +105,44 @@ describe('PaySelector', () => {
       target: { value: '42.50' },
     });
     fireEvent.click(
-      screen.getByRole('button', { name: /Continue for \$42.50/i })
+      screen.getByRole('button', { name: /Pay \$42.50 with Venmo/i })
     );
 
     expect(onContinue).toHaveBeenCalledWith(42.5);
+  });
+
+  it('keeps the selected preset visibly and semantically selected', () => {
+    render(
+      <PaySelector
+        onContinue={vi.fn()}
+        paymentLabel='Venmo'
+        presentation='drawer'
+      />
+    );
+
+    const selected = screen.getByRole('button', {
+      name: /Select \$10 payment amount/i,
+    });
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
+    expect(selected).toHaveAttribute('data-selected', 'true');
+    expect(selected).toHaveTextContent('$10');
+  });
+
+  it('only enables a provider when its capability is available', () => {
+    render(
+      <PaySelector
+        onContinue={vi.fn()}
+        paymentMethod={{
+          id: 'apple-pay',
+          label: 'Apple Pay',
+          availability: 'unavailable',
+        }}
+        presentation='drawer'
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Pay \$10 with Apple Pay/i })
+    ).toBeDisabled();
   });
 });

--- a/apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
-const sourcePath = join(appRoot, 'components/molecules/PaySelector.tsx');
+const sourcePath = join(appRoot, 'components/atoms/AmountSelector.tsx');
 
 const forbiddenPresetMotionClasses =
   /\b(?:transition-all|transition-transform|duration-\d+|hover:scale|hover:translate|hover:-translate|group-hover:scale|group-hover:translate|group-hover:-translate)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
@@ -12,15 +12,9 @@ const forbiddenPresetMotionClasses =
 describe('PaySelector System B style guard', () => {
   it('keeps amount preset state changes visually stable', async () => {
     const source = await readFile(sourcePath, 'utf8');
-    const presetButtonClass = source.match(
-      /'flex h-23 items-center justify-center[^']+'/
-    )?.[0];
-
-    expect(presetButtonClass).toBeDefined();
-    expect(presetButtonClass).not.toMatch(forbiddenPresetMotionClasses);
-    expect(presetButtonClass).toContain(
-      'transition-[border-color,background-color,box-shadow,color,opacity]'
-    );
-    expect(presetButtonClass).toContain('duration-subtle');
+    expect(source).not.toMatch(forbiddenPresetMotionClasses);
+    expect(source).toContain('data-selected');
+    expect(source).toContain('rounded-full');
+    expect(source).toContain('duration-subtle');
   });
 });

--- a/apps/web/tests/unit/organisms/TipSection.test.tsx
+++ b/apps/web/tests/unit/organisms/TipSection.test.tsx
@@ -160,7 +160,7 @@ describe('TipSection', () => {
 
     // Click the continue button to trigger payment
     const continueButton = screen.getByRole('button', {
-      name: /Continue with Venmo for \$5/i,
+      name: /Pay \$5 with Venmo/i,
     });
     fireEvent.click(continueButton);
 
@@ -226,7 +226,7 @@ describe('TipSection', () => {
 
     // Venmo payment flow should be available directly via the PaySelector continue button
     expect(
-      screen.getByRole('button', { name: /Continue with Venmo/i })
+      screen.getByRole('button', { name: /Pay \$10 with Venmo/i })
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
@@ -128,6 +128,25 @@ describe('ProfileDrawerShell', () => {
     expect(back.className).toMatch(/\bw-11\b/);
   });
 
+  it('optically centers a terminal title between equal header controls', () => {
+    render(
+      <ProfileDrawerShell
+        open
+        onOpenChange={vi.fn()}
+        title='Pay'
+        onBack={vi.fn()}
+        navigationLevel='secondary'
+        centerTitle
+      >
+        <div>Drawer body</div>
+      </ProfileDrawerShell>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Pay' })).toHaveClass(
+      'text-center'
+    );
+  });
+
   it('uses the simplified root header without nav chrome', () => {
     render(
       <ProfileDrawerShell open onOpenChange={vi.fn()} title='Menu'>


### PR DESCRIPTION
## Summary
- Gives the public-profile Pay terminal full-width, pill-shaped amount choices with an explicit selected state and custom-amount alternative.
- Reuses the shared provider-action primitive for a selected-amount Venmo handoff; adds a typed payment-capability seam so Apple Pay can render only when a caller has proven eligibility.
- Centers the Pay drawer title between equal 44px controls and replaces mobile drawer blur with a light flat dim.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/release/smart-link-provider-button.test.ts tests/unit/molecules/TipSelector.test.tsx tests/unit/molecules/pay-selector-system-b-style-guard.test.ts tests/unit/profile/ProfileDrawerShell.test.tsx components/features/profile/drawer-overlay-styles.test.ts` (24 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm exec biome check --write <10 changed files>`
- `pnpm --filter @jovie/web run test:bug-to-test` (not classified as bug fix)

## Visual evidence
- Local Next reached Ready on `:3239`, but could not produce a usable `/tim?mode=pay` visual render: the initial compile exceeded the request timeout, and the eventual route evaluated without `DATABASE_URL`. No visual claim is made from that server.

No migration, API, or provider eligibility behavior is added; the capability seam deliberately fails closed when a caller marks a method unavailable.
