### PR TITLE
fix(shell): place playback tray below main canvas (JOV-4534)

### DIFF
--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -80,17 +80,21 @@ export const AppShellFrame = memo(function AppShellFrame({
           {sidebar}
         </div>
 
-        <main
-          id='main-content'
-          className={cn(
-            // `isolate` gives <main> its own stacking context so the negative-z
-            // chat ambient layer below paints above main's background but
-            // beneath the in-flow header/content (#13386).
-            'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--color-bg-surface-0)/90',
-            'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
-          )}
+        <div
+          data-app-shell-content-column='true'
+          className='flex min-h-0 min-w-0 flex-1 flex-col'
         >
-          {/* Full-bleed ambient wash on chat routes — spans the whole content
+          <main
+            id='main-content'
+            className={cn(
+              // `isolate` gives <main> its own stacking context so the negative-z
+              // chat ambient layer below paints above main's background but
+              // beneath the in-flow header/content (#13386).
+              'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--color-bg-surface-0)/90',
+              'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
+            )}
+          >
+            {/* Full-bleed ambient wash on chat routes — spans the whole content
               panel so its top edge is above the (transparent) header band.
               Negative z-index is load-bearing: an absolute sibling with z-auto
               would paint ON TOP of the in-flow static header; `-z-10` inside
@@ -99,38 +103,46 @@ export const AppShellFrame = memo(function AppShellFrame({
               previous chat canvas tone on all breakpoints. Pure background:
               pointer-events-none, no layout impact (#13386, preserves the
               full-viewport guarantee from #12135 / JOV-3614). */}
-          {chatAmbientGradient ? (
+            {chatAmbientGradient ? (
+              <div
+                aria-hidden='true'
+                data-testid='chat-ambient-gradient'
+                className='pointer-events-none absolute inset-0 -z-10 bg-(--app-shell-content-surface)'
+                style={{ backgroundImage: CHAT_AMBIENT_GRADIENT_IMAGE }}
+              />
+            ) : null}
+            {isCodeFlagEnabled('CANVAS_GRAIN') && <CanvasGrain />}
+            {header}
             <div
-              aria-hidden='true'
-              data-testid='chat-ambient-gradient'
-              className='pointer-events-none absolute inset-0 -z-10 bg-(--app-shell-content-surface)'
-              style={{ backgroundImage: CHAT_AMBIENT_GRADIENT_IMAGE }}
-            />
-          ) : null}
-          {isCodeFlagEnabled('CANVAS_GRAIN') && <CanvasGrain />}
-          {header}
-          <div
-            className={cn(
-              'flex flex-1 min-h-0 min-w-0 overflow-hidden lg:gap-(--app-shell-gap)'
-            )}
-          >
-            <div
-              data-testid='app-shell-scroll'
               className={cn(
-                // Shell-level pane never owns vertical scroll — routes and table
-                // surfaces scroll inside this clip so the right rail stays fixed.
-                'flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden overflow-x-auto overscroll-contain pb-[var(--dev-toolbar-height,0px)]',
-                contentClassName
+                'flex flex-1 min-h-0 min-w-0 overflow-hidden lg:gap-(--app-shell-gap)'
               )}
             >
-              {main}
+              <div
+                data-testid='app-shell-scroll'
+                className={cn(
+                  // Shell-level pane never owns vertical scroll — routes and table
+                  // surfaces scroll inside this clip so the right rail stays fixed.
+                  'flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden overflow-x-auto overscroll-contain pb-[var(--dev-toolbar-height,0px)]',
+                  contentClassName
+                )}
+              >
+                {main}
+              </div>
+              {rightPanel ? (
+                <AppShellRightRail>{rightPanel}</AppShellRightRail>
+              ) : null}
             </div>
-            {rightPanel ? (
-              <AppShellRightRail>{rightPanel}</AppShellRightRail>
-            ) : null}
-          </div>
-          {audioPlayer}
-        </main>
+          </main>
+          {/* The player is shell chrome, not content-card chrome. Keeping it as
+              an in-flow sibling reserves its own tray below <main>, matching
+              the sidebar's canvas elevation without obscuring routes or rails. */}
+          {audioPlayer ? (
+            <div data-testid='app-shell-audio-tray' className='shrink-0'>
+              {audioPlayer}
+            </div>
+          ) : null}
+        </div>
       </div>
 
       {mobileBottomNav}

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -271,7 +271,7 @@ export function PersistentAudioBar() {
         aria-label='Playback Controls'
         inert={idleTrayOpen ? undefined : true}
         className={cn(
-          'shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--linear-bg-page)',
+          'shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--app-shell-content-surface)',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME,
           className
         )}
@@ -372,7 +372,7 @@ export function PersistentAudioBar() {
     <section
       aria-label='Audio Player'
       className={cn(
-        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--linear-bg-page) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
+        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--app-shell-content-surface) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
         className
       )}
     >
@@ -483,7 +483,7 @@ export function PersistentAudioBar() {
         data-shell-audio-surface='persistent-expanded'
         aria-hidden={barCollapsed}
         className={cn(
-          'hidden shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--linear-bg-page) lg:block',
+          'hidden shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--app-shell-content-surface) lg:block',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME
         )}
         style={{

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -271,7 +271,7 @@ export function PersistentAudioBar() {
         aria-label='Playback Controls'
         inert={idleTrayOpen ? undefined : true}
         className={cn(
-          'overflow-hidden border-t border-(--app-shell-border) bg-(--app-shell-content-surface)',
+          'shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--linear-bg-page)',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME,
           className
         )}
@@ -336,13 +336,10 @@ export function PersistentAudioBar() {
 
     return (
       <>
-        {idleTray(
-          'audio-surface-idle-shell-desktop',
-          'absolute inset-x-0 bottom-0 z-30 hidden lg:block'
-        )}
+        {idleTray('audio-surface-idle-shell-desktop', 'hidden lg:block')}
         {idleTray(
           'audio-surface-idle-shell-mobile',
-          'absolute inset-x-0 z-30 max-lg:bottom-[calc(3.5rem+env(safe-area-inset-bottom))] lg:hidden'
+          'max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))] lg:hidden'
         )}
       </>
     );
@@ -375,7 +372,7 @@ export function PersistentAudioBar() {
     <section
       aria-label='Audio Player'
       className={cn(
-        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--app-shell-content-surface) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
+        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--linear-bg-page) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
         className
       )}
     >
@@ -486,7 +483,7 @@ export function PersistentAudioBar() {
         data-shell-audio-surface='persistent-expanded'
         aria-hidden={barCollapsed}
         className={cn(
-          'hidden shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--app-shell-content-surface) lg:block',
+          'hidden shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--linear-bg-page) lg:block',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME
         )}
         style={{

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -174,7 +174,10 @@ describe('PersistentAudioBar', () => {
       expect(surface.style.maxHeight).toBe('0');
       expect(surface.style.pointerEvents).toBe('none');
     }
-    expect(idleSurfaces[0]).toHaveClass('absolute');
+    // The idle tray stays in document flow so opening it reserves shell space
+    // instead of covering the main canvas or right rail.
+    expect(idleSurfaces[0]).not.toHaveClass('absolute');
+    expect(idleSurfaces[0]).toHaveClass('shrink-0');
   });
 
   it('opens and closes the idle playback tray with the global toggle shortcuts', () => {

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -143,7 +143,7 @@ describe('AppShellFrame', () => {
     expect(screen.queryByTestId('chat-ambient-gradient')).toBeNull();
   });
 
-  it('renders the shared audio player slot inside the shell frame', () => {
+  it('reserves an in-flow shell tray below main for the shared audio player', () => {
     render(
       <AppShellFrame
         sidebar={<aside>Sidebar</aside>}
@@ -153,9 +153,17 @@ describe('AppShellFrame', () => {
       />
     );
 
-    expect(screen.getByTestId('audio-player')).toBeInTheDocument();
-    expect(screen.getByRole('main')).toContainElement(
-      screen.getByTestId('audio-player')
+    const main = screen.getByRole('main');
+    const audioPlayer = screen.getByTestId('audio-player');
+    const tray = screen.getByTestId('app-shell-audio-tray');
+
+    expect(audioPlayer).toBeInTheDocument();
+    expect(main).not.toContainElement(audioPlayer);
+    expect(tray).toContainElement(audioPlayer);
+    expect(tray.parentElement).toHaveAttribute(
+      'data-app-shell-content-column',
+      'true'
     );
+    expect(tray).toHaveClass('shrink-0');
   });
 });


### PR DESCRIPTION
## Summary
- Moves global playback chrome out of `<main>` into an in-flow shell tray below the content canvas.
- Converts desktop and mobile idle trays from absolute overlays to reserved in-flow shell geometry.
- Adds regression coverage that the player is not contained by main and idle trays are not absolute.

## Current exact source state
- Rebased onto `origin/main` `79c16d9b711265ab44282a4a95994c17c7609509`.
- Exact PR head: `709b558b5343d08f9e1d35f4535fd5edb380fdd8`.
- Scope remains four files: `AppShellFrame.tsx`, `PersistentAudioBar.tsx`, and their two focused tests.
- Focused Vitest: 42/42 passed.
- Biome and `git diff --check` passed.
- The normal protected push succeeded, but the isolated worktree inherited a non-resolving hooks path, so the canonical affected gate was invoked explicitly. It reached typecheck and failed only because the host had 126 MiB free and TypeScript could not write its incremental build-info file (`ENOSPC`); this is not a source failure.

## Required before admission
- Refresh authenticated desktop and mobile evidence against this exact rebased head.
- Verify console/network, overflow, keyboard focus, and tray geometry.
- Run a real Kimi `/design-review` against the exact captured state.

The PR remains draft, `gated`, and unqueued.

JOV-4534