### PR TITLE
fix(marketing): align public 404 chrome

### DIFF
--- a/apps/web/app/(marketing)/not-found.tsx
+++ b/apps/web/app/(marketing)/not-found.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import { MarketingContainer } from '@/components/marketing';
+import { Container } from '@/components/site/Container';
+import { NotFoundPageContent } from '@/components/site/NotFoundPageContent';
 
 export const revalidate = false;
 
@@ -11,37 +11,15 @@ export const revalidate = false;
  */
 export default function NotFound() {
   return (
-    <MarketingContainer
-      width='page'
-      className='system-b-marketing-not-found flex items-center justify-center'
-    >
-      <div className='w-full max-w-md mx-auto text-center px-4 py-16'>
-        {/* Error code — oversized, muted */}
-        <div className='mb-8 select-none'>
-          <span
-            className='system-b-marketing-not-found-code'
-            aria-hidden='true'
-          >
-            404
-          </span>
+    <section className='system-b-root-not-found-page flex flex-1'>
+      <Container className='system-b-root-not-found-container'>
+        <div
+          data-testid='not-found'
+          className='system-b-root-not-found-content'
+        >
+          <NotFoundPageContent variant='generic' surface='root' />
         </div>
-
-        {/* Content */}
-        <div className='-mt-16 relative'>
-          {/* ui-casing-allow: marketing display headline */}
-          <h1 className='text-xl font-semibold text-primary-token tracking-tight mb-2'>
-            Page not found
-          </h1>
-          <p className='text-app text-tertiary-token leading-relaxed mb-8'>
-            The link you followed may be broken, or the page may have been
-            removed.
-          </p>
-
-          <Link href='/' className='public-action-primary'>
-            Return home
-          </Link>
-        </div>
-      </div>
-    </MarketingContainer>
+      </Container>
+    </section>
   );
 }

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,26 +1,22 @@
 import { Container } from '@/components/site/Container';
-import { MarketingFooter } from '@/components/site/MarketingFooter';
-import { MarketingHeader } from '@/components/site/MarketingHeader';
 import { NotFoundPageContent } from '@/components/site/NotFoundPageContent';
+import { PublicPageShell } from '@/components/site/PublicPageShell';
 
 export default function NotFound() {
   return (
-    <div className='system-b-root-not-found-page system-b-marketing dark min-h-screen'>
-      <MarketingHeader logoSize='xs' variant='minimal' />
-
-      <main
-        id='main-content'
-        data-testid='not-found'
-        className='system-b-root-not-found-main'
-      >
-        <Container className='system-b-root-not-found-container'>
-          <div className='system-b-root-not-found-content'>
-            <NotFoundPageContent variant='generic' surface='root' />
-          </div>
-        </Container>
-      </main>
-
-      <MarketingFooter />
-    </div>
+    <PublicPageShell
+      className='system-b-root-not-found-page system-b-marketing dark'
+      headerVariant='landing'
+      logoSize='xs'
+    >
+      <Container className='system-b-root-not-found-container'>
+        <div
+          data-testid='not-found'
+          className='system-b-root-not-found-content'
+        >
+          <NotFoundPageContent variant='generic' surface='root' />
+        </div>
+      </Container>
+    </PublicPageShell>
   );
 }

--- a/apps/web/components/site/MarketingFooter.css
+++ b/apps/web/components/site/MarketingFooter.css
@@ -88,3 +88,61 @@
   max-width: 16rem;
   margin-top: 1.25rem;
 }
+
+/* The terminal CTA is a full composition, not a collapsed content block.
+   It is shared by every public route that does not supply its own final CTA. */
+.marketing-footer-premium .homepage-story-final-cta {
+  display: flex;
+  min-height: clamp(24rem, 42vw, 32rem);
+  align-items: stretch;
+}
+
+.marketing-footer-premium .homepage-final-cta-glow {
+  background:
+    radial-gradient(
+      circle at 50% 100%,
+      color-mix(in oklab, var(--color-accent-blue) 34%, transparent),
+      transparent 58%
+    ),
+    linear-gradient(
+      180deg,
+      var(--system-b-cinematic-black) 0%,
+      var(--system-b-bg-page) 100%
+    );
+}
+
+.marketing-footer-premium .homepage-final-cta-rays {
+  height: 100%;
+  min-height: clamp(24rem, 42vw, 32rem);
+}
+
+.marketing-footer-premium .homepage-final-cta-copy {
+  display: flex;
+  min-height: clamp(24rem, 42vw, 32rem);
+  max-width: 44rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-5);
+  padding-block: clamp(5rem, 10vw, 8rem);
+  padding-inline: var(--space-5);
+  text-align: center;
+}
+
+.marketing-footer-premium .homepage-final-cta-action {
+  margin-top: var(--space-2);
+}
+
+@media (max-width: 40rem) {
+  .marketing-footer-premium .homepage-story-final-cta,
+  .marketing-footer-premium .homepage-final-cta-rays,
+  .marketing-footer-premium .homepage-final-cta-copy {
+    min-height: 22rem;
+  }
+
+  .marketing-footer-premium .homepage-final-cta-copy {
+    gap: var(--space-4);
+    padding-block: var(--space-16);
+    padding-inline: var(--space-4);
+  }
+}

--- a/apps/web/tests/unit/components/site/NotFoundPageContent.test.tsx
+++ b/apps/web/tests/unit/components/site/NotFoundPageContent.test.tsx
@@ -10,6 +10,9 @@ import { APP_ROUTES } from '@/constants/routes';
 
 const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../../..');
 const componentPath = join(appRoot, 'components/site/NotFoundPageContent.tsx');
+const rootRoutePath = join(appRoot, 'app/not-found.tsx');
+const marketingLayoutPath = join(appRoot, 'app/(marketing)/layout.tsx');
+const marketingRoutePath = join(appRoot, 'app/(marketing)/not-found.tsx');
 
 const hashMark = String.fromCharCode(35);
 const hardcodedHashColorPattern = new RegExp(`${hashMark}[\\da-fA-F]{3,8}\\b`);
@@ -66,5 +69,26 @@ describe('NotFoundPageContent', () => {
     expect(source).toContain('`${prefix}-actions`');
     expect(source).toContain('`${prefix}-action-secondary`');
     expect(source).not.toContain('style={{');
+  });
+
+  it('keeps generic root and marketing 404s on the same public recovery system', async () => {
+    const [rootRoute, marketingLayout, marketingRoute] = await Promise.all([
+      readFile(rootRoutePath, 'utf8'),
+      readFile(marketingLayoutPath, 'utf8'),
+      readFile(marketingRoutePath, 'utf8'),
+    ]);
+
+    for (const route of [rootRoute, marketingRoute]) {
+      expect(route).toContain(
+        "<NotFoundPageContent variant='generic' surface='root' />"
+      );
+      expect(route).toContain('system-b-root-not-found-content');
+      expect(route).not.toContain("from 'next/link'");
+    }
+
+    expect(rootRoute).toContain('<PublicPageShell');
+    expect(rootRoute).not.toContain('<MarketingHeader');
+    expect(rootRoute).not.toContain('<MarketingFooter');
+    expect(marketingLayout).toContain('<PublicPageShell');
   });
 });


### PR DESCRIPTION
Closes #15056

## Summary
- route root and marketing 404 states through the canonical public shell and shared generic not-found content
- retain profile-specific 404 semantics untouched
- add scoped responsive terminal-CTA layout so the footer owns its full vertical rhythm
- add static route regression coverage for the canonical root/marketing composition

## Verification
- Node 22.23.1: Biome check for all 4 changed files
- Node 22.23.1: focused `NotFoundPageContent` Vitest suite: 5/5 passed
- Node 22.23.1: web typecheck passed
- normal pre-push gate passed: Biome, proxy guard, Tailwind guard, typecheck, affected tests (7/7), CI harness validation

## Rendered evidence (local, not embedded)
- Root 404: production-safe existing probe `/dev/root-not-found-probe` returns real HTTP 404 and invokes the root boundary; it is already part of the public-surface manifest.
  - desktop first fold: `/private/tmp/jovie-404-evidence-f7f087b/root-404-desktop-first-fold.png`
  - desktop terminal CTA/footer: `/private/tmp/jovie-404-evidence-f7f087b/root-404-desktop-footer.png`
  - 390px first fold: `/private/tmp/jovie-404-evidence-f7f087b/root-404-mobile-first-fold.png`
  - 390px footer: `/private/tmp/jovie-404-evidence-f7f087b/root-404-mobile-footer.png`
- Marketing 404: `/alternatives/this-page-does-not-exist` returns real HTTP 404 through `(marketing)/not-found.tsx`.
  - desktop first fold: `/private/tmp/jovie-404-evidence-f7f087b/marketing-404-desktop-first-fold.png`
  - 390px first fold: `/private/tmp/jovie-404-evidence-f7f087b/marketing-404-mobile-first-fold.png`

The screenshots show only the real route with local dev overlays suppressed. They are intentionally recorded as local evidence rather than represented as GitHub attachments. This draft remains out of the merge queue until evidence is uploaded/embedded and staging exact-head proof is recorded.