### PR TITLE
fix(ops): add durable stale-lease recovery guard

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -143,8 +143,7 @@ describe('stale lease guard', () => {
   const terminalComment = {
     id: 'agent-1',
     createdAt: '2026-07-25T12:00:00.000Z',
-    body:
-      'Jovie agent (codex issue shipper) released this issue for retry.\n\nAgent exited 0 but no open PR exists - releasing claim for retry.',
+    body: 'Jovie agent (codex issue shipper) released this issue for retry.\n\nAgent exited 0 but no open PR exists - releasing claim for retry.',
   };
 
   function staleIssue(overrides = {}) {
@@ -173,7 +172,8 @@ describe('stale lease guard', () => {
       },
       async transitionIssue(id, stateId) {
         calls.transitions.push({ id, stateId });
-        if (transitionError === 'transition') throw new Error('transition failed');
+        if (transitionError === 'transition')
+          throw new Error('transition failed');
         return { success: true };
       },
     };
@@ -192,9 +192,15 @@ describe('stale lease guard', () => {
   });
 
   it('does not recover issues with an active PR', async () => {
-    const issue = staleIssue({ pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/123' });
+    const issue = staleIssue({
+      pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/123',
+    });
     const client = fakeClient(issue);
-    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    const result = await staleLease.sweepStaleLeases({
+      issues: [issue],
+      client,
+      now,
+    });
     assert.equal(result.recovered.length, 0);
     assert.equal(client.calls.comments.length, 0);
     assert.equal(result.skipped[0].reason, 'active-pr');
@@ -214,12 +220,19 @@ describe('stale lease guard', () => {
       now,
     });
     assert.equal(assignedResult.skipped[0].reason, 'assigned');
-    assert.equal(unknownResult.skipped[0].reason, 'latest-agent-evidence-not-terminal');
+    assert.equal(
+      unknownResult.skipped[0].reason,
+      'latest-agent-evidence-not-terminal'
+    );
   });
   it('does not recover a fresh lease', async () => {
     const issue = staleIssue({ updatedAt: '2026-07-27T12:01:00.000Z' });
     const client = fakeClient(issue);
-    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    const result = await staleLease.sweepStaleLeases({
+      issues: [issue],
+      client,
+      now,
+    });
     assert.equal(result.recovered.length, 0);
     assert.equal(result.skipped[0].reason, 'lease-too-fresh');
   });
@@ -236,25 +249,55 @@ describe('stale lease guard', () => {
       ],
     });
     const client = fakeClient(issue);
-    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    const result = await staleLease.sweepStaleLeases({
+      issues: [issue],
+      client,
+      now,
+    });
     assert.equal(result.recovered.length, 0);
-    assert.equal(result.skipped[0].reason, 'latest-agent-evidence-not-terminal');
+    assert.equal(
+      result.skipped[0].reason,
+      'latest-agent-evidence-not-terminal'
+    );
   });
 
   it('recovers a safe stale lease with exactly one stable comment and verified mutations', async () => {
     const issue = staleIssue();
     const rereadAfterComment = staleIssue({
-      comments: [terminalComment, { id: 'recovery', createdAt: now, body: staleLease.STALE_LEASE_RECOVERY_COMMENT }],
+      comments: [
+        terminalComment,
+        {
+          id: 'recovery',
+          createdAt: now,
+          body: staleLease.STALE_LEASE_RECOVERY_COMMENT,
+        },
+      ],
     });
     const rereadAfterTransition = staleIssue({
       state: 'Todo',
-      comments: [terminalComment, { id: 'recovery', createdAt: now, body: staleLease.STALE_LEASE_RECOVERY_COMMENT }],
+      comments: [
+        terminalComment,
+        {
+          id: 'recovery',
+          createdAt: now,
+          body: staleLease.STALE_LEASE_RECOVERY_COMMENT,
+        },
+      ],
     });
-    const client = fakeClient(issue, { rereads: [rereadAfterComment, rereadAfterTransition] });
-    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    const client = fakeClient(issue, {
+      rereads: [rereadAfterComment, rereadAfterTransition],
+    });
+    const result = await staleLease.sweepStaleLeases({
+      issues: [issue],
+      client,
+      now,
+    });
     assert.equal(result.recovered.length, 1);
     assert.equal(client.calls.comments.length, 1);
-    assert.equal(client.calls.comments[0].body, staleLease.STALE_LEASE_RECOVERY_COMMENT);
+    assert.equal(
+      client.calls.comments[0].body,
+      staleLease.STALE_LEASE_RECOVERY_COMMENT
+    );
     assert.equal(client.calls.transitions.length, 1);
     assert.equal(client.calls.rereads, 3);
   });
@@ -262,10 +305,21 @@ describe('stale lease guard', () => {
   it('is idempotent when the recovery comment already exists and issue is Todo', async () => {
     const issue = staleIssue({
       state: 'Todo',
-      comments: [terminalComment, { id: 'recovery', createdAt: now, body: staleLease.STALE_LEASE_RECOVERY_COMMENT }],
+      comments: [
+        terminalComment,
+        {
+          id: 'recovery',
+          createdAt: now,
+          body: staleLease.STALE_LEASE_RECOVERY_COMMENT,
+        },
+      ],
     });
     const client = fakeClient(issue);
-    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    const result = await staleLease.sweepStaleLeases({
+      issues: [issue],
+      client,
+      now,
+    });
     assert.equal(result.recovered.length, 0);
     assert.equal(client.calls.comments.length, 0);
     assert.equal(client.calls.transitions.length, 0);
@@ -274,14 +328,28 @@ describe('stale lease guard', () => {
 
   it('fails closed when a mutation reread does not prove the requested state', async () => {
     const issue = staleIssue();
-    const rereadAfterComment = staleIssue({ comments: [terminalComment, { id: 'recovery', body: staleLease.STALE_LEASE_RECOVERY_COMMENT, createdAt: now }] });
-    const client = fakeClient(issue, { rereads: [rereadAfterComment, staleIssue()] });
-    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    const rereadAfterComment = staleIssue({
+      comments: [
+        terminalComment,
+        {
+          id: 'recovery',
+          body: staleLease.STALE_LEASE_RECOVERY_COMMENT,
+          createdAt: now,
+        },
+      ],
+    });
+    const client = fakeClient(issue, {
+      rereads: [rereadAfterComment, staleIssue()],
+    });
+    const result = await staleLease.sweepStaleLeases({
+      issues: [issue],
+      client,
+      now,
+    });
     assert.equal(result.recovered.length, 0);
     assert.equal(result.failed[0].reason, 'transition-verification-failed');
   });
 });
-
 
 describe('entrypoint contract', () => {
   it('keeps the cron wrapper beside the executable and config', async () => {

--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -11,6 +11,7 @@ const classifier = await import('../classifier.mjs');
 const scorer = await import('../scorer.mjs');
 const workstreamer = await import('../workstreamer.mjs');
 const reporter = await import('../reporter.mjs');
+const staleLease = await import('../stale-lease-guard.mjs');
 
 function makeIssue(overrides = {}) {
   return {
@@ -23,7 +24,8 @@ function makeIssue(overrides = {}) {
     updatedAt: overrides.updatedAt || '2026-07-01T12:00:00Z',
     priority: overrides.priority ?? 0,
     estimate: overrides.estimate ?? null,
-    assignee: null,
+    assignee: overrides.assignee ?? null,
+    pullRequestUrl: overrides.pullRequestUrl ?? null,
     creator: null,
     labels: {
       nodes: overrides.labels ? overrides.labels.map(n => ({ name: n })) : [],
@@ -135,6 +137,151 @@ describe('reporter', () => {
     assert.ok(report.includes('CLASSIFICATION SUMMARY'));
   });
 });
+
+describe('stale lease guard', () => {
+  const now = '2026-07-28T12:00:00.000Z';
+  const terminalComment = {
+    id: 'agent-1',
+    createdAt: '2026-07-25T12:00:00.000Z',
+    body:
+      'Jovie agent (codex issue shipper) released this issue for retry.\n\nAgent exited 0 but no open PR exists - releasing claim for retry.',
+  };
+
+  function staleIssue(overrides = {}) {
+    return makeIssue({
+      identifier: overrides.identifier || 'JOV-LEASE-1',
+      state: 'In Progress',
+      updatedAt: '2026-07-25T12:00:00.000Z',
+      comments: [terminalComment],
+      ...overrides,
+    });
+  }
+
+  function fakeClient(issue, { rereads = [], transitionError = null } = {}) {
+    const reads = [issue, ...rereads];
+    const calls = { comments: [], transitions: [], rereads: 0 };
+    return {
+      calls,
+      async fetchIssue() {
+        calls.rereads += 1;
+        return reads.shift() || issue;
+      },
+      async addComment(id, body) {
+        calls.comments.push({ id, body });
+        if (transitionError === 'comment') throw new Error('comment failed');
+        return { success: true };
+      },
+      async transitionIssue(id, stateId) {
+        calls.transitions.push({ id, stateId });
+        if (transitionError === 'transition') throw new Error('transition failed');
+        return { success: true };
+      },
+    };
+  }
+
+  it('does not recover protected-label issues', async () => {
+    const client = fakeClient(staleIssue({ labels: ['needs-human'] }));
+    const result = await staleLease.sweepStaleLeases({
+      issues: [staleIssue({ labels: ['needs-human'] })],
+      client,
+      now,
+    });
+    assert.equal(result.recovered.length, 0);
+    assert.equal(client.calls.transitions.length, 0);
+    assert.equal(result.skipped[0].reason, 'protected-label');
+  });
+
+  it('does not recover issues with an active PR', async () => {
+    const issue = staleIssue({ pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/123' });
+    const client = fakeClient(issue);
+    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    assert.equal(result.recovered.length, 0);
+    assert.equal(client.calls.comments.length, 0);
+    assert.equal(result.skipped[0].reason, 'active-pr');
+  });
+
+  it('does not recover assigned or unknown leases', async () => {
+    const assigned = staleIssue({ assignee: { id: 'tim', name: 'Tim White' } });
+    const unknown = staleIssue({ comments: [] });
+    const assignedResult = await staleLease.sweepStaleLeases({
+      issues: [assigned],
+      client: fakeClient(assigned),
+      now,
+    });
+    const unknownResult = await staleLease.sweepStaleLeases({
+      issues: [unknown],
+      client: fakeClient(unknown),
+      now,
+    });
+    assert.equal(assignedResult.skipped[0].reason, 'assigned');
+    assert.equal(unknownResult.skipped[0].reason, 'latest-agent-evidence-not-terminal');
+  });
+  it('does not recover a fresh lease', async () => {
+    const issue = staleIssue({ updatedAt: '2026-07-27T12:01:00.000Z' });
+    const client = fakeClient(issue);
+    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    assert.equal(result.recovered.length, 0);
+    assert.equal(result.skipped[0].reason, 'lease-too-fresh');
+  });
+
+  it('requires terminal latest machine-agent evidence', async () => {
+    const issue = staleIssue({
+      comments: [
+        terminalComment,
+        {
+          id: 'agent-2',
+          createdAt: '2026-07-28T10:00:00.000Z',
+          body: 'Jovie agent started a new attempt; work is in progress.',
+        },
+      ],
+    });
+    const client = fakeClient(issue);
+    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    assert.equal(result.recovered.length, 0);
+    assert.equal(result.skipped[0].reason, 'latest-agent-evidence-not-terminal');
+  });
+
+  it('recovers a safe stale lease with exactly one stable comment and verified mutations', async () => {
+    const issue = staleIssue();
+    const rereadAfterComment = staleIssue({
+      comments: [terminalComment, { id: 'recovery', createdAt: now, body: staleLease.STALE_LEASE_RECOVERY_COMMENT }],
+    });
+    const rereadAfterTransition = staleIssue({
+      state: 'Todo',
+      comments: [terminalComment, { id: 'recovery', createdAt: now, body: staleLease.STALE_LEASE_RECOVERY_COMMENT }],
+    });
+    const client = fakeClient(issue, { rereads: [rereadAfterComment, rereadAfterTransition] });
+    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    assert.equal(result.recovered.length, 1);
+    assert.equal(client.calls.comments.length, 1);
+    assert.equal(client.calls.comments[0].body, staleLease.STALE_LEASE_RECOVERY_COMMENT);
+    assert.equal(client.calls.transitions.length, 1);
+    assert.equal(client.calls.rereads, 3);
+  });
+
+  it('is idempotent when the recovery comment already exists and issue is Todo', async () => {
+    const issue = staleIssue({
+      state: 'Todo',
+      comments: [terminalComment, { id: 'recovery', createdAt: now, body: staleLease.STALE_LEASE_RECOVERY_COMMENT }],
+    });
+    const client = fakeClient(issue);
+    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    assert.equal(result.recovered.length, 0);
+    assert.equal(client.calls.comments.length, 0);
+    assert.equal(client.calls.transitions.length, 0);
+    assert.equal(result.skipped[0].reason, 'not-in-progress');
+  });
+
+  it('fails closed when a mutation reread does not prove the requested state', async () => {
+    const issue = staleIssue();
+    const rereadAfterComment = staleIssue({ comments: [terminalComment, { id: 'recovery', body: staleLease.STALE_LEASE_RECOVERY_COMMENT, createdAt: now }] });
+    const client = fakeClient(issue, { rereads: [rereadAfterComment, staleIssue()] });
+    const result = await staleLease.sweepStaleLeases({ issues: [issue], client, now });
+    assert.equal(result.recovered.length, 0);
+    assert.equal(result.failed[0].reason, 'transition-verification-failed');
+  });
+});
+
 
 describe('entrypoint contract', () => {
   it('keeps the cron wrapper beside the executable and config', async () => {

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -30,7 +30,9 @@ const scorer = await import(resolve(__dirname, 'scorer.mjs'));
 const workstreamer = await import(resolve(__dirname, 'workstreamer.mjs'));
 const admitter = await import(resolve(__dirname, 'admitter.mjs'));
 const reporter = await import(resolve(__dirname, 'reporter.mjs'));
-const staleLeaseGuard = await import(resolve(__dirname, 'stale-lease-guard.mjs'));
+const staleLeaseGuard = await import(
+  resolve(__dirname, 'stale-lease-guard.mjs')
+);
 
 // ----- Config -----
 const CACHE_FILE = resolve(__dirname, '.orchestrator-cache.json');

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -30,6 +30,7 @@ const scorer = await import(resolve(__dirname, 'scorer.mjs'));
 const workstreamer = await import(resolve(__dirname, 'workstreamer.mjs'));
 const admitter = await import(resolve(__dirname, 'admitter.mjs'));
 const reporter = await import(resolve(__dirname, 'reporter.mjs'));
+const staleLeaseGuard = await import(resolve(__dirname, 'stale-lease-guard.mjs'));
 
 // ----- Config -----
 const CACHE_FILE = resolve(__dirname, '.orchestrator-cache.json');
@@ -189,6 +190,29 @@ async function runReconcile(cache, isDryRun, issueArg) {
 
 async function runAdmitNext(cache, isDryRun) {
   console.log('Checking admission eligibility...');
+
+  // Release only provably stale machine leases before ordinary admission. This
+  // is intentionally scoped to unassigned In Progress issues; it never touches
+  // Tim-assigned or otherwise ambiguous work.
+  const inProgressIssues = await linear.fetchTeamInProgressIssues(TEAM_ID);
+  if (isDryRun) {
+    const planned = inProgressIssues
+      .map(issue => ({
+        identifier: issue.identifier,
+        decision: staleLeaseGuard.classifyStaleLease(issue),
+      }))
+      .filter(entry => entry.decision.eligible);
+    console.log(`Stale-lease sweep (dry-run): ${planned.length} eligible`);
+  } else {
+    const staleLeaseResult = await staleLeaseGuard.sweepStaleLeases({
+      issues: inProgressIssues,
+      client: linear,
+    });
+    console.log(
+      `Stale-lease sweep: recovered ${staleLeaseResult.recovered.length}, ` +
+        `skipped ${staleLeaseResult.skipped.length}, failed ${staleLeaseResult.failed.length}`
+    );
+  }
 
   const allIssues = await linear.fetchTeamActiveIssues(TEAM_ID);
   const classifications = [];

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -142,6 +142,51 @@ export async function fetchTeamActiveIssues(teamId, maxResults = 1000) {
 }
 
 /**
+ * Fetch all unassigned-eligible candidates currently in In Progress, including
+ * comments needed for terminal machine-agent evidence and recovery idempotency.
+ */
+export async function fetchTeamInProgressIssues(teamId, maxResults = 1000) {
+  const issues = [];
+  let cursor = null;
+  while (issues.length < maxResults) {
+    const data = await graphql(
+      `
+      query($teamId: String!, $cursor: String) {
+        team(id: $teamId) {
+          issues(
+            first: 50,
+            after: $cursor,
+            filter: { state: { name: { eq: "In Progress" } } }
+          ) {
+            nodes {
+              id
+              identifier
+              title
+              description
+              url
+              createdAt
+              updatedAt
+              assignee { id name }
+              labels { nodes { id name } }
+              state { id name type }
+              comments { nodes { id body createdAt } }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    `,
+      { teamId, cursor }
+    );
+    const edge = data.team.issues;
+    issues.push(...edge.nodes);
+    if (!edge.pageInfo.hasNextPage) break;
+    cursor = edge.pageInfo.endCursor;
+  }
+  return issues;
+}
+
+/**
  * Fetch a single issue by identifier (e.g. "JOV-1234").
  */
 export async function fetchIssue(identifier) {

--- a/scripts/backlog-orchestrator/stale-lease-guard.mjs
+++ b/scripts/backlog-orchestrator/stale-lease-guard.mjs
@@ -66,7 +66,9 @@ function hasOpenPullRequest(issue) {
     issue?.githubPrUrl,
     issue?.activePullRequestUrl,
   ];
-  if (directReferences.some(value => typeof value === 'string' && value.trim())) {
+  if (
+    directReferences.some(value => typeof value === 'string' && value.trim())
+  ) {
     return true;
   }
 
@@ -77,7 +79,10 @@ function hasOpenPullRequest(issue) {
   }
 
   const latestEvidence = latestMachineAgentEvidence(issue)?.body || '';
-  return PR_URL_PATTERN.test(latestEvidence) && !NEGATED_OPEN_PR_PATTERN.test(latestEvidence);
+  return (
+    PR_URL_PATTERN.test(latestEvidence) &&
+    !NEGATED_OPEN_PR_PATTERN.test(latestEvidence)
+  );
 }
 
 function ageHours(issue, now) {
@@ -138,7 +143,11 @@ export function classifyStaleLease(
   if (commentCount > 1) {
     return { eligible: false, reason: 'duplicate-recovery-comments' };
   }
-  return { eligible: true, ageHours: age, hasRecoveryComment: commentCount === 1 };
+  return {
+    eligible: true,
+    ageHours: age,
+    hasRecoveryComment: commentCount === 1,
+  };
 }
 
 function mutationSucceeded(result) {
@@ -179,7 +188,10 @@ export async function sweepStaleLeases({
 
     const decision = classifyStaleLease(issue, { now, ...policy });
     if (!decision.eligible) {
-      result.skipped.push({ identifier: issue.identifier, reason: decision.reason });
+      result.skipped.push({
+        identifier: issue.identifier,
+        reason: decision.reason,
+      });
       continue;
     }
 
@@ -207,7 +219,10 @@ export async function sweepStaleLeases({
         issue = afterComment;
       }
 
-      const transitionResult = await client.transitionIssue(issue.id, todoStateId);
+      const transitionResult = await client.transitionIssue(
+        issue.id,
+        todoStateId
+      );
       if (!mutationSucceeded(transitionResult)) {
         throw new Error('transition mutation returned success=false');
       }
@@ -222,7 +237,10 @@ export async function sweepStaleLeases({
         });
         continue;
       }
-      result.recovered.push({ identifier: issue.identifier, ageHours: decision.ageHours });
+      result.recovered.push({
+        identifier: issue.identifier,
+        ageHours: decision.ageHours,
+      });
     } catch (error) {
       result.failed.push({
         identifier: issue.identifier,

--- a/scripts/backlog-orchestrator/stale-lease-guard.mjs
+++ b/scripts/backlog-orchestrator/stale-lease-guard.mjs
@@ -1,0 +1,236 @@
+/**
+ * Durable recovery for stale machine-agent leases.
+ *
+ * This guard is deliberately narrower than ordinary backlog admission. It only
+ * releases an unassigned In Progress issue when the latest machine-agent
+ * evidence is terminal, the lease is stale but still within a bounded window,
+ * and there is no evidence of an open PR or human protection.
+ */
+
+export const TODO_STATE_ID = 'c6c00506-dc9f-4910-8ff7-3874dd77174c';
+export const STALE_LEASE_RECOVERY_COMMENT =
+  '<!-- stale-lease-recovery {"version":1,"action":"release-to-todo","reason":"terminal-machine-agent-evidence"} -->';
+
+export const DEFAULT_PROTECTED_LABELS = new Set([
+  'needs-human',
+  'no-auto',
+  'human-review-required',
+  'founder-fast-track',
+  'blocked',
+  'incident',
+  'risk:high',
+  'tim-approved',
+  'codex-blocked',
+]);
+
+const MACHINE_AGENT_PATTERN =
+  /jovie agent|codex issue shipper|machine-agent|machine agent/i;
+const TERMINAL_PATTERN =
+  /released|stopped|completed|finished|terminal|exited\s+(?:0|without|with)/i;
+const NEGATED_OPEN_PR_PATTERN =
+  /no\s+(?:open|active)\s+(?:github\s+)?pr|without\s+(?:an?\s+)?open\s+pr/i;
+const PR_URL_PATTERN = /https?:\/\/github\.com\/[^\s)]+\/pull\/\d+/i;
+
+function labelsOf(issue) {
+  const labels = issue?.labels?.nodes ?? issue?.labels ?? [];
+  return labels
+    .map(label => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean)
+    .map(label => label.toLowerCase());
+}
+
+function commentsOf(issue) {
+  return (issue?.comments?.nodes ?? issue?.comments ?? [])
+    .filter(comment => comment && typeof comment.body === 'string')
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt || 0).getTime() -
+        new Date(a.createdAt || 0).getTime()
+    );
+}
+
+function latestMachineAgentEvidence(issue) {
+  return commentsOf(issue).find(comment => {
+    const author = `${comment.author?.name || ''} ${comment.author?.email || ''}`;
+    return (
+      comment.machineAgent === true ||
+      comment.source === 'machine-agent' ||
+      MACHINE_AGENT_PATTERN.test(`${author} ${comment.body}`)
+    );
+  });
+}
+
+function hasOpenPullRequest(issue) {
+  const directReferences = [
+    issue?.pullRequestUrl,
+    issue?.githubPrUrl,
+    issue?.activePullRequestUrl,
+  ];
+  if (directReferences.some(value => typeof value === 'string' && value.trim())) {
+    return true;
+  }
+
+  const pullRequest = issue?.pullRequest || issue?.githubPullRequest;
+  if (pullRequest && typeof pullRequest === 'object') {
+    if (String(pullRequest.state || '').toUpperCase() === 'OPEN') return true;
+    if (pullRequest.isOpen === true) return true;
+  }
+
+  const latestEvidence = latestMachineAgentEvidence(issue)?.body || '';
+  return PR_URL_PATTERN.test(latestEvidence) && !NEGATED_OPEN_PR_PATTERN.test(latestEvidence);
+}
+
+function ageHours(issue, now) {
+  const updatedAt = new Date(issue?.updatedAt || 0).getTime();
+  const current = new Date(now).getTime();
+  if (!Number.isFinite(updatedAt) || !Number.isFinite(current)) return null;
+  return (current - updatedAt) / 3_600_000;
+}
+
+function recoveryCommentCount(issue) {
+  return commentsOf(issue).filter(
+    comment => comment.body.trim() === STALE_LEASE_RECOVERY_COMMENT
+  ).length;
+}
+
+export function isTerminalMachineAgentEvidence(issue) {
+  const latest = latestMachineAgentEvidence(issue);
+  if (!latest) return false;
+  const evidence = [latest.body, latest.event, latest.status, latest.type]
+    .filter(Boolean)
+    .join(' ');
+  return TERMINAL_PATTERN.test(evidence);
+}
+
+export function classifyStaleLease(
+  issue,
+  {
+    now = new Date().toISOString(),
+    minLeaseAgeHours = 24,
+    maxLeaseAgeHours = 24 * 30,
+    protectedLabels = DEFAULT_PROTECTED_LABELS,
+  } = {}
+) {
+  if (issue?.state?.name !== 'In Progress') {
+    return { eligible: false, reason: 'not-in-progress' };
+  }
+  if (issue.assignee) {
+    return { eligible: false, reason: 'assigned' };
+  }
+  if (labelsOf(issue).some(label => protectedLabels.has(label))) {
+    return { eligible: false, reason: 'protected-label' };
+  }
+  if (hasOpenPullRequest(issue)) {
+    return { eligible: false, reason: 'active-pr' };
+  }
+  const age = ageHours(issue, now);
+  if (age === null) return { eligible: false, reason: 'invalid-lease-age' };
+  if (age < minLeaseAgeHours) {
+    return { eligible: false, reason: 'lease-too-fresh', ageHours: age };
+  }
+  if (age > maxLeaseAgeHours) {
+    return { eligible: false, reason: 'lease-too-old', ageHours: age };
+  }
+  if (!isTerminalMachineAgentEvidence(issue)) {
+    return { eligible: false, reason: 'latest-agent-evidence-not-terminal' };
+  }
+  const commentCount = recoveryCommentCount(issue);
+  if (commentCount > 1) {
+    return { eligible: false, reason: 'duplicate-recovery-comments' };
+  }
+  return { eligible: true, ageHours: age, hasRecoveryComment: commentCount === 1 };
+}
+
+function mutationSucceeded(result) {
+  if (result === undefined || result === true) return true;
+  if (result === false || result?.success === false) return false;
+  const nestedSuccess = [
+    result?.commentCreate?.success,
+    result?.issueUpdate?.success,
+  ].filter(value => value !== undefined);
+  return nestedSuccess.length === 0 || nestedSuccess.every(Boolean);
+}
+
+/**
+ * Sweep and safely release stale leases. Every mutation is followed by an
+ * authoritative fetchIssue reread; an unproven mutation is reported failed.
+ */
+export async function sweepStaleLeases({
+  issues,
+  client,
+  now = new Date().toISOString(),
+  todoStateId = TODO_STATE_ID,
+  ...policy
+}) {
+  const result = { recovered: [], skipped: [], failed: [] };
+
+  for (const snapshot of issues) {
+    let issue = snapshot;
+    try {
+      issue = (await client.fetchIssue(snapshot.identifier)) || snapshot;
+    } catch (error) {
+      result.failed.push({
+        identifier: snapshot.identifier,
+        reason: 'reread-failed',
+        error: error.message,
+      });
+      continue;
+    }
+
+    const decision = classifyStaleLease(issue, { now, ...policy });
+    if (!decision.eligible) {
+      result.skipped.push({ identifier: issue.identifier, reason: decision.reason });
+      continue;
+    }
+
+    try {
+      if (!decision.hasRecoveryComment) {
+        const commentResult = await client.addComment(
+          issue.id,
+          STALE_LEASE_RECOVERY_COMMENT
+        );
+        if (!mutationSucceeded(commentResult)) {
+          throw new Error('comment mutation returned success=false');
+        }
+        const afterComment = await client.fetchIssue(issue.identifier);
+        const afterCommentCount = recoveryCommentCount(afterComment);
+        if (
+          afterComment?.state?.name !== 'In Progress' ||
+          afterCommentCount !== 1
+        ) {
+          result.failed.push({
+            identifier: issue.identifier,
+            reason: 'comment-verification-failed',
+          });
+          continue;
+        }
+        issue = afterComment;
+      }
+
+      const transitionResult = await client.transitionIssue(issue.id, todoStateId);
+      if (!mutationSucceeded(transitionResult)) {
+        throw new Error('transition mutation returned success=false');
+      }
+      const afterTransition = await client.fetchIssue(issue.identifier);
+      if (
+        afterTransition?.state?.name !== 'Todo' ||
+        recoveryCommentCount(afterTransition) !== 1
+      ) {
+        result.failed.push({
+          identifier: issue.identifier,
+          reason: 'transition-verification-failed',
+        });
+        continue;
+      }
+      result.recovered.push({ identifier: issue.identifier, ageHours: decision.ageHours });
+    } catch (error) {
+      result.failed.push({
+        identifier: issue.identifier,
+        reason: 'mutation-failed',
+        error: error.message,
+      });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Add a deterministic pre-admission stale-lease sweep for unassigned `In Progress` issues only.
- Require a terminal latest machine-agent event, no active PR, no protected labels, and a stale lease age within the bounded 24h–30d window.
- Recover with one stable machine-readable comment and verify the comment/state after every mutation.

## Tests
- `node --check scripts/backlog-orchestrator/stale-lease-guard.mjs`
- `node --check scripts/backlog-orchestrator/backlog-orchestrator.mjs`
- `node --check scripts/backlog-orchestrator/linear-client.mjs`
- `node --test scripts/backlog-orchestrator/__tests__/*.mjs` (15 passed)
- `git diff --check`

## Scope guard
- Assigned, Tim-assigned, unknown-evidence, protected-label, active-PR, fresh, and over-age leases remain untouched.
- No merge or production mutation performed.
