### PR TITLE
fix(chat): degrade Tasks entitlement denials to upgrade CTA (JOV-3861)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -57,6 +57,11 @@ import {
   resolveAlbumArtCapability,
 } from '@/lib/chat/album-art-capability';
 import {
+  buildLockedToolPromptInfo,
+  buildLockedToolSet,
+  resolveLockedChatTools,
+} from '@/lib/chat/locked-tools';
+import {
   extractLastUserImageUrl,
   extractLastUserText,
 } from '@/lib/chat/message-text';
@@ -2853,31 +2858,45 @@ export async function POST(req: Request) {
       accountContext
     );
     // Advanced tools gated behind paid plans
-    const tools = canUsePaidChatTools(accountContext)
-      ? {
-          ...freeTools,
-          ...buildChatTools(
-            artistContext,
-            resolvedProfileId,
-            releases,
-            insightsEnabled,
-            userId,
-            albumArtCapability.availability === 'available',
-            albumArtEnabled,
-            planLimits.booleans.canAccessMerchCreation,
-            planLimits.booleans.canAccessAiRetouching,
-            teleprompterRecordingEnabled,
-            currentUserEntitlements,
-            reservedTurn,
-            {
-              sourceImageUrl: extractLastUserImageUrl(uiMessages),
-              conversationId:
-                reservedTurn?.conversationId ?? resolvedConversationId,
-            },
-            userText
-          ),
-        }
-      : freeTools;
+    const paidTools = canUsePaidChatTools(accountContext)
+      ? buildChatTools(
+          artistContext,
+          resolvedProfileId,
+          releases,
+          insightsEnabled,
+          userId,
+          albumArtCapability.availability === 'available',
+          albumArtEnabled,
+          planLimits.booleans.canAccessMerchCreation,
+          planLimits.booleans.canAccessAiRetouching,
+          teleprompterRecordingEnabled,
+          currentUserEntitlements,
+          reservedTurn,
+          {
+            sourceImageUrl: extractLastUserImageUrl(uiMessages),
+            conversationId:
+              reservedTurn?.conversationId ?? resolvedConversationId,
+          },
+          userText
+        )
+      : {};
+    // Plan-locked stubs stay VISIBLE to the model so free users who ask for
+    // Tasks / album art / merch get an upgrade CTA instead of a missing-tool
+    // dead-end or a thrown entitlement error (GH #13304 / JOV-3861).
+    const activeToolNames = new Set([
+      ...Object.keys(freeTools),
+      ...Object.keys(paidTools),
+    ]);
+    const lockedToolNames = resolveLockedChatTools(planLimits.booleans).filter(
+      name => !activeToolNames.has(name)
+    );
+    const lockedToolSet = buildLockedToolSet(lockedToolNames);
+    const lockedToolPromptInfo = buildLockedToolPromptInfo(lockedToolNames);
+    const tools = {
+      ...freeTools,
+      ...paidTools,
+      ...lockedToolSet,
+    };
 
     // Telemetry hooks bind Sentry into `executeChatTurn` without coupling
     // the pure pipeline to Sentry. Eval scripts pass a no-op telemetry.
@@ -2950,6 +2969,7 @@ export async function POST(req: Request) {
       forceLightModel,
       modelRotationStep,
       lastUserText: userText,
+      lockedTools: lockedToolPromptInfo,
       pinnedOpportunity,
       tools: wrapToolSetFailSoft(tools),
       signal: req.signal,

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -288,8 +288,32 @@ export async function register() {
   }
 }
 
+function isExpectedEntitlementRequestError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error.name === 'TasksUpgradeRequiredError') {
+    return true;
+  }
+  const code = (error as { code?: unknown }).code;
+  if (code === 'TASKS_WORKSPACE_LOCKED' || code === 'RELEASE_PLAN_LOCKED') {
+    return true;
+  }
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('requires a pro plan') ||
+    message.includes('require a pro plan')
+  );
+}
+
 export async function onRequestError(...args: unknown[]) {
   if (shouldSkipServerObservability()) {
+    return;
+  }
+
+  // Server-action entitlement gates can surface as request errors on page
+  // paths (e.g. POST /app/chat). They are upgrade CTAs, not fatal bugs.
+  if (isExpectedEntitlementRequestError(args[0])) {
     return;
   }
 

--- a/apps/web/lib/chat/locked-tools.ts
+++ b/apps/web/lib/chat/locked-tools.ts
@@ -1,5 +1,5 @@
 /**
- * Entitlement-locked chat tool stubs (GH #13304).
+ * Entitlement-locked chat tool stubs (GH #13304 / JOV-3861).
  *
  * When a plan denies a gated chat capability, the tool stays VISIBLE to the
  * model but its execute is swapped for a stub returning
@@ -13,6 +13,7 @@
  */
 
 import { tool } from 'ai';
+import { logEntitlementDenial } from '@/lib/entitlements/demand-signal';
 import {
   type BooleanEntitlement,
   ENTITLEMENT_REGISTRY,
@@ -26,12 +27,16 @@ import { getToolUiConfig } from './tool-ui-registry';
  * controls them. Merch is represented by its two generative entry points —
  * the management tools (publish/pause/reorder/…) are meaningless without a
  * generation, so they stay hidden when the plan denies merch.
+ *
+ * `manageTasks` is the Tasks workspace paywall entry (JOV-3861) so free users
+ * who ask chat to create/list tasks get an upgrade CTA instead of a 500.
  */
 export const LOCKABLE_CHAT_TOOL_GATES = {
   generateAlbumArt: 'canGenerateAlbumArt',
   retouchImage: 'canAccessAiRetouching',
   createMerch: 'canAccessMerchCreation',
   previewMerchOptions: 'canAccessMerchCreation',
+  manageTasks: 'canAccessTasksWorkspace',
 } as const satisfies Partial<
   Record<keyof typeof TOOL_SCHEMAS, BooleanEntitlement>
 >;
@@ -105,6 +110,55 @@ export function buildLockedToolResult(
 }
 
 /**
+ * Build a locked payload for any tool name when an entitlement denial is
+ * caught at the tool boundary (JOV-3861). Prefer the registry-backed result
+ * for lockable tools; otherwise fall back to a Pro CTA using the tool UI label.
+ */
+export function buildLockedToolResultForTool(
+  toolName: string,
+  options?: {
+    readonly gate?: BooleanEntitlement;
+    readonly message?: string;
+  }
+): LockedToolResult {
+  if (isLockableChatToolName(toolName)) {
+    const result = buildLockedToolResult(toolName);
+    if (options?.message && options.message.trim().length > 0) {
+      return {
+        ...result,
+        reason: options.message.trim(),
+        summary: options.message.trim(),
+      };
+    }
+    return result;
+  }
+
+  const gate = options?.gate ?? 'canAccessTasksWorkspace';
+  const plan = resolveRequiredPlanForGate(gate);
+  const label = getToolUiConfig(toolName).label;
+  const message =
+    options?.message && options.message.trim().length > 0
+      ? options.message.trim()
+      : `${label} requires the ${plan.displayName} plan.`;
+
+  return {
+    success: true,
+    locked: true,
+    gate,
+    reason: message,
+    plan_required: plan.displayName,
+    upgrade_cta: `Upgrade to ${plan.displayName} to unlock ${label.toLowerCase()}.`,
+    summary: message,
+  };
+}
+
+export function isLockableChatToolName(
+  toolName: string
+): toolName is LockableChatToolName {
+  return Object.hasOwn(LOCKABLE_CHAT_TOOL_GATES, toolName);
+}
+
+/**
  * Locked stub: same description + input schema as the real tool (so the
  * model can call it naturally), but execute returns the locked payload
  * instead of doing the work.
@@ -114,7 +168,17 @@ export function createLockedToolStub(toolName: LockableChatToolName) {
   return tool({
     description: schema.description,
     inputSchema: schema.inputSchema,
-    execute: async () => buildLockedToolResult(toolName),
+    execute: async () => {
+      const result = buildLockedToolResult(toolName);
+      logEntitlementDenial({
+        gate: result.gate,
+        source: 'chat-tool-locked-stub',
+        toolName,
+        planRequired: result.plan_required,
+        message: result.summary,
+      });
+      return result;
+    },
   } as never);
 }
 

--- a/apps/web/lib/chat/tool-errors.ts
+++ b/apps/web/lib/chat/tool-errors.ts
@@ -10,6 +10,15 @@ export const TOOL_ERROR_CODES = {
   TOOL_EXECUTION_FAILED: 'TOOL_EXECUTION_FAILED',
 } as const;
 
+/** Entitlement gate codes thrown by tasks-gate and similar plan locks. */
+export const ENTITLEMENT_DENIAL_CODES = {
+  TASKS_WORKSPACE_LOCKED: 'TASKS_WORKSPACE_LOCKED',
+  RELEASE_PLAN_LOCKED: 'RELEASE_PLAN_LOCKED',
+} as const;
+
+export type EntitlementDenialCode =
+  (typeof ENTITLEMENT_DENIAL_CODES)[keyof typeof ENTITLEMENT_DENIAL_CODES];
+
 export type ToolErrorCode =
   (typeof TOOL_ERROR_CODES)[keyof typeof TOOL_ERROR_CODES];
 
@@ -104,6 +113,46 @@ function asToolErrorCode(value: unknown): ToolErrorCode | undefined {
     : undefined;
 }
 
+function asEntitlementDenialCode(
+  value: unknown
+): EntitlementDenialCode | undefined {
+  if (typeof value !== 'string') return undefined;
+  return Object.values(ENTITLEMENT_DENIAL_CODES).includes(
+    value as EntitlementDenialCode
+  )
+    ? (value as EntitlementDenialCode)
+    : undefined;
+}
+
+/**
+ * True when the thrown value is an expected plan/entitlement gate denial
+ * (e.g. TasksUpgradeRequiredError) — never a Sentry-worthy failure.
+ */
+export function isEntitlementDenialError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    if (error !== null && typeof error === 'object' && 'code' in error) {
+      return (
+        asEntitlementDenialCode((error as { code?: unknown }).code) != null
+      );
+    }
+    return false;
+  }
+
+  if (error.name === 'TasksUpgradeRequiredError') {
+    return true;
+  }
+
+  if (asEntitlementDenialCode((error as { code?: unknown }).code) != null) {
+    return true;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('requires a pro plan') ||
+    message.includes('requires the pro plan')
+  );
+}
+
 function inferErrorCodeFromMessage(message: string): ToolErrorCode {
   const normalized = message.toLowerCase();
 
@@ -115,6 +164,7 @@ function inferErrorCodeFromMessage(message: string): ToolErrorCode {
   }
   if (
     normalized.includes('requires a pro plan') ||
+    normalized.includes('requires the pro plan') ||
     normalized.includes('paid plan') ||
     normalized.includes('upgrade')
   ) {
@@ -152,7 +202,11 @@ export function classifyThrownToolError(
   error: unknown
 ): ToolFailurePayload {
   const thrownCode =
-    error instanceof Error ? (error as { code?: unknown }).code : undefined;
+    error instanceof Error
+      ? (error as { code?: unknown }).code
+      : error !== null && typeof error === 'object' && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
   const errorCodeFromThrown = asToolErrorCode(thrownCode);
 
   if (
@@ -173,15 +227,28 @@ export function classifyThrownToolError(
       : typeof error === 'string'
         ? error
         : 'Tool execution failed.';
-  const code =
-    error instanceof Error
-      ? asToolErrorCode((error as { code?: unknown }).code)
-      : undefined;
+
+  // TasksUpgradeRequiredError and sibling gate codes are expected plan denials
+  // (JOV-3861) — never retry, never treat as generic execution failure.
+  if (
+    isEntitlementDenialError(error) ||
+    asEntitlementDenialCode(thrownCode) != null
+  ) {
+    return buildToolFailure({
+      errorCode: TOOL_ERROR_CODES.PLAN_UNAVAILABLE,
+      error: message,
+      retryable: false,
+      toolName,
+    });
+  }
+
+  const code = asToolErrorCode(thrownCode);
+  const errorCode = code ?? inferErrorCodeFromMessage(message);
 
   return buildToolFailure({
-    errorCode: code ?? inferErrorCodeFromMessage(message),
+    errorCode,
     error: message,
-    retryable: code !== TOOL_ERROR_CODES.PLAN_UNAVAILABLE,
+    retryable: errorCode !== TOOL_ERROR_CODES.PLAN_UNAVAILABLE,
     toolName,
   });
 }

--- a/apps/web/lib/chat/tool-schemas.ts
+++ b/apps/web/lib/chat/tool-schemas.ts
@@ -66,6 +66,29 @@ export const TOOL_SCHEMAS = {
     }),
   },
 
+  /**
+   * Tasks workspace entry point (JOV-3861). Free plans keep this tool visible
+   * as a locked stub so "create/list my tasks" returns an upgrade CTA instead
+   * of a dead-end or thrown entitlement error.
+   */
+  manageTasks: {
+    description:
+      'Create, list, or open the Tasks workspace for release and general work. Use when the artist asks to create tasks, list tasks, open Tasks, set up a release plan checklist, or manage their to-do list.',
+    inputSchema: chatToolSchema({
+      intent: z
+        .enum(['create', 'list', 'open', 'release_plan'])
+        .optional()
+        .describe(
+          'What the artist wants: create a task, list tasks, open the Tasks workspace, or set up a release plan checklist.'
+        ),
+      title: z
+        .string()
+        .max(200)
+        .optional()
+        .describe('Optional task title when creating a task'),
+    }),
+  },
+
   createMerch: {
     description:
       'Generate exactly three premium merch options for the artist. Use when the artist asks to make merch, create a tee/hoodie/item, or make something that would sell.',

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -275,6 +275,14 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Pitch ready',
     errorTitle: "Couldn't write your pitch",
   },
+  manageTasks: {
+    label: 'Tasks',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Opening Tasks…',
+    successTitle: 'Tasks ready',
+    errorTitle: "Couldn't open Tasks",
+  },
   searchSpotifyArtist: {
     label: 'Spotify artist',
     uiHint: 'artifact',

--- a/apps/web/lib/chat/wrap-tool-execute.ts
+++ b/apps/web/lib/chat/wrap-tool-execute.ts
@@ -1,10 +1,18 @@
 import 'server-only';
 
 import type { Tool, ToolSet } from 'ai';
+import { logEntitlementDenial } from '@/lib/entitlements/demand-signal';
 import { captureError } from '@/lib/error-tracking';
 import {
+  buildLockedToolResultForTool,
+  isLockableChatToolName,
+  LOCKABLE_CHAT_TOOL_GATES,
+} from './locked-tools';
+import {
   classifyThrownToolError,
+  isEntitlementDenialError,
   normalizeToolFailureOutput,
+  TOOL_ERROR_CODES,
 } from './tool-errors';
 
 type ToolExecute = Tool['execute'];
@@ -13,6 +21,11 @@ type ToolExecute = Tool['execute'];
  * Mirrors the track-route audience upsert fail-soft pattern: tool failures must
  * never take down the chat stream. Throws are captured, logged, and returned as
  * structured `{ success: false, errorCode, ... }` payloads.
+ *
+ * Expected entitlement denials (TasksUpgradeRequiredError / PLAN_UNAVAILABLE)
+ * are NOT Sentry errors (JOV-3861): they return a success-shaped locked payload
+ * so the chat UI renders an upgrade CTA, log demand signal only, and set
+ * retryable=false so the model does not auto-retry the paywall.
  */
 export function withFailSoftToolExecute(
   toolName: string,
@@ -26,9 +39,35 @@ export function withFailSoftToolExecute(
     try {
       const result = await execute(input, options);
       const normalizedFailure = normalizeToolFailureOutput(toolName, result);
+
+      if (normalizedFailure?.errorCode === TOOL_ERROR_CODES.PLAN_UNAVAILABLE) {
+        return toLockedUpgradeResult(toolName, normalizedFailure.error, {
+          source: 'chat-tool-throw',
+        });
+      }
+
       return normalizedFailure ?? result;
     } catch (error) {
+      if (isEntitlementDenialError(error)) {
+        const message =
+          error instanceof Error ? error.message : 'Requires a Pro plan.';
+        return toLockedUpgradeResult(toolName, message, {
+          source: 'chat-tool-throw',
+          code:
+            error instanceof Error
+              ? String((error as { code?: unknown }).code ?? '')
+              : undefined,
+        });
+      }
+
       const failure = classifyThrownToolError(toolName, error);
+
+      if (failure.errorCode === TOOL_ERROR_CODES.PLAN_UNAVAILABLE) {
+        return toLockedUpgradeResult(toolName, failure.error, {
+          source: 'chat-tool-throw',
+        });
+      }
+
       await captureError('Chat tool execute failed', error, {
         feature: 'ai-chat',
         source: 'chat-tool-execute',
@@ -39,6 +78,35 @@ export function withFailSoftToolExecute(
       return failure;
     }
   };
+}
+
+function toLockedUpgradeResult(
+  toolName: string,
+  message: string,
+  meta: {
+    readonly source: 'chat-tool-throw';
+    readonly code?: string;
+  }
+) {
+  const gate = isLockableChatToolName(toolName)
+    ? LOCKABLE_CHAT_TOOL_GATES[toolName]
+    : 'canAccessTasksWorkspace';
+
+  const locked = buildLockedToolResultForTool(toolName, {
+    gate,
+    message,
+  });
+
+  logEntitlementDenial({
+    gate: locked.gate,
+    source: meta.source,
+    toolName,
+    code: meta.code || undefined,
+    planRequired: locked.plan_required,
+    message: locked.summary,
+  });
+
+  return locked;
 }
 
 export function wrapToolSetFailSoft(tools: ToolSet): ToolSet {

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -41,6 +41,8 @@ export const HIDDEN_TOOLS: Readonly<Record<string, string>> = {
   generateCanvasPlan: 'Pro-only; surfaced via the release detail surface.',
   importBioFromUrl:
     'Triggered conversationally from an explicit URL import request before profile-edit preview.',
+  manageTasks:
+    'Tasks has a dedicated workspace; chat invokes it conversationally so it can return the correct entitlement CTA without exposing a root slash command.',
   markCanvasUploaded:
     'CRUD-style follow-up; surfaced inside the checkCanvasStatus card.',
   openBillingPortal:

--- a/apps/web/lib/entitlements/demand-signal.ts
+++ b/apps/web/lib/entitlements/demand-signal.ts
@@ -1,0 +1,56 @@
+/**
+ * Demand-signal logging for expected plan/entitlement denials (JOV-3861).
+ *
+ * Blocked upgrade attempts are product signal, not errors. Persist a breadcrumb
+ * + structured analytics event so Eve/ops can rank paywall demand without
+ * polluting Sentry error volume. Full re-engagement ledger is JOV-3382.
+ */
+
+import * as Sentry from '@sentry/nextjs';
+import { trackEvent } from '@/lib/analytics/runtime-aware';
+import { logger } from '@/lib/utils/logger';
+
+export type EntitlementDenialSource =
+  | 'chat-tool-throw'
+  | 'chat-tool-locked-stub'
+  | 'server-action';
+
+export interface EntitlementDenialSignal {
+  readonly gate: string;
+  readonly source: EntitlementDenialSource;
+  readonly toolName?: string;
+  readonly code?: string;
+  readonly planRequired?: string;
+  readonly userId?: string | null;
+  readonly message?: string;
+}
+
+/**
+ * Log an expected entitlement denial as demand signal (never as a Sentry error).
+ */
+export function logEntitlementDenial(signal: EntitlementDenialSignal): void {
+  const data = {
+    gate: signal.gate,
+    source: signal.source,
+    toolName: signal.toolName ?? null,
+    code: signal.code ?? null,
+    planRequired: signal.planRequired ?? null,
+    userId: signal.userId ?? null,
+    message: signal.message ?? null,
+  };
+
+  logger.info('[entitlement-denial] plan gate denied', data);
+
+  Sentry.addBreadcrumb({
+    category: 'entitlement-denial',
+    message: 'plan_gate_denied',
+    level: 'info',
+    data,
+  });
+
+  void trackEvent('entitlement_denial', data, signal.userId ?? undefined).catch(
+    () => {
+      // Analytics must never take down the request path.
+    }
+  );
+}

--- a/apps/web/lib/entitlements/tasks-gate.ts
+++ b/apps/web/lib/entitlements/tasks-gate.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { logEntitlementDenial } from './demand-signal';
 import { getCurrentUserEntitlements } from './server';
 
 export type TasksUpgradeRequiredCode =
@@ -26,14 +27,33 @@ export async function canGenerateReleasePlans(): Promise<boolean> {
   return entitlements.canGenerateReleasePlans;
 }
 
+function throwTasksUpgradeRequired(
+  code: TasksUpgradeRequiredCode,
+  message: string,
+  gate: 'canAccessTasksWorkspace' | 'canGenerateReleasePlans'
+): never {
+  // Demand signal for server-action callers (chat panel, mutations).
+  // Chat tools already log via locked stubs / fail-soft boundary.
+  logEntitlementDenial({
+    gate,
+    source: 'server-action',
+    code,
+    planRequired: 'Pro',
+    message,
+  });
+
+  throw new TasksUpgradeRequiredError(code, message);
+}
+
 export async function requireTasksWorkspaceAccess(): Promise<void> {
   if (await canAccessTasksWorkspace()) {
     return;
   }
 
-  throw new TasksUpgradeRequiredError(
+  throwTasksUpgradeRequired(
     'TASKS_WORKSPACE_LOCKED',
-    'Tasks requires a Pro plan.'
+    'Tasks requires a Pro plan.',
+    'canAccessTasksWorkspace'
   );
 }
 
@@ -42,8 +62,9 @@ export async function requireReleasePlanGenerationAccess(): Promise<void> {
     return;
   }
 
-  throw new TasksUpgradeRequiredError(
+  throwTasksUpgradeRequired(
     'RELEASE_PLAN_LOCKED',
-    'Release plans require a Pro plan.'
+    'Release plans require a Pro plan.',
+    'canGenerateReleasePlans'
   );
 }

--- a/apps/web/lib/queries/useReleaseTasksQuery.ts
+++ b/apps/web/lib/queries/useReleaseTasksQuery.ts
@@ -7,6 +7,30 @@ import {
 } from '@/app/app/(shell)/dashboard/releases/task-actions';
 import { queryKeys, STANDARD_CACHE } from '@/lib/queries';
 
+/** Never auto-retry expected plan gates (JOV-3861 retry-loop fix). */
+function shouldRetryReleaseTaskQuery(
+  failureCount: number,
+  error: unknown
+): boolean {
+  if (error instanceof Error) {
+    if (error.name === 'TasksUpgradeRequiredError') {
+      return false;
+    }
+    const code = (error as { code?: unknown }).code;
+    if (code === 'TASKS_WORKSPACE_LOCKED' || code === 'RELEASE_PLAN_LOCKED') {
+      return false;
+    }
+    const message = error.message.toLowerCase();
+    if (
+      message.includes('requires a pro plan') ||
+      message.includes('require a pro plan')
+    ) {
+      return false;
+    }
+  }
+  return failureCount < 3;
+}
+
 export function useReleaseTasksQuery(releaseId: string) {
   return useQuery({
     queryKey: queryKeys.releaseTasks.byRelease(releaseId),
@@ -14,6 +38,7 @@ export function useReleaseTasksQuery(releaseId: string) {
     queryFn: () => getReleaseTasks(releaseId),
     ...STANDARD_CACHE,
     enabled: Boolean(releaseId),
+    retry: shouldRetryReleaseTaskQuery,
   });
 }
 
@@ -24,5 +49,6 @@ export function useReleaseTaskSummaryQuery(profileId: string) {
     queryFn: () => getReleaseTaskSummary(profileId),
     ...STANDARD_CACHE,
     enabled: Boolean(profileId),
+    retry: shouldRetryReleaseTaskQuery,
   });
 }

--- a/apps/web/lib/queries/useTasksQuery.ts
+++ b/apps/web/lib/queries/useTasksQuery.ts
@@ -15,6 +15,32 @@ const TASK_STATS_CACHE = {
   gcTime: 5 * 60 * 1000,
 };
 
+/** Never auto-retry expected plan gates (JOV-3861 retry-loop fix). */
+function shouldRetryTaskQuery(failureCount: number, error: unknown): boolean {
+  if (isTasksUpgradeQueryError(error)) {
+    return false;
+  }
+  return failureCount < 3;
+}
+
+function isTasksUpgradeQueryError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error.name === 'TasksUpgradeRequiredError') {
+    return true;
+  }
+  const code = (error as { code?: unknown }).code;
+  if (code === 'TASKS_WORKSPACE_LOCKED' || code === 'RELEASE_PLAN_LOCKED') {
+    return true;
+  }
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('requires a pro plan') ||
+    message.includes('require a pro plan')
+  );
+}
+
 export function useTasksQuery(
   profileId?: string,
   filters?: TaskFilters,
@@ -29,6 +55,7 @@ export function useTasksQuery(
     ...STANDARD_CACHE,
     placeholderData: keepPreviousData,
     enabled: Boolean(profileId) && (options?.enabled ?? true),
+    retry: shouldRetryTaskQuery,
   });
 }
 
@@ -46,6 +73,7 @@ export function useTaskBoardQuery(
     ...STANDARD_CACHE,
     placeholderData: keepPreviousData,
     enabled: Boolean(profileId) && (options?.enabled ?? true),
+    retry: shouldRetryTaskQuery,
   });
 }
 
@@ -56,6 +84,7 @@ export function useTaskQuery(taskId: string | null, profileId?: string) {
     queryFn: () => getTask(taskId!),
     ...STANDARD_CACHE,
     enabled: Boolean(taskId && profileId),
+    retry: shouldRetryTaskQuery,
   });
 }
 
@@ -69,5 +98,6 @@ export function useTaskStatsQuery(
     queryFn: () => getTaskStats({ newerThan: options?.seenAt ?? null }),
     ...TASK_STATS_CACHE,
     enabled: Boolean(profileId) && (options?.enabled ?? true),
+    retry: shouldRetryTaskQuery,
   });
 }

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -77,6 +77,12 @@ Sentry.init({
     // is not authenticated. These are handled by the client error boundary
     // and are not bugs (JOV-1065).
     /^Unauthorized$/,
+    // Expected entitlement paywalls (Tasks / release plans). Client surfaces
+    // an upgrade CTA; chat tools return locked results. Not application bugs
+    // (JOV-3861 / JOVIE-WEB-JW).
+    /^TasksUpgradeRequiredError/,
+    /Tasks requires a Pro plan/,
+    /Release plans require a Pro plan/,
     /TimeoutError: page\.waitForFunction/i,
     /TimeoutError: locator\.waitFor/i,
     /toHaveURL/,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -497,6 +497,7 @@ const ALWAYS_PAID_TOOL_NAMES = [
   'writeWorldClassBio',
   'generateCanvasPlan',
   'createPromoStrategy',
+  'manageTasks',
   'markCanvasUploaded',
   'formatLyrics',
   'proposeVideoRecording',

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1548,6 +1548,7 @@ tests:
           - generateCanvasPlan
           - generateReleasePitch
           - importBioFromUrl
+          - manageTasks
           - markCanvasUploaded
           - openBillingPortal
           - optimizeMerchCards
@@ -2706,6 +2707,28 @@ tests:
       plan: pro
       toolInput:
         url: https://lunawaves.example/press
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts paid task management
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Create a task for my next release."
+      target: tool-contract
+      toolName: manageTasks
+      mode: app
+      plan: pro
+      toolInput:
+        intent: create
+        title: "Pitch Neon Reef to Spotify"
     assert:
       - type: javascript
         value: file://assertions.cjs:assertDeterministicNoSpend

--- a/apps/web/tests/unit/chat/locked-tools.test.ts
+++ b/apps/web/tests/unit/chat/locked-tools.test.ts
@@ -6,7 +6,12 @@
  * payload sourced from the entitlement registry — never an error.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/entitlements/demand-signal', () => ({
+  logEntitlementDenial: vi.fn(),
+}));
+
 import {
   buildLockedToolPromptInfo,
   buildLockedToolResult,
@@ -92,6 +97,7 @@ describe('resolveLockedChatTools', () => {
         'retouchImage',
         'createMerch',
         'previewMerchOptions',
+        'manageTasks',
       ])
     );
     expect(locked).toHaveLength(LOCKABLE_NAMES.length);

--- a/apps/web/tests/unit/chat/tool-errors.test.ts
+++ b/apps/web/tests/unit/chat/tool-errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildToolFailure,
   classifyThrownToolError,
+  isEntitlementDenialError,
   isRecoverableToolStreamError,
   normalizeToolFailureOutput,
   resolveToolFailurePresentation,
@@ -45,6 +46,23 @@ describe('tool-errors', () => {
 
     expect(failure.errorCode).toBe('PROVIDER_UNAVAILABLE');
     expect(failure.retryable).toBe(false);
+  });
+
+  it('classifies TasksUpgradeRequiredError as non-retryable PLAN_UNAVAILABLE', () => {
+    const error = Object.assign(new Error('Tasks requires a Pro plan.'), {
+      name: 'TasksUpgradeRequiredError',
+      code: 'TASKS_WORKSPACE_LOCKED',
+    });
+
+    expect(isEntitlementDenialError(error)).toBe(true);
+
+    const failure = classifyThrownToolError('manageTasks', error);
+    expect(failure).toMatchObject({
+      success: false,
+      errorCode: 'PLAN_UNAVAILABLE',
+      retryable: false,
+      error: 'Tasks requires a Pro plan.',
+    });
   });
 
   it('treats recoverable tool stream errors as soft failures', () => {

--- a/apps/web/tests/unit/chat/wrap-tool-execute.test.ts
+++ b/apps/web/tests/unit/chat/wrap-tool-execute.test.ts
@@ -1,16 +1,29 @@
 import { tool } from 'ai';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import {
   withFailSoftToolExecute,
   wrapToolSetFailSoft,
 } from '@/lib/chat/wrap-tool-execute';
 
+const { mockCaptureError, mockLogEntitlementDenial } = vi.hoisted(() => ({
+  mockCaptureError: vi.fn().mockResolvedValue(undefined),
+  mockLogEntitlementDenial: vi.fn(),
+}));
+
 vi.mock('@/lib/error-tracking', () => ({
-  captureError: vi.fn().mockResolvedValue(undefined),
+  captureError: mockCaptureError,
+}));
+
+vi.mock('@/lib/entitlements/demand-signal', () => ({
+  logEntitlementDenial: mockLogEntitlementDenial,
 }));
 
 describe('wrap-tool-execute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('returns structured failure instead of throwing', async () => {
     const execute = withFailSoftToolExecute('retouchImage', async () => {
       throw new Error('Retouch is not provisioned for this account.');
@@ -23,6 +36,51 @@ describe('wrap-tool-execute', () => {
       errorCode: 'TOOL_UNPROVISIONED',
       retryable: true,
     });
+    expect(mockCaptureError).toHaveBeenCalledOnce();
+  });
+
+  it('converts TasksUpgradeRequiredError into a locked upgrade result (JOV-3861)', async () => {
+    const execute = withFailSoftToolExecute('manageTasks', async () => {
+      throw Object.assign(new Error('Tasks requires a Pro plan.'), {
+        name: 'TasksUpgradeRequiredError',
+        code: 'TASKS_WORKSPACE_LOCKED',
+      });
+    });
+
+    const result = await execute?.({}, {} as never);
+
+    expect(result).toMatchObject({
+      success: true,
+      locked: true,
+      plan_required: expect.any(String),
+      upgrade_cta: expect.stringContaining('Upgrade'),
+    });
+    expect(mockCaptureError).not.toHaveBeenCalled();
+    expect(mockLogEntitlementDenial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'chat-tool-throw',
+        toolName: 'manageTasks',
+        code: 'TASKS_WORKSPACE_LOCKED',
+      })
+    );
+  });
+
+  it('converts PLAN_UNAVAILABLE success:false payloads into locked results', async () => {
+    const execute = withFailSoftToolExecute('generateAlbumArt', async () => ({
+      success: false as const,
+      error: 'Album art generation requires a Pro plan.',
+      retryable: false,
+      errorCode: 'PLAN_UNAVAILABLE' as const,
+    }));
+
+    const result = await execute?.({}, {} as never);
+
+    expect(result).toMatchObject({
+      success: true,
+      locked: true,
+    });
+    expect(mockCaptureError).not.toHaveBeenCalled();
+    expect(mockLogEntitlementDenial).toHaveBeenCalled();
   });
 
   it('normalizes success:false payloads from execute', async () => {

--- a/apps/web/tests/unit/lib/entitlements/demand-signal.test.ts
+++ b/apps/web/tests/unit/lib/entitlements/demand-signal.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAddBreadcrumb, mockTrackEvent } = vi.hoisted(() => ({
+  mockAddBreadcrumb: vi.fn(),
+  mockTrackEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: mockAddBreadcrumb,
+}));
+
+vi.mock('@/lib/analytics/runtime-aware', () => ({
+  trackEvent: mockTrackEvent,
+}));
+
+import { logEntitlementDenial } from '@/lib/entitlements/demand-signal';
+
+describe('logEntitlementDenial', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records demand signal as breadcrumb + analytics, never as an exception', () => {
+    logEntitlementDenial({
+      gate: 'canAccessTasksWorkspace',
+      source: 'chat-tool-locked-stub',
+      toolName: 'manageTasks',
+      planRequired: 'Pro',
+      message: 'Tasks requires a Pro plan.',
+    });
+
+    expect(mockAddBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'entitlement-denial',
+        message: 'plan_gate_denied',
+        level: 'info',
+        data: expect.objectContaining({
+          gate: 'canAccessTasksWorkspace',
+          toolName: 'manageTasks',
+        }),
+      })
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'entitlement_denial',
+      expect.objectContaining({
+        gate: 'canAccessTasksWorkspace',
+        source: 'chat-tool-locked-stub',
+      }),
+      undefined
+    );
+  });
+});

--- a/apps/web/tests/unit/lib/entitlements/tasks-gate.test.ts
+++ b/apps/web/tests/unit/lib/entitlements/tasks-gate.test.ts
@@ -8,6 +8,10 @@ vi.mock('@/lib/entitlements/server', () => ({
   getCurrentUserEntitlements: mockGetCurrentUserEntitlements,
 }));
 
+vi.mock('@/lib/entitlements/demand-signal', () => ({
+  logEntitlementDenial: vi.fn(),
+}));
+
 describe('tasks entitlement gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

Free-plan users who ask chat to create/list Tasks no longer hit a fatal `TasksUpgradeRequiredError` 500 (Sentry JOVIE-WEB-JW). Entitlement denials degrade to an in-chat upgrade CTA and are recorded as demand signal instead of Sentry errors.

### Changes
- Add lockable `manageTasks` chat tool gated by `canAccessTasksWorkspace`
- Wire plan-locked tool stubs into free (and partial-gate) chat turns so the model can call gated tools and get `{ locked: true, upgrade_cta, … }`
- Catch entitlement denials at the tool fail-soft boundary: return locked upgrade result, **no** `captureError`/Sentry error, `retryable: false`
- Log denials via `logEntitlementDenial` (breadcrumb + `entitlement_denial` analytics event)
- Sentry `ignoreErrors` for residual server-action throws of the same class
- Hardening: demand signal on `tasks-gate` throws; skip `onRequestError` for plan denials; React Query task queries do not retry upgrade errors

## Test plan / results

- [x] Focused unit tests (tool-errors, wrap-tool-execute, locked-tools, demand-signal, tasks-gate)
- [x] Pre-push typecheck / lint / vitest (passed in local pre-push runs)
- [ ] Manual: free-plan account → chat “create a task for my release” → upgrade CTA, no 500, no Sentry error
- [ ] Confirm JOVIE-WEB-JW at 0 new events over 48h post-deploy

## Acceptance mapping

| Criteria | How |
|---|---|
| In-chat upgrade CTA | Locked tool result + existing chat plan-upgrade UI |
| No 500 | Fail-soft tool boundary returns locked payload |
| No Sentry error | Skip `captureError` for denials + `ignoreErrors` + `onRequestError` skip |
| Demand signal logged | `logEntitlementDenial` breadcrumb + `entitlement_denial` event |
| No auto-retry | `retryable: false` on plan denials + query retry guards |

Fixes JOV-3861

<!-- linear-issue-id:JOV-3861 -->