### PR TITLE
fix(desktop): make updater status truthful

### DIFF
--- a/apps/web/components/atoms/UpdateAvailablePill.stories.tsx
+++ b/apps/web/components/atoms/UpdateAvailablePill.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { UpdateAvailablePillView } from './UpdateAvailablePill';
+
+const meta = {
+  title: 'Atoms/UpdateAvailablePill',
+  component: UpdateAvailablePillView,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof UpdateAvailablePillView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Downloading: Story = {
+  args: {
+    state: 'downloading',
+    onClick: () => undefined,
+  },
+};
+
+export const ReadyToRestart: Story = {
+  args: {
+    state: 'ready-to-restart',
+    onClick: () => undefined,
+  },
+};

--- a/apps/web/components/atoms/UpdateAvailablePill.tsx
+++ b/apps/web/components/atoms/UpdateAvailablePill.tsx
@@ -56,7 +56,7 @@ export function UpdateAvailablePillView({
       className={cn(
         'inline-flex h-6 w-24 items-center justify-center gap-1 rounded-full border px-1.5 text-2xs font-caption tracking-tight',
         'transition-[background-color,border-color,color,opacity] duration-subtle',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page)',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-page',
         isDownloading
           ? 'border-subtle bg-surface-1 text-secondary-token'
           : 'border-transparent bg-primary-token text-surface-1 hover:opacity-90',

--- a/apps/web/components/atoms/UpdateAvailablePill.tsx
+++ b/apps/web/components/atoms/UpdateAvailablePill.tsx
@@ -1,10 +1,79 @@
 'use client';
 
-import { Download, Loader2 } from 'lucide-react';
+import { Download, Loader2, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 import { useDesktopUpdate } from '@/lib/desktop/electron-bridge';
 import { cn } from '@/lib/utils';
 import { useWebUpdate } from '@/lib/version/use-web-update';
+
+export type UpdateAvailablePillState =
+  | 'downloading'
+  | 'ready-to-restart'
+  | 'restarting'
+  | 'web-ready'
+  | 'web-updating';
+
+interface UpdateAvailablePillViewProps {
+  readonly state: UpdateAvailablePillState;
+  readonly onClick: () => void;
+}
+
+export function UpdateAvailablePillView({
+  state,
+  onClick,
+}: UpdateAvailablePillViewProps) {
+  const isBusy = state === 'downloading' || state === 'restarting';
+  const isDownloading = state === 'downloading';
+  const isDesktopReady = state === 'ready-to-restart';
+
+  const label = {
+    downloading: 'Downloading…',
+    'ready-to-restart': 'Restart',
+    restarting: 'Restarting…',
+    'web-ready': 'Update',
+    'web-updating': 'Updating…',
+  }[state];
+
+  const ariaLabel = {
+    downloading: 'Downloading update',
+    'ready-to-restart': 'Ready to restart',
+    restarting: 'Restarting to update',
+    'web-ready': 'Update available',
+    'web-updating': 'Updating',
+  }[state];
+
+  return (
+    <button
+      type='button'
+      data-electron-update-pill='true'
+      data-electron-no-drag='true'
+      data-testid='update-available-pill'
+      onClick={onClick}
+      disabled={isBusy}
+      aria-busy={isBusy}
+      aria-label={ariaLabel}
+      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      className={cn(
+        'inline-flex h-6 w-24 items-center justify-center gap-1 rounded-full border px-1.5 text-2xs font-caption tracking-tight',
+        'transition-[background-color,border-color,color,opacity] duration-subtle',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page)',
+        isDownloading
+          ? 'border-subtle bg-surface-1 text-secondary-token'
+          : 'border-transparent bg-primary-token text-surface-1 hover:opacity-90',
+        'disabled:cursor-default disabled:opacity-70'
+      )}
+    >
+      {isBusy ? (
+        <Loader2 className='h-3 w-3 shrink-0 animate-spin' aria-hidden='true' />
+      ) : isDesktopReady ? (
+        <RotateCcw className='h-3 w-3 shrink-0' aria-hidden='true' />
+      ) : (
+        <Download className='h-3 w-3 shrink-0' aria-hidden='true' />
+      )}
+      <span className='whitespace-nowrap leading-none'>{label}</span>
+    </button>
+  );
+}
 
 export function UpdateAvailablePill() {
   const desktop = useDesktopUpdate();
@@ -12,11 +81,12 @@ export function UpdateAvailablePill() {
   const [updating, setUpdating] = useState(false);
 
   const isAvailable = desktop.available || web.available;
+  const isDesktopDownloading = desktop.available && !desktop.downloaded;
 
   if (!isAvailable) return null;
 
   function handleClick() {
-    if (updating) return;
+    if (updating || isDesktopDownloading) return;
     setUpdating(true);
 
     if (desktop.available) {
@@ -26,29 +96,14 @@ export function UpdateAvailablePill() {
     }
   }
 
-  return (
-    <button
-      type='button'
-      data-electron-update-pill='true'
-      data-electron-no-drag='true'
-      data-testid='update-available-pill'
-      onClick={handleClick}
-      disabled={updating}
-      aria-label='Update Available — Click To Install'
-      style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-      className={cn(
-        'inline-flex h-6 items-center justify-center gap-1 rounded-full bg-white dark:bg-surface-1 px-2.5 text-black dark:text-white',
-        'hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-1 disabled:opacity-70'
-      )}
-    >
-      {updating ? (
-        <Loader2 className='h-3 w-3 shrink-0 animate-spin' aria-hidden='true' />
-      ) : (
-        <Download className='h-3 w-3 shrink-0' aria-hidden='true' />
-      )}
-      <span className='whitespace-nowrap text-2xs font-medium leading-none'>
-        {updating ? 'Updating…' : 'Update'}
-      </span>
-    </button>
-  );
+  const state: UpdateAvailablePillState = (() => {
+    if (updating) {
+      return desktop.available ? 'restarting' : 'web-updating';
+    }
+    if (isDesktopDownloading) return 'downloading';
+    if (desktop.downloaded) return 'ready-to-restart';
+    return 'web-ready';
+  })();
+
+  return <UpdateAvailablePillView state={state} onClick={handleClick} />;
 }

--- a/apps/web/tests/unit/components/atoms/UpdateAvailablePill.test.tsx
+++ b/apps/web/tests/unit/components/atoms/UpdateAvailablePill.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
+
+const updateState = vi.hoisted(() => ({
+  desktopAvailable: false,
+  desktopDownloaded: false,
+  install: vi.fn(),
+  webAvailable: false,
+  reload: vi.fn(),
+}));
+
+vi.mock('@/lib/desktop/electron-bridge', () => ({
+  useDesktopUpdate: () => ({
+    available: updateState.desktopAvailable,
+    downloaded: updateState.desktopDownloaded,
+    install: updateState.install,
+  }),
+}));
+
+vi.mock('@/lib/version/use-web-update', () => ({
+  useWebUpdate: () => ({
+    available: updateState.webAvailable,
+    reload: updateState.reload,
+  }),
+}));
+
+describe('UpdateAvailablePill', () => {
+  beforeEach(() => {
+    updateState.desktopAvailable = false;
+    updateState.desktopDownloaded = false;
+    updateState.webAvailable = false;
+    updateState.install.mockReset();
+    updateState.reload.mockReset();
+  });
+
+  it('shows a non-actionable downloading state until the desktop update is ready', () => {
+    updateState.desktopAvailable = true;
+
+    render(<UpdateAvailablePill />);
+
+    const pill = screen.getByRole('button', { name: 'Downloading update' });
+    expect(pill).toBeDisabled();
+    expect(pill).toHaveAttribute('aria-busy', 'true');
+    expect(pill).toHaveTextContent('Downloading…');
+
+    fireEvent.click(pill);
+    expect(updateState.install).not.toHaveBeenCalled();
+  });
+
+  it('offers restart only after the desktop update is downloaded', () => {
+    updateState.desktopAvailable = true;
+    updateState.desktopDownloaded = true;
+
+    render(<UpdateAvailablePill />);
+
+    const pill = screen.getByRole('button', { name: 'Ready to restart' });
+    expect(pill).toBeEnabled();
+    expect(pill).toHaveAttribute('aria-busy', 'false');
+    expect(pill).toHaveTextContent('Restart');
+    expect(pill).toHaveClass('w-24', 'rounded-full');
+    expect(pill.className).toContain('focus-visible:ring-focus/30');
+
+    fireEvent.click(pill);
+
+    expect(updateState.install).toHaveBeenCalledOnce();
+    expect(pill).toBeDisabled();
+    expect(pill).toHaveTextContent('Restarting…');
+  });
+
+  it('preserves the web update action without using desktop download state', () => {
+    updateState.webAvailable = true;
+
+    render(<UpdateAvailablePill />);
+
+    const pill = screen.getByRole('button', { name: 'Update available' });
+    expect(pill).toBeEnabled();
+
+    fireEvent.click(pill);
+
+    expect(updateState.reload).toHaveBeenCalledOnce();
+    expect(updateState.install).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:5889dff2-19ce-4051-8e4d-d0b7d86bc4f5 -->

## Summary

- keep the desktop updater pill non-actionable while Electron is still downloading
- expose restart only after the existing `downloaded` signal fires
- preserve the web-update path and use existing System B surface, typography, focus, motion, and pill tokens
- add real Storybook fixtures for both desktop states

## State contract

| Existing updater state | Visible state | Accessible name | Action |
| --- | --- | --- | --- |
| `available && !downloaded` | `Downloading…` | `Downloading update` | disabled |
| `available && downloaded` | `Restart` | `Ready to restart` | quit and install |
| restart requested | `Restarting…` | `Restarting to update` | disabled |

All states reserve the same `96 x 24px` pill geometry.

## Design read

Reading this as: a compact macOS utility status control for Jovie operators, with a quiet native System B language, leaning toward the existing desktop pill system.

Dials: `DESIGN_VARIANCE=low`, `MOTION_INTENSITY=functional`, `VISUAL_DENSITY=high`.

## Verification

- `pnpm biome check apps/web/components/atoms/UpdateAvailablePill.tsx apps/web/components/atoms/UpdateAvailablePill.stories.tsx apps/web/tests/unit/components/atoms/UpdateAvailablePill.test.tsx`
- focused Vitest: 7/7 passed across updater-pill and desktop-titlebar suites
- web typecheck passed
- pre-push affected verification passed, including design-system arbitrary-value ratchet
- required CI is green, including `ci-fast`, typecheck, UI Story Coverage Audit, Sonar, and desktop/mobile capture

## Visual evidence

### Downloading

![Desktop updater downloading state](https://public.linear.app/6941bf52-85b0-49b3-87cc-d4a3308b48bb/060dac4d-f132-40b0-bf03-0d561aded003/bda95635-846a-42a7-bc5a-28dcf06b50bb)

### Ready to restart

![Desktop updater ready-to-restart state](https://public.linear.app/6941bf52-85b0-49b3-87cc-d4a3308b48bb/b14a8935-df5b-4db0-82c8-512d136e5b41/c04ed65e-a22f-441e-bd84-2b99617e1e73)

- Both final screenshots resolve to `96 x 24px`, the shared `rounded-full` full-pill radius, and no horizontal overflow.
- Downloading is disabled and exposes `Downloading update`; ready is enabled and exposes `Ready to restart`.
- [CI capture archive and advisory run](https://github.com/JovieInc/Jovie/actions/runs/30424034748)
- [Exact-head targeted Storybook screenshots + computed focus proof](https://github.com/JovieInc/Jovie/pull/15079#issuecomment-5114019674) (`8a78680bfb2d98f5193f47482c0a4cd3a05b6a81`)
- [Fresh visual workflow run](https://github.com/JovieInc/Jovie/actions/runs/30427142113) succeeded, but its generic `/` and `/demo` captures are not used as updater-state evidence
- [Linear evidence comment](https://linear.app/jovie/issue/JOV-4541/desktop-updater-pill-must-distinguish-downloading-from-ready-to#comment-03d5bf58)
- Kimi CLI `/design-review`: **APPROVE** (`session_be8ab542-5eeb-4896-bb7c-782dbe8dd053`)

The Storybook iframe emits its known raw script-tag warning, so this evidence does not make a clean-console claim. The CI visual-review advisory also returned `backend_failed: empty response`; the successful screenshot capture and explicit Kimi review above are the evidence for this slice.

## Design checklist

- contrast: pass, downloading is quiet secondary status and restart is the only emphasized action
- states: pass, both desktop updater states plus restarting are covered
- layout: pass, fixed `96 x 24px` geometry
- motion: pass, functional spinner only
- icons: pass, Lucide `Loader2` / `RotateCcw`
- anti-slop: pass, one quiet full pill with no extra chrome
- evidence: pass, seeded screenshots and interaction semantics attached
