### PR TITLE
fix(ci): seed meaningful PR visual capture surfaces

### DIFF
--- a/.github/scripts/pr-visual-review-capture.mjs
+++ b/.github/scripts/pr-visual-review-capture.mjs
@@ -36,6 +36,9 @@ try {
         });
         if (!response || !response.ok())
           throw new Error(`HTTP ${response?.status() ?? 'unknown'}`);
+        const pageText = (await page.locator('body').innerText()).trim();
+        if (!pageText || /\b404\b|content not found/i.test(pageText))
+          throw new Error('Captured route did not render a meaningful surface');
         await page.screenshot({ path, fullPage: true });
         manifest.push({
           route,

--- a/.github/scripts/pr-visual-review-capture.mjs
+++ b/.github/scripts/pr-visual-review-capture.mjs
@@ -25,6 +25,27 @@ try {
         deviceScaleFactor: 1,
       });
       const page = await context.newPage();
+      const runtimeFailures = [];
+      page.on('console', message => {
+        if (message.type() === 'error') {
+          runtimeFailures.push({
+            type: 'console-error',
+            message: message.text(),
+          });
+        }
+      });
+      page.on('pageerror', error => {
+        runtimeFailures.push({ type: 'page-error', message: error.message });
+      });
+      page.on('response', response => {
+        if (response.status() >= 500) {
+          runtimeFailures.push({
+            type: 'http-5xx',
+            status: response.status(),
+            url: response.url(),
+          });
+        }
+      });
       const url = new URL(route, baseUrl).toString();
       if (route.startsWith('/app/')) {
         await page.goto(
@@ -60,6 +81,11 @@ try {
           /Welcome back|Continue with Google/.test(pageText)
         )
           throw new Error('Captured app route rendered sign-in shell');
+        if (runtimeFailures.length > 0) {
+          throw new Error(
+            `Captured route emitted runtime failures: ${JSON.stringify(runtimeFailures)}`
+          );
+        }
         await page.screenshot({ path, fullPage: true });
         manifest.push({
           route,

--- a/.github/scripts/pr-visual-review-capture.mjs
+++ b/.github/scripts/pr-visual-review-capture.mjs
@@ -26,6 +26,15 @@ try {
       });
       const page = await context.newPage();
       const url = new URL(route, baseUrl).toString();
+      if (route.startsWith('/app/')) {
+        await page.goto(
+          new URL(
+            '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat',
+            baseUrl
+          ).toString(),
+          { waitUntil: 'commit', timeout: 45_000 }
+        );
+      }
       const safeRoute =
         route.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'home';
       const path = join(outDir, `${safeRoute}-${viewportName}.png`);
@@ -36,6 +45,13 @@ try {
         });
         if (!response || !response.ok())
           throw new Error(`HTTP ${response?.status() ?? 'unknown'}`);
+        const pageText = (await page.locator('body').innerText()).trim();
+        if (!pageText || /\b404\b|content not found/i.test(pageText))
+          throw new Error('Captured route did not render a meaningful surface');
+        if (route.startsWith('/app/') && !/Inbox|Library|New Chat/.test(pageText))
+          throw new Error('Captured app route did not render authenticated shell');
+        if (route.startsWith('/app/') && /Welcome back|Continue with Google/.test(pageText))
+          throw new Error('Captured app route rendered sign-in shell');
         await page.screenshot({ path, fullPage: true });
         manifest.push({
           route,

--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -29,10 +29,11 @@ export function routeChangedFiles(files) {
     if (/admin|console|ops/i.test(file)) routes.add('/demo/admin');
     else if (/dynamic|profile|username|artist/i.test(file))
       routes.add('/demo/profile');
-    else if (/chat|shell/i.test(file)) routes.add('/demo/chat');
+    else if (/chat|shell/i.test(file)) routes.add('/app/chat');
     else routes.add('/');
   }
-  // Demo routes are deterministic and do not require user data or credentials.
+  // Demo routes are deterministic; chat/shell routes use the seeded test-auth
+  // app surface above so captures show the changed authenticated chrome.
   routes.add('/demo');
   return {
     shouldReview: true,

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -37,6 +37,16 @@ describe('bounded PR visual review contract', () => {
     });
   });
 
+  it('routes chat and shell changes through the seeded authenticated surface', () => {
+    expect(
+      routeChangedFiles(['apps/web/components/organisms/AppShellFrame.tsx'])
+    ).toEqual({
+      shouldReview: true,
+      routes: ['/demo', '/app/chat'],
+      reason: 'ui-change',
+    });
+  });
+
   it('keeps prompt input bounded and removes credential-shaped values', () => {
     const prompt = buildReviewPrompt({
       diff: 'const x = process.env.API_KEY;\n'.repeat(10000),

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -91,4 +91,15 @@ describe('bounded PR visual review contract', () => {
     );
     expect(workflow).toContain('Do not alter subjective/taste findings.');
   });
+
+  it('fails visual capture closed on runtime console, page, and server errors', () => {
+    const capture = readFileSync(
+      '.github/scripts/pr-visual-review-capture.mjs',
+      'utf8'
+    );
+    expect(capture).toContain("message.type() === 'error'");
+    expect(capture).toContain("type: 'page-error'");
+    expect(capture).toContain('response.status() >= 500');
+    expect(capture).toContain('Captured route emitted runtime failures');
+  });
 });


### PR DESCRIPTION
## Summary
- captures app-shell chat proof through the canonical creator-ready test-auth route
- treats anonymous, empty, 404, console-error, page-error, and HTTP 5xx captures as failures rather than evidence
- keeps `/demo` demo coverage alongside seeded `/app/chat` coverage

## Verification
- `pnpm exec vitest run scripts/lib/__tests__/pr-visual-review.test.mjs` — 7/7 passed
- `pnpm exec biome check .github/scripts/pr-visual-review-capture.mjs scripts/lib/__tests__/pr-visual-review.test.mjs` — passed
- deliberate runtime-gate proof: `/tmp/jov4542-runtime-gate.ooW099/manifest.json` exits 1 and records both desktop/mobile failures from `500 /api/auth/get-session` plus the matching console error

## Blocked
Draft pending [JOV-4543](https://linear.app/jovie/issue/JOV-4543/fixauth-make-seeded-better-auth-get-session-capture-safe). That focused successor must make the seeded Better Auth session clean before this guardrail is eligible for queue/merge.

## Scope
CI capture reliability only; no user-facing design change.