### PR TITLE
fix(shell): sidebar badge spacing and active-state clarity (JOV-4449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Sidebar nav badges no longer crowd labels; active section is clearer (JOV-4449):** badge track grows for Pro/count chips instead of overflowing into truncated labels, and the active row uses a left accent rail on the filled surface.
 - **Homepage hero focuses the next-move promise (JOV-4475):** approved music-forward headline and supporting line stay primary, Get started remains the sole conversion action, and See a live profile is quiet secondary proof on a truthful product screenshot.
 - [internal] **Manual Full E2E shards now run concurrently (JOV-4483):** all four hosted Preview shards can start together while retaining fail-fast behavior, shared Neon setup, Playwright workers, and cleanup.
 - [internal] **Merge-group visual CI harness repair:** the filtered web workspace can resolve the repository Chromatic config again, DB-free mobile overflow excludes only explicitly database-backed redirects, and a forward-only Storybook audit now requires five clean runs before newly opened UI PRs can be gated.

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -37,8 +37,10 @@ interface SidebarNavChromeOptions {
 const SIDEBAR_PRIMARY_CHROME =
   'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)] text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,white_14%)]';
 
+// Active: filled surface + left accent rail (not a full border — #13217) so
+// the current section is obvious at a glance on dark sidebar chrome.
 const SIDEBAR_ACTIVE_CHROME =
-  'bg-sidebar-accent-active text-primary-token font-medium';
+  'bg-sidebar-accent-active text-primary-token font-medium shadow-[inset_2px_0_0_0_var(--color-accent)]';
 
 const SIDEBAR_INACTIVE_CHROME =
   'text-sidebar-item-foreground hover:bg-sidebar-accent hover:text-sidebar-item-foreground';
@@ -78,7 +80,9 @@ export function getSidebarNavRowClassName({
     collapsed
       ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center before:hidden after:hidden'
       : cn(
-          'grid-cols-[22px_minmax(0,1fr)_34px]',
+          // Badge track: min 34px keeps empty rows aligned; auto grows so Pro /
+          // multi-digit count badges never overflow into the truncated label.
+          'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
           nonCollapsedSize,
           'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'
         ),

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -307,7 +307,9 @@ describe('DashboardNav', () => {
     });
     const tasksLink = getByRole('link', { name: 'Tasks 7 active tasks' });
 
-    expect(tasksLink).toHaveClass('grid-cols-[22px_minmax(0,1fr)_34px]');
+    expect(tasksLink).toHaveClass(
+      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
+    );
     expect(getByText('7')).toHaveAttribute('data-nav-badge', 'count');
     expect(getByText('7')).toHaveAttribute('aria-label', '7 active tasks');
   });
@@ -352,7 +354,7 @@ describe('DashboardNav', () => {
     });
 
     expect(getByRole('link', { name: 'Tasks' })).toHaveClass(
-      'grid-cols-[22px_minmax(0,1fr)_34px]'
+      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
     );
     expect(
       container.querySelector('[data-nav-badge="count"]')

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -178,13 +178,16 @@ describe('Sidebar row alignment', () => {
     expect(settingsRow).toContain('grid-cols-[minmax(0,1fr)]');
     expect(settingsRow).toContain('before:hidden');
     expect(settingsRow).toContain('after:hidden');
-    expect(settingsRow).not.toContain('grid-cols-[22px_minmax(0,1fr)_34px]');
+    expect(settingsRow).not.toContain(
+      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
+    );
   });
 
   it('keeps nav-row chrome borderless in resting, hover, and active states', () => {
     // #13217: sidebar nav rows are borderless — active state is a filled
     // background only. No resting border, no hover border, no active border
     // or border-by-inset-ring shadow may reappear on the canonical row chrome.
+    // A left accent rail (inset 2px solid accent) is allowed for active clarity.
     for (const row of [
       getSidebarNavRowClassName({}),
       getSidebarNavRowClassName({ active: true }),
@@ -206,7 +209,9 @@ describe('Sidebar row alignment', () => {
     expect(rowClassName).toContain('h-7');
     expect(rowClassName).toContain('px-2.5');
     expect(rowClassName).toContain('gap-x-2.5');
-    expect(rowClassName).toContain('grid-cols-[22px_minmax(0,1fr)_34px]');
+    expect(rowClassName).toContain(
+      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
+    );
     expect(rowClassName).toContain('before:left-6');
     expect(rowClassName).toContain('after:left-10');
     expect(rowClassName).toContain('text-xs');
@@ -220,6 +225,9 @@ describe('Sidebar row alignment', () => {
     expect(activeRowClassName).toContain('bg-sidebar-accent-active');
     expect(activeRowClassName).toContain('text-primary-token');
     expect(activeRowClassName).toContain('font-medium');
+    expect(activeRowClassName).toContain(
+      'shadow-[inset_2px_0_0_0_var(--color-accent)]'
+    );
     expect(iconClassName).toContain('h-3.5');
     expect(iconClassName).toContain('text-sidebar-muted/70');
     expect(getSidebarNavIconClassName({ active: true })).toContain(


### PR DESCRIPTION
## Summary
- Grow the sidebar nav badge track from a fixed `34px` column to `minmax(34px, auto)` so Pro / multi-digit count badges cannot overflow into truncated labels.
- Strengthen the active nav row with a left accent rail (`inset` shadow using `--color-accent`) on the existing filled surface so the current section is obvious at a glance, without reintroducing full row borders (#13217).
- Update alignment / DashboardNav unit contracts for the new grid template and active chrome.

Fixes JOV-4449

<!-- linear-issue-id:JOV-4449 -->

## Test plan / results
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/sidebar-row-alignment.test.tsx tests/unit/dashboard/DashboardNav.test.tsx components/shell/SidebarThreadsSection.test.tsx components/atoms/NavBadge.test.tsx` — **33/33 passed**
- [x] Pre-commit: biome, eslint, typecheck, a11y staged checks
- [x] Pre-push: biome, tailwind guard, typecheck, affected unit tests (26/26), ci harness check
- [ ] Visual check on `/app/chat`: Tasks Pro/count badge no longer crowds the label; active New Chat / thread row is obvious

## Risk
Low — shell chrome class-string only; no route, data, or entitlement changes.