### PR TITLE
fix(ci): resolve PR visual capture browser cache path

### DIFF
--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -28,7 +28,6 @@ concurrency:
 
 env:
   PR_VISUAL_OUT: pr-visual-artifacts
-  PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
 
 jobs:
   capture:

--- a/apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts
+++ b/apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+const workflowPath = resolve(
+  repoRoot,
+  '.github/workflows/pr-visual-review.yml'
+);
+
+describe('PR visual review workflow', () => {
+  it("uses Playwright's default absolute browser cache after installing Chromium", () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain(
+      'pnpm --filter @jovie/web exec playwright install --with-deps chromium'
+    );
+    expect(workflow).not.toMatch(
+      /PLAYWRIGHT_BROWSERS_PATH:\s*~\/\.cache\/ms-playwright/
+    );
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4537 -->

## Summary
- Removes the literal `~/.cache/ms-playwright` workflow environment value that GitHub Actions does not shell-expand.
- Leaves Chromium installation and required desktop/mobile capture intact, using Playwright's default runner cache path.
- Adds a workflow contract test that rejects a literal tilde path.

## Verification
- CI run [30422824702](https://github.com/JovieInc/Jovie/actions/runs/30422824702): `ci-fast` typecheck and remaining lanes passed.
- `actionlint .github/workflows/pr-visual-review.yml`: passed.
- Exact capture script launched Chromium with no `PLAYWRIGHT_BROWSERS_PATH` override and wrote both artifacts: [`manifest.json`](/tmp/jov4537-browser-proof.PzJ5mb/manifest.json), desktop 1440×900 (`home-desktop.png`, 22,712 bytes), and mobile 390×844 (`home-mobile.png`, 19,047 bytes).

## Event-scope note
This PR cannot self-run `PR Visual Review`: that workflow's `pull_request_target.paths` deliberately excludes its own workflow file and the unit-test path. The next UI PR rerun after this merges is the authoritative GitHub artifact proof. No capture check was skipped or weakened.

## Scope
No product UI changes.