### PR TITLE
feat(chat): recover New Chat starter actions carousel

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -18,11 +18,12 @@ import { useAppFlag } from '@/lib/flags/client';
 import { usePendingOpportunityCardsQuery, usePlanGate } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { deriveChatRailContextTargets } from './chat-context-rail';
-import { ChatActionCard } from './components/ChatActionCard';
+import { resolveChatEmptyStateAffordance } from './chat-empty-state-contract';
 import { ChatDropZoneOverlay } from './components/ChatDropZoneOverlay';
 import { ChatEmptyStateOpportunityCards } from './components/ChatEmptyStateOpportunityCards';
 import { ChatPinnedOpportunityHeader } from './components/ChatPinnedOpportunityHeader';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
+import { ChatStarterActionsRail } from './components/ChatStarterActionsRail';
 import { EntityResolutionProvider } from './components/EntityResolutionProvider';
 import { SuggestedPrompts } from './components/SuggestedPrompts';
 import {
@@ -457,16 +458,22 @@ export function JovieChat({
   // conversation content yet. Zero pending → restore actionCards + prompt rail
   // first-run scaffolding (JOV-3547) instead of a bare composer.
   // Also load when deep-linking a pin from the inbox (JOV-3933).
+  const conversationExists = Boolean(
+    hasMessages || conversationId || activeConversationId
+  );
+  const conversationInProgress = isLoading || isSubmitting || isStreaming;
   const shouldLoadOpportunityCards =
-    (!hasMessages && !conversationId && !isLoadingConversation) ||
+    (!conversationExists &&
+      !conversationInProgress &&
+      !isLoadingConversation) ||
     Boolean(deepLinkOpportunityId && !pinnedOpportunity);
   const { data: pendingOpportunityCards = [] } =
     usePendingOpportunityCardsQuery({
       enabled: shouldLoadOpportunityCards,
     });
   const showEmptyOpportunityCards =
-    !hasMessages &&
-    !conversationId &&
+    !conversationExists &&
+    !conversationInProgress &&
     !isLoadingConversation &&
     !pinnedOpportunity &&
     pendingOpportunityCards.length > 0;
@@ -501,22 +508,21 @@ export function JovieChat({
 
   // Pin mode uses the thread chrome (docked composer + header) so the card
   // stays above the transcript, matching inbox → pinned-card behavior.
-  const showThreadView = hasMessages || pinnedOpportunity !== null;
+  const showThreadView =
+    conversationExists || conversationInProgress || pinnedOpportunity !== null;
   const showBottomComposer = showThreadView;
-  // Hide scaffolding while typing/chips/picker so the composer owns attention.
-  const showEmptyScaffolding =
-    !showThreadView &&
-    !composerPickerOpen &&
-    !input.trim() &&
-    chipTray.chips.length === 0;
-  const showEmptyActionCards =
-    showEmptyScaffolding &&
-    !showEmptyOpportunityCards &&
-    Boolean(actionCards?.length);
-  // Prompt rail is the zero-opportunity scaffolding path (JOV-3547). Hide it
-  // when opportunity cards own the empty state so the rail does not compete.
-  const showEmptyPromptRail =
-    showEmptyScaffolding && !showEmptyOpportunityCards;
+  const emptyStateAffordance = resolveChatEmptyStateAffordance({
+    conversationExists,
+    conversationInProgress,
+    composerHasIntent:
+      composerPickerOpen || Boolean(input.trim()) || chipTray.chips.length > 0,
+    opportunityCardCount: showEmptyOpportunityCards
+      ? pendingOpportunityCards.length
+      : 0,
+    starterActionCount: visibleActionCards.length,
+  });
+  const showEmptyActionCards = emptyStateAffordance === 'starter-actions';
+  const showEmptyPromptRail = emptyStateAffordance === 'suggestion-pills';
   const shouldReservePickerClearance = showBottomComposer && composerPickerOpen;
   const messageViewportPaddingBottom = shouldReservePickerClearance
     ? CHAT_PICKER_THREAD_CLEARANCE
@@ -734,18 +740,13 @@ export function JovieChat({
           >
             {!showThreadView ? (
               <div
-                className={cn(
-                  'flex flex-1 flex-col',
-                  // Docked scaffolds (cards/opportunity) fill the viewport so the
-                  // composer can sit at the bottom; welcome state stays centered.
-                  showEmptyActionCards || showEmptyOpportunityCards
-                    ? 'min-h-0'
-                    : 'items-center justify-center'
-                )}
+                className='flex min-h-0 flex-1 flex-col'
+                data-empty-affordance={emptyStateAffordance}
                 data-testid='chat-empty-state-viewport'
               >
                 <ChatEmptyStateComposerRegion
                   greetingName={displayName ?? username ?? null}
+                  stableDocked
                   above={
                     showEmptyOpportunityCards ? (
                       <ChatEmptyStateOpportunityCards
@@ -754,40 +755,33 @@ export function JovieChat({
                       />
                     ) : showEmptyActionCards ? (
                       <div
-                        className='mx-auto flex w-full max-w-[28rem] flex-col gap-2'
+                        className='mx-auto flex min-h-full w-full max-w-[46rem] items-center py-3'
                         data-testid='chat-empty-state-action-card-slot'
                       >
-                        {visibleActionCards.map(card => (
-                          <ChatActionCard
-                            key={card.id}
-                            title={card.title}
-                            body={card.body}
-                            actionLabel={card.actionLabel}
-                            ariaLabel={card.title}
-                            onAct={() => handleActOnActionCard(card)}
-                            onDismiss={() => handleDismissActionCard(card)}
-                          />
-                        ))}
+                        <ChatStarterActionsRail
+                          cards={visibleActionCards}
+                          onAct={handleActOnActionCard}
+                          onDismiss={handleDismissActionCard}
+                        />
+                      </div>
+                    ) : showEmptyPromptRail ? (
+                      <div
+                        className='mx-auto flex min-h-full w-full max-w-[46rem] items-end pb-3'
+                        data-testid='chat-empty-state-soft-suggestions-slot'
+                      >
+                        <SuggestedPrompts
+                          onSelect={handleSuggestedPrompt}
+                          isFirstSession={isFirstSession}
+                          isProfileComplete={isProfileComplete}
+                          layout='rail'
+                          dimmed={composerPickerOpen}
+                          excludeActionIds={promptRailExcludeActionIds}
+                        />
                       </div>
                     ) : undefined
                   }
                 >
                   {composerSurface}
-                  {showEmptyPromptRail ? (
-                    <div
-                      className='mt-4 w-full'
-                      data-testid='chat-empty-state-soft-suggestions-slot'
-                    >
-                      <SuggestedPrompts
-                        onSelect={handleSuggestedPrompt}
-                        isFirstSession={isFirstSession}
-                        isProfileComplete={isProfileComplete}
-                        layout='rail'
-                        dimmed={composerPickerOpen}
-                        excludeActionIds={promptRailExcludeActionIds}
-                      />
-                    </div>
-                  ) : null}
                   {inlineChatError ? (
                     <div className='mt-3 w-full'>{inlineChatError}</div>
                   ) : null}

--- a/apps/web/components/jovie/chat-empty-state-contract.test.ts
+++ b/apps/web/components/jovie/chat-empty-state-contract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { resolveChatEmptyStateAffordance } from './chat-empty-state-contract';
+
+const emptyState = {
+  conversationExists: false,
+  conversationInProgress: false,
+  composerHasIntent: false,
+  opportunityCardCount: 0,
+  starterActionCount: 0,
+} as const;
+
+describe('resolveChatEmptyStateAffordance', () => {
+  it('prioritizes opportunities, then starter actions, then suggestion pills', () => {
+    expect(
+      resolveChatEmptyStateAffordance({
+        ...emptyState,
+        opportunityCardCount: 1,
+        starterActionCount: 3,
+      })
+    ).toBe('opportunity-cards');
+    expect(
+      resolveChatEmptyStateAffordance({ ...emptyState, starterActionCount: 3 })
+    ).toBe('starter-actions');
+    expect(resolveChatEmptyStateAffordance(emptyState)).toBe(
+      'suggestion-pills'
+    );
+  });
+
+  it.each([
+    { conversationExists: true },
+    { conversationInProgress: true },
+    { composerHasIntent: true },
+  ])('shows no empty affordance for $s', override => {
+    expect(
+      resolveChatEmptyStateAffordance({
+        ...emptyState,
+        starterActionCount: 3,
+        ...override,
+      })
+    ).toBe('none');
+  });
+});

--- a/apps/web/components/jovie/chat-empty-state-contract.ts
+++ b/apps/web/components/jovie/chat-empty-state-contract.ts
@@ -1,0 +1,29 @@
+export type ChatEmptyStateAffordance =
+  | 'none'
+  | 'opportunity-cards'
+  | 'starter-actions'
+  | 'suggestion-pills';
+
+interface ResolveChatEmptyStateAffordanceInput {
+  readonly conversationExists: boolean;
+  readonly conversationInProgress: boolean;
+  readonly composerHasIntent: boolean;
+  readonly opportunityCardCount: number;
+  readonly starterActionCount: number;
+}
+
+/** One visibility contract for empty-chat affordances. */
+export function resolveChatEmptyStateAffordance({
+  conversationExists,
+  conversationInProgress,
+  composerHasIntent,
+  opportunityCardCount,
+  starterActionCount,
+}: ResolveChatEmptyStateAffordanceInput): ChatEmptyStateAffordance {
+  if (conversationExists || conversationInProgress || composerHasIntent) {
+    return 'none';
+  }
+  if (opportunityCardCount > 0) return 'opportunity-cards';
+  if (starterActionCount > 0) return 'starter-actions';
+  return 'suggestion-pills';
+}

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
@@ -108,4 +108,17 @@ describe('ChatEmptyStateComposerRegion', () => {
     expect(composer.className).toContain('shrink-0');
     expect(screen.getByTestId('composer-child')).toBeTruthy();
   });
+
+  it('keeps a stable dock while an empty-state affordance is temporarily hidden', () => {
+    render(
+      <ChatEmptyStateComposerRegion stableDocked>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    expect(
+      screen.getByTestId('chat-empty-state-composer-region')
+    ).toHaveAttribute('data-layout', 'docked');
+    expect(screen.getByTestId('chat-empty-state-above-scroll')).toBeTruthy();
+  });
 });

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -21,17 +21,20 @@ export function ChatEmptyStateComposerRegion({
   children,
   greetingName,
   hideWelcomeHeader = false,
+  stableDocked = false,
 }: {
   readonly above?: ReactNode;
   readonly children: ReactNode;
   readonly greetingName?: string | null;
   readonly hideWelcomeHeader?: boolean;
+  /** Keep composer geometry docked when transient empty-state affordances hide. */
+  readonly stableDocked?: boolean;
 }) {
   const trimmedName = greetingName?.trim();
   const greeting = trimmedName ? `Hi, ${trimmedName}` : 'Hi there';
   const showWelcomeHeader = !above && !hideWelcomeHeader;
 
-  if (above) {
+  if (above || stableDocked) {
     return (
       <div
         className={`${CHAT_CONTENT_SHELL_CLASSNAME} relative flex min-h-full flex-col px-1 py-4 sm:py-5`}
@@ -43,7 +46,7 @@ export function ChatEmptyStateComposerRegion({
           className='min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pb-3'
           data-testid='chat-empty-state-above-scroll'
         >
-          {above}
+          {above ?? <div className='h-full' aria-hidden='true' />}
         </div>
         {/* Bottom-docked composer + quick-action chips (passed as children) */}
         <div

--- a/apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
+++ b/apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatActionCard } from '../types';
+import { ChatStarterActionsRail } from './ChatStarterActionsRail';
+
+const cards: ChatActionCard[] = [
+  {
+    id: 'plan-release',
+    title: 'Plan a Release',
+    body: 'Plan the rollout.',
+    actionLabel: 'Start Planning',
+    prompt: 'Plan it.',
+  },
+  {
+    id: 'review-signals',
+    title: 'Review Signals',
+    body: 'Review momentum.',
+    actionLabel: 'Review Signals',
+    prompt: 'Review it.',
+  },
+  {
+    id: 'generate-album-art',
+    title: 'Generate Art',
+    body: 'Create a cover direction.',
+    actionLabel: 'Generate Art',
+    prompt: 'Create it.',
+  },
+];
+
+describe('ChatStarterActionsRail', () => {
+  it('uses direct pagination dots and keyboard navigation without auto-advance', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatStarterActionsRail
+        cards={cards}
+        onAct={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('group', { name: '1 of 3: Plan a Release' })
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show Starter Action 2 Of 3: Review Signals',
+      })
+    );
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'Show Starter Action 2 Of 3: Review Signals',
+      }),
+      { key: 'ArrowLeft' }
+    );
+    expect(
+      screen.getByRole('group', { name: '1 of 3: Plan a Release' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders at most three pagination dots', () => {
+    render(
+      <ChatStarterActionsRail
+        cards={[
+          ...cards,
+          { ...cards[1], id: 'build-artist-profile', title: 'Build Profile' },
+        ]}
+        onAct={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(
+      screen.getAllByRole('button', { name: /Show Starter Action/ })
+    ).toHaveLength(3);
+  });
+});

--- a/apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
+++ b/apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
@@ -72,4 +72,35 @@ describe('ChatStarterActionsRail', () => {
       screen.getAllByRole('button', { name: /Show Starter Action/ })
     ).toHaveLength(3);
   });
+
+  it('keeps endpoint controls mounted and retains dot focus at the boundary', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatStarterActionsRail
+        cards={cards}
+        onAct={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    const next = screen.getByRole('button', {
+      name: 'Show Next Starter Action',
+    });
+    await user.click(next);
+    await user.click(next);
+
+    expect(next).toBeDisabled();
+    expect(next).toBeInTheDocument();
+
+    const finalDot = screen.getByRole('button', {
+      name: 'Show Starter Action 3 Of 3: Generate Art',
+    });
+    finalDot.focus();
+    fireEvent.keyDown(finalDot, { key: 'ArrowRight' });
+
+    expect(finalDot).toHaveFocus();
+    expect(
+      screen.getByRole('group', { name: '3 of 3: Generate Art' })
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/jovie/components/ChatStarterActionsRail.tsx
+++ b/apps/web/components/jovie/components/ChatStarterActionsRail.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChatActionCard as ChatActionCardModel } from '../types';
+import { ChatActionCard } from './ChatActionCard';
+
+interface ChatStarterActionsRailProps {
+  readonly cards: readonly ChatActionCardModel[];
+  readonly onAct: (card: ChatActionCardModel) => void;
+  readonly onDismiss: (card: ChatActionCardModel) => void;
+}
+
+const MAX_VISIBLE_PAGINATION_DOTS = 3;
+
+function getVisiblePaginationIndexes(
+  activeIndex: number,
+  cardCount: number
+): number[] {
+  const visibleCount = Math.min(cardCount, MAX_VISIBLE_PAGINATION_DOTS);
+  const maxStart = Math.max(cardCount - visibleCount, 0);
+  const centeredStart = activeIndex - Math.floor(visibleCount / 2);
+  const start = Math.min(Math.max(centeredStart, 0), maxStart);
+  return Array.from({ length: visibleCount }, (_, offset) => start + offset);
+}
+
+export function ChatStarterActionsRail({
+  cards,
+  onAct,
+  onDismiss,
+}: ChatStarterActionsRailProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const lastIndex = Math.max(cards.length - 1, 0);
+  const boundedIndex = Math.min(activeIndex, lastIndex);
+  const activeCard = cards[boundedIndex];
+  const visiblePaginationIndexes = getVisiblePaginationIndexes(
+    boundedIndex,
+    cards.length
+  );
+
+  useEffect(() => {
+    setActiveIndex(current => Math.min(current, lastIndex));
+  }, [lastIndex]);
+
+  if (!activeCard) return null;
+
+  const handlePaginationKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setActiveIndex(current => (current <= 0 ? lastIndex : current - 1));
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setActiveIndex(current => (current >= lastIndex ? 0 : current + 1));
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      setActiveIndex(lastIndex);
+    }
+  };
+
+  return (
+    <section
+      aria-label='Starter Actions'
+      aria-roledescription='carousel'
+      className='group/carousel relative mx-auto w-full max-w-[28rem]'
+      data-testid='chat-starter-actions-rail'
+    >
+      <fieldset
+        aria-roledescription='slide'
+        aria-label={`${boundedIndex + 1} of ${cards.length}: ${activeCard.title}`}
+        className='m-0 min-w-0 border-0 p-0'
+      >
+        <ChatActionCard
+          title={activeCard.title}
+          body={activeCard.body}
+          actionLabel={activeCard.actionLabel}
+          ariaLabel={activeCard.title}
+          onAct={() => onAct(activeCard)}
+          onDismiss={() => onDismiss(activeCard)}
+        />
+      </fieldset>
+      {boundedIndex > 0 ? (
+        <button
+          type='button'
+          aria-label='Show Previous Starter Action'
+          onClick={() => setActiveIndex(current => current - 1)}
+          className='absolute -left-12 top-20 hidden size-11 -translate-y-1/2 cursor-pointer place-items-center rounded-full text-secondary-token opacity-0 transition-[opacity,transform,color] duration-subtle ease-out group-hover/carousel:opacity-100 hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus motion-reduce:transition-none sm:grid'
+        >
+          <ChevronLeft
+            className='size-7'
+            strokeWidth={2.75}
+            aria-hidden='true'
+          />
+        </button>
+      ) : null}
+      {boundedIndex < lastIndex ? (
+        <button
+          type='button'
+          aria-label='Show Next Starter Action'
+          onClick={() => setActiveIndex(current => current + 1)}
+          className='absolute -right-12 top-20 hidden size-11 -translate-y-1/2 cursor-pointer place-items-center rounded-full text-secondary-token opacity-0 transition-[opacity,transform,color] duration-subtle ease-out group-hover/carousel:opacity-100 hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus motion-reduce:transition-none sm:grid'
+        >
+          <ChevronRight
+            className='size-7'
+            strokeWidth={2.75}
+            aria-hidden='true'
+          />
+        </button>
+      ) : null}
+      {cards.length > 1 ? (
+        <fieldset className='mt-2 flex min-h-5 items-center justify-center border-0 p-0'>
+          <legend className='sr-only'>Choose Starter Action</legend>
+          {visiblePaginationIndexes.map(index => (
+            <button
+              key={cards[index]?.id ?? index}
+              type='button'
+              aria-label={`Show Starter Action ${index + 1} Of ${cards.length}: ${cards[index]?.title ?? ''}`}
+              aria-current={index === boundedIndex ? 'true' : undefined}
+              onClick={() => setActiveIndex(index)}
+              onKeyDown={handlePaginationKeyDown}
+              className='group relative grid size-8 place-items-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-0'
+            >
+              <span
+                className='size-1 rounded-full bg-quaternary-token/65 transition-[transform,background-color] duration-subtle group-hover:bg-tertiary-token group-aria-[current=true]:scale-125 group-aria-[current=true]:bg-secondary-token motion-reduce:transition-none'
+                aria-hidden='true'
+              />
+            </button>
+          ))}
+          <span className='sr-only' aria-live='polite'>
+            Starter Action {boundedIndex + 1} Of {cards.length}
+          </span>
+        </fieldset>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/jovie/components/ChatStarterActionsRail.tsx
+++ b/apps/web/components/jovie/components/ChatStarterActionsRail.tsx
@@ -48,10 +48,10 @@ export function ChatStarterActionsRail({
   const handlePaginationKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'ArrowLeft') {
       event.preventDefault();
-      setActiveIndex(current => (current <= 0 ? lastIndex : current - 1));
+      setActiveIndex(current => Math.max(current - 1, 0));
     } else if (event.key === 'ArrowRight') {
       event.preventDefault();
-      setActiveIndex(current => (current >= lastIndex ? 0 : current + 1));
+      setActiveIndex(current => Math.min(current + 1, lastIndex));
     } else if (event.key === 'Home') {
       event.preventDefault();
       setActiveIndex(0);
@@ -82,34 +82,30 @@ export function ChatStarterActionsRail({
           onDismiss={() => onDismiss(activeCard)}
         />
       </fieldset>
-      {boundedIndex > 0 ? (
-        <button
-          type='button'
-          aria-label='Show Previous Starter Action'
-          onClick={() => setActiveIndex(current => current - 1)}
-          className='absolute -left-12 top-20 hidden size-11 -translate-y-1/2 cursor-pointer place-items-center rounded-full text-secondary-token opacity-0 transition-[opacity,transform,color] duration-subtle ease-out group-hover/carousel:opacity-100 hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus motion-reduce:transition-none sm:grid'
-        >
-          <ChevronLeft
-            className='size-7'
-            strokeWidth={2.75}
-            aria-hidden='true'
-          />
-        </button>
-      ) : null}
-      {boundedIndex < lastIndex ? (
-        <button
-          type='button'
-          aria-label='Show Next Starter Action'
-          onClick={() => setActiveIndex(current => current + 1)}
-          className='absolute -right-12 top-20 hidden size-11 -translate-y-1/2 cursor-pointer place-items-center rounded-full text-secondary-token opacity-0 transition-[opacity,transform,color] duration-subtle ease-out group-hover/carousel:opacity-100 hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus motion-reduce:transition-none sm:grid'
-        >
-          <ChevronRight
-            className='size-7'
-            strokeWidth={2.75}
-            aria-hidden='true'
-          />
-        </button>
-      ) : null}
+      <button
+        type='button'
+        aria-label='Show Previous Starter Action'
+        disabled={boundedIndex === 0}
+        onClick={() => setActiveIndex(current => Math.max(current - 1, 0))}
+        className='absolute -left-12 top-20 hidden size-11 -translate-y-1/2 cursor-pointer place-items-center rounded-full text-secondary-token opacity-0 transition-[opacity,transform,color] duration-subtle ease-out group-hover/carousel:opacity-100 hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-default disabled:opacity-0 motion-reduce:transition-none sm:grid'
+      >
+        <ChevronLeft className='size-7' strokeWidth={2.75} aria-hidden='true' />
+      </button>
+      <button
+        type='button'
+        aria-label='Show Next Starter Action'
+        disabled={boundedIndex === lastIndex}
+        onClick={() =>
+          setActiveIndex(current => Math.min(current + 1, lastIndex))
+        }
+        className='absolute -right-12 top-20 hidden size-11 -translate-y-1/2 cursor-pointer place-items-center rounded-full text-secondary-token opacity-0 transition-[opacity,transform,color] duration-subtle ease-out group-hover/carousel:opacity-100 hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-default disabled:opacity-0 motion-reduce:transition-none sm:grid'
+      >
+        <ChevronRight
+          className='size-7'
+          strokeWidth={2.75}
+          aria-hidden='true'
+        />
+      </button>
       {cards.length > 1 ? (
         <fieldset className='mt-2 flex min-h-5 items-center justify-center border-0 p-0'>
           <legend className='sr-only'>Choose Starter Action</legend>

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -179,7 +179,7 @@ describe('JovieChat empty state', () => {
     mockChatState.chipTray.chips = [];
   });
 
-  it('renders logo, composer, and prompt rail scaffolding when empty (JOV-3547)', () => {
+  it('renders a stable docked composer with prompt-pill fallback when empty', () => {
     const {
       container,
       getByTestId,
@@ -195,9 +195,13 @@ describe('JovieChat empty state', () => {
     expect(queryByText("Hey, I'm Jovie.")).toBeNull();
     const emptyViewport = getByTestId('chat-empty-state-viewport');
     expect(emptyViewport.className).toContain('flex-1');
-    expect(emptyViewport.className).toContain('justify-center');
+    expect(emptyViewport).toHaveAttribute(
+      'data-empty-affordance',
+      'suggestion-pills'
+    );
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
-    expect(getByTestId('chat-empty-state-logo')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-logo')).toBeNull();
+    expect(queryByTestId('chat-empty-state-greeting')).toBeNull();
     expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
     // No actionCards prop → no action-card slot, but prompt rail is wired.
     expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
@@ -223,7 +227,7 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Release link')).toBeNull();
   });
 
-  it('renders typed actionCards above the composer when provided (JOV-3547)', () => {
+  it('renders the canonical starter-actions rail without the legacy card map', () => {
     renderWithQueryClient(
       <JovieChat
         profileId='profile-1'
@@ -258,6 +262,11 @@ describe('JovieChat empty state', () => {
     expect(
       screen.getByTestId('chat-empty-state-action-card-slot')
     ).toBeTruthy();
+    expect(screen.getByTestId('chat-starter-actions-rail')).toBeTruthy();
+    expect(screen.getByTestId('chat-empty-state-viewport')).toHaveAttribute(
+      'data-empty-affordance',
+      'starter-actions'
+    );
     expect(
       screen.getByTestId('chat-empty-state-centered-composer')
     ).toBeTruthy();
@@ -270,12 +279,14 @@ describe('JovieChat empty state', () => {
         .getByTestId('chat-empty-state-centered-composer')
         .getAttribute('data-dock')
     ).toBe('bottom');
-    expect(screen.getByTestId('suggested-prompts-rail')).toBeTruthy();
-    expect(screen.getAllByTestId('chat-action-card')).toHaveLength(3);
-    // Cards own these intents — rail must not re-advertise conflicting chips.
-    const rail = within(screen.getByTestId('suggested-prompts-rail'));
-    expect(rail.queryByLabelText('Plan a Release')).toBeNull();
-    expect(rail.queryByLabelText('Review Signals')).toBeNull();
+    expect(screen.queryByTestId('suggested-prompts-rail')).toBeNull();
+    expect(screen.getAllByTestId('chat-action-card')).toHaveLength(1);
+    expect(
+      within(screen.getByTestId('chat-starter-actions-rail')).getAllByRole(
+        'button',
+        { name: /Show Starter Action/ }
+      )
+    ).toHaveLength(3);
   });
 
   it('does not resurrect dismissed primary actions as chips or recenter the composer', () => {
@@ -328,8 +339,15 @@ describe('JovieChat empty state', () => {
 
     expect(screen.queryAllByTestId('chat-action-card')).toHaveLength(0);
     expect(
-      screen.getByTestId('chat-empty-state-action-card-slot')
+      screen.queryByTestId('chat-empty-state-action-card-slot')
+    ).toBeNull();
+    expect(
+      screen.getByTestId('chat-empty-state-soft-suggestions-slot')
     ).toBeTruthy();
+    expect(screen.getByTestId('chat-empty-state-viewport')).toHaveAttribute(
+      'data-empty-affordance',
+      'suggestion-pills'
+    );
     expect(
       screen.getByTestId('chat-empty-state-composer-region')
     ).toHaveAttribute('data-layout', 'docked');


### PR DESCRIPTION
## Summary

Recovers the New Chat starter-action carousel through the shared `ChatStarterActionsRail` and restores the empty-state composer contract.

## Current exact head

`d887e75aab454f59877ed133590cf9dfc5c277da` — normal history-preserving merge of current `origin/main` followed by the focused carousel accessibility repair.

## Focus repair

Kimi identified endpoint focus loss in the carousel. This head keeps the prev/next chevrons mounted and disabled at endpoints, and clamps pagination ArrowLeft/ArrowRight at endpoints instead of wrapping into a dot-window change that can unmount the focused control.

Regression coverage is limited to `ChatStarterActionsRail.test.tsx`, asserting endpoint control persistence and retained dot focus.

## Validation

- Scoped carousel/empty-state Vitest: 4 files / 26 tests passed before commit.
- Normal pre-push affected verification: 5 files / 28 tests passed.
- Biome and `git diff --check` passed.
- Normal protected push completed; no force push or hook bypass.

## Hosted visual artifact inspection — BLOCKED

The earlier current-head hosted capture artifact from [run 30423517850](https://github.com/JovieInc/Jovie/actions/runs/30423517850) is not acceptance evidence:

- `demo-chat-desktop.png` and `demo-chat-mobile.png` are full-page **404 Content Not Found** screenshots for `/demo/chat`, despite the manifest recording `status: captured`.
- `demo-desktop.png` and `demo-mobile.png` render the unauthenticated demo Releases library, not the changed authenticated New Chat empty state.
- It therefore provides none of the required seeded authenticated desktop/mobile carousel, long-label, pointer-hover, or keyboard-focus proof.

## Kimi /design-review

Actual Kimi CLI review completed in root session `session_3db153cf-c961-472f-8d22-7277933e0033` on the prior exact diff and downloaded artifact (not a timeout). Its focus-lifecycle findings are addressed by this head; its evidence verdict remains **BLOCKED** until fresh current-head rendered proof exists.

Required before readiness:

1. Seeded authenticated `/app/chat` desktop capture showing the starter-actions carousel.
2. The same authenticated mobile capture.
3. A seeded long title/action-label capture in the 28rem slide.
4. Pointer hover and keyboard `focus-visible` capture for carousel navigation.
5. Fresh Kimi `/design-review` against this head plus those valid captures.

The PR remains draft and is not queued.