### PR TITLE
fix(app): gate Sonner until client mount [JOV-4505]

### DIFF
--- a/apps/web/components/feedback/FeedbackProvider.tsx
+++ b/apps/web/components/feedback/FeedbackProvider.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import type React from 'react';
+import { useEffect, useState } from 'react';
 import { Toaster } from 'sonner';
 import { useCookieBannerHeight } from '@/lib/hooks/useCookieBannerHeight';
 import { isProfileRoute } from '@/lib/sentry/route-detector';
@@ -37,10 +38,17 @@ function getToasterTheme(
   return 'system';
 }
 
+const TOAST_DESCRIPTION_CLASS_NAME = 'font-normal text-tertiary-token';
+
 export function FeedbackProvider({ children }: FeedbackProviderProps) {
   const { resolvedTheme } = useTheme();
   const bottomOffset = useCookieBannerHeight();
   const pathname = usePathname() ?? '';
+  const [isClientMounted, setIsClientMounted] = useState(false);
+
+  useEffect(() => {
+    setIsClientMounted(true);
+  }, []);
 
   // Public profile pages are visitor-facing surfaces — suppress all app
   // feedback chrome (PWA install, error copy, etc.) to keep them clean.
@@ -52,47 +60,50 @@ export function FeedbackProvider({ children }: FeedbackProviderProps) {
     <>
       {children}
       <BannerViewport />
-      <Toaster
-        theme={getToasterTheme(resolvedTheme)}
-        position='bottom-right'
-        // Expand stacked notifications on hover
-        expand
-        // Manual close affordance on every toast (accessibility)
-        closeButton
-        // Keep transient feedback quiet and secondary to primary workflows
-        richColors={false}
-        // Gap between toasts
-        gap={8}
-        // Dynamic offset: floats toasts above the cookie banner when
-        // visible, and always respects the device safe-area inset.
-        offset={`calc(${bottomOffset}px + env(safe-area-inset-bottom, 0px))`}
-        // Stack limit: max 3 visible toasts; overflow queues
-        visibleToasts={3}
-        // Styling driven by CSS overrides in globals.css on
-        // [data-sonner-toaster] / [data-sonner-toast] selectors.
-        // Sonner CSS variables (--normal-bg, --success-bg, etc.) are
-        // mapped to design-system tokens there, so we only need
-        // lightweight classNames here for icon coloring.
-        toastOptions={{
-          // Canonical auto-dismiss default (4s, within the 3–5s window).
-          // Per-call durations (e.g. useNotifications presets) still win.
-          duration: TOAST_DURATIONS.DEFAULT,
-          classNames: {
-            toast: 'items-start border border-subtle bg-surface-1 shadow-card',
-            title: 'font-medium text-secondary-token',
-            description: 'font-normal text-tertiary-token',
-            actionButton:
-              'border border-default bg-transparent text-primary-token font-medium hover:bg-surface-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
-            cancelButton:
-              'bg-surface-2 text-secondary-token font-medium hover:bg-surface-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
-            success: '[&>svg]:text-tertiary-token',
-            error: '[&>svg]:text-tertiary-token',
-            warning: '[&>svg]:text-tertiary-token',
-            info: '[&>svg]:text-tertiary-token',
-            loading: '[&>svg]:text-tertiary-token',
-          },
-        }}
-      />
+      {isClientMounted ? (
+        <Toaster
+          theme={getToasterTheme(resolvedTheme)}
+          position='bottom-right'
+          // Expand stacked notifications on hover
+          expand
+          // Manual close affordance on every toast (accessibility)
+          closeButton
+          // Keep transient feedback quiet and secondary to primary workflows
+          richColors={false}
+          // Gap between toasts
+          gap={8}
+          // Dynamic offset: floats toasts above the cookie banner when
+          // visible, and always respects the device safe-area inset.
+          offset={`calc(${bottomOffset}px + env(safe-area-inset-bottom, 0px))`}
+          // Stack limit: max 3 visible toasts; overflow queues
+          visibleToasts={3}
+          // Styling driven by CSS overrides in globals.css on
+          // [data-sonner-toaster] / [data-sonner-toast] selectors.
+          // Sonner CSS variables (--normal-bg, --success-bg, etc.) are
+          // mapped to design-system tokens there, so we only need
+          // lightweight classNames here for icon coloring.
+          toastOptions={{
+            // Canonical auto-dismiss default (4s, within the 3–5s window).
+            // Per-call durations (e.g. useNotifications presets) still win.
+            duration: TOAST_DURATIONS.DEFAULT,
+            classNames: {
+              toast:
+                'items-start border border-subtle bg-surface-1 shadow-card',
+              title: 'font-medium text-secondary-token',
+              description: TOAST_DESCRIPTION_CLASS_NAME,
+              actionButton:
+                'border border-default bg-transparent text-primary-token font-medium hover:bg-surface-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
+              cancelButton:
+                'bg-surface-2 text-secondary-token font-medium hover:bg-surface-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
+              success: '[&>svg]:text-tertiary-token',
+              error: '[&>svg]:text-tertiary-token',
+              warning: '[&>svg]:text-tertiary-token',
+              info: '[&>svg]:text-tertiary-token',
+              loading: '[&>svg]:text-tertiary-token',
+            },
+          }}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/web/tests/unit/providers/core-providers-hydration.test.ts
+++ b/apps/web/tests/unit/providers/core-providers-hydration.test.ts
@@ -1,13 +1,81 @@
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+// @vitest-environment jsdom
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { act, createElement } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { toast as sonnerToast } from 'sonner';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/app/chat',
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'dark' }),
+}));
+
+vi.mock('@/lib/env-client', () => ({
+  env: {
+    IS_E2E: false,
+    IS_TEST: true,
+  },
+}));
+
+vi.mock('@/lib/hooks/useCookieBannerHeight', () => ({
+  useCookieBannerHeight: () => 0,
+}));
+
+import { LazyProviders } from '@/components/providers/LazyProviders';
 
 const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const coreProvidersSource = readFileSync(
   resolve(webRoot, 'components/providers/CoreProviders.tsx'),
   'utf8'
 );
+
+function findFeedbackProviderMounts(directory: string): string[] {
+  const mounts: string[] = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (
+      entry.name === '.next' ||
+      entry.name === 'node_modules' ||
+      entry.name === 'tests'
+    ) {
+      continue;
+    }
+
+    const entryPath = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      mounts.push(...findFeedbackProviderMounts(entryPath));
+      continue;
+    }
+
+    if (
+      !entry.name.endsWith('.tsx') ||
+      entry.name.includes('.test.') ||
+      entry.name.includes('.spec.') ||
+      entry.name.includes('.stories.')
+    ) {
+      continue;
+    }
+
+    if (/<FeedbackProvider(?:\s|>)/.test(readFileSync(entryPath, 'utf8'))) {
+      mounts.push(relative(webRoot, entryPath));
+    }
+  }
+
+  return mounts;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
 
 describe('CoreProviders hydration contract (JOV-4505)', () => {
   it('keeps the global feedback tree out of a dynamic hydration boundary', () => {
@@ -18,5 +86,74 @@ describe('CoreProviders hydration contract (JOV-4505)', () => {
     expect(coreProvidersSource).not.toMatch(
       /const LazyProviders = dynamic[\s\S]*?\{[\s\S]*?ssr:\s*true/
     );
+  });
+
+  it('keeps one source owner for the global feedback mount', () => {
+    expect(findFeedbackProviderMounts(webRoot)).toEqual([
+      'components/providers/LazyProviders.tsx',
+    ]);
+  });
+
+  it('hydrates before mounting exactly one Sonner viewport', async () => {
+    const recoverableErrors: unknown[] = [];
+    const consoleErrors: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      consoleErrors.push(args);
+    });
+
+    const tree = createElement(
+      LazyProviders,
+      { enableAnalytics: false },
+      createElement('main', { 'data-testid': 'hydration-child' }, 'Workspace')
+    );
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(tree);
+    document.body.append(container);
+
+    expect(container.querySelector('[aria-label^="Notifications"]')).toBeNull();
+    expect(document.querySelectorAll('[data-sonner-toaster]')).toHaveLength(0);
+
+    // Match the runtime failure boundary: feedback may be queued while the
+    // server-rendered shell is still hydrating. The canonical provider must
+    // keep Sonner out of both SSR and the first client render.
+    const queuedToastId = sonnerToast('Queued hydration probe', {
+      duration: Number.POSITIVE_INFINITY,
+    });
+
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(container, tree, {
+        onRecoverableError: error => recoverableErrors.push(error),
+      });
+    });
+
+    expect(recoverableErrors).toEqual([]);
+    expect(
+      consoleErrors.filter(args =>
+        args.some(value => /hydrat/i.test(String(value)))
+      )
+    ).toEqual([]);
+    expect(container.querySelector('[data-testid="hydration-child"]')).not.toBe(
+      null
+    );
+
+    sonnerToast.dismiss(queuedToastId);
+
+    // Sonner commits its toast list only after the canonical client mount.
+    // Duplicate provider mounts would each subscribe to the same store and
+    // render duplicate viewports.
+    const toastId = sonnerToast('Hydration probe', {
+      duration: Number.POSITIVE_INFINITY,
+    });
+    await waitFor(() => {
+      expect(document.querySelectorAll('[data-sonner-toaster]')).toHaveLength(
+        1
+      );
+    });
+    sonnerToast.dismiss(toastId);
+
+    await act(async () => {
+      root?.unmount();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- gate only the canonical Sonner `Toaster` until the client mount while keeping children and `BannerViewport` SSR-stable
- preserve the single `FeedbackProvider` owner and avoid dynamic wrappers, hydration suppression, or duplicate providers
- add an SSR-to-`hydrateRoot` regression that pre-seeds feedback, asserts zero recoverable hydration errors, and proves exactly one Sonner viewport

## Failure boundary
A warmed authenticated `/app/chat` reload reproduced React hydration failure at `FeedbackProvider -> Toaster`: client `section[aria-label="Notifications alt+T"]` versus server `Suspense`. The client-mount gate removed both that mismatch and the accompanying React script-tag render error.

## Verification
- Node 22.23.1 / pnpm 9.15.4
- focused + adjacent Vitest: 2 files, 8/8 tests passed
- Biome on both changed files: passed
- targeted ESLint + staged a11y + web typecheck: passed in commit gate
- normal pre-push: proxy guard, Tailwind guard, web typecheck, affected monorepo typecheck/lint, selected tests, CI harness all passed
- desktop 1280x720: stable loaded route, one visible `Link copied` toast, one Sonner toaster/toast, no horizontal overflow
- mobile 375x812: stable loaded route, no console/hydration/Sonner errors, zero CLS entries/value, no horizontal overflow

## Visual evidence
- desktop visible single toast: `~/.gstack/projects/JovieInc-Jovie/designs/jov-4505-sonner-single-mount/desktop-1280x720-visible-single-toast.png`
- mobile clean reload: `~/.gstack/projects/JovieInc-Jovie/designs/jov-4505-sonner-single-mount/mobile-375x812-fixed-stable.png`

## Review
Kimi `/design-review`: approve, no in-scope blockers. Existing mobile chat-title truncation is out of scope and is not claimed as fixed.

Linear: JOV-4505