### PR TITLE
fix(shell): quiet active sidebar chrome

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
@@ -98,7 +98,7 @@ function getFocusedSettingsHref(sectionId: string): string {
 export function getSettingsSidebarRowClassName(isActive: boolean): string {
   return getSidebarNavRowClassName({
     active: isActive,
-    className: 'grid-cols-[minmax(0,1fr)] before:hidden after:hidden text-left',
+    className: 'grid-cols-[minmax(0,1fr)] text-left',
   });
 }
 

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -522,7 +522,7 @@ export function UnifiedSidebar({
           {/* Bottom Settings button opens the existing user menu via UserButton.
               Uses Sidebar atoms for native feel (icon + label, tooltip in icon mode).
               Placed above Now Playing / audio area. */}
-          <div className='min-h-(--app-shell-footer-row-height) border-t border-(--app-shell-frame-seam) px-2.5 py-0.5'>
+          <div className='min-h-(--app-shell-footer-row-height) border-t border-subtle px-2.5 py-0.5'>
             <SidebarMenu>
               <SidebarMenuItem>
                 <UserButton

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -522,7 +522,7 @@ export function UnifiedSidebar({
           {/* Bottom Settings button opens the existing user menu via UserButton.
               Uses Sidebar atoms for native feel (icon + label, tooltip in icon mode).
               Placed above Now Playing / audio area. */}
-          <div className='min-h-(--app-shell-footer-row-height) border-t border-(--linear-border-divider-subtle) px-2.5 py-0.5'>
+          <div className='min-h-(--app-shell-footer-row-height) border-t border-(--linear-border-subtle) px-2.5 py-0.5'>
             <SidebarMenu>
               <SidebarMenuItem>
                 <UserButton

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -522,7 +522,7 @@ export function UnifiedSidebar({
           {/* Bottom Settings button opens the existing user menu via UserButton.
               Uses Sidebar atoms for native feel (icon + label, tooltip in icon mode).
               Placed above Now Playing / audio area. */}
-          <div className='min-h-(--app-shell-footer-row-height) border-t border-subtle px-2.5 py-0.5'>
+          <div className='min-h-(--app-shell-footer-row-height) border-t border-(--linear-border-divider-subtle) px-2.5 py-0.5'>
             <SidebarMenu>
               <SidebarMenuItem>
                 <UserButton

--- a/apps/web/components/shell/SidebarNavItem.test.tsx
+++ b/apps/web/components/shell/SidebarNavItem.test.tsx
@@ -1,17 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   getSidebarNavIconClassName,
   getSidebarNavRowClassName,
+  SidebarNavItem,
 } from './SidebarNavItem';
 
 describe('SidebarNavItem active chrome', () => {
-  it('uses white text and an accent-blue icon without a left rail', () => {
+  it('uses white text and a Jovie teal icon without a left rail or decoration', () => {
     const row = getSidebarNavRowClassName({ active: true });
     const icon = getSidebarNavIconClassName({ active: true });
 
     expect(row).toContain('text-white');
     expect(row).toContain('shadow-none');
     expect(row).not.toContain('inset_2px_0');
-    expect(icon).toContain('text-accent-blue!');
+    expect(row).not.toContain('before:');
+    expect(row).not.toContain('after:');
+    expect(icon).toContain('text-accent-teal!');
+  });
+
+  it('keeps long labels inside the grid and preserves keyboard focus chrome', () => {
+    const longLabel =
+      'A deliberately long navigation destination that must fade instead of overflowing';
+    const TestIcon = (props: { className?: string }) => <svg {...props} />;
+
+    render(
+      <SidebarNavItem
+        item={{ icon: TestIcon, label: longLabel }}
+        collapsed={false}
+      />
+    );
+
+    const row = screen.getByRole('button', { name: longLabel });
+    const label = screen.getByText(longLabel);
+    row.focus();
+    fireEvent.focus(row);
+
+    expect(row).toHaveFocus();
+    expect(row.className).toContain('focus-visible:ring-2');
+    expect(label.className).toContain('overflow-hidden');
+    expect(label.className).toContain('text-clip');
+    expect(label.className).toContain('mask-image:linear-gradient');
   });
 });

--- a/apps/web/components/shell/SidebarNavItem.test.tsx
+++ b/apps/web/components/shell/SidebarNavItem.test.tsx
@@ -40,6 +40,8 @@ describe('SidebarNavItem active chrome', () => {
     expect(row.className).toContain('focus-visible:ring-2');
     expect(label.className).toContain('overflow-hidden');
     expect(label.className).toContain('text-clip');
+    expect(label.className).toContain('justify-self-stretch');
+    expect(label.className).not.toContain('justify-self-start');
     expect(label.className).toContain('mask-image:linear-gradient');
   });
 });

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -37,8 +37,9 @@ interface SidebarNavChromeOptions {
 const SIDEBAR_PRIMARY_CHROME =
   'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)] text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,white_14%)]';
 
-// Active state uses type and icon color only. Avoid a left rail so every shared
-// sidebar consumer keeps the same compact, decoration-free geometry.
+// Active state uses a quiet neutral fill with white type and a Jovie teal icon.
+// Avoid a left rail or guide decoration so every shared sidebar consumer keeps
+// the same compact geometry.
 const SIDEBAR_ACTIVE_CHROME =
   'bg-sidebar-accent-active text-white font-medium shadow-none';
 
@@ -73,12 +74,9 @@ export function getSidebarNavRowClassName({
   return cn(
     'relative grid items-center rounded-full w-full transition-[background-color,box-shadow,color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
     'font-normal',
-    'before:pointer-events-none before:absolute before:inset-y-1.5 before:left-6 before:w-px before:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_32%,transparent)]',
-    'after:pointer-events-none after:absolute after:inset-y-1.5 after:left-10 after:w-px after:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_32%,transparent)]',
-    'group-data-[collapsible=icon]:before:hidden group-data-[collapsible=icon]:after:hidden',
     tight ? 'gap-x-2 text-xs' : 'gap-x-2.5 text-xs',
     collapsed
-      ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center before:hidden after:hidden'
+      ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center'
       : cn(
           // Badge track: min 34px keeps empty rows aligned; auto grows so Pro /
           // multi-digit count badges never overflow into the truncated label.
@@ -104,9 +102,9 @@ export function getSidebarNavIconClassName({
   return cn(
     'shrink-0 justify-self-center',
     tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
-    // The active row deliberately owns white label text. Make the icon's
-    // semantic accent explicit so it cannot inherit that foreground color.
-    active ? 'text-accent-blue!' : inactiveIconColor,
+    // The selected row deliberately owns white label text. Keep its icon on
+    // the canonical Jovie teal token so the active signal remains quiet.
+    active ? 'text-accent-teal!' : inactiveIconColor,
     className
   );
 }
@@ -137,7 +135,7 @@ export function SidebarNavItem({
         strokeWidth={2.25}
       />
       {!collapsed && (
-        <span className='min-w-0 truncate text-left justify-self-start'>
+        <span className='min-w-0 overflow-hidden whitespace-nowrap text-clip text-left justify-self-start [mask-image:linear-gradient(to_right,black_calc(100%_-_1rem),transparent)]'>
           {item.label}
         </span>
       )}

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -135,7 +135,7 @@ export function SidebarNavItem({
         strokeWidth={2.25}
       />
       {!collapsed && (
-        <span className='min-w-0 overflow-hidden whitespace-nowrap text-clip text-left justify-self-start [mask-image:linear-gradient(to_right,black_calc(100%_-_1rem),transparent)]'>
+        <span className='min-w-0 justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left [mask-image:linear-gradient(to_right,black_calc(100%_-_1rem),transparent)]'>
           {item.label}
         </span>
       )}

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -24,6 +24,34 @@ const threads: SidebarThread[] = [
 ];
 
 describe('SidebarThreadsSection', () => {
+  it('anchors a long thread title fade to the row track instead of shrink-wrapping it', () => {
+    const title =
+      'Reply with exactly one short sentence confirming the artist release plan';
+
+    render(
+      <SidebarThreadsSection
+        threads={[
+          {
+            id: 'thread-long-title',
+            href: '/app/chat/thread-long-title',
+            title,
+            status: 'complete',
+            updatedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ]}
+        activeThreadId={null}
+        tight
+        collapsed={false}
+      />
+    );
+
+    const label = screen.getByText(title);
+
+    expect(label).toHaveClass('justify-self-stretch', 'overflow-hidden');
+    expect(label).not.toHaveClass('justify-self-start', 'truncate');
+    expect(label.className).toContain('mask-image:linear-gradient');
+  });
+
   it('renders dense thread links with canonical shell row state', () => {
     render(
       <SidebarThreadsSection

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -232,7 +232,7 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
       />
       <span
         className={cn(
-          'min-w-0 truncate text-left justify-self-start',
+          'min-w-0 justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left [mask-image:linear-gradient(to_right,black_calc(100%_-_1rem),transparent)]',
           'text-xs',
           unread && 'font-medium'
         )}

--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -68,7 +68,6 @@
      ============================================ */
   --linear-border-subtle: rgba(0, 0, 0, 0.06);
   /* Low-emphasis separators inside shell chrome must stay quieter than a frame seam. */
-  --linear-border-divider-subtle: rgba(0, 0, 0, 0.03);
   --linear-border-default: rgba(0, 0, 0, 0.1);
   --linear-border-strong: rgba(0, 0, 0, 0.15);
   --linear-border-focus: rgba(0, 0, 0, 0.28);
@@ -416,7 +415,6 @@
      edge-less in dark mode). */
   --linear-border-subtle: rgba(255, 255, 255, 0.07);
   /* Low-emphasis separators inside shell chrome must stay quieter than a frame seam. */
-  --linear-border-divider-subtle: rgba(255, 255, 255, 0.05);
   --linear-border-default: rgba(255, 255, 255, 0.11);
   --linear-border-strong: rgba(255, 255, 255, 0.18);
   --linear-border-focus: rgba(255, 255, 255, 0.32);

--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -67,6 +67,8 @@
      BORDERS — LIGHT MODE
      ============================================ */
   --linear-border-subtle: rgba(0, 0, 0, 0.06);
+  /* Low-emphasis separators inside shell chrome must stay quieter than a frame seam. */
+  --linear-border-divider-subtle: rgba(0, 0, 0, 0.03);
   --linear-border-default: rgba(0, 0, 0, 0.1);
   --linear-border-strong: rgba(0, 0, 0, 0.15);
   --linear-border-focus: rgba(0, 0, 0, 0.28);
@@ -413,6 +415,8 @@
      into surface-1 `#17171a` and page `#08090a`, making cards/panels/inputs
      edge-less in dark mode). */
   --linear-border-subtle: rgba(255, 255, 255, 0.07);
+  /* Low-emphasis separators inside shell chrome must stay quieter than a frame seam. */
+  --linear-border-divider-subtle: rgba(255, 255, 255, 0.05);
   --linear-border-default: rgba(255, 255, 255, 0.11);
   --linear-border-strong: rgba(255, 255, 255, 0.18);
   --linear-border-focus: rgba(255, 255, 255, 0.32);

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -175,28 +175,29 @@ describe('UnifiedSidebar library route', () => {
     ).toHaveClass(
       'min-h-(--app-shell-footer-row-height)',
       'border-t',
-      'border-(--linear-border-divider-subtle)'
+      'border-(--linear-border-subtle)'
     );
   });
 
-  it('uses a divider token softer than the app frame seam in both themes', () => {
+  it('uses existing subtle border token without growing --linear-* namespace', () => {
     const linearTokens = readFileSync(
       join(__dirname, '../../../..', 'styles/linear-tokens.css'),
       'utf8'
     );
 
     expect(linearTokens).toMatch(
-      /--linear-border-divider-subtle:\s*rgba\(0, 0, 0, 0\.03\);/
+      /--linear-border-subtle:\s*rgba\(0, 0, 0, 0\.06\);/
     );
     expect(linearTokens).toMatch(
       /--linear-app-frame-seam:\s*rgba\(0, 0, 0, 0\.045\);/
     );
     expect(linearTokens).toMatch(
-      /:root\.dark[\s\S]*--linear-border-divider-subtle:\s*rgba\(255, 255, 255, 0\.05\);/
+      /:root\.dark[\s\S]*--linear-border-subtle:\s*rgba\(255, 255, 255, 0\.07\);/
     );
     expect(linearTokens).toMatch(
       /:root\.dark[\s\S]*--linear-app-frame-seam:\s*rgba\(255, 255, 255, 0\.07\);/
     );
+    expect(linearTokens).not.toMatch(/--linear-border-divider-subtle/);
   });
 
   it('preserves the generic route-override contract for legitimate consumers', async () => {

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { TooltipProvider } from '@jovie/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -173,7 +175,27 @@ describe('UnifiedSidebar library route', () => {
     ).toHaveClass(
       'min-h-(--app-shell-footer-row-height)',
       'border-t',
-      'border-subtle'
+      'border-(--linear-border-divider-subtle)'
+    );
+  });
+
+  it('uses a divider token softer than the app frame seam in both themes', () => {
+    const linearTokens = readFileSync(
+      join(__dirname, '../../../..', 'styles/linear-tokens.css'),
+      'utf8'
+    );
+
+    expect(linearTokens).toMatch(
+      /--linear-border-divider-subtle:\s*rgba\(0, 0, 0, 0\.03\);/
+    );
+    expect(linearTokens).toMatch(
+      /--linear-app-frame-seam:\s*rgba\(0, 0, 0, 0\.045\);/
+    );
+    expect(linearTokens).toMatch(
+      /:root\.dark[\s\S]*--linear-border-divider-subtle:\s*rgba\(255, 255, 255, 0\.05\);/
+    );
+    expect(linearTokens).toMatch(
+      /:root\.dark[\s\S]*--linear-app-frame-seam:\s*rgba\(255, 255, 255, 0\.07\);/
     );
   });
 

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -173,7 +173,7 @@ describe('UnifiedSidebar library route', () => {
     ).toHaveClass(
       'min-h-(--app-shell-footer-row-height)',
       'border-t',
-      'border-(--app-shell-frame-seam)'
+      'border-subtle'
     );
   });
 

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1740
+  "count": 1739
 }

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -144,8 +144,8 @@ describe('Sidebar row alignment', () => {
   it('keeps settings sidebar rows byte-identical to shell nav-row chrome', () => {
     // Settings-vs-shell parity (#12025): the settings sidebar must derive its
     // rows from the canonical shell helper. Its only allowed divergence is
-    // structural — no icon column (single-column grid) and hidden icon guide
-    // lines — never padding/density/active/hover treatment.
+    // structural — no icon column (single-column grid) — never
+    // padding/density/active/hover treatment.
     const settingsRow = getSettingsSidebarRowClassName(false);
     const settingsActiveRow = getSettingsSidebarRowClassName(true);
     const shellRow = getSidebarNavRowClassName({});
@@ -172,12 +172,10 @@ describe('Sidebar row alignment', () => {
     expect(settingsActiveRow).toContain('text-white');
     expect(settingsActiveRow).toContain('font-medium');
 
-    // Allowed structural divergence: icon-less single-column grid with the
-    // icon guide lines hidden. `cn()` runs tailwind-merge, so the settings
-    // override must fully replace the shell's icon-column grid template.
+    // Allowed structural divergence: icon-less single-column grid. `cn()` runs
+    // tailwind-merge, so the settings override must fully replace the shell's
+    // icon-column grid template.
     expect(settingsRow).toContain('grid-cols-[minmax(0,1fr)]');
-    expect(settingsRow).toContain('before:hidden');
-    expect(settingsRow).toContain('after:hidden');
     expect(settingsRow).not.toContain(
       'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
     );
@@ -187,7 +185,6 @@ describe('Sidebar row alignment', () => {
     // #13217: sidebar nav rows are borderless — active state is a filled
     // background only. No resting border, no hover border, no active border
     // or border-by-inset-ring shadow may reappear on the canonical row chrome.
-    // A left accent rail (inset 2px solid accent) is allowed for active clarity.
     for (const row of [
       getSidebarNavRowClassName({}),
       getSidebarNavRowClassName({ active: true }),
@@ -212,8 +209,8 @@ describe('Sidebar row alignment', () => {
     expect(rowClassName).toContain(
       'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
     );
-    expect(rowClassName).toContain('before:left-6');
-    expect(rowClassName).toContain('after:left-10');
+    expect(rowClassName).not.toContain('before:');
+    expect(rowClassName).not.toContain('after:');
     expect(rowClassName).toContain('text-xs');
     expect(rowClassName).toContain('font-normal');
     expect(rowClassName).toContain('hover:bg-sidebar-accent');
@@ -230,7 +227,7 @@ describe('Sidebar row alignment', () => {
     expect(iconClassName).toContain('h-3.5');
     expect(iconClassName).toContain('text-sidebar-muted/70');
     expect(getSidebarNavIconClassName({ active: true })).toContain(
-      'text-accent-blue!'
+      'text-accent-teal!'
     );
   });
 });


### PR DESCRIPTION
## Summary

Quiet the active authenticated-shell sidebar row while retaining a distinct keyboard focus ring, compact icon treatment, overflow-safe labels, and a right-edge thread-title fade. This applies the canonical SidebarNavItem helpers to Settings and library consumers and locks parity with regression tests.

Closes JOV-4526.

## Verification

- Focused sidebar and overflow suites: 29/29 passed.
- Linear namespace ratchet baseline corrected after the shared token count dropped from 1740 to 1739.
- Full required unit shards passed; durable shard 8 receipt: 280 files passed, 2422 tests passed, exit 0.
- CI harness manifest and documentation checks passed with exit 0.
- Biome and diff-check passed.
- Normal push path only; no hook bypass.

## Visual review

Design review now uses Grok 4.5 through the Grok CLI, with Codex vision fallback. Model findings are advisory and do not replace required source or merge-group checks. No Kimi dependency remains.

## Delivery state

The corrected branch is being rebased onto current main and republished through the normal pre-push gate. Native queue admission will use only the exact repaired remote head.