### PR TITLE
fix(auth): return to Jovie after native sign-in

### DIFF
--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -66,6 +66,13 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     const link = screen.getByRole('link', { name: 'Open Jovie' });
     expect(link).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
+    expect(
+      screen.getByRole('heading', { name: 'Return to Jovie' })
+    ).toBeVisible();
+    expect(
+      screen.getByText('Authentication is complete. Return to Jovie.')
+    ).toBeVisible();
+    expect(screen.queryByText('Jovie Desktop')).toBeNull();
   });
 
   it('preserves the deep link without desktop_flow when absent', () => {

--- a/apps/web/app/(auth)/auth/native-return/page.test.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.test.tsx
@@ -57,13 +57,13 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     setLocationOrigin('https://jov.ie');
   });
 
-  it('renders an Open Jovie button pointing at the jovie:// deep link', () => {
+  it('renders a Return to Jovie button pointing at the jovie:// deep link', () => {
     const hrefWrites = setLocationOrigin('https://jov.ie');
     setSearchParams(`code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`);
     render(<NativeReturnPage />);
 
     const expectedDeepLink = `jovie://auth/complete?code=${CODE}&state=${STATE}&desktop_flow=${FLOW}`;
-    const link = screen.getByRole('link', { name: 'Open Jovie' });
+    const link = screen.getByRole('link', { name: 'Return to Jovie' });
     expect(link).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
     expect(
@@ -79,7 +79,9 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     setSearchParams(`code=${CODE}&state=${STATE}`);
     render(<NativeReturnPage />);
 
-    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute(
       'href',
       `jovie://auth/complete?code=${CODE}&state=${STATE}`
     );
@@ -91,10 +93,9 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     render(<NativeReturnPage />);
 
     const expectedDeepLink = `jovie-staging://auth/complete?code=${CODE}&state=${STATE}`;
-    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
-      'href',
-      expectedDeepLink
-    );
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
   });
 
@@ -104,10 +105,9 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     render(<NativeReturnPage />);
 
     const expectedDeepLink = `jovie-local://auth/complete?code=${CODE}&state=${STATE}`;
-    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
-      'href',
-      expectedDeepLink
-    );
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
   });
 
@@ -116,14 +116,14 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     setSearchParams(`code=${CODE}&state=${STATE}`);
 
     expect(() => render(<NativeReturnPage />)).not.toThrow();
-    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Return to Jovie' })).toBeNull();
   });
 
   it('shows a recovery message and no deep link when required params are missing', () => {
     setSearchParams(`state=${STATE}`);
     render(<NativeReturnPage />);
 
-    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Return to Jovie' })).toBeNull();
     expect(
       screen.getByText(/missing required information/i)
     ).toBeInTheDocument();
@@ -133,6 +133,6 @@ describe('NativeReturnPage (desktop auth bounce)', () => {
     setSearchParams(`code=jovie%3A%2F%2Fevil&state=${STATE}`);
     render(<NativeReturnPage />);
 
-    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Return to Jovie' })).toBeNull();
   });
 });

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -70,13 +70,11 @@ function NativeReturnContent() {
   return (
     <main className='grid min-h-dvh place-items-center bg-base px-6 text-primary-token'>
       <section className='w-full max-w-sm rounded-2xl border border-subtle bg-surface-1 px-6 py-7 text-center shadow-card'>
-        <p className='text-sm leading-5 text-tertiary-token'>Jovie Desktop</p>
-        <h1 className='mt-2 text-xl font-semibold leading-7'>
-          Return To The App
-        </h1>
+        {/* eslint-disable-next-line @jovie/canonical-ui-label-casing -- Approved conversational return phrase. */}
+        <h1 className='text-xl font-semibold leading-7'>Return to Jovie</h1>
         <p className='mt-3 text-sm leading-5 text-secondary-token'>
           {deepLink || nativeReturnParams
-            ? 'Authentication is complete. Continue in the Jovie desktop app.'
+            ? 'Authentication is complete. Return to Jovie.'
             : 'This sign-in link is missing required information. Start sign-in again from Jovie.'}
         </p>
         {deepLink ? (

--- a/apps/web/app/(auth)/auth/native-return/page.tsx
+++ b/apps/web/app/(auth)/auth/native-return/page.tsx
@@ -15,8 +15,8 @@ import { Suspense, useEffect, useMemo, useState } from 'react';
 // (shell.openExternal), not inside an ASWebAuthenticationSession. A raw
 // server 302 to `jovie://auth/complete` is NOT reliably handed off to the app
 // by modern browsers without a user gesture, so users would sign in on the web
-// and never bounce back to the Mac app. This page fires the deep link
-// automatically AND exposes an "Open Jovie" button (guaranteed user gesture),
+// and never bounce back to the Mac client. This page fires the deep link
+// automatically AND exposes a "Return to Jovie" button (guaranteed user gesture),
 // mirroring the proven legacy `/auth-return` page.
 
 const DESKTOP_FLOW_PATTERN = /^[A-Za-z0-9_-]{16,64}$/;
@@ -82,7 +82,7 @@ function NativeReturnContent() {
             href={deepLink}
             className='focus-ring-transparent-offset mt-6 inline-flex h-10 w-full items-center justify-center rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
           >
-            Open Jovie
+            Return to Jovie
           </Link>
         ) : null}
       </section>

--- a/apps/web/app/auth-return/page.test.tsx
+++ b/apps/web/app/auth-return/page.test.tsx
@@ -63,6 +63,13 @@ describe('AuthReturnPage (legacy desktop auth bounce)', () => {
       expectedDeepLink
     );
     expect(hrefWrites).toEqual([expectedDeepLink]);
+    expect(
+      screen.getByRole('heading', { name: 'Return to Jovie' })
+    ).toBeVisible();
+    expect(
+      screen.getByText('Authentication is complete. Return to Jovie.')
+    ).toBeVisible();
+    expect(screen.queryByText('Jovie Desktop')).toBeNull();
   });
 
   it('uses the staging app scheme on staging origin', () => {

--- a/apps/web/app/auth-return/page.test.tsx
+++ b/apps/web/app/auth-return/page.test.tsx
@@ -52,16 +52,15 @@ describe('AuthReturnPage (legacy desktop auth bounce)', () => {
     setLocationOrigin('https://jov.ie');
   });
 
-  it('renders an Open Jovie button pointing at the production deep link', () => {
+  it('renders a Return to Jovie button pointing at the production deep link', () => {
     const hrefWrites = setLocationOrigin('https://jov.ie');
     setSearchParams('route=%2Fapp%2Fsettings');
     render(<AuthReturnPage />);
 
     const expectedDeepLink = 'jovie://auth-return?route=%2Fapp%2Fsettings';
-    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
-      'href',
-      expectedDeepLink
-    );
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
     expect(
       screen.getByRole('heading', { name: 'Return to Jovie' })
@@ -79,10 +78,9 @@ describe('AuthReturnPage (legacy desktop auth bounce)', () => {
 
     const expectedDeepLink =
       'jovie-staging://auth-return?route=%2Fapp%2Fsettings';
-    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
-      'href',
-      expectedDeepLink
-    );
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
   });
 
@@ -93,10 +91,9 @@ describe('AuthReturnPage (legacy desktop auth bounce)', () => {
 
     const expectedDeepLink =
       'jovie-local://auth-return?route=%2Fapp%2Fsettings';
-    expect(screen.getByRole('link', { name: 'Open Jovie' })).toHaveAttribute(
-      'href',
-      expectedDeepLink
-    );
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute('href', expectedDeepLink);
     expect(hrefWrites).toEqual([expectedDeepLink]);
   });
 
@@ -105,6 +102,6 @@ describe('AuthReturnPage (legacy desktop auth bounce)', () => {
     setSearchParams('route=%2Fapp%2Fsettings');
 
     expect(() => render(<AuthReturnPage />)).not.toThrow();
-    expect(screen.queryByRole('link', { name: 'Open Jovie' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Return to Jovie' })).toBeNull();
   });
 });

--- a/apps/web/app/auth-return/page.tsx
+++ b/apps/web/app/auth-return/page.tsx
@@ -51,7 +51,7 @@ function AuthReturnContent() {
             href={deepLink}
             className='focus-ring-transparent-offset mt-6 inline-flex h-10 w-full items-center justify-center rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
           >
-            Open Jovie
+            Return to Jovie
           </Link>
         ) : null}
       </section>

--- a/apps/web/app/auth-return/page.tsx
+++ b/apps/web/app/auth-return/page.tsx
@@ -41,12 +41,10 @@ function AuthReturnContent() {
   return (
     <main className='grid min-h-dvh place-items-center bg-base px-6 text-primary-token'>
       <section className='w-full max-w-sm rounded-2xl border border-subtle bg-surface-1 px-6 py-7 text-center shadow-card'>
-        <p className='text-sm leading-5 text-tertiary-token'>Jovie Desktop</p>
-        <h1 className='mt-2 text-xl font-semibold leading-7'>
-          Return To The App
-        </h1>
+        {/* eslint-disable-next-line @jovie/canonical-ui-label-casing -- Approved conversational return phrase. */}
+        <h1 className='text-xl font-semibold leading-7'>Return to Jovie</h1>
         <p className='mt-3 text-sm leading-5 text-secondary-token'>
-          Authentication is complete. Continue in the Jovie desktop app.
+          Authentication is complete. Return to Jovie.
         </p>
         {deepLink ? (
           <Link


### PR DESCRIPTION
## Summary
- replace desktop/app framing with the approved “Return to Jovie” auth-return copy
- retain automatic deep-link and explicit **Return to Jovie** user-gesture fallback
- cover both native and legacy return routes

## Verification
- `pnpm --filter @jovie/web exec vitest run app/(auth)/auth/native-return/page.test.tsx app/auth-return/page.test.tsx --maxWorkers 1` — 11 passed
- exact-file Biome + ESLint — passed
- normal pre-commit and pre-push gates — passed (affected tests 13 passed)

## Browser evidence
- 1440px seeded route rendered the exact heading, body, and `jovie-local://auth/complete` fallback control.
- Pointer-hover and attempted keyboard-focus captures were collected locally.
- Runtime-clean acceptance is **blocked**: browser console recorded `GET /api/auth/get-session` returning 500 (plus an unrelated GA preload warning). The input/session failure is tracked outside this narrow copy slice; no workaround was added.

## Status
Draft and intentionally `gated`. The proof server was stopped after capture. Do not queue until the runtime boundary is clean, a real keyboard-focus pass succeeds, and Kimi `/design-review` runs against clean artifacts.