### PR TITLE
fix(app): stabilize feedback provider hydration

### DIFF
--- a/apps/web/components/providers/CoreProviders.tsx
+++ b/apps/web/components/providers/CoreProviders.tsx
@@ -2,7 +2,6 @@
 
 import { TooltipProvider } from '@jovie/ui';
 import { PacerProvider } from '@tanstack/react-pacer';
-import dynamic, { type DynamicOptionsLoadingProps } from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { ThemeProvider } from 'next-themes';
 import React, { useEffect, useMemo } from 'react';
@@ -12,17 +11,9 @@ import { PACER_TIMING } from '@/lib/pacer/hooks';
 import { isFormElement } from '@/lib/utils/keyboard';
 import { logger } from '@/lib/utils/logger';
 import type { ThemeMode } from '@/types';
-import type { LazyProvidersProps } from './LazyProviders';
+import { LazyProviders } from './LazyProviders';
 import { NuqsProvider } from './NuqsProvider';
 import { QueryProvider } from './QueryProvider';
-
-type LazyProvidersLoadingProps = LazyProvidersProps &
-  DynamicOptionsLoadingProps;
-
-function LazyProvidersSkeleton(props: DynamicOptionsLoadingProps) {
-  const { children } = props as LazyProvidersLoadingProps;
-  return <>{children}</>;
-}
 
 // Deferral delay shared by the keyboard-shortcut listeners and the monitoring
 // chunk imports. 300ms gives the first-paint burst of work room to finish
@@ -89,17 +80,6 @@ function SearchKeyboardShortcut() {
 
   return null;
 }
-
-// Lazy load non-critical providers to reduce initial bundle size
-// SSR enabled to allow page content to render server-side for SEO
-// Analytics components inside LazyProviders remain client-only
-const LazyProviders = dynamic<LazyProvidersProps>(
-  () => import('./LazyProviders').then(mod => ({ default: mod.LazyProviders })),
-  {
-    ssr: true,
-    loading: LazyProvidersSkeleton,
-  }
-);
 
 export interface CoreProvidersProps {
   readonly children: React.ReactNode;

--- a/apps/web/tests/unit/providers/core-providers-hydration.test.ts
+++ b/apps/web/tests/unit/providers/core-providers-hydration.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const coreProvidersSource = readFileSync(
+  resolve(webRoot, 'components/providers/CoreProviders.tsx'),
+  'utf8'
+);
+
+describe('CoreProviders hydration contract (JOV-4505)', () => {
+  it('keeps the global feedback tree out of a dynamic hydration boundary', () => {
+    expect(coreProvidersSource).toContain(
+      "import { LazyProviders } from './LazyProviders';"
+    );
+    expect(coreProvidersSource).not.toContain("from 'next/dynamic'");
+    expect(coreProvidersSource).not.toMatch(
+      /const LazyProviders = dynamic[\s\S]*?\{[\s\S]*?ssr:\s*true/
+    );
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4505 -->

## Summary
- remove the SSR-enabled dynamic boundary that wrapped the global feedback tree
- retain the single FeedbackProvider and its internally deferred analytics work
- add a regression contract preventing the shared shell from reintroducing that boundary

## Evidence
- seeded `creator-ready` `/app/chat` at 1280×720 and 375×812: stable authenticated System B shell, no horizontal overflow, and no hydration error in the DOM after reload
- exact runtime check: one `[aria-label="Notifications alt+T"]` region after hydration
- local captures: `/tmp/jov4505-chat-desktop.png`, `/tmp/jov4505-chat-mobile-final.png`
- Kimi CLI `/design-review`: PASS, safe for draft PR

## Verification
- `pnpm --filter web exec vitest run tests/unit/providers/core-providers-hydration.test.ts tests/unit/core-providers-route-variant.test.tsx`
- `pnpm biome check apps/web/components/providers/CoreProviders.tsx apps/web/tests/unit/providers/core-providers-hydration.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push affected verification and typecheck passed

## Known baseline observation
- Reload still logs `Encountered a script tag while rendering React component` from the root-layout script path. It is unrelated to the FeedbackProvider hydration mismatch and is not suppressed or changed by this PR.