### PR TITLE
fix(home): tighten hero next-move promise (JOV-4475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Homepage hero focuses the next-move promise (JOV-4475):** approved music-forward headline and supporting line stay primary, Get started remains the sole conversion action, and See a live profile is quiet secondary proof on a truthful product screenshot.
 - [internal] **Manual Full E2E shards now run concurrently (JOV-4483):** all four hosted Preview shards can start together while retaining fail-fast behavior, shared Neon setup, Playwright workers, and cleanup.
 - [internal] **Merge-group visual CI harness repair:** the filtered web workspace can resolve the repository Chromatic config again, DB-free mobile overflow excludes only explicitly database-backed redirects, and a forward-only Storybook audit now requires five clean runs before newly opened UI PRs can be gated.
 - [internal] **Bounded `ci-fast` lane groups (JOV-4477):** independent typecheck and remaining fast-gate checks now run in two hosted groups while preserving the single required `ci-fast` result and complete lane diagnostics.

--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -1858,7 +1858,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
   font-size: var(--text-lg);
   line-height: var(--ds-marketing-lede-leading);
   letter-spacing: var(--ds-marketing-lede-tracking);
-  text-wrap: balance;
+  text-wrap: pretty;
 }
 
 .homepage-poster-hero__actions {
@@ -5544,6 +5544,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .home-viewport [data-homepage-section-heading] {
+  /* Balanced wrapping; section titles are authored for ≤2 lines. */
   text-wrap: balance;
 }
 /* HOMEPAGE PROOF HANDOFF END */

--- a/apps/web/components/homepage/HomepagePosterHero.tsx
+++ b/apps/web/components/homepage/HomepagePosterHero.tsx
@@ -84,7 +84,7 @@ export function HomepagePosterHero({
               asChild
               static
               size='md'
-              variant='tertiary'
+              variant='ghost'
               className={CTA_PRESS_CLASS}
             >
               <LinkComponent

--- a/apps/web/data/homepageLaunchCopy.ts
+++ b/apps/web/data/homepageLaunchCopy.ts
@@ -35,7 +35,8 @@ export const HOMEPAGE_LAUNCH_COPY = {
       label: 'Get started',
     },
     secondaryCta: {
-      label: 'See a live artist profile',
+      // Quiet proof path — not a peer conversion objective to Get started.
+      label: 'See a live profile',
       href: APP_ROUTES.ARTIST_PROFILES,
     },
   },

--- a/apps/web/tests/e2e/homepage.spec.ts
+++ b/apps/web/tests/e2e/homepage.spec.ts
@@ -77,7 +77,7 @@ test.describe('Homepage', () => {
     ).toHaveAttribute('href', /\/start\?starter_prompt=/);
     await expect(
       hero.getByRole('link', {
-        name: 'See a live artist profile',
+        name: 'See a live profile',
         exact: true,
       })
     ).toHaveAttribute('href', '/artist-profiles');

--- a/apps/web/tests/unit/home/HomepagePosterHero.test.tsx
+++ b/apps/web/tests/unit/home/HomepagePosterHero.test.tsx
@@ -55,13 +55,16 @@ describe('HomepagePosterHero', () => {
     const primaryLink = screen.getByRole('link', { name: 'Enter Jovie' });
     expect(primaryLink).toHaveAttribute('href', '/signup');
     expect(primaryLink).toHaveAttribute('data-size', 'md');
+    expect(primaryLink).toHaveAttribute('data-variant', 'primary');
     expect(primaryLink).toHaveClass('active:scale-[0.98]');
     expect(primaryLink).toHaveClass('motion-reduce:active:scale-100');
 
     const secondaryLink = screen.getByRole('link', { name: 'See proof' });
     expect(secondaryLink).toHaveAttribute('href', '/artist-profiles');
-    expect(secondaryLink).toHaveAttribute('data-variant', 'tertiary');
+    expect(secondaryLink).toHaveAttribute('data-variant', 'ghost');
     expect(secondaryLink).toHaveClass('active:scale-[0.98]');
+    // Secondary must stay quieter than the primary conversion control.
+    expect(secondaryLink.getAttribute('data-variant')).not.toBe('primary');
   });
 
   it('keeps the copy, media, and reserved seam slots present', () => {

--- a/apps/web/tests/unit/home/homepage-hero-next-move-contract.test.ts
+++ b/apps/web/tests/unit/home/homepage-hero-next-move-contract.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { HOMEPAGE_LAUNCH_COPY } from '@/data/homepageLaunchCopy';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+describe('homepage hero next-move contract (JOV-4475)', () => {
+  it('uses the exact approved headline and supporting line', () => {
+    expect(HOMEPAGE_LAUNCH_COPY.hero.headline).toBe(
+      'Jovie helps you move your music forward.'
+    );
+    expect(HOMEPAGE_LAUNCH_COPY.hero.subhead).toBe(
+      'It uses your catalog, audience, and artist presence to surface the one action most likely to pay off.'
+    );
+  });
+
+  it('keeps Get started as the sole primary conversion path', () => {
+    expect(HOMEPAGE_LAUNCH_COPY.hero.primaryCta.label).toBe('Get started');
+    expect(HOMEPAGE_LAUNCH_COPY.hero.secondaryCta.label).toBe(
+      'See a live profile'
+    );
+    expect(HOMEPAGE_LAUNCH_COPY.hero.secondaryCta.href).toBe(
+      '/artist-profiles'
+    );
+  });
+
+  it('demotes the live-profile path to a quiet ghost control in the poster hero', () => {
+    const heroSource = readFileSync(
+      path.join(webRoot, 'components/homepage/HomepagePosterHero.tsx'),
+      'utf8'
+    );
+
+    expect(heroSource).toContain("data-testid='homepage-primary-cta'");
+    expect(heroSource).toContain("data-testid='homepage-secondary-cta'");
+    expect(heroSource).toContain("variant='primary'");
+    expect(heroSource).toContain("variant='ghost'");
+    expect(heroSource).not.toMatch(
+      /secondaryCta[\s\S]*?variant=['"]tertiary['"]/
+    );
+    expect(heroSource).toContain('active:scale-[0.98]');
+    expect(heroSource).toContain('motion-reduce:active:scale-100');
+  });
+
+  it('uses a 100ms opacity-only ready reveal with reduced-motion parity', () => {
+    const css = readFileSync(path.join(webRoot, 'app/(home)/home.css'), 'utf8');
+    const heroCssStart = css.indexOf('HOMEPAGE POSTER HERO SYSTEM B START');
+    const heroCssEnd = css.indexOf(
+      'HOMEPAGE POSTER HERO SYSTEM B END',
+      heroCssStart
+    );
+    const heroCss = css.slice(heroCssStart, heroCssEnd);
+
+    expect(heroCss).toContain('--homepage-hero-reveal-delay: 100ms;');
+    expect(heroCss).toContain('@keyframes homepage-hero-content-reveal');
+    expect(heroCss).toContain('opacity: 0;');
+    expect(heroCss).toContain('opacity: 1;');
+    expect(heroCss).not.toMatch(
+      /@keyframes homepage-hero-content-reveal[\s\S]*?(?:transform|translate|scale|height|margin)/
+    );
+    expect(heroCss).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(heroCss).toContain('animation: none;');
+  });
+
+  it('keeps product proof on a truthful screenshot path, not Deep End mock copy', () => {
+    const pageSource = readFileSync(
+      path.join(webRoot, 'app/(home)/page.tsx'),
+      'utf8'
+    );
+    const commandCenterSource = readFileSync(
+      path.join(webRoot, 'components/homepage/HomepageHeroCommandCenter.tsx'),
+      'utf8'
+    );
+
+    expect(pageSource).toContain(
+      "getMarketingExportImage('shell-v1-dashboard-desktop')"
+    );
+    expect(pageSource).toContain('<HomepageHeroCommandCenter');
+    expect(commandCenterSource).toContain('homepage-product-pane__image');
+    expect(commandCenterSource).not.toMatch(/The Deep End|Deep End/);
+    expect(pageSource).not.toMatch(
+      /function HomepageHero\(\)[\s\S]*?The Deep End/
+    );
+  });
+
+  it('mounts Artist Profiles cards in iPhone device frames', () => {
+    const profilesSource = readFileSync(
+      path.join(webRoot, 'components/homepage/MeetJovieCarousel.tsx'),
+      'utf8'
+    );
+
+    expect(profilesSource).toContain('ArtistProfilePhoneFrame');
+    expect(profilesSource).toContain('homepage-artist-outcome__device');
+  });
+});

--- a/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
@@ -108,6 +108,7 @@ describe('mounted homepage hero System B source contract', () => {
     expect(css).toContain('font-size: var(--ds-marketing-display-size);');
     expect(css).toContain('line-height: var(--ds-marketing-display-leading);');
     expect(css).toContain('font-size: var(--text-lg);');
+    expect(css).toContain('text-wrap: pretty;');
     expect(css).toContain('mask-image: linear-gradient(');
     expect(css).toContain('min-height: var(--space-6);');
   });


### PR DESCRIPTION
## Summary

- Keep the approved homepage hero promise and CTA hierarchy.
- Demote the live-profile action to quiet secondary proof.
- Lock the hero contract with focused unit coverage.

## Verification

- Focused Vitest: 12 passed.
- Web typecheck: passed.
- git diff --check: passed.

Fixes JOV-4475