### PR TITLE
fix(tasks): stabilize workspace loading and compact layout

### DIFF
--- a/apps/web/app/app/(shell)/layout.ov-mode.test.tsx
+++ b/apps/web/app/app/(shell)/layout.ov-mode.test.tsx
@@ -10,6 +10,7 @@ const {
   getCurrentAdminPageAccessMock,
   headersMock,
   redirectMock,
+  suspendShellContentMock,
 } = vi.hoisted(() => ({
   dashboardShellContentMock: vi.fn(),
   getAppFlagValueMock: vi.fn(),
@@ -19,6 +20,7 @@ const {
   redirectMock: vi.fn((href: string) => {
     throw new Error(`NEXT_REDIRECT:${href}`);
   }),
+  suspendShellContentMock: { value: false },
 }));
 
 vi.mock('server-only', () => ({}));
@@ -32,9 +34,9 @@ vi.mock('next/navigation', () => ({
   },
 }));
 
-vi.mock('@/components/organisms/CinematicAppBoot', () => ({
-  CinematicAppBoot: ({ brandVariant }: { brandVariant?: string }) => (
-    <div data-testid='shell-fallback' data-brand-variant={brandVariant} />
+vi.mock('@/components/organisms/AppShellSkeleton', () => ({
+  AppShellSkeleton: ({ main }: { readonly main?: ReactNode }) => (
+    <div data-testid='app-shell-skeleton'>{main}</div>
   ),
 }));
 vi.mock('@/components/organisms/PersistentAudioBar', () => ({
@@ -47,7 +49,7 @@ vi.mock('@/components/shell/LyricsRouteSkeleton', () => ({
   LyricsRouteSkeleton: () => null,
 }));
 vi.mock('@/components/shell/TasksRouteSkeleton', () => ({
-  TasksRouteSkeleton: () => null,
+  TasksRouteSkeleton: () => <div data-testid='tasks-route-skeleton' />,
 }));
 vi.mock('@/features/feedback/ErrorBanner', () => ({
   ErrorBanner: () => null,
@@ -70,7 +72,9 @@ vi.mock('@/lib/flags/server', () => ({
   getAppFlagValue: getAppFlagValueMock,
 }));
 
-vi.mock('./chat/loading', () => ({ default: () => null }));
+vi.mock('./chat/loading', () => ({
+  default: () => <div data-testid='chat-route-skeleton' />,
+}));
 vi.mock('./dashboard/releases/loading', () => ({
   ReleaseTableSkeleton: () => null,
 }));
@@ -83,6 +87,9 @@ vi.mock('./DashboardShellContent', () => ({
     readonly mode: string;
   }) => {
     dashboardShellContentMock(props);
+    if (suspendShellContentMock.value) {
+      throw new Promise(() => {});
+    }
     return <div data-shell-mode={props.mode}>{props.children}</div>;
   },
 }));
@@ -94,6 +101,7 @@ describe('AppShellLayout OV mode', () => {
     vi.clearAllMocks();
     getCachedAuthMock.mockResolvedValue({ userId: 'user_test' });
     getAppFlagValueMock.mockResolvedValue(true);
+    suspendShellContentMock.value = false;
   });
 
   it('terminates unauthorized OV requests before shell or flag data loads', async () => {
@@ -142,5 +150,44 @@ describe('AppShellLayout OV mode', () => {
     expect(
       screen.getByText('Customer content').closest('[data-shell-mode]')
     ).toHaveAttribute('data-shell-mode', 'customer');
+  });
+
+  it('keeps every app-shell route on the stable shell fallback while content streams', async () => {
+    headersMock.mockResolvedValue(
+      new Headers({
+        'next-url': APP_ROUTES.TASKS,
+        'x-jovie-app-shell-mode': 'customer',
+      })
+    );
+    suspendShellContentMock.value = true;
+
+    render(await AppShellLayout({ children: <div>Tasks content</div> }));
+
+    expect(screen.getByTestId('app-shell-skeleton')).toContainElement(
+      screen.getByTestId('tasks-route-skeleton')
+    );
+
+    headersMock.mockResolvedValue(
+      new Headers({
+        'next-url': APP_ROUTES.LIBRARY,
+        'x-jovie-app-shell-mode': 'customer',
+      })
+    );
+
+    render(await AppShellLayout({ children: <div>Library content</div> }));
+
+    expect(screen.getAllByTestId('app-shell-skeleton')).toHaveLength(2);
+  });
+
+  it('keeps unknown loading routes neutral instead of flashing chat', async () => {
+    headersMock.mockResolvedValue(
+      new Headers({ 'x-jovie-app-shell-mode': 'customer' })
+    );
+    suspendShellContentMock.value = true;
+
+    render(await AppShellLayout({ children: <div>Unknown content</div> }));
+
+    expect(screen.getByTestId('app-shell-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-route-skeleton')).toBeNull();
   });
 });

--- a/apps/web/app/app/(shell)/layout.tsx
+++ b/apps/web/app/app/(shell)/layout.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import { headers } from 'next/headers';
 import { redirect, unstable_rethrow } from 'next/navigation';
 import { Suspense } from 'react';
-import { CinematicAppBoot } from '@/components/organisms/CinematicAppBoot';
+import { AppShellSkeleton } from '@/components/organisms/AppShellSkeleton';
 import { PersistentAudioBar } from '@/components/organisms/PersistentAudioBar';
 import { NuqsProvider } from '@/components/providers/NuqsProvider';
 import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
@@ -28,6 +28,7 @@ import {
   isLyricsShellRoute,
   isReleasesShellRoute,
   isTasksShellRoute,
+  resolveAppShellLoadingPath,
   resolveAppShellRequestPath,
 } from './shell-route-matches';
 
@@ -76,6 +77,11 @@ export default async function AppShellLayout({
       headerStore.get('x-matched-path'),
       headerStore.get('x-invoke-path')
     );
+    const loadingPathname = resolveAppShellLoadingPath(
+      nextUrlHeader,
+      headerStore.get('x-matched-path'),
+      headerStore.get('x-invoke-path')
+    );
     const mode = parseTrustedAppShellMode(
       headerStore.get(APP_SHELL_MODE_HEADER)
     );
@@ -109,25 +115,23 @@ export default async function AppShellLayout({
 
     // Pick the route-specific skeleton main slot.
     let routeMain: React.ReactNode = undefined;
-    if (isChatShellRoute(pathname)) {
+    if (isChatShellRoute(loadingPathname)) {
       routeMain = <ChatLoading />;
-    } else if (isReleasesShellRoute(pathname)) {
+    } else if (isReleasesShellRoute(loadingPathname)) {
       routeMain = <ReleaseTableSkeleton showHeader={false} />;
-    } else if (isLibraryShellRoute(pathname)) {
+    } else if (isLibraryShellRoute(loadingPathname)) {
       routeMain = <LibraryLoadingState />;
-    } else if (isLyricsShellRoute(pathname)) {
+    } else if (isLyricsShellRoute(loadingPathname)) {
       routeMain = <LyricsRouteSkeleton />;
-    } else if (isTasksShellRoute(pathname)) {
+    } else if (isTasksShellRoute(loadingPathname)) {
       routeMain = <TasksRouteSkeleton />;
     }
 
-    // CinematicAppBoot internally renders <AppShellSkeleton main={routeMain}
-    // /> unless this is the FIRST shell mount of the
-    // tab AND prefers-reduced-motion is off, in which case it plays a 2.4s
-    // cinematic timeline before the underlying tree resolves. Per-tab gate
-    // via sessionStorage flag `jovie:cinematic-boot-played`.
+    // The authenticated shell must remain visible while route data streams.
+    // Route-specific main slots keep the final workspace geometry, avoiding a
+    // separate composer/logo composition or a route-dependent flash.
     const shellFallback = (
-      <CinematicAppBoot
+      <AppShellSkeleton
         main={routeMain}
         audioPlayer={audioPlayer}
         brandVariant={mode === 'ov' ? 'ov' : 'jovie'}

--- a/apps/web/app/app/(shell)/loading.test.tsx
+++ b/apps/web/app/app/(shell)/loading.test.tsx
@@ -43,7 +43,9 @@ vi.mock('@/components/shell/TasksRouteSkeleton', () => ({
 vi.mock('./calendar/CalendarRouteSkeleton', () => ({
   CalendarRouteSkeleton: () => null,
 }));
-vi.mock('./chat/loading', () => ({ default: () => null }));
+vi.mock('./chat/loading', () => ({
+  default: () => <div data-testid='chat-route-skeleton' />,
+}));
 vi.mock('./dashboard/releases/loading', () => ({
   ReleaseTableSkeleton: () => null,
 }));
@@ -111,5 +113,17 @@ describe('ShellLoading', () => {
 
     expect(getByTestId('settings-route-skeleton')).toBeInTheDocument();
     expect(queryByTestId('dashboard-segment-skeleton')).toBeNull();
+  });
+
+  it('uses a neutral segment skeleton when loading headers are absent', async () => {
+    mockHeaders.mockResolvedValue(new Headers());
+
+    const { getByTestId, queryByTestId } = render(await ShellLoading());
+
+    expect(getByTestId('dashboard-segment-skeleton')).toHaveAttribute(
+      'data-skeleton-variant',
+      'default'
+    );
+    expect(queryByTestId('chat-route-skeleton')).toBeNull();
   });
 });

--- a/apps/web/app/app/(shell)/loading.tsx
+++ b/apps/web/app/app/(shell)/loading.tsx
@@ -20,7 +20,7 @@ import {
   isSettingsShellRoute,
   isTasksShellRoute,
   isTouringShellRoute,
-  resolveAppShellRequestPath,
+  resolveAppShellLoadingPath,
   resolveDashboardSegmentSkeletonVariant,
 } from './shell-route-matches';
 
@@ -54,7 +54,7 @@ function SettingsShellLoading() {
  */
 export default async function ShellLoading() {
   const headerStore = await headers();
-  const pathname = resolveAppShellRequestPath(
+  const pathname = resolveAppShellLoadingPath(
     headerStore.get('next-url'),
     headerStore.get('x-matched-path'),
     headerStore.get('x-invoke-path')

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -62,6 +62,19 @@ function matchesNestedRoute(
 export function resolveAppShellRequestPath(
   ...headerValues: readonly (string | null)[]
 ): string | null {
+  return resolveAppShellLoadingPath(...headerValues) ?? APP_ROUTES.DASHBOARD;
+}
+
+/**
+ * Resolves only paths explicitly supplied by Next's request headers.
+ *
+ * Loading boundaries must not borrow the `/app` fallback used by the
+ * authenticated dashboard flow: `/app` is a chat route and would flash a
+ * composer while the actual destination is still unknown.
+ */
+export function resolveAppShellLoadingPath(
+  ...headerValues: readonly (string | null)[]
+): string | null {
   for (const headerValue of headerValues) {
     const pathname = parseAppShellPath(headerValue);
     if (pathname) {
@@ -69,11 +82,7 @@ export function resolveAppShellRequestPath(
     }
   }
 
-  // Next dev and some test/bypass flows do not always populate the route
-  // headers that the app shell normally relies on. Defaulting to `/app`
-  // preserves the onboarding redirect guard for fresh users instead of
-  // falling through to a broken null-profile shell.
-  return APP_ROUTES.DASHBOARD;
+  return null;
 }
 
 export function isChatShellRoute(pathname: string | null): boolean {

--- a/apps/web/app/app/loading.test.tsx
+++ b/apps/web/app/app/loading.test.tsx
@@ -8,14 +8,21 @@ vi.mock('next/headers', () => ({ headers: headersMock }));
 vi.mock('@/components/organisms/AppShellSkeleton', () => ({
   AppShellSkeleton: ({
     brandVariant,
+    main,
   }: {
     readonly brandVariant?: 'jovie' | 'ov';
+    readonly main?: React.ReactNode;
   }) => (
     <div
       data-testid='app-shell-skeleton'
       data-brand-variant={brandVariant ?? 'jovie'}
-    />
+    >
+      {main}
+    </div>
   ),
+}));
+vi.mock('@/components/shell/TasksRouteSkeleton', () => ({
+  TasksRouteSkeleton: () => <div data-testid='tasks-route-skeleton' />,
 }));
 
 import AppLoading from './loading';
@@ -52,5 +59,20 @@ describe('app/app/loading.tsx', () => {
     expect(
       getByTestId('app-shell-skeleton').getAttribute('data-brand-variant')
     ).toBe('jovie');
+  });
+
+  it('reserves the Tasks frame in the app-root loading boundary', async () => {
+    headersMock.mockResolvedValue(
+      new Headers({
+        'x-jovie-app-shell-mode': 'customer',
+        'next-url': '/app/tasks',
+      })
+    );
+
+    const { getByTestId } = render(await AppLoading());
+
+    expect(getByTestId('app-shell-skeleton')).toContainElement(
+      getByTestId('tasks-route-skeleton')
+    );
   });
 });

--- a/apps/web/app/app/loading.tsx
+++ b/apps/web/app/app/loading.tsx
@@ -1,9 +1,14 @@
 import { headers } from 'next/headers';
 import { AppShellSkeleton } from '@/components/organisms/AppShellSkeleton';
+import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
 import {
   APP_SHELL_MODE_HEADER,
   parseTrustedAppShellMode,
 } from '@/lib/app-shell/mode';
+import {
+  isTasksShellRoute,
+  resolveAppShellLoadingPath,
+} from './(shell)/shell-route-matches';
 
 /**
  * App root loading screen
@@ -13,6 +18,16 @@ import {
 export default async function AppLoading() {
   const headerStore = await headers();
   const mode = parseTrustedAppShellMode(headerStore.get(APP_SHELL_MODE_HEADER));
+  const pathname = resolveAppShellLoadingPath(
+    headerStore.get('next-url'),
+    headerStore.get('x-matched-path'),
+    headerStore.get('x-invoke-path')
+  );
 
-  return <AppShellSkeleton brandVariant={mode === 'ov' ? 'ov' : 'jovie'} />;
+  return (
+    <AppShellSkeleton
+      main={isTasksShellRoute(pathname) ? <TasksRouteSkeleton /> : undefined}
+      brandVariant={mode === 'ov' ? 'ov' : 'jovie'}
+    />
+  );
 }

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -103,7 +103,7 @@ export function DashboardHeader({
         className={cn(
           'relative flex w-full items-center gap-2',
           MOBILE_HEADER_PADDING,
-          'sm:h-(--linear-app-header-height-compact) sm:px-2.5 sm:py-0'
+          'sm:h-(--linear-app-header-height-compact) sm:px-app-header sm:py-0'
         )}
       >
         {leading ? (

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -44,6 +44,7 @@ import {
   getTaskPriorityVisual,
   getTaskStageVisual,
   getTaskStatusVisual,
+  TASK_STATUS_LABEL_CLASSNAME,
 } from './task-presentation';
 
 interface TaskBoardProps {
@@ -52,6 +53,7 @@ interface TaskBoardProps {
   readonly isLoading: boolean;
   readonly artistName?: string | null;
   readonly selectedTaskId: string | null;
+  readonly compactColumnLabels?: boolean;
   readonly showAssigneeChip?: boolean;
   readonly onOpenTask: (task: TaskView) => void;
   readonly onCreateTask: () => void;
@@ -113,6 +115,7 @@ export function TaskBoard({
   isLoading,
   artistName,
   selectedTaskId,
+  compactColumnLabels = false,
   showAssigneeChip = true,
   onOpenTask,
   onCreateTask,
@@ -165,16 +168,11 @@ export function TaskBoard({
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveTaskId(null)}
     >
-      {/* gh-9799 HOT ZONE: task board column grid. Pragmatic Tailwind-only fix for horizontal overflow + clearer scroll affordance (snap) when needed.
-         Completeness (P1): covers edge content + responsive viewports.
-         Boil lakes (P2): strictly this file + direct styles.
-         DRY (P4) + explicit (P5): reuses min-w-0/overflow patterns + existing tokens; added comments.
-         Bias action (P6): small delta, no new components. */}
       <div
-        className='grid h-full min-h-0 min-w-full gap-3 overflow-x-auto overflow-y-hidden px-3 pb-3 pt-1.5 snap-x snap-mandatory'
+        className='grid h-full min-h-0 min-w-0 gap-3 overflow-hidden px-3 pb-3 pt-1.5'
         data-testid='tasks-board'
         style={{
-          gridTemplateColumns: `repeat(${Math.max(columns.length, 1)}, minmax(15.5rem, 1fr))`,
+          gridTemplateColumns: `repeat(${Math.max(columns.length, 1)}, minmax(0, 1fr))`,
         }}
       >
         {columns.map(column => (
@@ -183,6 +181,7 @@ export function TaskBoard({
             column={column}
             artistName={artistName}
             selectedTaskId={selectedTaskId}
+            compactColumnLabels={compactColumnLabels}
             showAssigneeChip={showAssigneeChip}
             onOpenTask={onOpenTask}
             onCreateTask={onCreateTask}
@@ -209,6 +208,7 @@ function TaskBoardColumn({
   column,
   artistName,
   selectedTaskId,
+  compactColumnLabels,
   showAssigneeChip,
   onOpenTask,
   onCreateTask,
@@ -217,6 +217,7 @@ function TaskBoardColumn({
   column: TaskBoardColumnResult;
   artistName?: string | null;
   selectedTaskId: string | null;
+  compactColumnLabels: boolean;
   showAssigneeChip: boolean;
   onOpenTask: (task: TaskView) => void;
   onCreateTask: () => void;
@@ -225,6 +226,10 @@ function TaskBoardColumn({
   const visual = getTaskStatusVisual(column.status);
   const accent = getAccentCssVars(visual.accent);
   const StatusIcon = visual.icon;
+  const columnLabel =
+    compactColumnLabels && column.status === 'in_progress'
+      ? 'Active'
+      : visual.label;
   const { setNodeRef, isOver } = useDroppable({
     id: getTaskBoardColumnDroppableId(column.status),
     data: { type: 'column', status: column.status },
@@ -236,13 +241,13 @@ function TaskBoardColumn({
       aria-label={`${visual.label} tasks`}
       data-testid={`tasks-board-column-${column.status}`}
       className={cn(
-        'flex h-full min-h-0 w-full min-w-0 flex-col rounded-xl border border-subtle bg-surface-0 snap-start',
+        'flex h-full min-h-0 w-full min-w-0 flex-col rounded-xl border border-subtle bg-surface-0',
         isOver &&
           'border-[color-mix(in_oklab,var(--linear-border-focus)_70%,transparent)] bg-[color-mix(in_oklab,var(--linear-row-hover)_36%,var(--linear-app-content-surface))]'
       )}
     >
-      <div className='sticky top-0 z-10 flex h-10 min-h-10 items-center justify-between gap-2 border-b border-subtle bg-surface-0 px-3'>
-        <div className='flex min-w-0 items-center gap-2'>
+      <div className='sticky top-0 z-10 flex h-10 min-h-10 items-center justify-between gap-1 border-b border-subtle bg-surface-0 px-2'>
+        <div className='flex min-w-0 items-center gap-1'>
           <StatusIcon
             className={cn(
               'h-3.5 w-3.5 shrink-0',
@@ -250,8 +255,14 @@ function TaskBoardColumn({
             )}
             style={{ color: accent.solid }}
           />
-          <h2 className='truncate text-xs font-semibold text-primary-token'>
-            {visual.label}
+          <h2
+            className={cn(
+              'min-w-0 truncate text-2xs font-semibold text-primary-token',
+              TASK_STATUS_LABEL_CLASSNAME
+            )}
+          >
+            <span className='sr-only'>{visual.label}</span>
+            <span aria-hidden='true'>{columnLabel}</span>
           </h2>
           <span className='text-3xs tabular-nums text-tertiary-token'>
             {column.totalCount}

--- a/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
@@ -13,7 +13,7 @@ export const TASK_DATA_TABLE_CONTAINER_CLASSNAME =
   'h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5';
 
 export const TASK_DATA_TABLE_ROW_CLASSNAME =
-  'group/row group/task-row bg-transparent shadow-none hover:bg-transparent focus-within:shadow-none focus-visible:bg-transparent focus-visible:shadow-none';
+  'group/row group/task-row !bg-transparent !shadow-none hover:!bg-transparent hover:!shadow-none focus-within:!bg-transparent focus-within:!shadow-none';
 
 export type TaskDataTableProps<TData> = UnifiedTableProps<TData>;
 

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -15,6 +15,7 @@ import {
   getTaskPriorityVisual,
   getTaskStageVisual,
   isTaskAgentWorking,
+  TASK_STATUS_LABEL_CLASSNAME,
 } from './task-presentation';
 
 interface TaskListRowProps {
@@ -174,7 +175,7 @@ export const TaskListRow = memo(function TaskListRow({
       isSelected={isSelected}
       interaction='task-row-group'
       className={cn(
-        'group/row flex h-full items-center gap-3 px-3 py-1.5 transition-[opacity] duration-subtle ease-subtle',
+        'group/row flex h-full items-center gap-2.5 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
         isDone && !isSelected && 'opacity-75',
         isCancelled && !isSelected && 'opacity-60'
       )}
@@ -202,12 +203,17 @@ export const TaskListRow = memo(function TaskListRow({
         <div
           data-testid={`task-list-row-meta-${task.id}`}
           className={cn(
-            'flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 overflow-hidden text-3xs leading-none text-secondary-token',
-            !hideTitle && 'mt-0.5'
+            'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 overflow-hidden text-3xs leading-none text-secondary-token',
+            !hideTitle && 'mt-px'
           )}
         >
           {dueIso ? <DueChip dueIso={dueIso} muted={isMuted} /> : null}
-          <span className='shrink-0 truncate text-tertiary-token'>
+          <span
+            className={cn(
+              'shrink-0 truncate text-tertiary-token',
+              TASK_STATUS_LABEL_CLASSNAME
+            )}
+          >
             {stage.label}
           </span>
           <span className='shrink-0 truncate font-semibold text-tertiary-token'>

--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -191,7 +191,7 @@ export function TaskWorkspaceHeaderBar({
       <PageToolbar
         start={toolbarStart}
         end={toolbarEnd}
-        className='h-(--linear-app-header-height-compact) min-h-(--linear-app-header-height-compact)'
+        className='h-(--linear-app-header-height-compact) min-h-(--linear-app-header-height-compact) max-sm:px-4'
         startClassName='overflow-visible'
         endClassName='gap-0.5'
       />
@@ -214,7 +214,7 @@ export function TaskSubviewTabs({
 }>) {
   if (subviews.length === 0) {
     return (
-      <div className={cn('flex h-full items-center pl-1.5', className)}>
+      <div className={cn('flex h-full items-center', className)}>
         {typeof taskCount === 'number' ? (
           <span className='text-3xs font-semibold text-tertiary-token'>
             {taskCount === 1 ? '1 Task' : `${taskCount} Tasks`}
@@ -231,7 +231,7 @@ export function TaskSubviewTabs({
       ariaLabel='Task subviews'
       overflowMode='collapse'
       variant='segment'
-      className={cn('pl-1.5', className)}
+      className={className}
       triggerClassName='gap-1.5 px-2 text-xs'
       options={subviews.map(subview => ({
         value: subview.id,

--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceLoadingRows.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceLoadingRows.tsx
@@ -1,0 +1,58 @@
+import { ShellListRowFrame } from '@/components/organisms/table';
+
+const TASK_LOADING_ROWS = [
+  { key: 'task-loading-1', titleWidth: '72%', metaWidth: '40%' },
+  { key: 'task-loading-2', titleWidth: '56%', metaWidth: '30%' },
+  { key: 'task-loading-3', titleWidth: '86%', metaWidth: '44%' },
+  { key: 'task-loading-4', titleWidth: '64%', metaWidth: '34%' },
+  { key: 'task-loading-5', titleWidth: '77%', metaWidth: '38%' },
+] as const;
+
+/** Shared Tasks route/client loading geometry to prevent reload composition swaps. */
+export function TaskWorkspaceLoadingRows() {
+  return (
+    <div
+      role='status'
+      aria-busy='true'
+      className='flex min-h-0 flex-1 flex-col gap-1.5 px-2.5 pb-2 pt-0.5 max-sm:px-4 max-sm:pb-4 max-sm:pt-2'
+      data-testid='task-workspace-loading-rows'
+    >
+      <span className='sr-only'>Loading tasks</span>
+      {TASK_LOADING_ROWS.map(row => (
+        <ShellListRowFrame
+          key={row.key}
+          interaction='none'
+          data-testid='task-loading-row'
+          className='group/row flex min-h-16 items-center gap-3 px-3 py-1.5'
+        >
+          <span className='flex shrink-0 items-center'>
+            <span
+              className='skeleton h-5 w-5 rounded-full'
+              aria-hidden='true'
+            />
+          </span>
+          <span className='min-w-0 flex-1'>
+            <span
+              className='skeleton block h-3.5 max-w-full rounded'
+              style={{ width: row.titleWidth }}
+              aria-hidden='true'
+            />
+            <span className='mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1'>
+              <span
+                className='skeleton h-3 rounded'
+                style={{ width: row.metaWidth }}
+                aria-hidden='true'
+              />
+            </span>
+          </span>
+          <span className='flex shrink-0 items-center justify-end'>
+            <span
+              className='skeleton h-5 w-14 rounded-full'
+              aria-hidden='true'
+            />
+          </span>
+        </ShellListRowFrame>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -62,10 +62,8 @@ import { ReleaseSidebar } from '@/components/organisms/release-sidebar';
 import {
   type ContextMenuItemType,
   ShellListRowButton,
-  ShellListRowFrame,
   TableEmptyState,
 } from '@/components/organisms/table';
-import { rowState } from '@/components/organisms/table/table.styles';
 import {
   isFormElement,
   resolveTableNavAction,
@@ -125,12 +123,14 @@ import {
   TaskSubviewTabs,
   TaskWorkspaceHeaderBar,
 } from './TaskWorkspaceHeaderBar';
+import { TaskWorkspaceLoadingRows } from './TaskWorkspaceLoadingRows';
 import { distinctTaskTitles, taskSearchFromPills } from './task-header-search';
 import {
   getTaskAssigneeVisual,
   getTaskPriorityVisual,
   getTaskStageVisual,
   getTaskStatusVisual,
+  TASK_STATUS_LABEL_CLASSNAME,
 } from './task-presentation';
 
 const columnHelper = createColumnHelper<TaskView>();
@@ -191,13 +191,6 @@ const MOBILE_TASK_SCOPE_OPTIONS = [
   ['open', 'Open'],
   ['done', 'Closed'],
 ] as const satisfies ReadonlyArray<readonly [MobileTaskScope, string]>;
-
-const TASK_LOADING_ROWS = [
-  { key: 'task-loading-1', titleWidth: '72%', metaWidth: '40%' },
-  { key: 'task-loading-2', titleWidth: '56%', metaWidth: '30%' },
-  { key: 'task-loading-3', titleWidth: '84%', metaWidth: '48%' },
-  { key: 'task-loading-4', titleWidth: '64%', metaWidth: '34%' },
-] as const;
 
 function getTaskSubviewForAssigneeFilter(
   assigneeFilter: TaskAssigneeKind | 'all'
@@ -354,7 +347,14 @@ function TaskStageInline({
         className={cn('h-3.5 w-3.5', task.status === 'done' && 'fill-current')}
         style={{ color: accent.solid }}
       />
-      <span className='font-semibold text-secondary-token'>{stage.label}</span>
+      <span
+        className={cn(
+          'font-semibold text-secondary-token',
+          TASK_STATUS_LABEL_CLASSNAME
+        )}
+      >
+        {stage.label}
+      </span>
       {withChevron ? (
         <ChevronDown className='h-3 w-3 shrink-0 text-tertiary-token' />
       ) : null}
@@ -390,10 +390,12 @@ function TaskAssigneeInline({
   assigneeKind,
   artistName,
   withChevron = false,
+  compact = false,
 }: Readonly<{
   assigneeKind: TaskAssigneeKind;
   artistName?: string | null;
   withChevron?: boolean;
+  compact?: boolean;
 }>) {
   const meta = getTaskAssigneeVisual(assigneeKind, artistName);
   const accent = getAccentCssVars(meta.accent);
@@ -412,7 +414,11 @@ function TaskAssigneeInline({
       >
         <UserAvatar name={meta.avatarName} size='xs' />
       </span>
-      <span className='font-semibold text-secondary-token'>{meta.label}</span>
+      {compact ? (
+        <span className='sr-only'>{meta.label}</span>
+      ) : (
+        <span className='font-semibold text-secondary-token'>{meta.label}</span>
+      )}
       {withChevron ? (
         <ChevronDown className='h-3 w-3 shrink-0 text-tertiary-token' />
       ) : null}
@@ -603,6 +609,7 @@ function TaskDocumentPanel({
   onUpdateAssignee,
   artistName,
   isDesktopLayout,
+  compactMetadata = false,
 }: Readonly<{
   task: TaskView | null;
   title: string;
@@ -616,6 +623,7 @@ function TaskDocumentPanel({
   onUpdateAssignee: (taskId: string, assigneeKind: TaskAssigneeKind) => void;
   artistName?: string | null;
   isDesktopLayout: boolean;
+  compactMetadata?: boolean;
 }>) {
   const descriptionEditorRef = useRef<HTMLTextAreaElement>(null);
   const [descriptionHelperDismissed, setDescriptionHelperDismissed] =
@@ -694,7 +702,14 @@ function TaskDocumentPanel({
           <div className='mx-auto flex w-full max-w-[40rem] flex-col gap-3 px-4 pb-5 pt-4 sm:px-5 sm:pb-6 sm:pt-5'>
             <TaskTitleEditor value={title} onChange={onTitleChange} />
 
-            <div className='flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_68%,transparent)] pb-3 text-2xs text-secondary-token'>
+            <div
+              className={cn(
+                'flex items-center border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_68%,transparent)] pb-2 text-3xs text-secondary-token',
+                compactMetadata
+                  ? 'flex-nowrap gap-1'
+                  : 'flex-wrap gap-x-2 gap-y-1'
+              )}
+            >
               <TaskMetaMenuNumber
                 task={task}
                 onOpenRelease={onOpenRelease}
@@ -769,6 +784,7 @@ function TaskDocumentPanel({
                       assigneeKind={task.assigneeKind}
                       artistName={artistName}
                       withChevron
+                      compact={compactMetadata}
                     />
                   </TaskMetaTrigger>
                 </DropdownMenuTrigger>
@@ -958,52 +974,6 @@ function TaskEmptyState({
   );
 }
 
-function TaskLoadingState() {
-  return (
-    <div
-      role='status'
-      aria-busy='true'
-      className='flex min-h-0 flex-1 flex-col gap-1.5 px-3 pb-4 pt-2'
-    >
-      <span className='sr-only'>Loading tasks</span>
-      {TASK_LOADING_ROWS.map(row => (
-        <ShellListRowFrame
-          key={row.key}
-          interaction='none'
-          data-testid='task-loading-row'
-          className='group/row flex min-h-16 items-center gap-3 px-3 py-1.5'
-        >
-          <span className='flex shrink-0 items-center'>
-            <div className='skeleton h-5 w-5 rounded-full' aria-hidden='true' />
-          </span>
-
-          <div className='min-w-0 flex-1'>
-            <div
-              className='skeleton h-3.5 max-w-full rounded'
-              style={{ width: row.titleWidth }}
-              aria-hidden='true'
-            />
-            <div className='mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1'>
-              <div
-                className='skeleton h-3 rounded'
-                style={{ width: row.metaWidth }}
-                aria-hidden='true'
-              />
-            </div>
-          </div>
-
-          <div className='flex shrink-0 items-center justify-end'>
-            <div
-              className='skeleton h-5 w-14 rounded-full'
-              aria-hidden='true'
-            />
-          </div>
-        </ShellListRowFrame>
-      ))}
-    </div>
-  );
-}
-
 function TaskErrorState({
   onRetry,
 }: Readonly<{
@@ -1087,7 +1057,7 @@ function MobileTaskSection({
   }
 
   return (
-    <section className='px-3 pb-4'>
+    <section className='px-4 pb-4'>
       <div className='mb-2 flex items-center justify-between px-1'>
         <h2 className='text-2xs font-semibold text-tertiary-token'>{title}</h2>
         <span className='text-3xs text-tertiary-token'>{tasks.length}</span>
@@ -1155,7 +1125,9 @@ function MobileTaskListItem({
           {task.title}
         </span>
         <span className='mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-3xs text-secondary-token'>
-          <span className='truncate'>{stage.label}</span>
+          <span className={cn('truncate', TASK_STATUS_LABEL_CLASSNAME)}>
+            {stage.label}
+          </span>
           <span className='text-tertiary-token'>J-{task.taskNumber}</span>
           <span className='inline-flex items-center gap-1'>
             <PriorityBars
@@ -1400,7 +1372,11 @@ export function TasksPageClient() {
     () => taskSearchFromPills(deferredPills),
     [deferredPills]
   );
-  const { viewMode, setViewMode } = useViewMode({
+  const {
+    viewMode,
+    setViewMode,
+    isHydrated: isViewModeHydrated,
+  } = useViewMode({
     storageKey: 'jovie-dashboard-tasks-view-mode',
     defaultMode: 'list',
     availableModes: TASK_VIEW_MODES,
@@ -1448,10 +1424,11 @@ export function TasksPageClient() {
       }),
     [showCancelledColumn, statusFilter]
   );
+  const isTaskLayoutReady = hasResolvedResponsiveLayout && isViewModeHydrated;
   const shouldFetchBoard =
-    hasResolvedResponsiveLayout && isBoardMode && Boolean(profileId);
+    isTaskLayoutReady && isBoardMode && Boolean(profileId);
   const shouldFetchList =
-    hasResolvedResponsiveLayout && !isBoardMode && Boolean(profileId);
+    isTaskLayoutReady && !isBoardMode && Boolean(profileId);
 
   const { data, isLoading, isError, refetch } = useTasksQuery(
     profileId,
@@ -1562,7 +1539,7 @@ export function TasksPageClient() {
     statusFilter !== 'all' ||
     priorityFilter !== 'all' ||
     assigneeFilter !== 'human';
-  const isResolvingProfile = !profileId || !hasResolvedResponsiveLayout;
+  const isResolvingProfile = !profileId || !isTaskLayoutReady;
   const isActiveBoardLoading = isResolvingProfile || isBoardLoading;
   const isActiveListLoading = isResolvingProfile || isLoading;
   const showTaskListPane =
@@ -2009,8 +1986,7 @@ export function TasksPageClient() {
   useRegisterHeaderActions(headerActions);
 
   const showAssigneeInListRows = assigneeFilter === 'all';
-  const suppressSelectedRowDetailDuplicates =
-    showTaskDocumentPane && Boolean(selectedTask);
+  const hideSelectedRowDue = showTaskDocumentPane && Boolean(selectedTask);
 
   const renderTaskCell = useCallback(
     (info: { row: { original: TaskView } }) => {
@@ -2023,8 +1999,7 @@ export function TasksPageClient() {
           artistName={artistName}
           isSelected={isRowSelected}
           showAssignee={showAssigneeInListRows}
-          hideTitle={suppressSelectedRowDetailDuplicates && isRowSelected}
-          hideDue={suppressSelectedRowDetailDuplicates && isRowSelected}
+          hideDue={hideSelectedRowDue && isRowSelected}
           actionSlot={
             <TaskRowActionMenu
               items={getTaskContextMenuItems(info.row.original)}
@@ -2041,7 +2016,7 @@ export function TasksPageClient() {
       getTaskContextMenuItems,
       openReleaseSidebar,
       showAssigneeInListRows,
-      suppressSelectedRowDetailDuplicates,
+      hideSelectedRowDue,
     ]
   );
 
@@ -2058,12 +2033,6 @@ export function TasksPageClient() {
       ] as ColumnDef<TaskView, unknown>[],
     [renderTaskCell]
   );
-  const getTaskRowClassName = useCallback(
-    (task: TaskView) =>
-      task.id === effectiveSelectedTaskId ? rowState.selected : '',
-    [effectiveSelectedTaskId]
-  );
-
   const handleCreateTask = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -2084,7 +2053,12 @@ export function TasksPageClient() {
   };
 
   let desktopTaskPane: React.ReactNode;
-  if (showTaskWorkbenchEmptyState) {
+  if (
+    isResolvingProfile ||
+    (isBoardMode ? isActiveBoardLoading : isActiveListLoading)
+  ) {
+    desktopTaskPane = <TaskWorkspaceLoadingRows />;
+  } else if (showTaskWorkbenchEmptyState) {
     desktopTaskPane = (
       <div className='flex h-full items-center justify-center px-6 py-6'>
         <div className='w-full max-w-[26rem] px-6 py-8'>
@@ -2105,6 +2079,7 @@ export function TasksPageClient() {
         isLoading={isActiveBoardLoading}
         artistName={artistName}
         selectedTaskId={effectiveSelectedTaskId}
+        compactColumnLabels={Boolean(selectedTask)}
         showAssigneeChip={assigneeFilter === 'all'}
         onOpenTask={openTaskDocument}
         onCreateTask={() => setHeaderMode('create')}
@@ -2120,7 +2095,6 @@ export function TasksPageClient() {
         isLoading={isActiveListLoading}
         getRowId={row => row.id}
         onRowClick={row => openTaskDocument(row)}
-        getRowClassName={getTaskRowClassName}
         getContextMenuItems={getTaskContextMenuItems}
         emptyState={
           <TaskEmptyState
@@ -2137,8 +2111,8 @@ export function TasksPageClient() {
   }
 
   let mobileTaskContent: React.ReactNode;
-  if (isActiveListLoading) {
-    mobileTaskContent = <TaskLoadingState />;
+  if (isResolvingProfile || isActiveListLoading) {
+    mobileTaskContent = <TaskWorkspaceLoadingRows />;
   } else if (mobileScopedTasks.length === 0) {
     mobileTaskContent = (
       <div className='px-4 pt-6'>
@@ -2200,6 +2174,7 @@ export function TasksPageClient() {
       />
       <PageShell
         className='absolute inset-0 overflow-hidden'
+        surfaceClassName='p-0'
         data-testid='tasks-workspace'
         toolbar={
           isDesktopTaskLayout || headerMode !== 'default' ? (
@@ -2239,7 +2214,7 @@ export function TasksPageClient() {
       >
         <section
           className={cn(
-            'flex min-h-0 flex-1 flex-col gap-2 overflow-hidden pb-2'
+            'flex min-h-0 flex-1 flex-col gap-1 overflow-hidden pb-1'
           )}
           data-testid='tasks-content-panel'
         >
@@ -2250,15 +2225,24 @@ export function TasksPageClient() {
               }}
             />
           ) : (
-            <div className='flex min-h-0 flex-1 overflow-hidden'>
+            <div
+              className={cn(
+                'grid min-h-0 min-w-0 flex-1 grid-cols-1 overflow-hidden',
+                isBoardMode
+                  ? selectedTask
+                    ? 'lg:grid-cols-[minmax(0,1fr)_minmax(18rem,20rem)] xl:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]'
+                    : 'lg:grid-cols-1'
+                  : 'lg:grid-cols-[minmax(20rem,0.9fr)_minmax(0,1.1fr)]'
+              )}
+            >
               <div
                 data-testid='task-list-pane'
                 className={cn(
                   'min-h-0 min-w-0',
                   TASK_WORKSPACE_PANE_CLASSNAME,
                   viewMode !== 'board'
-                    ? 'lg:flex-none lg:basis-[32rem] lg:min-w-[28rem] lg:max-w-xl lg:border-r lg:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
-                    : 'flex-1',
+                    ? 'lg:border-r lg:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
+                    : !selectedTask && 'lg:col-span-1',
                   showTaskListPane ? 'block' : 'hidden',
                   !selectedTask && 'lg:max-w-none'
                 )}
@@ -2277,7 +2261,7 @@ export function TasksPageClient() {
                       subviews={taskSubviewOptions}
                       activeSubview={activeTaskSubview}
                       onSubviewChange={setTaskSubview}
-                      className='px-3 pb-1 pt-2'
+                      className='px-4 pb-1 pt-2'
                     />
                     <MobileTaskScopeTabs
                       scope={mobileScope}
@@ -2294,8 +2278,8 @@ export function TasksPageClient() {
                 className={cn(
                   'min-h-0 min-w-0 overflow-hidden',
                   isBoardMode
-                    ? 'lg:flex-none lg:w-[min(34rem,42vw)] lg:border-l lg:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
-                    : 'flex-1',
+                    ? 'lg:border-l lg:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
+                    : '',
                   TASK_WORKSPACE_PANE_CLASSNAME,
                   showTaskDocumentPane
                     ? isDesktopTaskLayout
@@ -2325,6 +2309,7 @@ export function TasksPageClient() {
                     }
                     artistName={artistName}
                     isDesktopLayout={isDesktopTaskLayout}
+                    compactMetadata={isBoardMode}
                   />
                 ) : (
                   <TaskDocumentPanel
@@ -2340,6 +2325,7 @@ export function TasksPageClient() {
                     onUpdateAssignee={NOOP_TASK_ASSIGNEE_UPDATE}
                     artistName={artistName}
                     isDesktopLayout={isDesktopTaskLayout}
+                    compactMetadata={false}
                   />
                 )}
               </div>

--- a/apps/web/components/features/dashboard/tasks/task-presentation.ts
+++ b/apps/web/components/features/dashboard/tasks/task-presentation.ts
@@ -40,6 +40,9 @@ export interface TaskPriorityVisual {
   readonly bars: number;
 }
 
+/** Shared guardrail for task status copy across list, board, and detail surfaces. */
+export const TASK_STATUS_LABEL_CLASSNAME = 'whitespace-nowrap';
+
 const TASK_VISUAL_STAGE_META: Record<
   TaskStatus,
   (agentStatus: TaskAgentStatus) => TaskVisualStage

--- a/apps/web/components/molecules/tab-bar/TabBar.tsx
+++ b/apps/web/components/molecules/tab-bar/TabBar.tsx
@@ -28,10 +28,10 @@ export const TAB_BAR_DRAWER_TRIGGER_ACTIVE_CLASSNAME =
   'ring-2 ring-(--color-accent) text-primary-token';
 
 export const TAB_BAR_SEGMENT_TRIGGER_CLASSNAME =
-  'inline-flex h-7 shrink-0 items-center justify-center whitespace-nowrap rounded-full bg-transparent px-2.5 text-xs font-caption tracking-tight text-tertiary-token transition-[background-color,color,box-shadow] duration-fast hover:bg-surface-0 hover:text-secondary-token';
+  'inline-flex h-7 shrink-0 items-center justify-center whitespace-nowrap rounded-full border-0 bg-transparent px-2.5 text-xs font-caption tracking-tight text-tertiary-token transition-[background-color,color] duration-fast hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16';
 
 export const TAB_BAR_SEGMENT_TRIGGER_ACTIVE_CLASSNAME =
-  'ring-2 ring-(--color-accent) text-primary-token';
+  'bg-surface-0 font-semibold text-primary-token';
 
 export interface TabBarProps<T extends string> {
   readonly value: T;

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
@@ -98,9 +98,8 @@ function VirtualizedTableRowComponent<TData>({
       } else {
         onRowClick?.(rowData);
       }
-      onFocusChange(rowIndex);
     },
-    [onRowClick, onRowShiftClick, rowData, onFocusChange, rowIndex]
+    [onRowClick, onRowShiftClick, rowData, rowIndex]
   );
 
   const handleKeyDown = useCallback(
@@ -108,11 +107,17 @@ function VirtualizedTableRowComponent<TData>({
     [onKeyDown, rowIndex, rowData]
   );
 
-  const handleFocusChange = useCallback(() => {
-    if (shouldEnableKeyboardNav) {
-      onFocusChange(rowIndex);
-    }
-  }, [shouldEnableKeyboardNav, onFocusChange, rowIndex]);
+  const handleFocusChange = useCallback(
+    (event: React.FocusEvent<HTMLTableRowElement>) => {
+      if (
+        shouldEnableKeyboardNav &&
+        event.currentTarget.matches(':focus-visible')
+      ) {
+        onFocusChange(rowIndex);
+      }
+    },
+    [shouldEnableKeyboardNav, onFocusChange, rowIndex]
+  );
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent<HTMLTableRowElement>) => {

--- a/apps/web/components/shell/TasksRouteSkeleton.tsx
+++ b/apps/web/components/shell/TasksRouteSkeleton.tsx
@@ -1,16 +1,6 @@
-import { Skeleton } from '@jovie/ui';
+import { TaskWorkspaceLoadingRows } from '@/components/features/dashboard/tasks/TaskWorkspaceLoadingRows';
 import { PageShell } from '@/components/organisms/PageShell';
 import { PageToolbar } from '@/components/organisms/table';
-
-const TASK_ROWS = [
-  { key: 'task-1', titleWidth: '72%', metaWidth: '38%' },
-  { key: 'task-2', titleWidth: '84%', metaWidth: '44%' },
-  { key: 'task-3', titleWidth: '64%', metaWidth: '32%' },
-  { key: 'task-4', titleWidth: '78%', metaWidth: '48%' },
-  { key: 'task-5', titleWidth: '58%', metaWidth: '36%' },
-] as const;
-
-const BOARD_COLUMNS = ['backlog', 'todo', 'progress'] as const;
 
 export function TasksRouteSkeleton() {
   return (
@@ -19,73 +9,28 @@ export function TasksRouteSkeleton() {
       aria-busy='true'
       aria-live='polite'
       className='absolute inset-0 overflow-hidden'
+      surfaceClassName='p-0'
       toolbar={
         <PageToolbar
           start={
             <div className='flex items-center gap-1.5'>
-              <Skeleton className='h-7 w-20' rounded='full' />
-              <Skeleton className='h-7 w-28' rounded='full' />
-              <Skeleton className='h-7 w-32' rounded='full' />
+              <span className='skeleton h-7 w-20 rounded-full' />
+              <span className='skeleton h-7 w-28 rounded-full' />
+              <span className='skeleton h-7 w-32 rounded-full' />
             </div>
           }
           end={
             <div className='flex items-center gap-1'>
-              <Skeleton className='h-7 w-7' rounded='full' />
-              <Skeleton className='h-7 w-7' rounded='full' />
+              <span className='skeleton h-7 w-7 rounded-full' />
+              <span className='skeleton h-7 w-7 rounded-full' />
             </div>
           }
-          className='h-(--linear-app-header-height-compact) min-h-(--linear-app-header-height-compact)'
+          className='h-(--linear-app-header-height-compact) min-h-(--linear-app-header-height-compact) max-sm:px-4'
         />
       }
     >
-      <section className='flex min-h-0 flex-1 flex-col overflow-hidden pb-2'>
-        <div className='hidden min-h-0 flex-1 gap-2 px-2.5 pt-0.5 lg:flex'>
-          {BOARD_COLUMNS.map(column => (
-            <div
-              key={`task-board-skeleton-${column}`}
-              className='min-w-0 flex-1 rounded-lg border border-subtle bg-surface-1 p-2'
-            >
-              <Skeleton className='mb-3 h-4 w-20' />
-              <div className='space-y-2'>
-                {TASK_ROWS.slice(0, 3).map(row => (
-                  <div
-                    key={`${column}-${row.key}`}
-                    className='rounded-md border border-subtle bg-surface-0 p-2.5'
-                  >
-                    <Skeleton
-                      className='h-3.5 rounded'
-                      style={{ width: row.titleWidth }}
-                    />
-                    <Skeleton
-                      className='mt-2 h-3 rounded'
-                      style={{ width: row.metaWidth }}
-                    />
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className='flex min-h-0 flex-1 flex-col px-2.5 pt-0.5 lg:hidden'>
-          {TASK_ROWS.map(row => (
-            <div
-              key={row.key}
-              className='flex h-16 shrink-0 items-center border-b border-subtle px-2'
-            >
-              <div className='min-w-0 flex-1 space-y-2'>
-                <Skeleton
-                  className='h-3.5 rounded'
-                  style={{ width: row.titleWidth }}
-                />
-                <Skeleton
-                  className='h-3 rounded'
-                  style={{ width: row.metaWidth }}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
+      <section className='flex min-h-0 flex-1 flex-col gap-1 overflow-hidden pb-1'>
+        <TaskWorkspaceLoadingRows />
       </section>
     </PageShell>
   );

--- a/apps/web/lib/testing/test-user-provision.server.ts
+++ b/apps/web/lib/testing/test-user-provision.server.ts
@@ -203,6 +203,47 @@ export async function ensureBetterAuthTestUser({
     throw new Error('Better Auth test user conflict could not be resolved');
   }
 
+  // Old local databases can retain the pre-cutover `ba_dev_*` row for an
+  // otherwise valid browse persona. Its text id is not the persisted app-user
+  // UUID and would leak into queries keyed by `users.id`, producing 22P02.
+  // These identities are strictly allowlisted dev fixtures, so replacing the
+  // obsolete Better Auth row (and its cascade-owned sessions) is safer than
+  // perpetuating the invalid identity through the app shell.
+  if (
+    user.id !== baUserId &&
+    user.id.startsWith('ba_dev_') &&
+    isAllowlistedTestAccountEmail(normalizedEmail)
+  ) {
+    await db.delete(baUsers).where(eq(baUsers.id, user.id));
+
+    const [replacement] = await db
+      .insert(baUsers)
+      .values({
+        id: baUserId,
+        name: fullName,
+        email: normalizedEmail,
+        emailVerified: true,
+      })
+      .onConflictDoNothing()
+      .returning({ id: baUsers.id });
+
+    if (replacement) {
+      return replacement.id;
+    }
+
+    const [resolvedReplacement] = await db
+      .select({ id: baUsers.id })
+      .from(baUsers)
+      .where(or(eq(baUsers.email, normalizedEmail), eq(baUsers.id, baUserId)))
+      .limit(1);
+
+    if (resolvedReplacement?.id === baUserId) {
+      return resolvedReplacement.id;
+    }
+
+    throw new Error('Better Auth test user replacement could not be resolved');
+  }
+
   return user.id;
 }
 

--- a/apps/web/tests/e2e/tasks-layout.spec.ts
+++ b/apps/web/tests/e2e/tasks-layout.spec.ts
@@ -34,6 +34,7 @@ const TASK_ROW_SELECTOR =
 const TASK_BOARD_CARD_SELECTOR = '[data-testid^="task-board-card-"]';
 const TASK_VIEW_MODE_STORAGE_KEY = 'jovie-dashboard-tasks-view-mode';
 const VIEWPORTS = [
+  { name: 'desktop-1159', width: 1159, height: 863 },
   { name: 'desktop-1280', width: 1280, height: 900 },
   { name: 'desktop-1440', width: 1440, height: 960 },
 ] as const;
@@ -392,6 +393,9 @@ async function assertTasksBoardLayout(
   const boardCard = getTaskBoardCardByTitle(page, taskTitle);
   await expect(boardCard).toBeVisible();
   await boardCard.click();
+  await expect
+    .poll(() => boardCard.evaluate(card => !card.matches(':focus-visible')))
+    .toBe(true);
   await expect(getVisibleTaskTitleEditor(page)).toHaveValue(taskTitle, {
     timeout: 15_000,
   });
@@ -451,6 +455,26 @@ async function assertTasksLayout(
 
   await expect(listPane).toBeVisible();
   await expect(targetRow).toBeVisible({ timeout: 30_000 });
+
+  await targetRow.click();
+  await expect
+    .poll(() => targetRow.evaluate(row => !row.matches(':focus-visible')))
+    .toBe(true);
+
+  const keyboardRow = targetRow.locator('xpath=ancestor::tr[1]');
+  await keyboardRow.focus();
+  await page.keyboard.press('ArrowDown');
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const activeElement = document.activeElement;
+        return (
+          activeElement?.matches('tr[tabindex="0"]') === true &&
+          activeElement.matches(':focus-visible')
+        );
+      })
+    )
+    .toBe(true);
 
   const [
     headerBox,

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -15,6 +15,7 @@ import {
   isTasksShellRoute,
   isThreadsShellRoute,
   isTouringShellRoute,
+  resolveAppShellLoadingPath,
   resolveAppShellRequestPath,
   resolveDashboardSegmentSkeletonVariant,
   shouldRedirectToOnboarding,
@@ -55,6 +56,10 @@ describe('resolveAppShellRequestPath', () => {
 
   it('falls back to the dashboard path when no path-like header is present', () => {
     expect(resolveAppShellRequestPath(null, null)).toBe(APP_ROUTES.DASHBOARD);
+  });
+
+  it('keeps loading route selection neutral when request headers are absent', () => {
+    expect(resolveAppShellLoadingPath(null, null)).toBeNull();
   });
 });
 

--- a/apps/web/tests/unit/components/tab-bar/TabBar.test.tsx
+++ b/apps/web/tests/unit/components/tab-bar/TabBar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -112,5 +112,45 @@ describe('TabBar distribution', () => {
     for (const tab of screen.getAllByRole('tab')) {
       expect(tab.className).not.toContain('flex-1');
     }
+  });
+
+  it('uses the quiet segment selection treatment while preserving keyboard focus', () => {
+    const onValueChange = vi.fn();
+
+    render(
+      <TabBar
+        value='overview'
+        onValueChange={onValueChange}
+        options={OPTIONS}
+        ariaLabel='Segment tabs'
+        variant='segment'
+      />
+    );
+
+    const activeTab = screen.getByRole('tab', { name: 'Overview' });
+    const inactiveTab = screen.getByRole('tab', { name: 'Activity' });
+
+    expect(activeTab).toHaveAttribute('aria-selected', 'true');
+    expect(activeTab.className).toContain('bg-surface-0');
+    expect(activeTab.className).toContain('rounded-full');
+    expect(activeTab.className).toContain('font-semibold');
+    expect(activeTab.className).not.toContain('border-b-accent');
+    expect(activeTab.className).not.toContain('ring-(--color-accent)');
+    expect(inactiveTab.className).toContain('focus-visible:ring-2');
+
+    const canvas = document.createElement('button');
+    document.body.append(canvas);
+    activeTab.focus();
+    expect(document.activeElement).toBe(activeTab);
+
+    fireEvent.click(activeTab);
+    expect(onValueChange).toHaveBeenCalledWith('overview');
+
+    fireEvent.click(canvas);
+    fireEvent.keyDown(document, { key: 'Tab' });
+    activeTab.focus();
+    expect(document.activeElement).toBe(activeTab);
+    expect(activeTab).not.toHaveAttribute('data-focus-origin');
+    canvas.remove();
   });
 });

--- a/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
@@ -64,6 +64,12 @@ describe('TaskDataTable', () => {
     expect(table).toHaveAttribute('data-row-height', '56');
     expect(table).toHaveAttribute('data-skeleton-rows', '8');
     expect(table).toHaveAttribute('data-virtualized', 'false');
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).toContain(
+      'focus-within:!shadow-none'
+    );
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).not.toContain(
+      'focus-visible:!ring-0'
+    );
   });
 
   it('allows callers to extend task table chrome without losing row defaults', () => {

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -53,11 +53,25 @@ describe('TaskListRow', () => {
     const meta = getByTestId('task-list-row-meta-task-1');
     expect(meta.className).toContain('flex-wrap');
     expect(meta.className).not.toContain('grid-cols-');
+    expect(meta.className).toContain('gap-x-2');
+    expect(meta.className).toContain('gap-y-0.5');
+  });
+
+  it('keeps row controls at the shared compact hit-area density', () => {
+    const { getByTestId } = fastRender(
+      <TaskListRow
+        task={mockTask}
+        artistName='Tim White'
+        onOpenRelease={vi.fn()}
+      />
+    );
+
+    expect(getByTestId('task-list-row-task-1').className).toContain('py-1');
   });
 
   it('keeps the release link clickable and marks the selected state on the row shell', () => {
     const onOpenRelease = vi.fn();
-    const { getByRole, getByTestId } = fastRender(
+    const { getByRole, getByTestId, getByText } = fastRender(
       <TaskListRow
         task={mockTask}
         artistName='Tim White'
@@ -76,6 +90,7 @@ describe('TaskListRow', () => {
     expect(getByTestId('task-list-row-task-1').className).toContain(
       'system-b-table-row-selected'
     );
+    expect(getByText(mockTask.title)).toBeVisible();
   });
 
   it('renders shell due metadata inline inside the wrapping meta row', () => {

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -205,6 +205,7 @@ let mockListQueryIsError = false;
 let mockBoardQueryIsLoading = false;
 let mockBoardQueryIsError = false;
 let mockViewMode: 'board' | 'list' = 'list';
+let mockViewModeHydrated = true;
 let mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
 const mockUnifiedTable = vi.fn();
 const mockSetViewMode = vi.fn((viewMode: 'board' | 'list') => {
@@ -291,7 +292,7 @@ vi.mock('@/components/organisms/table/utils/useViewMode', () => ({
     viewMode: mockViewMode,
     setViewMode: mockSetViewMode,
     availableModes: ['board', 'list'],
-    isHydrated: true,
+    isHydrated: mockViewModeHydrated,
   }),
 }));
 
@@ -661,6 +662,7 @@ describe('TasksPageClient', () => {
     mockBoardQueryIsLoading = false;
     mockBoardQueryIsError = false;
     mockViewMode = 'list';
+    mockViewModeHydrated = true;
     mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
   });
 
@@ -708,10 +710,17 @@ describe('TasksPageClient', () => {
     expect(screen.getByTestId('tasks-board')).toBeInTheDocument();
     expect(screen.queryByTestId('tasks-table')).not.toBeInTheDocument();
     expect(screen.getByTestId('task-document-pane')).toHaveClass('hidden');
+    expect(screen.getByTestId('task-list-pane').parentElement).toHaveClass(
+      'lg:grid-cols-1'
+    );
 
     fireEvent.click(screen.getByTestId('mock-board-card-task-2'));
 
     expect(screen.getByLabelText('Task Title')).toHaveValue(mockTaskTwo.title);
+    expect(screen.getByTestId('task-document-pane')).toHaveClass('lg:flex');
+    expect(screen.getByTestId('task-list-pane').parentElement).toHaveClass(
+      'lg:grid-cols-[minmax(0,1fr)_minmax(18rem,20rem)]'
+    );
   });
 
   it('uses board data for subview counts when the list query is not loaded', () => {
@@ -806,25 +815,28 @@ describe('TasksPageClient', () => {
     });
 
     expect(screen.getByLabelText('Task Title')).toHaveValue(mockTaskTwo.title);
+    expect(screen.getByTestId('task-list-pane').parentElement).toHaveClass(
+      'lg:grid-cols-[minmax(20rem,0.9fr)_minmax(0,1.1fr)]'
+    );
   });
 
-  it('marks the opened canonical task with the shared selected row state', () => {
+  it('leaves table shells unselected so the task row owns selection treatment', () => {
     renderPage();
 
     expect(
       getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)
     ).not.toContain('system-b-table-row-selected');
+    expect(getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)).toContain(
+      '!bg-transparent'
+    );
 
     act(() => {
       getLatestTableProps()?.onRowClick?.(mockTaskTwo);
     });
 
-    expect(getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)).toContain(
-      'system-b-table-row-selected'
-    );
-    expect(getLatestTableProps()?.getRowClassName?.(mockTask, 1)).not.toContain(
-      'system-b-table-row-selected'
-    );
+    expect(
+      getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)
+    ).not.toContain('system-b-table-row-selected');
   });
 
   it('resets the canonical detail selection when subview filters exclude the selected task', () => {
@@ -934,18 +946,33 @@ describe('TasksPageClient', () => {
     );
   });
 
-  it('keeps the list pane in loading mode through the responsive-layout handoff', () => {
+  it('keeps one shared loading canvas through the responsive-layout handoff', () => {
     mockListQueryData = undefined;
+    mockListQueryIsLoading = true;
 
     renderPage();
 
-    const firstTableProps = mockUnifiedTable.mock.calls[0]?.[0] as
-      | {
-          readonly isLoading?: boolean;
-        }
-      | undefined;
+    expect(
+      screen.getByTestId('task-workspace-loading-rows')
+    ).toBeInTheDocument();
+    expect(mockUnifiedTable).not.toHaveBeenCalled();
+  });
 
-    expect(firstTableProps?.isLoading).toBe(true);
+  it('does not fetch or swap canvas composition before saved view mode resolves', () => {
+    mockViewMode = 'board';
+    mockViewModeHydrated = false;
+
+    renderPage();
+
+    expect(
+      screen.getByTestId('task-workspace-loading-rows')
+    ).toBeInTheDocument();
+    expect(mockUseTasksQuery.mock.calls.at(-1)?.[2]).toEqual({
+      enabled: false,
+    });
+    expect(mockUseTaskBoardQuery.mock.calls.at(-1)?.[2]).toEqual({
+      enabled: false,
+    });
   });
 
   it('shows shell loading rows on mobile instead of flashing the empty state', () => {

--- a/apps/web/tests/unit/lib/testing/test-user-provision.server.test.ts
+++ b/apps/web/tests/unit/lib/testing/test-user-provision.server.test.ts
@@ -5,6 +5,14 @@ const { mockCreateUser, mockGetUserList } = vi.hoisted(() => ({
   mockGetUserList: vi.fn(),
 }));
 
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    delete: vi.fn(),
+    insert: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
 const { mockInvalidateProxyUserStateCache, mockRedisDel, mockRevalidateTag } =
   vi.hoisted(() => ({
     mockInvalidateProxyUserStateCache: vi.fn(),
@@ -37,11 +45,90 @@ vi.mock('@/lib/auth/proxy-state', () => ({
   invalidateProxyUserStateCache: mockInvalidateProxyUserStateCache,
 }));
 
+vi.mock('@/lib/db', () => ({ db: mockDb }));
+
 describe('test-user-provision.server', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
     vi.stubEnv('CLERK_SECRET_KEY', 'sk_test_123');
+  });
+
+  it('replaces a legacy allowlisted Better Auth fixture with its UUID actor', async () => {
+    const legacyId = 'ba_dev_browse_ready_clerk_test_jov_ie';
+    const insertWithoutReplacement = {
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => []),
+        })),
+      })),
+    };
+    const insertReplacement = {
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => [
+            { id: 'c2c206c9-6f48-872d-b1bd-a1b572e67060' },
+          ]),
+        })),
+      })),
+    };
+
+    mockDb.insert
+      .mockReturnValueOnce(insertWithoutReplacement)
+      .mockReturnValueOnce(insertReplacement);
+    mockDb.select.mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [{ id: legacyId }]),
+        })),
+      })),
+    });
+    mockDb.delete.mockReturnValue({ where: vi.fn(async () => undefined) });
+
+    const { ensureBetterAuthTestUser, getDeterministicTestBetterAuthUserId } =
+      await import('@/lib/testing/test-user-provision.server');
+
+    await expect(
+      ensureBetterAuthTestUser({
+        email: 'browse-ready+clerk_test@jov.ie',
+        fullName: 'Browse Ready User',
+      })
+    ).resolves.toBe(
+      getDeterministicTestBetterAuthUserId('browse-ready+clerk_test@jov.ie')
+    );
+    expect(mockDb.delete).toHaveBeenCalledTimes(1);
+    expect(mockDb.insert).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not replace a non-legacy Better Auth identity', async () => {
+    const existingId = 'ba_live_non_fixture';
+    mockDb.insert.mockReturnValue({
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => []),
+        })),
+      })),
+    });
+    mockDb.select.mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [{ id: existingId }]),
+        })),
+      })),
+    });
+
+    const { ensureBetterAuthTestUser } = await import(
+      '@/lib/testing/test-user-provision.server'
+    );
+
+    await expect(
+      ensureBetterAuthTestUser({
+        email: 'person@example.com',
+        fullName: 'A Real Person',
+      })
+    ).resolves.toBe(existingId);
+    expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockDb.insert).toHaveBeenCalledTimes(1);
   });
 
   it('derives a stable schema-valid UUID for each Better Auth test persona', async () => {

--- a/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
+++ b/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
@@ -115,4 +115,34 @@ describe('VirtualizedTableRow', () => {
     expect(row.className).toContain('system-b-table-row-selected');
     expect(row.className).toContain('system-b-table-row-focus-within');
   });
+
+  it('keeps pointer activation separate from keyboard-visible row focus', () => {
+    const onRowClick = vi.fn();
+    const onFocusChange = vi.fn();
+
+    render(
+      <table>
+        <tbody>
+          <VirtualizedTableRow
+            {...baseProps}
+            shouldEnableKeyboardNav
+            onFocusChange={onFocusChange}
+            onRowClick={onRowClick}
+          />
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByRole('row');
+    fireEvent.click(row);
+    expect(onRowClick).toHaveBeenCalledWith({ id: '1', name: 'One' });
+    expect(onFocusChange).not.toHaveBeenCalled();
+
+    const matches = vi
+      .spyOn(row, 'matches')
+      .mockImplementation(selector => selector === ':focus-visible');
+    fireEvent.focus(row);
+    expect(onFocusChange).toHaveBeenCalledWith(0);
+    matches.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- Keeps every authenticated app-shell loading boundary on the stable `AppShellSkeleton`; unknown route headers now resolve to a neutral loading surface rather than flashing the chat composer.
- Makes Tasks loading route-shaped and stable through data settlement; tightens list/board density, selected pills, compact board headers, nowrap status labels, and responsive containment.
- Restores shared-primitive-safe modality: pointer activation stays quiet through CSS `:focus-visible`, while keyboard row focus remains visible.
- Repairs the allowlisted local review fixture so the deterministic creator-ready user is a UUID and Tasks can render seeded data.

## Final visual proof
- Shell filmstrip: 40ms and 220ms retain the same shell/neutral Tasks skeleton; 600ms and 4500ms settle to real task data with no composer frame.
- Desktop board with detail rail: compact `In Progress` becomes `Active`; all board headers are contained with no horizontal overflow.
- Desktop/mobile list and keyboard proof: status labels remain single-line; pointer selection has no visible focus ring; Tab/Arrow keyboard navigation has a visible `:focus-visible` task row.
- Final local captures retained for review: `.context/tasks-shell-final-{40,220,600,1400}ms.png`, `.context/tasks-shell-final-4500ms-settled.png`, `.context/tasks-settled-board-compact-header-1159x863.png`, `.context/tasks-settled-list-{desktop-1159x863,mobile-390x844}.png`, `.context/tasks-keyboard-list-1159x863.png`.

## Verification
- Kimi design gate: **APPROVED**.
- Focused regression suite: **9 files / 171 tests passed**.
- Canonical pre-push: Biome, proxy guard, Tailwind guard, typecheck, affected verification (8 shards), and lint all passed.
- Rebased on current `origin/main`; pushed head `43a3663a2b3`.

No merge-queue enqueue requested until required source CI is green.