### PR TITLE
docs(design): codify icon alignment policy

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -131,6 +131,13 @@ tertiary, ghost, or `PageToolbarActionButton` treatment.
 - For decorative indicators, use small SVG icon components (Lucide icons or inline SVGs).
 - Applies to marketing pages, dashboards, mockups, and all user-facing surfaces.
 
+### Icon and Text Alignment
+
+- **Geometric centering is the default** for icon-and-text pairs and icon controls. Lucide and arbitrary web SVGs do not provide a guaranteed typographic baseline.
+- Use **baseline alignment only when both paired assets expose compatible, meaningful baselines**. System symbols with baseline metadata are the exception, not a reason to baseline-align arbitrary SVGs.
+- A **1–2px optical correction** is allowed only after screenshot evidence across the affected sizes and both themes. It must live in the shared primitive, helper, or token that owns the pair.
+- Never add an optical correction as a call-site margin or translate utility. It must be static, preserve layout and hit-target geometry, and must not appear on hover.
+
 ### Text Casing Rules
 
 - All user-facing text must follow `DESIGN.md` casing rules.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -203,6 +203,13 @@ The example above says one thing three times. Jovie should say it once.
 - Hover feedback should stay visual, not positional. Prefer color, border, or shadow changes. Do not make the interface jump on hover unless the motion communicates direct manipulation.
 - Before shipping a UI, run this check: does it look like a generic AI-generated SaaS mockup? If yes, remove chrome until it feels native to Jovie
 
+### Icon and Text Alignment
+
+- **Geometric centering is the default** for icon-and-text pairs and icon controls. It is the stable choice for Lucide and other arbitrary web SVGs, whose CSS baseline is synthesized rather than a compatible typographic metric.
+- Use **baseline alignment only when both items expose meaningful, compatible baselines**. Apple SF Symbols are the model: they carry baseline information and are designed to align with adjacent text. Do not infer that guarantee for arbitrary SVG assets.
+- A component may apply a **1–2px optical correction** only after screenshot evidence at the affected sizes and in both light and dark themes. Put that correction in the shared primitive, helper, or token that owns the pairing, never in a call-site margin or translate utility.
+- Optical correction must preserve the control's box, hit target, and layout geometry. It is static, never a hover effect or other motion.
+
 ### Ovie Ops Cockpit Guardrail
 
 Ovie UI/UX work must use the make-interfaces-better path: load gstack `/design-review`, load `design-taste-frontend` where available, and run the checklist in `docs/ovie-design-guardrails.md`.
@@ -945,6 +952,7 @@ mark intentional marketing sentence-case headlines with
 | 2026-04-11 | Canonical 1200px width for all marketing | Fixed inconsistent widths (header 1200px, hero 1120px). **Superseded 2026-06-28** by DS_FOUNDATION_V1 1298px. |
 | 2026-06-28 | Canonical 1298px public/marketing width (DS_FOUNDATION_V1) | One width in code + docs. `--ds-public-content-max` is canonical; legacy 1200/1280 aliases resolve to 1298px. Linear.app container parity. |
 | 2026-07-02 | Canonical button variants shipped (DS_FOUNDATION_V1 Wave 1) | 5 variants (`primary`, `secondary`, `tertiary`, `ghost`, `link`) + `destructive` prop. 3 sizes (`sm`/`md`/`lg`) + `icon`. 19 surface-specific `system-b-*-button` classes migrated behind a shrink-only ratchet. |
+| 2026-07-28 | Icon/text alignment policy (JOV-4511) | Geometric centering is the web default; baseline alignment requires compatible baseline-bearing assets. Optical correction is component-scoped, measured, static, and geometry-preserving. |
 | 2026-04-11 | Ban emoji-on-colored-square icons | Replaced with accent color on card title text. Icon-on-square reads as AI slop and cheapens the brand. |
 | 2026-04-11 | Ban gold colors | Gold signals prestige-seeking. Not appropriate for Jovie's DJ audience. |
 | 2026-06-18 | **Unify on one design system, two languages.** Retire System A; conform whole app to System B tokens. | Founder-directed (supersedes the 2026-04-22 "defer 3 months" note). Target = one token foundation, one palette, one core typeface (Inter), expressed as a compact product language + an editorial marketing language. Aligns with gbrain "design system review" canon ("not two design systems — one system, two languages"). Editorial layouts are preserved; surfaces are reskinned onto System B tokens, each with a `*-system-b-style-guard` test + a global shrink-only ratchet. |

--- a/apps/web/tests/unit/design-system/icon-alignment-policy.test.ts
+++ b/apps/web/tests/unit/design-system/icon-alignment-policy.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = join(import.meta.dirname, '..', '..', '..');
+const REPO_ROOT = join(WEB_ROOT, '..', '..');
+
+const design = readFileSync(join(REPO_ROOT, 'DESIGN.md'), 'utf8');
+const uiRule = readFileSync(join(REPO_ROOT, '.claude/rules/ui.md'), 'utf8');
+
+describe('icon and text alignment policy (JOV-4511)', () => {
+  it('keeps geometric centering as the default for arbitrary web SVGs', () => {
+    for (const source of [design, uiRule]) {
+      expect(source).toMatch(
+        /geometric center(?:ing)? is the (?:web )?default/i
+      );
+      expect(source).toMatch(/arbitrary (?:web )?SVG/i);
+    }
+  });
+
+  it('limits baseline alignment and optical correction to evidence-backed shared ownership', () => {
+    for (const source of [design, uiRule]) {
+      expect(source).toMatch(
+        /baseline alignment only when both.*compatible.*baseline/i
+      );
+      expect(source).toMatch(/1–2px optical correction/i);
+      expect(source).toMatch(
+        /screenshot evidence.*both (?:light and dark )?themes/i
+      );
+      expect(source).toMatch(/shared primitive, helper, (?:or )?token/i);
+      expect(source).toMatch(/call-site margin or translate/i);
+      expect(source).toMatch(/preserve.*hit.target.*geometry/i);
+      expect(source).toMatch(/must not appear on hover|never a hover effect/i);
+    }
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4511 -->

## Summary
- documents geometric centering as the default for arbitrary web SVG and Lucide icon/text pairs
- limits baseline alignment to compatible baseline-bearing assets, with SF Symbols as the reference case
- allows only evidence-backed, shared 1–2px static optical corrections that preserve geometry
- adds a focused documentation contract test

## Evidence
Apple documents that SF Symbols include baseline information and should baseline-align with adjacent text. Arbitrary web SVGs do not carry that platform metadata.

Design-read: Reading this as: design-system policy for Jovie product UI, with a low-variance restrained language, leaning toward the existing System B contract.
Dials: DESIGN_VARIANCE=low, MOTION_INTENSITY=none, VISUAL_DENSITY=high
Before/after evidence: UI evidence not applicable, documentation contract plus official Apple source reviewed.
Checklist: contrast pass, states not applicable, layout pass, motion pass, icons pass, anti-slop pass, evidence pass.
Verification: `pnpm --filter web exec vitest run --pool=forks --maxWorkers=1 tests/unit/design-system/icon-alignment-policy.test.ts` (2 passed); `pnpm biome check .claude/rules/ui.md DESIGN.md apps/web/tests/unit/design-system/icon-alignment-policy.test.ts` (passed).

References: [Apple SF Symbols alignment guidance](https://developer.apple.com/documentation/uikit/configuring-and-displaying-symbol-images-in-your-ui), [Apple SF Symbols HIG](https://developer.apple.com/design/human-interface-guidelines/sf-symbols)