### PR TITLE
fix(desktop): restore mac plist packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **macOS desktop packaging accepts the secured XML parser:** Electron Builder's property-list dependency now supplies the MIME type required by the repository's security-patched xmldom floor, so signed and notarized desktop releases can reach artifact creation again.
 - **macOS sign-in cancellation returns to Jovie:** if a native auth redirect leaves the hidden desktop window blank, canceling sign-in now restores the canonical sign-in shell instead of showing a black window.
 - [internal] **Desktop memory baseline evidence (JOV-2712):** the Electron shell can now capture bounded main/renderer RSS and macOS physical-footprint samples, record clean shutdown evidence, and classify growth regressions without claiming native leak proof when the platform tool is unavailable.
 - [internal] **Desktop packaging toolchain updated:** Electron Builder now uses 26.15.3 for current signing, notarization, and installer support.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "lodash-es": ">=4.18.1",
       "handlebars": ">=4.7.9",
       "@xmldom/xmldom": ">=0.9.10",
+      "app-builder-lib@26.15.3>plist": "3.1.1",
       "brace-expansion": "5.0.7",
       "@isaacs/brace-expansion": ">=5.0.1",
       "minimatch@^10.0.0": "10.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   lodash-es: '>=4.18.1'
   handlebars: '>=4.7.9'
   '@xmldom/xmldom': '>=0.9.10'
+  app-builder-lib@26.15.3>plist: 3.1.1
   brace-expansion: 5.0.7
   '@isaacs/brace-expansion': '>=5.0.1'
   minimatch@^10.0.0: 10.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13659,10 +13659,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  plist@3.1.0:
-    resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
-    engines: {node: '>=10.4.0'}
-
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
@@ -24797,7 +24793,7 @@ snapshots:
       lazy-val: 1.0.5
       minimatch: 10.2.4
       pkijs: 3.4.0
-      plist: 3.1.0
+      plist: 3.1.1
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
@@ -31501,12 +31497,6 @@ snapshots:
       playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
-
-  plist@3.1.0:
-    dependencies:
-      '@xmldom/xmldom': 0.9.10
-      base64-js: 1.5.1
-      xmlbuilder: 15.1.1
 
   plist@3.1.1:
     dependencies:

--- a/scripts/desktop-release-guard.test.mjs
+++ b/scripts/desktop-release-guard.test.mjs
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import test from 'node:test';
 import { evaluateDesktopReleaseGuard } from './desktop-release-guard.mjs';
 
+const desktopRequire = createRequire(
+  new URL('../apps/desktop/package.json', import.meta.url)
+);
 const desktopWorkflow = readFileSync(
   new URL('../.github/workflows/desktop-release.yml', import.meta.url),
   'utf8'
@@ -35,6 +39,27 @@ function step(workflow, stepName) {
 function assertPatterns(source, patterns) {
   patterns.forEach(pattern => assert.match(source, pattern));
 }
+
+test('desktop builder can parse Electron macOS property lists', () => {
+  const electronBuilderPackage = desktopRequire.resolve(
+    'electron-builder/package.json'
+  );
+  const electronBuilderRequire = createRequire(electronBuilderPackage);
+  const appBuilderPackage = electronBuilderRequire.resolve(
+    'app-builder-lib/package.json'
+  );
+  const appBuilderRequire = createRequire(appBuilderPackage);
+  const plist = appBuilderRequire('plist');
+
+  const parsed = plist.parse(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<plist version="1.0"><dict>' +
+      '<key>CFBundleName</key><string>Jovie</string>' +
+      '</dict></plist>'
+  );
+
+  assert.deepEqual(parsed, { CFBundleName: 'Jovie' });
+});
 
 test('passes when no desktop files changed', () => {
   const result = evaluateDesktopReleaseGuard([


### PR DESCRIPTION
## Summary
- resolve Electron Builder 26 macOS plist parsing through a narrow `app-builder-lib@26.15.3>plist` override to upstream `plist@3.1.1`
- retain the repository security floor `@xmldom/xmldom@0.9.10` and preserve signing, hardened-runtime, notarization, and publish gates
- add a regression test that resolves `plist` through the actual desktop `electron-builder -> app-builder-lib` package graph

## Tracking
- JOV-4540

## Root cause
Electron Builder 26 moved macOS property-list reads into `app-builder-lib` JavaScript. `app-builder-lib@26.15.3` pins `plist@3.1.0`, which calls xmldom without a MIME type; the repository security override correctly resolves xmldom 0.9.10, which rejects an undefined MIME type. The narrow root override selects `plist@3.1.1`, whose upstream fix supplies `text/xml`, without changing the xmldom security floor.

## Bug-to-Test
- satisfied by `scripts/desktop-release-guard.test.mjs`
- the new test reproduces the pre-fix MIME failure through the actual packaged dependency graph and passes with the declared override

## Verification
- `pnpm install --frozen-lockfile`
- installed graph proof: `app-builder-lib@26.15.3` declares `plist@3.1.0` and resolves `plist@3.1.1`
- exact-head mandatory pre-push gate: typecheck passed, lint passed, all 8/8 partitioned Vitest shards passed, CI harness manifest and generated docs current
- `node --test scripts/desktop-release-guard.test.mjs`: 16/16 passed on merged-current-main head
- `pnpm --filter @jovie/desktop package:local`: Electron Builder 26.15.3 packaged Electron 42.4.0 for darwin arm64 to `dist/mac-arm64/Jovie Local.app`, clearing the failing `createMacApp` plist boundary
- `plutil -lint`: packaged `Info.plist` OK
- `codesign --verify --deep --strict`: local app valid on disk and satisfies its designated requirement

## Delivery caveat
The local host keychain automatically selected the Developer ID identity, so local packaging also proved signing. The local config explicitly disables notarization and publish. Hosted exact-main production release evidence is still required before this fix or the dependent auth-cancel binary is called shipped.

## Scope review
- no auth or UI changes in this PR
- no signing, hardened-runtime, notarization, workflow, or publish configuration changed
- no version bump on the feature branch
- generated asset churn from local packaging was restored; PR diff is changelog, root package override, lockfile, and regression guard