### PR TITLE
fix: recover mac auth cancel shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **macOS sign-in cancellation returns to Jovie:** if a native auth redirect leaves the hidden desktop window blank, canceling sign-in now restores the canonical sign-in shell instead of showing a black window.
 - [internal] **Desktop memory baseline evidence (JOV-2712):** the Electron shell can now capture bounded main/renderer RSS and macOS physical-footprint samples, record clean shutdown evidence, and classify growth regressions without claiming native leak proof when the platform tool is unavailable.
 - [internal] **Desktop packaging toolchain updated:** Electron Builder now uses 26.15.3 for current signing, notarization, and installer support.
 - **Profile rail edits no longer flicker back to stale data (JOV-4450):** concurrent optimistic bio/link changes keep the newest paint while dashboard/chat hydrations merge by CAS version and skip clobbering mid-save.

--- a/apps/desktop/scripts/renderer-recovery.test.ts
+++ b/apps/desktop/scripts/renderer-recovery.test.ts
@@ -3,6 +3,7 @@ import {
   decideRendererRecovery,
   RENDERER_BOOT_WATCHDOG_MS,
   shouldArmRendererBootWatchdog,
+  shouldRecoverAuthHandoffToCanonicalShell,
 } from '../src/renderer-recovery.ts';
 
 const MAX = 2;
@@ -15,6 +16,17 @@ test('clean-exit is normal teardown, never recovered', () => {
       maxReloads: MAX,
     })
   ).toBe('ignore');
+});
+
+test('canceling auth recovers an intercepted blank main window to the canonical shell', () => {
+  expect(shouldRecoverAuthHandoffToCanonicalShell('about:blank')).toBe(true);
+  expect(shouldRecoverAuthHandoffToCanonicalShell('')).toBe(true);
+  expect(
+    shouldRecoverAuthHandoffToCanonicalShell('https://jov.ie/app/chat')
+  ).toBe(false);
+  expect(
+    shouldRecoverAuthHandoffToCanonicalShell('data:text/html,recovery')
+  ).toBe(false);
 });
 
 test('a crash reloads while within the budget', () => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -49,6 +49,7 @@ import { evaluateRemoteDebuggingGuard } from './remote-debugging-guard';
 import {
   decideRendererRecovery,
   RENDERER_BOOT_WATCHDOG_MS,
+  shouldRecoverAuthHandoffToCanonicalShell,
   shouldArmRendererBootWatchdog,
 } from './renderer-recovery';
 import { SYSTEM_B_DESKTOP_TOKENS } from './system-b-tokens';
@@ -616,6 +617,14 @@ function restoreMainWindowAfterAuthHandoff(): void {
   if (!mainWindowHiddenForAuthHandoff) return;
   mainWindowHiddenForAuthHandoff = false;
   if (mainWindow && !mainWindow.isDestroyed()) {
+    if (
+      shouldRecoverAuthHandoffToCanonicalShell(
+        mainWindow.webContents.getURL()
+      )
+    ) {
+      const authUrl = buildCentralDesktopAuthUrl('sign_in', '/app');
+      void mainWindow.loadURL(buildDesktopAuthHandoffUrl(authUrl));
+    }
     showWindow(mainWindow);
   }
 }

--- a/apps/desktop/src/renderer-recovery.ts
+++ b/apps/desktop/src/renderer-recovery.ts
@@ -64,3 +64,13 @@ export function shouldArmRendererBootWatchdog(
     return false;
   }
 }
+
+/**
+ * The main window is hidden while the dedicated desktop auth handoff is open.
+ * If its initial auth redirect was intercepted, Electron can leave that hidden
+ * renderer at about:blank. Revealing it after cancellation would look like a
+ * black app window, so return it to the canonical auth shell instead.
+ */
+export function shouldRecoverAuthHandoffToCanonicalShell(url: string): boolean {
+  return url === '' || url === 'about:blank';
+}


### PR DESCRIPTION
## Summary
- Restore the canonical `/desktop-auth` shell when a hidden main window was left at `about:blank` during native auth handoff cancellation.
- Add deterministic regression coverage for blank-window recovery.
- Add the required Unreleased desktop release note.

## Bug-to-Test
- JOV-4533: deterministic desktop renderer recovery test covers the cancel/blank boundary.

## Design Review
- Kimi `/design-review` approved the exact `origin/main...67db53fba` diff and `/tmp/jov4533-desktop-auth-desktop.png`. Session: `session_e684d4db-be64-4876-bcbd-5854dd938c9c`.

## Test plan
- [x] `pnpm --filter desktop run test`
- [x] `pnpm --filter desktop run typecheck`
- [x] `pnpm --filter desktop run test:release-guard` (15/15)
- [x] Source PR `ci-fast` and `PR Ready`

## Runtime proof
- [x] Fresh credential-free browse harness: `PORT=3225 pnpm --filter @jovie/web run dev:local:browse`, Ready in 281ms.
- [x] `/desktop-auth` returned HTTP 200 after first compile.
- [x] Desktop screenshot: `/tmp/jov4533-desktop-auth-desktop.png` at 1440x900, canonical System B shell visible.
- [x] Headless browser console: `handoff: 1`, `consoleErrors: []`.
- [x] Deterministic cancel boundary: `renderer-recovery.test.ts` verifies `about:blank` reloads canonical `/desktop-auth` rather than being revealed.

## Current head
- `67db53fbaa2658d306a598568792cb034fbe8299`

## Release posture
- Ready for native merge queue. No direct merge and no production claim until controller proof.

## Linear follow-ups
- none

Linear: JOV-4533