### PR TITLE
fix(dashboard): simplify fatal error recovery

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/ReleaseCatalogPageClient.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleaseCatalogPageClient.tsx
@@ -147,10 +147,6 @@ export function ReleaseCatalogPageClient({
         onRetry={() => {
           refetch();
         }}
-        secondaryAction={{
-          label: 'Refresh Page',
-          onClick: () => globalThis.location.reload(),
-        }}
         extraContext={{ Profile: profileId }}
       />
     );

--- a/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
+++ b/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
@@ -177,10 +177,6 @@ export function ChatsPageClient() {
               onRetry={() => {
                 refetch();
               }}
-              secondaryAction={{
-                label: 'Refresh Page',
-                onClick: () => globalThis.location.reload(),
-              }}
             />
           ) : filteredThreads.length === 0 ? (
             <div className='grid min-h-72 place-items-center rounded-2xl border border-dashed border-subtle bg-surface-0 px-6 py-10 text-center'>

--- a/apps/web/components/features/feedback/ErrorDetails.tsx
+++ b/apps/web/components/features/feedback/ErrorDetails.tsx
@@ -40,6 +40,8 @@ interface ErrorDetailsProps {
   readonly extraContext?: Record<string, string>;
   /** Keep diagnostic information out of the initial recovery view. */
   readonly collapsible?: boolean;
+  /** Render a raw diagnostic only when it adds information beyond the recovery copy. */
+  readonly showMessage?: boolean;
 }
 
 /**
@@ -51,6 +53,7 @@ export function ErrorDetails({
   error,
   extraContext,
   collapsible = false,
+  showMessage = false,
 }: ErrorDetailsProps) {
   const [timestamp] = useState(() => new Date());
   const [errorRef] = useState(() =>
@@ -99,7 +102,7 @@ export function ErrorDetails({
         </div>
       </div>
 
-      {collapsible && error?.message ? (
+      {collapsible && showMessage && error?.message ? (
         <p className='text-center text-xs text-quaternary-token break-words'>
           {error.message}
         </p>

--- a/apps/web/components/features/feedback/ErrorDetails.tsx
+++ b/apps/web/components/features/feedback/ErrorDetails.tsx
@@ -38,6 +38,8 @@ export function buildErrorDetails(
 interface ErrorDetailsProps {
   readonly error?: Error & { digest?: string };
   readonly extraContext?: Record<string, string>;
+  /** Keep diagnostic information out of the initial recovery view. */
+  readonly collapsible?: boolean;
 }
 
 /**
@@ -45,7 +47,11 @@ interface ErrorDetailsProps {
  * Used across PageErrorState, ErrorDialog, DashboardErrorFallback, and ErrorBoundary
  * to eliminate copy-pasted code.
  */
-export function ErrorDetails({ error, extraContext }: ErrorDetailsProps) {
+export function ErrorDetails({
+  error,
+  extraContext,
+  collapsible = false,
+}: ErrorDetailsProps) {
   const [timestamp] = useState(() => new Date());
   const [errorRef] = useState(() =>
     error?.digest ? undefined : generateErrorRef()
@@ -68,7 +74,7 @@ export function ErrorDetails({ error, extraContext }: ErrorDetailsProps) {
       });
   };
 
-  return (
+  const content = (
     <>
       <div className='space-y-2 border-t border-subtle pt-4'>
         {displayId && (
@@ -93,17 +99,41 @@ export function ErrorDetails({ error, extraContext }: ErrorDetailsProps) {
         </div>
       </div>
 
+      {collapsible && error?.message ? (
+        <p className='text-center text-xs text-quaternary-token break-words'>
+          {error.message}
+        </p>
+      ) : null}
+
       {process.env.NODE_ENV === 'development' && error?.message && (
-        <details className='mt-4 rounded-md bg-surface-2 p-3'>
-          <summary className='cursor-pointer text-xs font-medium text-tertiary-token hover:text-primary-token'>
-            Developer Info (dev only)
-          </summary>
+        <div className='mt-4 rounded-md bg-surface-2 p-3'>
+          {collapsible ? (
+            <p className='text-xs font-medium text-tertiary-token'>
+              Developer info
+            </p>
+          ) : null}
           <pre className='mt-2 overflow-auto text-xs text-quaternary-token whitespace-pre-wrap break-words'>
             {error.message}
             {error.stack && `\n\n${error.stack}`}
           </pre>
-        </details>
+        </div>
       )}
     </>
+  );
+
+  if (!collapsible) {
+    return content;
+  }
+
+  return (
+    <details className='pt-1 text-left'>
+      <summary
+        data-focus-treatment='underline-only'
+        className='cursor-pointer list-none text-center text-xs text-quaternary-token transition-colors duration-normal ease-interactive hover:text-tertiary-token'
+      >
+        Error Details
+      </summary>
+      <div className='pt-3'>{content}</div>
+    </details>
   );
 }

--- a/apps/web/components/features/feedback/PageErrorState.stories.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { PageErrorState } from './PageErrorState';
+
+const meta: Meta<typeof PageErrorState> = {
+  title: 'Feedback/PageErrorState',
+  component: PageErrorState,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className='flex min-h-screen'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PageErrorState>;
+
+const error = Object.assign(new Error('The dashboard request timed out.'), {
+  digest: 'dashboard-timeout',
+});
+
+export const DashboardFatalErrorDesktop: Story = {
+  args: {
+    title: 'Unable to Load Dashboard',
+    message: 'Try again in a moment.',
+    error,
+    onRetry: fn(),
+  },
+};
+
+export const DashboardFatalErrorMobile: Story = {
+  args: DashboardFatalErrorDesktop.args,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};
+
+export const LongErrorDetails: Story = {
+  args: {
+    title: 'Unable to Load Dashboard',
+    message: 'Try again in a moment.',
+    error: Object.assign(
+      new Error(
+        'The dashboard request exceeded its timeout while loading profile, audience, release, and analytics data. Please retry after checking your connection.'
+      ),
+      { digest: 'dashboard-long-error' }
+    ),
+    onRetry: fn(),
+  },
+};

--- a/apps/web/components/features/feedback/PageErrorState.test.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PageErrorState } from './PageErrorState';
+
+describe('PageErrorState', () => {
+  it('keeps the initial fatal-error view to one retry action and collapsed details', async () => {
+    const user = userEvent.setup();
+    render(
+      <PageErrorState
+        title='Unable to Load Dashboard'
+        message='Try again in a moment.'
+        error={Object.assign(new Error('Request timed out'), {
+          digest: 'dashboard-timeout',
+        })}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveClass('min-h-64');
+    expect(
+      screen.getByRole('heading', { name: 'Unable to Load Dashboard' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    const summary = screen.getByText('Error Details');
+    const details = summary.closest('details');
+    expect(document.querySelectorAll('details')).toHaveLength(1);
+    expect(details).not.toHaveAttribute('open');
+    expect(
+      details?.querySelector('[aria-label="Copy error details to clipboard"]')
+    ).not.toBeNull();
+    expect(document.querySelector('.lucide-triangle-alert')).toBeNull();
+
+    await user.click(summary);
+    expect(details).toHaveAttribute('open');
+    expect(summary).not.toHaveFocus();
+    expect(summary).toHaveAttribute('data-focus-treatment', 'underline-only');
+    expect(summary).not.toHaveClass('focus-visible:ring-0');
+
+    summary.focus();
+    expect(summary).toHaveFocus();
+    expect(summary).toHaveAttribute('data-focus-treatment', 'underline-only');
+  });
+
+  it('uses the supplied retry handler', () => {
+    const onRetry = vi.fn();
+    render(
+      <PageErrorState
+        title='Unable to Load Dashboard'
+        message='Try again in a moment.'
+        onRetry={onRetry}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('contains long diagnostic content behind the details disclosure', () => {
+    const longMessage =
+      'Timed out while loading profile, audience, release, and analytics data.';
+    render(
+      <PageErrorState
+        title='Unable to Load Dashboard'
+        message='Try again in a moment.'
+        error={new Error(longMessage)}
+      />
+    );
+
+    const details = screen.getByText('Error Details').closest('details');
+    expect(details).not.toHaveAttribute('open');
+    expect(details).toHaveTextContent(longMessage);
+    expect(
+      details?.querySelector('[aria-label="Copy error details to clipboard"]')
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/components/features/feedback/PageErrorState.test.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.test.tsx
@@ -55,22 +55,36 @@ describe('PageErrorState', () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
-  it('contains long diagnostic content behind the details disclosure', () => {
+  it('keeps a repeated error message out of the diagnostic disclosure', () => {
     const longMessage =
       'Timed out while loading profile, audience, release, and analytics data.';
     render(
       <PageErrorState
         title='Unable to Load Dashboard'
-        message='Try again in a moment.'
+        message={longMessage}
         error={new Error(longMessage)}
       />
     );
 
     const details = screen.getByText('Error Details').closest('details');
     expect(details).not.toHaveAttribute('open');
-    expect(details).toHaveTextContent(longMessage);
+    expect(screen.getAllByText(longMessage)).toHaveLength(1);
+    expect(details).not.toHaveTextContent(longMessage);
     expect(
       details?.querySelector('[aria-label="Copy error details to clipboard"]')
     ).not.toBeNull();
+  });
+
+  it('keeps a distinct diagnostic message in the disclosure', () => {
+    render(
+      <PageErrorState
+        title='Unable to Load Dashboard'
+        message='Try again in a moment.'
+        error={new Error('Request timed out after 30 seconds.')}
+      />
+    );
+
+    const details = screen.getByText('Error Details').closest('details');
+    expect(details).toHaveTextContent('Request timed out after 30 seconds.');
   });
 });

--- a/apps/web/components/features/feedback/PageErrorState.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.tsx
@@ -75,6 +75,7 @@ export function PageErrorState({
           error={error}
           extraContext={mergedContext}
           collapsible={true}
+          showMessage={Boolean(error?.message && error.message !== message)}
         />
       </div>
     </div>

--- a/apps/web/components/features/feedback/PageErrorState.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.tsx
@@ -1,29 +1,23 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import { AlertTriangle } from 'lucide-react';
 import { ErrorDetails } from './ErrorDetails';
 
 interface PageErrorStateProps {
   readonly title?: string;
   readonly message: string;
   readonly error?: Error & { digest?: string };
-  /** Label for the primary action button (default: "Refresh page") */
+  /** Label for the primary action button (default: "Retry") */
   readonly actionLabel?: string;
   /** Custom handler for the primary action (default: reload page) */
   readonly onRetry?: () => void;
-  /** Optional secondary action */
-  readonly secondaryAction?: {
-    label: string;
-    onClick: () => void;
-  };
   /** Extra context passed to ErrorDetails (e.g., { Context: 'Dashboard' }) */
   readonly extraContext?: Record<string, string>;
 }
 
 /**
  * Canonical error state component for pages, sections, and error boundaries.
- * Shows a centered error message with retry/refresh actions and copyable error details.
+ * Keeps recovery focused on one retry action, with diagnostic information disclosed on demand.
  *
  * @example
  * // Server-side page error
@@ -45,9 +39,8 @@ export function PageErrorState({
   title = 'Something went wrong',
   message,
   error,
-  actionLabel = 'Refresh page',
+  actionLabel = 'Retry',
   onRetry,
-  secondaryAction,
   extraContext,
 }: PageErrorStateProps) {
   const mergedContext = {
@@ -58,23 +51,17 @@ export function PageErrorState({
 
   return (
     <div
-      className='flex flex-1 flex-col items-center justify-center px-4 py-12 text-center'
+      className='flex min-h-64 flex-1 flex-col items-center justify-center px-4 py-10 text-center'
       role='alert'
       aria-live='polite'
     >
-      <div className='w-full max-w-sm space-y-4'>
-        <div className='flex justify-center'>
-          <div className='flex h-10 w-10 items-center justify-center text-destructive'>
-            <AlertTriangle className='h-6 w-6' aria-hidden='true' />
-          </div>
-        </div>
-
-        <div className='space-y-1.5'>
-          <h1 className='text-sm font-medium text-secondary-token'>{title}</h1>
+      <div className='w-full max-w-sm space-y-3'>
+        <div className='space-y-1'>
+          <h1 className='text-app font-medium text-primary-token'>{title}</h1>
           <p className='text-app text-tertiary-token'>{message}</p>
         </div>
 
-        <div className='flex justify-center gap-3'>
+        <div className='flex justify-center'>
           <Button
             variant='primary'
             size='sm'
@@ -82,18 +69,13 @@ export function PageErrorState({
           >
             {actionLabel}
           </Button>
-          {secondaryAction ? (
-            <Button
-              variant='outline'
-              size='sm'
-              onClick={secondaryAction.onClick}
-            >
-              {secondaryAction.label}
-            </Button>
-          ) : null}
         </div>
 
-        <ErrorDetails error={error} extraContext={mergedContext} />
+        <ErrorDetails
+          error={error}
+          extraContext={mergedContext}
+          collapsible={true}
+        />
       </div>
     </div>
   );

--- a/apps/web/components/organisms/DashboardErrorFallback.tsx
+++ b/apps/web/components/organisms/DashboardErrorFallback.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import type { FallbackProps } from 'react-error-boundary';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
 
@@ -12,20 +11,18 @@ export function DashboardErrorFallback({
   error,
   resetErrorBoundary,
 }: FallbackProps) {
-  const router = useRouter();
   const errorWithDigest = error as Error & { digest?: string };
 
   return (
     <PageErrorState
-      title='Unable to load dashboard'
+      title='Unable to Load Dashboard'
       message={
         errorWithDigest.message ||
         'An unexpected error occurred while loading your dashboard.'
       }
       error={errorWithDigest}
-      actionLabel='Reload dashboard'
+      actionLabel='Retry'
       onRetry={resetErrorBoundary}
-      secondaryAction={{ label: 'Go home', onClick: () => router.push('/') }}
       extraContext={{ Context: 'Dashboard' }}
     />
   );

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2203,6 +2203,21 @@ html:not(.dark) .smart-link-powered-by {
     border-color 150ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
+/* A quiet disclosure needs a keyboard cue without the global focus halo.
+   This is deliberately declared after the fallback so it wins for pointer and
+   keyboard focus alike; the underline is limited to :focus-visible. */
+[data-focus-treatment="underline-only"]:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+[data-focus-treatment="underline-only"]:focus-visible {
+  box-shadow: none;
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
 :where(
   input,
   textarea,


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4509 -->

## Summary
- Simplify the shared fatal-error state to one Retry action and a collapsed Error Details disclosure.
- Remove duplicate recovery actions from chat and release callers.
- Add semantic underline-only focus treatment that suppresses the global halo for pointer focus.

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter web exec vitest run components/features/feedback/PageErrorState.test.tsx` (3 passed)
- Focused Biome (8 files)
- `pnpm --filter @jovie/web run test:bug-to-test` (not classified as a bug fix)
- Live Storybook 6011: valid rendered desktop evidence at `.context/dashboard-error-desktop-v4-collapsed-1159x863.png` (1159x863), mobile at `.context/dashboard-error-mobile-v4-collapsed-390x844.png` (390x844); pointer Error Details computed `boxShadow: none`.

No merge performed.