### PR TITLE
fix(auth): trust active loopback dev host [JOV-4543]

### DIFF
--- a/apps/web/lib/auth/better-auth.ts
+++ b/apps/web/lib/auth/better-auth.ts
@@ -126,15 +126,18 @@ function resolveLocalBetterAuthUrl(): URL | undefined {
  * session lookup's host check doesn't 500 public routes. Loopback-only and
  * never applied to Vercel preview/production deployments.
  */
-function resolveServingPortHost(): string | undefined {
+function resolveServingPortHosts(): string[] {
   if (env.VERCEL_ENV === 'preview' || env.VERCEL_ENV === 'production') {
-    return undefined;
+    return [];
   }
   const port = process.env.PORT?.trim();
   if (!port || !/^\d{2,5}$/.test(port)) {
-    return undefined;
+    return [];
   }
-  return `localhost:${port}`;
+  // Local visual QA and Playwright often use 127.0.0.1 while the dev server
+  // advertises localhost. They are both loopback, but Better Auth validates
+  // the request host exactly; allow both forms for this process port only.
+  return [`localhost:${port}`, `127.0.0.1:${port}`];
 }
 
 function resolveBaseUrl(): NonNullable<BetterAuthOptions['baseURL']> {
@@ -149,7 +152,7 @@ function resolveBaseUrl(): NonNullable<BetterAuthOptions['baseURL']> {
           'staging.jov.ie',
           'localhost:3100',
           localBetterAuthUrl?.host,
-          resolveServingPortHost(),
+          ...resolveServingPortHosts(),
           env.VERCEL_URL,
           env.VERCEL_BRANCH_URL,
         ].filter((host): host is string => Boolean(host))

--- a/apps/web/tests/unit/lib/auth/better-auth-provision-hook.test.ts
+++ b/apps/web/tests/unit/lib/auth/better-auth-provision-hook.test.ts
@@ -175,6 +175,46 @@ describe('Better Auth base URL', () => {
       )
     ).toBe('http://127.0.0.1:3260/api/auth');
   });
+
+  it('allows both loopback host spellings for the active local dev port', async () => {
+    const originalPort = process.env.PORT;
+    mocks.env.VERCEL_ENV = undefined;
+    mocks.env.NODE_ENV = 'development';
+    mocks.env.VERCEL_URL = undefined;
+    mocks.env.VERCEL_BRANCH_URL = undefined;
+    mocks.env.BETTER_AUTH_URL = 'http://localhost:3100';
+    process.env.PORT = '3257';
+    mocks.betterAuth.mockClear();
+    vi.resetModules();
+
+    try {
+      await import('@/lib/auth/better-auth');
+
+      expect(getOptions().baseURL).toEqual({
+        allowedHosts: [
+          'jov.ie',
+          'www.jov.ie',
+          'staging.jov.ie',
+          'localhost:3100',
+          'localhost:3257',
+          '127.0.0.1:3257',
+        ],
+        protocol: 'http',
+      });
+
+      expect(
+        resolveBaseURL(
+          getOptions().baseURL,
+          '/api/auth',
+          new Request('http://127.0.0.1:3257/identity'),
+          false
+        )
+      ).toBe('http://127.0.0.1:3257/api/auth');
+    } finally {
+      if (originalPort === undefined) delete process.env.PORT;
+      else process.env.PORT = originalPort;
+    }
+  });
 });
 
 describe('Better Auth app-user provisioning hook', () => {


### PR DESCRIPTION
## Description

Better Auth dynamic base URL validation trusted the configured `localhost:3100` origin but not the active local capture port. Requests to `/api/auth/get-session` through `127.0.0.1:<PORT>` could therefore fail host validation with a 500.

This keeps the existing production/preview allowlist unchanged and, only for local runtimes with a valid active `PORT`, allows both `localhost:<PORT>` and `127.0.0.1:<PORT>`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Node `v22.23.1`, pnpm `9.15.4`
- [x] Focused regression: `pnpm --filter web exec vitest run tests/unit/lib/auth/better-auth-provision-hook.test.ts` — 11/11 pass
- [x] Exact-file Biome check — pass
- [x] Normal pre-push gate — affected typecheck/lint, full unit shards, CI harness all pass
- [x] Exact runtime proof on both `localhost:3230` and `127.0.0.1:3230` — each `GET /api/auth/get-session` returned `200 application/json` with body `null`; Playwright recorded 0 console messages/errors/warnings

### Bug-to-Test Rule

- [x] Regression test added
- [x] bug-to-test: satisfied

## Risk / Rollback

Risk is bounded to non-Vercel local development. Preview and production return no active-port hosts. Rollback is a single-commit revert.

Release serialization: keep this PR draft + `gated`; do not ready, enroll, or merge until current-main Production Verified and the forced signed/notarized desktop build publishes assets.

## Design

design-canonical: not applicable — runtime auth plumbing only.

## Related Issues

JOV-4543