### PR TITLE
fix(shell): unify active sidebar nav state

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2699,6 +2699,8 @@ body {
   --color-warning-subtle: var(--color-warning-subtle);
   --color-info: var(--color-info);
   --color-info-subtle: var(--color-info-subtle);
+  /* Named accent utilities use the existing carbon palette runtime tokens. */
+  --color-accent-blue: var(--color-accent-blue);
   --color-error-subtle: var(--color-error-subtle);
   --color-error-foreground: var(--color-error-foreground);
   /* Accent token — enables bg-accent-subtle, text-accent, border-accent */

--- a/apps/web/components/shell/SidebarNavItem.stories.tsx
+++ b/apps/web/components/shell/SidebarNavItem.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof SidebarNavItem> = {
   parameters: { layout: 'centered' },
   decorators: [
     Story => (
-      <div className='w-60 bg-(--linear-app-content-surface) p-3'>
+      <div className='w-60 bg-sidebar p-3'>
         <Story />
       </div>
     ),

--- a/apps/web/components/shell/SidebarNavItem.stories.tsx
+++ b/apps/web/components/shell/SidebarNavItem.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { House } from 'lucide-react';
+import { SidebarNavItem } from './SidebarNavItem';
+
+const meta: Meta<typeof SidebarNavItem> = {
+  title: 'Shell/SidebarNavItem',
+  component: SidebarNavItem,
+  parameters: { layout: 'centered' },
+  decorators: [
+    Story => (
+      <div className='w-60 bg-(--linear-app-content-surface) p-3'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SidebarNavItem>;
+
+export const Active: Story = {
+  args: {
+    collapsed: false,
+    item: { label: 'Inbox', icon: House, active: true },
+  },
+};
+
+export const ActiveCollapsed: Story = {
+  args: {
+    collapsed: true,
+    item: { label: 'Inbox', icon: House, active: true },
+  },
+};

--- a/apps/web/components/shell/SidebarNavItem.test.tsx
+++ b/apps/web/components/shell/SidebarNavItem.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSidebarNavIconClassName,
+  getSidebarNavRowClassName,
+} from './SidebarNavItem';
+
+describe('SidebarNavItem active chrome', () => {
+  it('uses white text and an accent-blue icon without a left rail', () => {
+    const row = getSidebarNavRowClassName({ active: true });
+    const icon = getSidebarNavIconClassName({ active: true });
+
+    expect(row).toContain('text-white');
+    expect(row).toContain('shadow-none');
+    expect(row).not.toContain('inset_2px_0');
+    expect(icon).toContain('text-accent-blue!');
+  });
+});

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -37,10 +37,10 @@ interface SidebarNavChromeOptions {
 const SIDEBAR_PRIMARY_CHROME =
   'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)] text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,white_14%)]';
 
-// Active: filled surface + left accent rail (not a full border — #13217) so
-// the current section is obvious at a glance on dark sidebar chrome.
+// Active state uses type and icon color only. Avoid a left rail so every shared
+// sidebar consumer keeps the same compact, decoration-free geometry.
 const SIDEBAR_ACTIVE_CHROME =
-  'bg-sidebar-accent-active text-primary-token font-medium shadow-[inset_2px_0_0_0_var(--color-accent)]';
+  'bg-sidebar-accent-active text-white font-medium shadow-none';
 
 const SIDEBAR_INACTIVE_CHROME =
   'text-sidebar-item-foreground hover:bg-sidebar-accent hover:text-sidebar-item-foreground';
@@ -104,7 +104,9 @@ export function getSidebarNavIconClassName({
   return cn(
     'shrink-0 justify-self-center',
     tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
-    active ? 'text-primary-token' : inactiveIconColor,
+    // The active row deliberately owns white label text. Make the icon's
+    // semantic accent explicit so it cannot inherit that foreground color.
+    active ? 'text-accent-blue!' : inactiveIconColor,
     className
   );
 }

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -43,7 +43,10 @@ describe('SidebarThreadsSection', () => {
     expect(activeThread).toHaveAttribute('aria-current', 'page');
     expect(activeThread).toHaveClass('h-6');
     expect(activeThread).toHaveClass('bg-sidebar-accent-active');
-    expect(activeThread).toHaveClass('text-primary-token');
+    expect(activeThread).toHaveClass('text-white');
+    expect(activeThread).not.toHaveClass(
+      'shadow-[inset_2px_0_0_0_var(--color-accent)]'
+    );
     expect(inactiveThread).toHaveClass('text-secondary-token');
     expect(inactiveThread).toHaveClass('hover:bg-surface-1');
     expect(inactiveThread).toHaveClass('focus-visible:ring-2');

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -169,7 +169,7 @@ describe('Sidebar row alignment', () => {
 
     // Same active treatment as the shell sidebar.
     expect(settingsActiveRow).toContain('bg-sidebar-accent-active');
-    expect(settingsActiveRow).toContain('text-primary-token');
+    expect(settingsActiveRow).toContain('text-white');
     expect(settingsActiveRow).toContain('font-medium');
 
     // Allowed structural divergence: icon-less single-column grid with the
@@ -223,15 +223,14 @@ describe('Sidebar row alignment', () => {
       'text-sidebar-muted/65'
     );
     expect(activeRowClassName).toContain('bg-sidebar-accent-active');
-    expect(activeRowClassName).toContain('text-primary-token');
+    expect(activeRowClassName).toContain('text-white');
     expect(activeRowClassName).toContain('font-medium');
-    expect(activeRowClassName).toContain(
-      'shadow-[inset_2px_0_0_0_var(--color-accent)]'
-    );
+    expect(activeRowClassName).toContain('shadow-none');
+    expect(activeRowClassName).not.toContain('inset_2px_0');
     expect(iconClassName).toContain('h-3.5');
     expect(iconClassName).toContain('text-sidebar-muted/70');
     expect(getSidebarNavIconClassName({ active: true })).toContain(
-      'text-primary-token'
+      'text-accent-blue!'
     );
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4526 -->

## Summary
- centralize the active shell-nav treatment in `SidebarNavItem`: white label, accent-blue icon, quiet fill, no left rail or inset shadow
- register the existing accent-blue runtime token with Tailwind v4 so the shared semantic icon class emits correctly
- add active and compact Storybook coverage plus a focused regression test

## Verification
- `pnpm biome check apps/web/app/globals.css apps/web/components/shell/SidebarNavItem.tsx apps/web/components/shell/SidebarNavItem.stories.tsx apps/web/components/shell/SidebarNavItem.test.tsx`
- `pnpm --filter @jovie/web exec vitest run components/shell/SidebarNavItem.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push gate: Tailwind guard, proxy guard, affected test bundle (including arbitrary-values ratchet), typecheck, lint, CI harness
- seeded authenticated desktop runtime: active SVG color/stroke `rgb(77, 125, 255)`, label white, no box shadow
- Kimi design review: PASS, no blockers

## Scope
Shared sidebar primitive only. Review artifacts remain local and are not committed.