### PR TITLE
fix(desktop): quiet renderer recovery surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Desktop recovery stays quiet and actionable (JOV-4539):** the renderer-failure fallback now keeps just the recovery action and browser escape hatch on a calm System B canvas, without diagnostic runtime chrome or a heavy error card.
 - **macOS sign-in cancellation returns to Jovie:** if a native auth redirect leaves the hidden desktop window blank, canceling sign-in now restores the canonical sign-in shell instead of showing a black window.
 - [internal] **Desktop memory baseline evidence (JOV-2712):** the Electron shell can now capture bounded main/renderer RSS and macOS physical-footprint samples, record clean shutdown evidence, and classify growth regressions without claiming native leak proof when the platform tool is unavailable.
 - [internal] **Desktop packaging toolchain updated:** Electron Builder now uses 26.15.3 for current signing, notarization, and installer support.

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -92,22 +92,10 @@ test('desktop window fails into a branded Jovie recovery surface', async () => {
     /const APP_BACKGROUND_COLOR = SYSTEM_B_DESKTOP_TOKENS\.backgroundColor;/
   );
   assert.match(mainSource, /function buildDesktopLoadFailureUrl\(\): string/);
-  assert.match(mainSource, /Jovie Desktop/);
-  assert.match(mainSource, /Built for artists/);
-  assert.match(mainSource, /const DESKTOP_RUNTIME_LABEL_BY_PLATFORM/);
-  assert.match(mainSource, /darwin: 'Mac OS'/);
-  assert.match(mainSource, /linux: 'Linux'/);
-  assert.match(mainSource, /win32: 'Windows'/);
-  assert.match(
-    mainSource,
-    /function getDesktopRuntimeLabel\(\s*platform: NodeJS\.Platform = process\.platform\s*\): string/
-  );
-  assert.match(
-    mainSource,
-    /const runtimeLabel = escapeHtmlAttribute\(getDesktopRuntimeLabel\(\)\);/
-  );
-  assert.match(mainSource, /Desktop shell runtime: \$\{runtimeLabel\}/);
-  assert.doesNotMatch(mainSource, /Desktop shell runtime: Mac OS/);
+  assert.match(mainSource, /Jovie couldn’t load/);
+  assert.match(mainSource, /Check your connection, then try again\./);
+  assert.doesNotMatch(mainSource, /Desktop shell runtime:/);
+  assert.doesNotMatch(mainSource, /Built for artists/);
   assert.match(mainSource, /data:text\/html;charset=utf-8/);
   assert.match(
     mainSource,
@@ -116,6 +104,18 @@ test('desktop window fails into a branded Jovie recovery surface', async () => {
   assert.match(
     mainSource,
     /<a class="primary" href="\$\{retryUrl\}">Retry<\/a>/
+  );
+  assert.match(
+    mainSource,
+    /<a class="secondary" href="\$\{appOrigin\}">Open Jovie<\/a>/
+  );
+  assert.doesNotMatch(
+    mainSource,
+    /box-shadow: var\(--system-b-shadow-popover\)/
+  );
+  assert.doesNotMatch(
+    mainSource,
+    /border: 1px solid var\(--system-b-border-subtle\)/
   );
   assert.doesNotMatch(mainSource, /onclick="window\.location\.href/);
   assert.match(mainSource, /did-fail-load/);
@@ -172,11 +172,10 @@ test('desktop window fails into a branded Jovie recovery surface', async () => {
   assert.doesNotMatch(mainSource, /M31 10A20 20 0 0 0 11 30H31V10Z/);
   assert.doesNotMatch(mainSource, /M11 31L30 31M14 36L31 36M18 41L32 41/);
   assert.match(mainSource, /--system-b-bg-base:/);
-  assert.match(mainSource, /--system-b-shadow-popover:/);
   assert.match(mainSource, /min-height: 100vh/);
   assert.match(mainSource, /background: var\(--system-b-bg-base\)/);
-  assert.match(mainSource, /background: var\(--system-b-surface-1\)/);
   assert.match(mainSource, /border-radius: var\(--system-b-radius-pill\)/);
+  assert.match(mainSource, /opacity: 0\.035/);
   assert.doesNotMatch(
     mainSource,
     /background: linear-gradient\(145deg, rgba\(15,16,17,0\.94\), rgba\(8,9,10,0\.98\)\)/

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -120,14 +120,6 @@ const TRAY_SET_STATE_CHANNEL = 'tray-set-state';
 const TRAY_ACTION_CHANNEL = 'tray-action';
 /** Renderer → main: first successful React paint of the hosted app (JOV-3595). */
 const APP_BOOTED_CHANNEL = 'app-booted';
-const DESKTOP_RUNTIME_LABEL_BY_PLATFORM: Partial<
-  Record<NodeJS.Platform, string>
-> = {
-  darwin: 'Mac OS',
-  linux: 'Linux',
-  win32: 'Windows',
-} as const;
-
 type UpdateChannel =
   | typeof UPDATE_AVAILABLE_CHANNEL
   | typeof UPDATE_DOWNLOADED_CHANNEL;
@@ -898,16 +890,9 @@ function escapeHtmlAttribute(value: string): string {
   return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
 }
 
-function getDesktopRuntimeLabel(
-  platform: NodeJS.Platform = process.platform
-): string {
-  return DESKTOP_RUNTIME_LABEL_BY_PLATFORM[platform] ?? platform;
-}
-
 function buildDesktopLoadFailureUrl(): string {
   const retryUrl = escapeHtmlAttribute(APP_ENTRY_URL);
   const appOrigin = escapeHtmlAttribute(APP_ORIGIN);
-  const runtimeLabel = escapeHtmlAttribute(getDesktopRuntimeLabel());
   const html = `<!doctype html>
 <html lang="en">
   <head>
@@ -915,19 +900,18 @@ function buildDesktopLoadFailureUrl(): string {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Jovie Desktop</title>
     <style>
-      :root { color-scheme: dark; --system-b-bg-base: ${SYSTEM_B_DESKTOP_TOKENS.backgroundColor}; --system-b-surface-1: ${SYSTEM_B_DESKTOP_TOKENS.surfaceColor}; --system-b-text-primary: ${SYSTEM_B_DESKTOP_TOKENS.textPrimary}; --system-b-text-secondary: ${SYSTEM_B_DESKTOP_TOKENS.textSecondary}; --system-b-border-subtle: ${SYSTEM_B_DESKTOP_TOKENS.borderSubtle}; --system-b-primary-bg: ${SYSTEM_B_DESKTOP_TOKENS.primaryBackground}; --system-b-primary-fg: ${SYSTEM_B_DESKTOP_TOKENS.primaryForeground}; --system-b-radius-shell: ${SYSTEM_B_DESKTOP_TOKENS.radiusShell}; --system-b-radius-pill: ${SYSTEM_B_DESKTOP_TOKENS.radiusPill}; --system-b-shadow-popover: ${SYSTEM_B_DESKTOP_TOKENS.shadowPopover}; }
+      :root { color-scheme: dark; --system-b-bg-base: ${SYSTEM_B_DESKTOP_TOKENS.backgroundColor}; --system-b-text-primary: ${SYSTEM_B_DESKTOP_TOKENS.textPrimary}; --system-b-text-secondary: ${SYSTEM_B_DESKTOP_TOKENS.textSecondary}; --system-b-primary-bg: ${SYSTEM_B_DESKTOP_TOKENS.primaryBackground}; --system-b-primary-fg: ${SYSTEM_B_DESKTOP_TOKENS.primaryForeground}; --system-b-radius-pill: ${SYSTEM_B_DESKTOP_TOKENS.radiusPill}; }
       html, body { margin: 0; min-height: 100vh; background: var(--system-b-bg-base); color: var(--system-b-text-primary); font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", Inter, sans-serif; }
       body { display: grid; place-items: center; overflow: hidden; }
-      .shell { position: relative; display: grid; width: min(520px, calc(100vw - 48px)); gap: 22px; padding: 40px; border: 1px solid var(--system-b-border-subtle); border-radius: var(--system-b-radius-shell); background: var(--system-b-surface-1); box-shadow: var(--system-b-shadow-popover); }
-      .mark { position: absolute; right: -52px; top: -46px; width: 220px; height: 220px; opacity: 0.055; }
-      .brand { display: flex; align-items: center; gap: 14px; }
-      .icon { display: grid; width: 42px; height: 42px; place-items: center; border-radius: var(--system-b-radius-shell); background: var(--system-b-primary-bg); color: var(--system-b-primary-fg); }
-      h1 { margin: 0; font-size: 17px; font-weight: 650; letter-spacing: 0; }
-      p { margin: 0; max-width: 38ch; color: var(--system-b-text-secondary); font-size: 13px; line-height: 1.55; }
-      .actions { display: flex; flex-wrap: wrap; gap: 10px; }
-      a { display: inline-flex; height: 34px; align-items: center; justify-content: center; border-radius: var(--system-b-radius-pill); padding: 0 13px; border: 1px solid var(--system-b-border-subtle); background: transparent; color: var(--system-b-text-primary); font-size: 12px; font-weight: 590; text-decoration: none; }
+      .shell { position: relative; display: grid; width: min(420px, calc(100vw - 48px)); gap: 16px; padding: 32px 24px; text-align: center; }
+      .mark { position: absolute; left: 50%; top: 50%; width: 180px; height: 180px; opacity: 0.035; pointer-events: none; transform: translate(-50%, -50%); }
+      .copy { position: relative; display: grid; gap: 8px; justify-items: center; }
+      h1 { margin: 0; font-size: 17px; font-weight: 650; letter-spacing: -0.01em; }
+      p { margin: 0; max-width: 34ch; color: var(--system-b-text-secondary); font-size: 13px; line-height: 1.55; }
+      .actions { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; }
+      a { display: inline-flex; height: 34px; align-items: center; justify-content: center; border-radius: var(--system-b-radius-pill); padding: 0 13px; color: var(--system-b-text-primary); font-size: 12px; font-weight: 590; text-decoration: none; }
       .primary { background: var(--system-b-primary-bg); color: var(--system-b-primary-fg); }
-      .meta { color: var(--system-b-text-secondary); font-size: 11px; }
+      .secondary { color: var(--system-b-text-secondary); }
     </style>
   </head>
   <body>
@@ -935,23 +919,14 @@ function buildDesktopLoadFailureUrl(): string {
       <svg class="mark" viewBox="0 0 353.68 347.97" aria-hidden="true">
         <path fill="currentColor" d="${JOVIE_MARK_SVG_PATH}"/>
       </svg>
-      <div class="brand">
-        <div class="icon" aria-hidden="true">
-          <svg width="28" height="28" viewBox="0 0 353.68 347.97">
-            <path fill="currentColor" d="${JOVIE_MARK_SVG_PATH}"/>
-          </svg>
-        </div>
-        <div>
-          <h1>Jovie Desktop</h1>
-          <p>Built for artists.</p>
-        </div>
+      <div class="copy">
+        <h1>Jovie couldn’t load</h1>
+        <p>Check your connection, then try again.</p>
       </div>
-      <p>Jovie could not load the app shell. Check your connection, then retry. If this keeps happening, open Jovie in your browser and install the latest desktop build.</p>
       <div class="actions">
         <a class="primary" href="${retryUrl}">Retry</a>
-        <a href="${appOrigin}">Open Jovie</a>
+        <a class="secondary" href="${appOrigin}">Open Jovie</a>
       </div>
-      <div class="meta">Desktop shell runtime: ${runtimeLabel}</div>
     </main>
   </body>
 </html>`;


### PR DESCRIPTION
## Summary
- Simplifies the Electron renderer-failure fallback to a quiet System B recovery composition.
- Preserves Retry and Open Jovie; removes runtime diagnostics, card border, and popover shadow.
- Keeps the Jovie mark as a low-emphasis watermark.

## Bug-to-Test
- JOV-4539: desktop shell contract locks the concise copy, both recovery actions, quiet watermark, and absence of heavy recovery-card chrome.

## Visual states
- Loading: native window keeps the shared `backgroundColor` token before hosted content is interactive.
- Failure: fixed centered recovery footprint with a low-opacity mark; no status insertion or layout shift.
- Retry/Open Jovie: existing native anchor behavior remains unchanged.

## Checks
- `pnpm --filter desktop run test:desktop-renderer-recovery`
- `pnpm --filter desktop run test:system-b-tokens`
- `pnpm --filter desktop run test:desktop-shell`
- `pnpm --filter desktop run typecheck`
- Mobile render: no horizontal overflow; keyboard order Retry → Open Jovie.

## Evidence
- Local desktop render: `/tmp/jov-4539-desktop-recovery.png`; local mobile render: `/tmp/jov-4539-desktop-recovery-mobile.png`.
- Packaged/runtime capture remains blocked by the separate Electron packaging failure tracked in JOV-4540.

Linear: JOV-4539

## Post-merge design audit (recorded after merge)
- **Kimi CLI `/design-review`: APPROVE**. Session: `session_753d3119-4ed2-45f8-b932-0939dd5d1644`. It reviewed exact head `9d3db22ba8e800ca5682d0eee9224b24bbb8152f` against `de5bb61bac2670a1b3c1ec7a068cc9c0b75bf7db` and the desktop/mobile captures.
- Re-run on Node `v22.23.1` / pnpm `9.15.4`: renderer recovery 6/6, System B tokens 3/3, desktop shell 12/12, desktop typecheck all passed.
- Visual audit: no desktop/mobile overflow in the captured 1280×800 and 390×844 recovery states; visible keyboard focus reached the second action, with DOM order Retry then Open Jovie.
- **Important sequencing note:** PR #15073 merged at `2026-07-29T05:09:48Z` before this external Kimi verdict was completed. This is an exact post-merge audit record, not a claim that Kimi gated the merge.
- **Remaining runtime blocker:** packaged Electron proof cannot yet be produced because the production desktop-release package step fails in electron-builder/plist parsing (JOV-4540). No desktop binary publication is implied by this PR.
