### PR TITLE
ci: add bounded PR visual review lane

### DIFF
--- a/.github/scripts/pr-visual-review-capture.mjs
+++ b/.github/scripts/pr-visual-review-capture.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.BASE_URL ?? 'http://127.0.0.1:3100';
+const routes = JSON.parse(process.env.PR_VISUAL_ROUTES ?? '[]');
+const outDir = process.env.PR_VISUAL_OUT ?? 'pr-visual-artifacts';
+const viewports = {
+  desktop: { width: 1440, height: 900 },
+  mobile: { width: 390, height: 844 },
+};
+if (!Array.isArray(routes) || routes.length === 0)
+  throw new Error('No routes supplied');
+
+await mkdir(outDir, { recursive: true });
+const browser = await chromium.launch({ headless: true });
+const manifest = [];
+try {
+  for (const route of routes) {
+    for (const [viewportName, viewport] of Object.entries(viewports)) {
+      const context = await browser.newContext({
+        viewport,
+        colorScheme: 'dark',
+        deviceScaleFactor: 1,
+      });
+      const page = await context.newPage();
+      const url = new URL(route, baseUrl).toString();
+      const safeRoute =
+        route.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'home';
+      const path = join(outDir, `${safeRoute}-${viewportName}.png`);
+      try {
+        const response = await page.goto(url, {
+          waitUntil: 'networkidle',
+          timeout: 45_000,
+        });
+        if (!response || !response.ok())
+          throw new Error(`HTTP ${response?.status() ?? 'unknown'}`);
+        await page.screenshot({ path, fullPage: true });
+        manifest.push({
+          route,
+          viewport: viewportName,
+          path,
+          status: 'captured',
+        });
+      } catch (error) {
+        manifest.push({
+          route,
+          viewport: viewportName,
+          status: 'failed',
+          error: String(error.message ?? error),
+        });
+      } finally {
+        await context.close();
+      }
+    }
+  }
+} finally {
+  await browser.close();
+}
+await writeFile(
+  join(outDir, 'manifest.json'),
+  JSON.stringify({ baseUrl, routes, viewports, captures: manifest }, null, 2)
+);
+if (manifest.some(item => item.status === 'failed')) process.exitCode = 1;

--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const MAX_DIFF = 18_000;
+const UI_FILE =
+  /^(apps\/web\/(app|components|features|lib|public|styles|tests\/visual-qa)|packages\/ui|apps\/console\/.*screenshot|apps\/ios\/.*(View|Screen|Snapshot)|.*\.(css|scss|tsx|jsx))\//;
+const SECRET =
+  /(api[_-]?key|secret|password|token|private[_-]?key|database[_-]?url|authorization)\s*[:=]\s*[^\s,;]+/gi;
+const ALLOWED_MODELS = /(?:glm[-_ ]?5(?:\.2)?|kimi[-_ ]?k3)/i;
+
+export function sanitizeForPrompt(value) {
+  return String(value ?? '')
+    .replace(
+      /(?:[A-Z][A-Z0-9]*_)*(?:API[_-]?KEY|SECRET|PASSWORD|TOKEN|PRIVATE[_-]?KEY)\s*[:=]\s*[^\s,;]+/gi,
+      '[redacted-secret]'
+    )
+    .replace(SECRET, '[redacted-secret]');
+}
+
+export function routeChangedFiles(files) {
+  const changed = files.filter(
+    file => UI_FILE.test(file) || /(^|\/)DESIGN\.md$/.test(file)
+  );
+  if (changed.length === 0)
+    return { shouldReview: false, routes: [], reason: 'no-ui-change' };
+  const routes = new Set();
+  for (const file of changed) {
+    if (/admin|console|ops/i.test(file)) routes.add('/demo/admin');
+    else if (/dynamic|profile|username|artist/i.test(file))
+      routes.add('/demo/profile');
+    else if (/chat|shell/i.test(file)) routes.add('/demo/chat');
+    else routes.add('/');
+  }
+  // Demo routes are deterministic and do not require user data or credentials.
+  routes.add('/demo');
+  return {
+    shouldReview: true,
+    routes: [...routes].sort((a, b) =>
+      a === '/'
+        ? -1
+        : b === '/'
+          ? 1
+          : a === '/demo'
+            ? -1
+            : b === '/demo'
+              ? 1
+              : a.localeCompare(b)
+    ),
+    reason: 'ui-change',
+  };
+}
+
+export function classifyFinding(finding) {
+  const subjective =
+    /^(taste|preference|brand|identity|composition|copy-tone)$/i.test(
+      String(finding?.category ?? '')
+    );
+  return {
+    kind: subjective ? 'subjective' : 'objective',
+    autoFollowUpEligible:
+      !subjective &&
+      ['high', 'medium'].includes(String(finding?.severity).toLowerCase()),
+  };
+}
+
+export function buildReviewPrompt({ diff, changedFiles, screenshots }) {
+  const safeDiff = sanitizeForPrompt(diff).slice(0, MAX_DIFF);
+  const files = changedFiles.map(sanitizeForPrompt).slice(0, 80).join('\n');
+  const images = screenshots.map(sanitizeForPrompt).join(', ');
+  return `You are reviewing a Jovie UI PR. Return ONLY JSON matching this shape: {"summary":string,"findings":[{"title":string,"category":"layout|accessibility|responsive|functional|taste|preference|brand|identity|composition|copy-tone","severity":"high|medium|low","kind":"objective|subjective","evidence":string,"recommendation":string}],"backend":"glm-5.2|kimi-k3"}.\n\nRules: objective means an observable defect (overflow, clipping, inaccessible contrast/focus, broken interaction, missing content, desktop/mobile regression). Subjective means taste, preference, brand, identity, composition, or copy tone. Never turn a subjective finding into an auto-fix. Mention only evidence visible in the screenshots or grounded in the diff. Do not repeat secrets or credentials.\n\nChanged files:\n${files}\n\nDiff context:\n${safeDiff}\n\nScreenshots (desktop and mobile are paired per route): ${images}`;
+}
+
+function requireBackend({ apiKey, baseUrl, model }) {
+  if (!apiKey)
+    throw new Error('backend_unconfigured: VISUAL_REVIEW_API_KEY is missing');
+  if (!baseUrl)
+    throw new Error('backend_unconfigured: VISUAL_REVIEW_BASE_URL is missing');
+  if (!ALLOWED_MODELS.test(model ?? ''))
+    throw new Error(
+      'backend_unconfigured: VISUAL_REVIEW_MODEL must be GLM 5.2 or Kimi K3'
+    );
+}
+
+export async function reviewWithBackend({
+  apiKey,
+  baseUrl,
+  model,
+  prompt,
+  images,
+  timeoutMs = 90_000,
+  fetchImpl = fetch,
+}) {
+  requireBackend({ apiKey, baseUrl, model });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const content = [
+      { type: 'text', text: prompt },
+      ...images.map(data => ({
+        type: 'image_url',
+        image_url: { url: `data:image/png;base64,${data}` },
+      })),
+    ];
+    const response = await fetchImpl(
+      `${baseUrl.replace(/\/$/, '')}/chat/completions`,
+      {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          temperature: 0,
+          max_tokens: 2_000,
+          messages: [{ role: 'user', content }],
+        }),
+      }
+    );
+    if (!response.ok)
+      throw new Error(`backend_failed: HTTP ${response.status}`);
+    const payload = await response.json();
+    const text = payload?.choices?.[0]?.message?.content;
+    if (typeof text !== 'string' || text.length === 0)
+      throw new Error('backend_failed: empty response');
+    return JSON.parse(text.replace(/^```json\s*|\s*```$/g, ''));
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function normalizeFindings(review) {
+  const findings = Array.isArray(review?.findings) ? review.findings : [];
+  return findings.map(finding => ({ ...finding, ...classifyFinding(finding) }));
+}
+
+export function formatReviewBody({
+  review,
+  runId,
+  artifactUrl,
+  followUp = null,
+}) {
+  const findings = normalizeFindings(review);
+  const objective = findings.filter(f => f.kind === 'objective');
+  const subjective = findings.filter(f => f.kind === 'subjective');
+  const render = rows =>
+    rows.length
+      ? rows
+          .map(
+            f =>
+              `- **${f.severity} — ${f.title}** (${f.category})\n  Evidence: ${f.evidence}\n  Recommendation: ${f.recommendation}`
+          )
+          .join('\n')
+      : '- None';
+  return `## Visual review (${runId})\n\n${review?.summary ?? 'No summary returned.'}\n\n### Objective findings\n${render(objective)}\n\n### Subjective / taste findings (review-only)\n${render(subjective)}\n\nArtifacts: ${artifactUrl}\n\nFollow-up: ${followUp ?? 'No automatic follow-up created. Subjective findings never create follow-up PRs.'}`;
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === 'route') {
+    const files = JSON.parse(await readFile(args[0], 'utf8'));
+    process.stdout.write(`${JSON.stringify(routeChangedFiles(files))}\n`);
+    return;
+  }
+  if (command === 'prompt') {
+    const input = JSON.parse(await readFile(args[0], 'utf8'));
+    process.stdout.write(`${buildReviewPrompt(input)}\n`);
+    return;
+  }
+  if (command === 'review') {
+    const input = JSON.parse(await readFile(args[0], 'utf8'));
+    const artifactDir = resolve(input.artifactDir);
+    const manifest = JSON.parse(
+      await readFile(join(artifactDir, 'manifest.json'), 'utf8')
+    );
+    const screenshots = [];
+    for (const capture of manifest.captures ?? []) {
+      if (capture.status !== 'captured') continue;
+      screenshots.push(
+        (await readFile(resolve(capture.path))).toString('base64')
+      );
+    }
+    const prompt = buildReviewPrompt({
+      diff: input.diff,
+      changedFiles: input.changedFiles,
+      screenshots:
+        manifest.captures
+          ?.filter(c => c.status === 'captured')
+          .map(c => c.path) ?? [],
+    });
+    try {
+      const review = await reviewWithBackend({
+        apiKey: process.env.VISUAL_REVIEW_API_KEY,
+        baseUrl: process.env.VISUAL_REVIEW_BASE_URL,
+        model: process.env.VISUAL_REVIEW_MODEL,
+        prompt,
+        images: screenshots,
+      });
+      await writeFile(
+        input.output,
+        JSON.stringify(
+          { status: 'completed', review, promptLength: prompt.length },
+          null,
+          2
+        )
+      );
+    } catch (error) {
+      await writeFile(
+        input.output,
+        JSON.stringify(
+          {
+            status: error.name === 'AbortError' ? 'timed_out' : 'blocked',
+            error: String(error.message ?? error),
+          },
+          null,
+          2
+        )
+      );
+      process.exitCode = 0;
+    }
+    return;
+  }
+  throw new Error(
+    'Usage: pr-visual-review.mjs route <files.json> | prompt <input.json>'
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`)
+  main().catch(error => {
+    console.error(error.message);
+    process.exit(1);
+  });

--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -121,7 +121,7 @@ export async function reviewWithBackend({
     );
     if (!response.ok)
       throw new Error(`backend_failed: HTTP ${response.status}`);
-    const payload = await response.json();
+    const payload = JSON.parse(JSON.stringify(await response.json()));
     const text = payload?.choices?.[0]?.message?.content;
     if (typeof text !== 'string' || text.length === 0)
       throw new Error('backend_failed: empty response');

--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -1,0 +1,213 @@
+name: PR Visual Review
+
+# Bounded, advisory UI evidence lane. Capture runs on PR code without secrets;
+# the review step uses only the trusted base script and a configured backend.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'apps/web/app/**'
+      - 'apps/web/components/**'
+      - 'apps/web/features/**'
+      - 'apps/web/lib/**'
+      - 'apps/web/public/**'
+      - 'apps/web/styles/**'
+      - 'apps/console/**'
+      - 'apps/ios/**'
+      - 'packages/ui/**'
+      - '**/*.css'
+      - '**/*.scss'
+      - 'DESIGN.md'
+      - 'canon/DESIGN.md'
+
+permissions: {}
+
+concurrency:
+  group: pr-visual-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PR_VISUAL_OUT: pr-visual-artifacts
+  PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+
+jobs:
+  capture:
+    name: Capture changed UI (desktop + mobile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR code (no secrets)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @jovie/web exec playwright install --with-deps chromium
+
+      - name: Route changed files
+        id: route
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/changed-files.txt"
+          mkdir -p "$PR_VISUAL_OUT"
+          node --input-type=module - <<'NODE'
+          import { readFile, writeFile } from 'node:fs/promises';
+          import { routeChangedFiles } from './.github/scripts/pr-visual-review.mjs';
+          const files = (await readFile(process.env.RUNNER_TEMP + '/changed-files.txt', 'utf8')).split('\n').filter(Boolean);
+          const route = routeChangedFiles(files);
+          await writeFile(process.env.PR_VISUAL_OUT + '/routing.json', JSON.stringify({ ...route, files }, null, 2));
+          await writeFile(process.env.GITHUB_OUTPUT, `should_review=${route.shouldReview}\nroutes<<ROUTES\n${JSON.stringify(route.routes)}\nROUTES\n`, { flag: 'a' });
+          console.log(JSON.stringify(route));
+          NODE
+
+      - name: Build web app for deterministic capture
+        if: steps.route.outputs.should_review == 'true'
+        run: pnpm turbo build --filter=@jovie/web
+        env:
+          DATABASE_URL: postgresql://localhost/noop
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_mock
+          CLERK_SECRET_KEY: sk_test_mock
+          NEXT_DISABLE_TOOLBAR: '1'
+          NEXT_PUBLIC_CLERK_PROXY_DISABLED: '1'
+          E2E_USE_TEST_AUTH_BYPASS: '1'
+          E2E_CLERK_USER_ID: user_test
+
+      - name: Start production server
+        if: steps.route.outputs.should_review == 'true'
+        run: |
+          set -euo pipefail
+          (cd apps/web && PORT=3100 DATABASE_URL=postgresql://localhost/noop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock CLERK_SECRET_KEY=sk_test_mock NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 E2E_USE_TEST_AUTH_BYPASS=1 pnpm run start) > "$RUNNER_TEMP/pr-visual-server.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/pr-visual-server.pid"
+          for _ in $(seq 1 30); do curl -fsS http://127.0.0.1:3100 >/dev/null 2>&1 && exit 0; sleep 2; done
+          cat "$RUNNER_TEMP/pr-visual-server.log"
+          exit 1
+
+      - name: Capture routed surfaces
+        if: steps.route.outputs.should_review == 'true'
+        env:
+          BASE_URL: http://127.0.0.1:3100
+          PR_VISUAL_ROUTES: ${{ steps.route.outputs.routes }}
+        run: |
+          set -euo pipefail
+          PR_VISUAL_ROUTES="$(node -p "JSON.stringify(require('./pr-visual-artifacts/routing.json').routes)")" node .github/scripts/pr-visual-review-capture.mjs || true
+          test -f pr-visual-artifacts/manifest.json
+
+      - name: Stop server
+        if: always()
+        run: kill "$(cat "$RUNNER_TEMP/pr-visual-server.pid" 2>/dev/null)" 2>/dev/null || true
+
+      - name: Upload visual evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-visual-review-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: pr-visual-artifacts/
+          if-no-files-found: error
+          retention-days: 14
+
+  review:
+    name: Review screenshots and post advisory review
+    needs: capture
+    if: ${{ always() && needs.capture.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      VISUAL_REVIEW_API_KEY: ${{ secrets.VISUAL_REVIEW_API_KEY || secrets.AI_GATEWAY_API_KEY }}
+      VISUAL_REVIEW_BASE_URL: ${{ vars.VISUAL_REVIEW_BASE_URL || 'https://ai-gateway.vercel.sh/v1' }}
+      VISUAL_REVIEW_MODEL: ${{ vars.VISUAL_REVIEW_MODEL || 'zai/glm-5.2' }}
+    steps:
+      - name: Checkout trusted base helpers
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/scripts/pr-visual-review.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-visual-review-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: pr-visual-artifacts
+
+      - name: Skip non-UI changes
+        id: routed
+        run: |
+          if [ "$(node -p "require('./pr-visual-artifacts/routing.json').shouldReview")" != "true" ]; then
+            echo "No UI surface changed; review is a deliberate no-op."
+            echo "review=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "review=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare bounded diff context
+        if: steps.routed.outputs.review == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags --depth=2 origin "$BASE_SHA" "$HEAD_SHA"
+          git diff --no-ext-diff "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr.diff"
+          node --input-type=module - <<'NODE'
+          import { readFile, writeFile } from 'node:fs/promises';
+          const routing = JSON.parse(await readFile('pr-visual-artifacts/routing.json', 'utf8'));
+          const diff = await readFile(process.env.RUNNER_TEMP + '/pr.diff', 'utf8');
+          await writeFile('review-input.json', JSON.stringify({ artifactDir: 'pr-visual-artifacts', changedFiles: routing.files, diff, output: 'review-result.json' }));
+          NODE
+
+      - name: Call configured GLM 5.2 / Kimi K3 backend
+        if: steps.routed.outputs.review == 'true'
+        run: node .github/scripts/pr-visual-review.mjs review review-input.json
+
+      - name: Post structured PR review (idempotent)
+        if: steps.routed.outputs.review == 'true'
+        run: |
+          set -euo pipefail
+          BODY=$(node --input-type=module - <<'NODE'
+          import { readFile } from 'node:fs/promises';
+          import { formatReviewBody } from './.github/scripts/pr-visual-review.mjs';
+          const result = JSON.parse(await readFile('review-result.json', 'utf8'));
+          const run = process.env.GITHUB_RUN_ID;
+          const body = result.status === 'completed'
+            ? formatReviewBody({ review: result.review, runId: run, artifactUrl: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${run}` })
+            : `## Visual review (${run})\n\n**Status: ${result.status}**\n\n${result.error}\n\nNo findings were generated; rerun after configuring a GLM 5.2 or Kimi K3 backend.`;
+          process.stdout.write(body);
+          NODE
+          )
+          EXISTING=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Visual review ("))) ] | length')
+          if [ "$EXISTING" -gt 0 ]; then echo "Existing visual review found; idempotent no-op."; exit 0; fi
+          jq -n --arg body "$BODY" '{body:$body,event:"COMMENT"}' > review-payload.json
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --method POST --input review-payload.json >/dev/null
+
+      - name: Bounded objective follow-up through coder path (opt-in)
+        if: steps.routed.outputs.review == 'true' && vars.VISUAL_REVIEW_AUTOFIX_ENABLED == 'true'
+        run: |
+          set -euo pipefail
+          ELIGIBLE=$(node --input-type=module - <<'NODE'
+          import { readFile } from 'node:fs/promises';
+          const result = JSON.parse(await readFile('review-result.json', 'utf8'));
+          const findings = result.status === 'completed' ? (result.review?.findings ?? []) : [];
+          const ok = findings.length > 0 && findings.length <= 1 && findings.every(f => !/^(taste|preference|brand|identity|composition|copy-tone)$/i.test(f.category) && ['high','medium'].includes(String(f.severity).toLowerCase()));
+          process.stdout.write(ok ? 'true' : 'false');
+          NODE
+          )
+          [ "$ELIGIBLE" = true ] || { echo "No bounded objective finding eligible for follow-up."; exit 0; }
+          if gh issue list --state open --search "visual-review-pr:${PR_NUMBER}" --json number --jq 'length' | grep -qv '^0$'; then echo "Follow-up already exists; idempotent no-op."; exit 0; fi
+          BODY="visual-review-pr:${PR_NUMBER}\n\nBounded objective UI finding from PR #${PR_NUMBER}. Use the canonical GitHub AI coder path. Do not alter subjective/taste findings.\n\n$(jq -r '.review.findings[0] | "Title: \(.title)\nEvidence: \(.evidence)\nRecommendation: \(.recommendation)"' review-result.json)"
+          ISSUE=$(gh issue create --title "fix: objective UI finding from PR #${PR_NUMBER}" --body "$BODY" --label agent-ready)
+          gh workflow run github-ai-orchestrator.yml --ref main -f issue_number="${ISSUE##*/}"

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  buildReviewPrompt,
+  classifyFinding,
+  routeChangedFiles,
+  sanitizeForPrompt,
+} from '../../../.github/scripts/pr-visual-review.mjs';
+
+describe('bounded PR visual review contract', () => {
+  it('routes UI changes to the changed surface and always captures desktop/mobile', () => {
+    expect(
+      routeChangedFiles([
+        'apps/web/app/(home)/page.tsx',
+        'packages/ui/src/button.tsx',
+        'docs/README.md',
+      ])
+    ).toEqual({
+      shouldReview: true,
+      routes: ['/', '/demo'],
+      reason: 'ui-change',
+    });
+  });
+
+  it('routes known profile and admin surfaces without broadening to the whole app', () => {
+    expect(
+      routeChangedFiles(['apps/web/app/(dynamic)/[username]/page.tsx'])
+    ).toEqual({
+      shouldReview: true,
+      routes: ['/demo', '/demo/profile'],
+      reason: 'ui-change',
+    });
+    expect(routeChangedFiles(['scripts/format.mjs'])).toEqual({
+      shouldReview: false,
+      routes: [],
+      reason: 'no-ui-change',
+    });
+  });
+
+  it('keeps prompt input bounded and removes credential-shaped values', () => {
+    const prompt = buildReviewPrompt({
+      diff: 'const x = process.env.API_KEY;\n'.repeat(10000),
+      changedFiles: ['apps/web/app/page.tsx'],
+      screenshots: ['desktop/home.png', 'mobile/home.png'],
+    });
+    expect(prompt.length).toBeLessThan(30_000);
+    expect(sanitizeForPrompt('AI_GATEWAY_API_KEY=secret-value')).toBe(
+      '[redacted-secret]'
+    );
+    expect(prompt).not.toContain('secret-value');
+  });
+
+  it('separates objective findings from taste and never auto-fixes taste', () => {
+    expect(classifyFinding({ category: 'layout', severity: 'high' })).toEqual({
+      kind: 'objective',
+      autoFollowUpEligible: true,
+    });
+    expect(classifyFinding({ category: 'taste', severity: 'high' })).toEqual({
+      kind: 'subjective',
+      autoFollowUpEligible: false,
+    });
+    expect(
+      classifyFinding({ category: 'accessibility', severity: 'medium' })
+    ).toEqual({
+      kind: 'objective',
+      autoFollowUpEligible: true,
+    });
+  });
+
+  it('keeps the workflow bounded, idempotent, and artifact-retained', () => {
+    const workflow = readFileSync(
+      '.github/workflows/pr-visual-review.yml',
+      'utf8'
+    );
+    expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain('cancel-in-progress: true');
+    expect(workflow).toContain('retention-days: 14');
+    expect(workflow).toContain('VISUAL_REVIEW_AUTOFIX_ENABLED');
+    expect(workflow).toContain(
+      'Existing visual review found; idempotent no-op.'
+    );
+    expect(workflow).toContain('Do not alter subjective/taste findings.');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a path-aware PR visual-review lane for UI changes.
- Captures routed demo surfaces at desktop 1440x900 and mobile 390x844.
- Uploads 14-day artifacts and posts an idempotent structured review split into objective vs subjective/taste findings.
- Uses configured Vercel AI Gateway GLM 5.2; Kimi K3-compatible selection is supported.
- Objective follow-up is opt-in, bounded to one finding, and uses existing GitHub AI coder workflow. Subjective findings remain review-only.

## Verification
- Focused Vitest contract: 5 passed.
- Biome: clean.
- actionlint: clean.
- Node syntax checks and git diff check: clean.
- Real GLM 5.2 readiness request returned structured JSON.
- Real capture smoke captured desktop + mobile against a local HTTP server.

## Configuration
- Uses existing AI_GATEWAY_API_KEY secret fallback.
- Repo vars: VISUAL_REVIEW_BASE_URL=https://ai-gateway.vercel.sh/v1, VISUAL_REVIEW_MODEL=zai/glm-5.2.
- VISUAL_REVIEW_AUTOFIX_ENABLED remains false/unset.

Do not merge from this task; leave draft for CI inspection.