### PR TITLE
fix(chat): clarify composer placeholder, disabled send, and a11y (JOV-4447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Chat composer empty state is clearer (JOV-4447):** product-voice placeholder, disabled send with an explanatory tooltip, stable ARIA labels on the composer region, and a loading skeleton that matches the live surface without exposing stub controls to assistive tech.
 - **Sidebar nav badges no longer crowd labels; active section is clearer (JOV-4449):** badge track grows for Pro/count chips instead of overflowing into truncated labels, and the active row uses a left accent rail on the filled surface.
 - **Homepage hero focuses the next-move promise (JOV-4475):** approved music-forward headline and supporting line stay primary, Get started remains the sole conversion action, and See a live profile is quiet secondary proof on a truthful product screenshot.
 - [internal] **Manual Full E2E shards now run concurrently (JOV-4483):** all four hosted Preview shards can start together while retaining fail-fast behavior, shared Neon setup, Playwright workers, and cleanup.

--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -1,6 +1,11 @@
 import { Skeleton } from '@jovie/ui';
 import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
+import {
+  CHAT_COMPOSER_ATTACH_ARIA_LABEL,
+  CHAT_COMPOSER_EMPTY_PLACEHOLDER,
+  CHAT_COMPOSER_SEND_ARIA_LABEL,
+} from '@/components/jovie/chat-composer-copy';
 import { CHAT_CONTENT_SHELL_CLASSNAME } from '@/components/jovie/chat-layout';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 
@@ -32,30 +37,27 @@ export default function ChatLoading() {
             <div
               className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative z-10 space-y-2`}
             >
-              <div className='system-b-shell-loading-composer'>
+              {/* Decorative only — parent is aria-busy; hide control stubs from AT. */}
+              <div
+                className='system-b-shell-loading-composer'
+                aria-hidden='true'
+              >
                 <div className='relative flex items-end gap-2 px-3 py-2.5'>
-                  <button
-                    type='button'
-                    disabled
-                    aria-label='Attachment Options'
-                    className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token opacity-80'
-                  >
-                    <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
-                  </button>
                   <div
-                    aria-hidden='true'
-                    className='min-w-0 flex-1 py-1.5 text-sm leading-6 text-tertiary-token'
-                  >
-                    What are you working on?
-                  </div>
-                  <button
-                    type='button'
-                    disabled
-                    aria-label='Send Message'
-                    className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-tertiary-token'
+                    className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token opacity-80'
+                    data-label={CHAT_COMPOSER_ATTACH_ARIA_LABEL}
                   >
                     <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
-                  </button>
+                  </div>
+                  <div className='min-w-0 flex-1 py-1.5 text-sm leading-6 text-tertiary-token'>
+                    {CHAT_COMPOSER_EMPTY_PLACEHOLDER}
+                  </div>
+                  <div
+                    className='system-b-chat-composer-primary-action flex h-9 w-9 shrink-0 cursor-not-allowed items-center justify-center rounded-full opacity-80'
+                    data-label={CHAT_COMPOSER_SEND_ARIA_LABEL}
+                  >
+                    <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
+                  </div>
                 </div>
               </div>
               <Skeleton className='mx-auto h-3 w-32' rounded='lg' />

--- a/apps/web/components/jovie/JovieChatSections.tsx
+++ b/apps/web/components/jovie/JovieChatSections.tsx
@@ -2,6 +2,7 @@
 
 import type { Virtualizer } from '@tanstack/react-virtual';
 import type { ReactNode, RefCallback } from 'react';
+import { CHAT_COMPOSER_EMPTY_PLACEHOLDER } from './chat-composer-copy';
 import {
   CHAT_COMPOSER_DOCK_CLASSNAME,
   CHAT_COMPOSER_SCROLL_FADE_CLASSNAME,
@@ -110,7 +111,7 @@ export function ChatComposerSurface({
 
       <ChatInput
         {...chatInputProps}
-        placeholder='Ask Jovie to plan your next release...' // ui-casing-allow: brand placeholder
+        placeholder={CHAT_COMPOSER_EMPTY_PLACEHOLDER} // ui-casing-allow: brand placeholder
         variant={showThreadView ? 'compact' : 'hero'}
       />
     </div>

--- a/apps/web/components/jovie/chat-composer-copy.ts
+++ b/apps/web/components/jovie/chat-composer-copy.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared product-voice copy and accessible names for the chat composer.
+ * Keep loading skeleton, ChatInput defaults, and live surface in lockstep.
+ */
+
+/** Empty-state placeholder — product voice, brand casing allowed. */
+export const CHAT_COMPOSER_EMPTY_PLACEHOLDER =
+  'Ask Jovie to plan your next release...';
+
+/** Form region accessible name (Title Case product UI). */
+export const CHAT_COMPOSER_FORM_ARIA_LABEL =
+  'Compose A Message — Type / For Skills And References';
+
+/** Textarea accessible name (Title Case product UI). */
+export const CHAT_COMPOSER_INPUT_ARIA_LABEL = 'Chat Message Input';
+
+/** Primary send control accessible name. */
+export const CHAT_COMPOSER_SEND_ARIA_LABEL = 'Send message';
+
+/** Stop-generation control accessible name. */
+export const CHAT_COMPOSER_STOP_ARIA_LABEL = 'Stop generating';
+
+/** Attach control accessible name (Title Case product UI). */
+export const CHAT_COMPOSER_ATTACH_ARIA_LABEL = 'Attach Files';

--- a/apps/web/components/jovie/components/ChatComposerToolbar.tsx
+++ b/apps/web/components/jovie/components/ChatComposerToolbar.tsx
@@ -13,6 +13,11 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useRef } from 'react';
 
 import { cn } from '@/lib/utils';
+import {
+  CHAT_COMPOSER_ATTACH_ARIA_LABEL,
+  CHAT_COMPOSER_SEND_ARIA_LABEL,
+  CHAT_COMPOSER_STOP_ARIA_LABEL,
+} from '../chat-composer-copy';
 import { TRANSITION_FAST } from './chat-motion';
 
 /**
@@ -75,32 +80,48 @@ export function ComposerSendButton({
   const motionInit = reducedMotion ? undefined : { scale: 0.5, opacity: 0 };
   const isInteractive = showStop || canSend;
 
+  const actionLabel = showStop
+    ? CHAT_COMPOSER_STOP_ARIA_LABEL
+    : CHAT_COMPOSER_SEND_ARIA_LABEL;
+  // When empty, keep the same accessible name (tests + AT) but clarify the
+  // disabled reason in the hover tooltip — disabled buttons need a span wrapper
+  // so the tooltip trigger can still receive pointer events.
+  const tooltipContent =
+    showStop || canSend ? actionLabel : 'Type a message to send';
+
   return (
-    <SimpleTooltip content={showStop ? 'Stop generating' : 'Send message'}>
-      <button
-        type='button'
-        onMouseDown={onMouseDown}
-        onClick={showStop ? onStop : onSend}
-        disabled={!showStop && !canSend}
+    <SimpleTooltip content={tooltipContent}>
+      <span
         className={cn(
-          'system-b-chat-composer-primary-action flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+          'inline-flex shrink-0',
           !isInteractive && 'cursor-not-allowed'
         )}
-        aria-label={showStop ? 'Stop generating' : 'Send message'}
       >
-        <AnimatePresence mode='wait' initial={false}>
-          <motion.span
-            key={key}
-            initial={motionInit}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={motionInit}
-            transition={TRANSITION_FAST}
-            className='flex items-center justify-center'
-          >
-            {icon}
-          </motion.span>
-        </AnimatePresence>
-      </button>
+        <button
+          type='button'
+          onMouseDown={onMouseDown}
+          onClick={showStop ? onStop : onSend}
+          disabled={!showStop && !canSend}
+          className={cn(
+            'system-b-chat-composer-primary-action flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+            !isInteractive && 'cursor-not-allowed'
+          )}
+          aria-label={actionLabel}
+        >
+          <AnimatePresence mode='wait' initial={false}>
+            <motion.span
+              key={key}
+              initial={motionInit}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={motionInit}
+              transition={TRANSITION_FAST}
+              className='flex items-center justify-center'
+            >
+              {icon}
+            </motion.span>
+          </AnimatePresence>
+        </button>
+      </span>
     </SimpleTooltip>
   );
 }
@@ -148,7 +169,7 @@ export function ComposerAttachButton({
               plusMenuOpen && 'border-subtle bg-surface-1 text-primary-token',
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
-            aria-label='Attach Files'
+            aria-label={CHAT_COMPOSER_ATTACH_ARIA_LABEL}
           >
             {isProcessing ? (
               <Loader2 className='h-4 w-4 animate-spin' strokeWidth={2.25} />

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -24,6 +24,11 @@ import { SYSTEM_B_RADIUS_PX } from '@/lib/design/system-b-radius';
 import { useEntityRecents } from '@/lib/queries/useEntityRecents';
 import { cn } from '@/lib/utils';
 
+import {
+  CHAT_COMPOSER_EMPTY_PLACEHOLDER,
+  CHAT_COMPOSER_FORM_ARIA_LABEL,
+  CHAT_COMPOSER_INPUT_ARIA_LABEL,
+} from '../chat-composer-copy';
 import { CHAT_COMPOSER_MAX_WIDTH } from '../chat-layout';
 import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
 import {
@@ -214,7 +219,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       onSubmit,
       isLoading,
       isSubmitting,
-      placeholder = 'What are you working on?',
+      placeholder = CHAT_COMPOSER_EMPTY_PLACEHOLDER,
       variant = 'default',
       onFileAttach,
       isFileProcessing = false,
@@ -549,16 +554,20 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     const handleFormSubmit = useCallback(
       (e: React.FormEvent) => {
         e.preventDefault();
+        // Empty / blocked drafts must not submit — send is disabled, but native
+        // form events and programmatic submits can still reach this handler.
+        if (!canSend) return;
         onSubmit(e);
         scheduleTextareaRefocus();
       },
-      [onSubmit, scheduleTextareaRefocus]
+      [canSend, onSubmit, scheduleTextareaRefocus]
     );
 
     const handleSendClick = useCallback(() => {
+      if (!canSend) return;
       onSubmit();
       scheduleTextareaRefocus();
-    }, [onSubmit, scheduleTextareaRefocus]);
+    }, [canSend, onSubmit, scheduleTextareaRefocus]);
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -702,7 +711,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     return (
       <form
         onSubmit={handleFormSubmit}
-        aria-label='Compose A Message — Type / For Skills And References'
+        aria-label={CHAT_COMPOSER_FORM_ARIA_LABEL}
         className='relative z-10 w-full focus-within:outline-none'
       >
         <div className={dockClass}>
@@ -1172,7 +1181,7 @@ function InputRow({
               setComposerFocused(false);
             }}
             maxLength={MAX_MESSAGE_LENGTH + 100}
-            aria-label='Chat Message Input'
+            aria-label={CHAT_COMPOSER_INPUT_ARIA_LABEL}
             aria-describedby={isNearLimit ? 'char-limit-status' : undefined}
             // WAI-ARIA combobox pattern: the textarea is the input that
             // controls the listbox rendered by SlashCommandMenu. Focus stays

--- a/apps/web/tests/unit/chat/ChatComposerSurface.test.tsx
+++ b/apps/web/tests/unit/chat/ChatComposerSurface.test.tsx
@@ -191,6 +191,18 @@ describe('ChatComposerSurface accessibility states', () => {
     expect(dictate).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('explains the disabled send control via tooltip when empty', async () => {
+    const user = userEvent.setup();
+    renderComposer();
+
+    const send = screen.getByRole('button', { name: 'Send message' });
+    expect(send).toBeDisabled();
+    await user.hover(send);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Type a message to send'
+    );
+  });
+
   it('enables keyboard send for typed input without changing control dimensions', () => {
     const onSubmit = vi.fn();
     renderComposer({ value: 'Plan my next release', onSubmit });

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -737,6 +737,15 @@ describe('ChatInput', () => {
     expect(sendButton).toBeDisabled();
     await user.click(sendButton);
     expect(onSubmit).not.toHaveBeenCalled();
+
+    // Form submit must also fail closed when the draft is empty.
+    const form = screen.getByRole('form', { name: /compose a message/i });
+    fireEvent.submit(form);
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    expect(
+      screen.getByRole('textbox', { name: /chat message input/i })
+    ).toHaveAttribute('placeholder', 'Ask Jovie to plan your next release...');
   });
 
   it('enables send when textarea DOM input is replayed into controlled state', async () => {

--- a/apps/web/tests/unit/chat/ChatLoading.test.tsx
+++ b/apps/web/tests/unit/chat/ChatLoading.test.tsx
@@ -73,10 +73,12 @@ describe('ChatLoading (chat home)', () => {
     render(<ChatLoading />);
 
     expect(screen.queryByRole('textbox')).toBeNull();
-    expect(screen.getByText('What are you working on?')).toHaveAttribute(
-      'aria-hidden',
-      'true'
+    expect(screen.queryByRole('button')).toBeNull();
+    // Product-voice placeholder is decorative under the busy shell.
+    const placeholder = screen.getByText(
+      'Ask Jovie to plan your next release...'
     );
+    expect(placeholder.closest('[aria-hidden="true"]')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Lock the empty composer to one product-voice placeholder (`Ask Jovie to plan your next release...`) across live ChatInput, ChatComposerSurface, and the chat home loading skeleton.
- Keep send disabled when the draft is empty (and fail closed on form submit / send click), with a span-wrapped tooltip that explains “Type a message to send”.
- Centralize composer region ARIA labels (`Compose A Message…`, `Chat Message Input`, `Send message`, `Attach Files`) and hide loading-skeleton control stubs from assistive tech under `aria-busy`.

Fixes JOV-4447

<!-- linear-issue-id:JOV-4447 -->

## Test plan / results
- [x] `pnpm --filter web exec vitest run tests/unit/chat/ChatComposerSurface.test.tsx tests/unit/chat/ChatLoading.test.tsx tests/unit/chat/ChatInput.aria.test.tsx tests/unit/chat/ChatInput.test.tsx tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/chat-composer-system-b-style-guard.test.ts` — **61/61 passed**
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false` — **passed**
- [x] Pre-commit: biome, eslint, typecheck, a11y staged checks
- [x] Pre-push: biome, affected unit tests (43/43), ci harness check
- [ ] Visual/a11y spot-check on `/app/chat`: empty placeholder, disabled send styling + tooltip, no loading stub buttons in the a11y tree

## Risk
Low — composer copy/ARIA and empty-submit guard only; no route, data, or entitlement changes.