### PR TITLE
fix(dev): collapse flag drawer so it cannot overwhelm chat (JOV-4448)

### DIFF
--- a/apps/web/components/features/dev/DevToolbar.tsx
+++ b/apps/web/components/features/dev/DevToolbar.tsx
@@ -325,10 +325,14 @@ export function DevToolbar({
     };
   }, []);
 
-  // Restore state from localStorage and mark as mounted
+  // Restore state from localStorage and mark as mounted.
+  // Compact surfaces (e.g. /app/chat via defaultHidden) always start with the
+  // flag drawer collapsed — only the bottom bar + badge count may show — so a
+  // prior expanded session on another route cannot overwhelm the chat UI.
   useEffect(() => {
     setMounted(true);
-    setOpen(localStorage.getItem(TOOLBAR_STORAGE_KEY) === '1');
+    const storedOpen = localStorage.getItem(TOOLBAR_STORAGE_KEY) === '1';
+    setOpen(defaultHidden ? false : storedOpen);
     const storedHidden = localStorage.getItem(TOOLBAR_HIDDEN_KEY);
     setHidden(storedHidden === null ? defaultHidden : storedHidden === '1');
     setSwEnabled(localStorage.getItem(SW_ENABLED_KEY) === '1');
@@ -564,6 +568,11 @@ export function DevToolbar({
     });
   }
 
+  const collapseDrawer = useCallback(() => {
+    setOpen(false);
+    localStorage.setItem(TOOLBAR_STORAGE_KEY, '0');
+  }, []);
+
   const hide = useCallback(() => {
     setHidden(true);
     localStorage.setItem(TOOLBAR_HIDDEN_KEY, '1');
@@ -593,6 +602,8 @@ export function DevToolbar({
    * no-op overrides don't accumulate. Read current state from the
    * `overrides` map directly (not from `useAppFlag` closure) so rapid
    * double-clicks don't race against a pending re-render.
+   * After selection, collapse the flag drawer so it cannot overwhelm chat
+   * (or other compact surfaces); the override badge keeps the count visible.
    */
   const setOrClearOverride = useCallback(
     (key: string, value: boolean) => {
@@ -605,9 +616,23 @@ export function DevToolbar({
         overridesCtx.setOverride(key, value);
       }
       flashFlag(key);
+      collapseDrawer();
     },
-    [flashFlag, overridesCtx]
+    [collapseDrawer, flashFlag, overridesCtx]
   );
+
+  const clearOverrideAndCollapse = useCallback(
+    (key: string) => {
+      overridesCtx.removeOverride(key);
+      collapseDrawer();
+    },
+    [collapseDrawer, overridesCtx]
+  );
+
+  const clearAllOverridesAndCollapse = useCallback(() => {
+    overridesCtx.clearOverrides();
+    collapseDrawer();
+  }, [collapseDrawer, overridesCtx]);
 
   // Unified flag list: filter by search, sort overrides to top
   const filteredFlags = useMemo(() => {
@@ -822,7 +847,7 @@ export function DevToolbar({
                     <Button
                       type='button'
                       variant='link'
-                      onClick={overridesCtx.clearOverrides}
+                      onClick={clearAllOverridesAndCollapse}
                       className='text-3xs text-(--color-text-tertiary) hover:text-(--color-text-primary) underline transition-colors'
                     >
                       Clear All
@@ -838,7 +863,7 @@ export function DevToolbar({
                         checked={overrides[flag.key]}
                         serverDefault={flag.serverDefault}
                         onCheckedChange={v => setOrClearOverride(flag.key, v)}
-                        onClear={() => overridesCtx.removeOverride(flag.key)}
+                        onClear={() => clearOverrideAndCollapse(flag.key)}
                         source={flag.source}
                       />
                     ))}
@@ -868,7 +893,7 @@ export function DevToolbar({
                         isOverridden={false}
                         checked={checked}
                         onCheckedChange={v => setOrClearOverride(flag.key, v)}
-                        onClear={() => overridesCtx.removeOverride(flag.key)}
+                        onClear={() => clearOverrideAndCollapse(flag.key)}
                         source={flag.source}
                       />
                     );

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -560,30 +560,75 @@ describe('DevToolbar', () => {
     });
   });
 
-  // ─── Toggle Flash Feedback ─────────────────────────────────
+  // ─── Flag drawer collapse (JOV-4448) ────────────────────────
 
-  describe('toggle flash feedback', () => {
-    it('applies flash class when a non-override flag toggle creates a new override', () => {
-      // Toggling a flag that matches the server default to its non-default
-      // value creates a meaningful override. The new row in the Overrides
-      // section briefly flashes for visual confirmation. (When a flag is
-      // toggled BACK to the server default the row is removed instead —
-      // see auto-clear tests above; the row going away IS the feedback.)
+  describe('flag drawer collapse', () => {
+    it('auto-collapses after a flag selection and keeps the override badge', () => {
       localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
       renderToolbar();
 
-      // CLAIM_HANDLE server default is false. Click the row in the
-      // non-overrides list to toggle it to true (creates an override).
+      expect(screen.getByTestId('dev-toolbar-flag-drawer')).toBeInTheDocument();
+
       const flagLabel = screen.getByText('claim handle');
       const row = flagLabel.closest('[class*="rounded-sm"]');
       const flagSwitch = row?.querySelector('[role="switch"]');
       expect(flagSwitch).toBeTruthy();
       fireEvent.click(flagSwitch as Element);
 
-      // The flag now lives in the Overrides section — find its new row.
-      const newLabel = screen.getByText('claim handle');
-      const newRow = newLabel.closest('[class*="rounded-sm"]');
-      expect(newRow?.className).toContain('bg-accent/10');
+      // Drawer collapses after selection; badge count remains on the bar.
+      expect(
+        screen.queryByTestId('dev-toolbar-flag-drawer')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Expand Dev Toolbar' })
+      ).toBeInTheDocument();
+      expect(screen.getByText('1 override')).toBeInTheDocument();
+      expect(localStorage.getItem(TOOLBAR_OPEN_KEY)).toBe('0');
+    });
+
+    it('auto-collapses after Clear All', () => {
+      setLocalOverrides({ 'code:CLAIM_HANDLE': true });
+      localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
+      renderToolbar();
+
+      fireEvent.click(screen.getByText('Clear All'));
+
+      expect(localStorage.getItem(FF_OVERRIDES_KEY)).toBeNull();
+      expect(
+        screen.queryByTestId('dev-toolbar-flag-drawer')
+      ).not.toBeInTheDocument();
+      expect(localStorage.getItem(TOOLBAR_OPEN_KEY)).toBe('0');
+    });
+
+    it('does not restore an expanded drawer on compact surfaces (chat)', () => {
+      // Prior session left the flag drawer open on another route.
+      localStorage.setItem(TOOLBAR_OPEN_KEY, '1');
+      localStorage.setItem(TOOLBAR_HIDDEN_KEY, '0');
+      setLocalOverrides({ 'code:CLAIM_HANDLE': true });
+
+      renderToolbar({ defaultHidden: true });
+
+      // Compact surfaces force collapsed drawer; badge count still visible.
+      expect(
+        screen.queryByTestId('dev-toolbar-flag-drawer')
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('1 override')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Expand Dev Toolbar' })
+      ).toBeInTheDocument();
+    });
+
+    it('expands on badge click even on compact surfaces', () => {
+      localStorage.setItem(TOOLBAR_HIDDEN_KEY, '0');
+      setLocalOverrides({ 'code:CLAIM_HANDLE': true });
+      renderToolbar({ defaultHidden: true });
+
+      fireEvent.click(screen.getByText('1 override'));
+
+      expect(screen.getByTestId('dev-toolbar-flag-drawer')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Collapse Dev Toolbar' })
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- On compact surfaces (`defaultHidden`, e.g. `/app/chat`), the flag drawer no longer restores expanded from localStorage — only the bottom bar and override badge count show.
- Expanding the drawer remains click-driven (override badge or expand control).
- Selecting a flag, clearing an override, or Clear All auto-collapses the drawer so it cannot cover chat.

## Test plan
- [x] `pnpm --filter web exec vitest run tests/unit/dev/DevToolbar.test.tsx tests/unit/dev/DevToolbarGate.test.tsx` — 82 passed
- [x] Pre-commit typecheck + eslint + biome
- [x] Pre-push biome + web typecheck + affected tests

### Manual (dev)
1. Open `/app/chat` with a prior session that left the flag drawer expanded (`__dev_toolbar_open=1`, toolbar visible).
2. Confirm drawer starts collapsed with only the bottom bar (+ override badge if any).
3. Click the override badge (or Expand) → drawer opens.
4. Toggle a flag → drawer collapses; badge count remains accurate.

Fixes JOV-4448

<!-- linear-issue-id:JOV-4448 -->