### PR TITLE
fix(dsp): use canonical app user for match ownership

### DIFF
--- a/apps/web/lib/dsp-enrichment/queries.server.ts
+++ b/apps/web/lib/dsp-enrichment/queries.server.ts
@@ -8,7 +8,6 @@
 import { and, eq } from 'drizzle-orm';
 
 import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema/auth';
 import { dspArtistMatches } from '@/lib/db/schema/dsp-enrichment';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import type { DspMatchStatus } from '@/lib/dsp-enrichment/types';
@@ -19,21 +18,20 @@ const MAX_MATCHES = 200;
  * Fetches DSP artist matches for a creator profile with ownership verification.
  *
  * @param profileId - Creator profile ID
- * @param clerkUserId - Clerk user ID for ownership check
+ * @param appUserId - Canonical app user ID for ownership check
  * @param status - Optional status filter (omit or 'all' for no filter)
  * @returns Array of DSP match objects
  * @throws Error if profile not found or user lacks permission
  */
 export async function getDspMatchesForProfile(
   profileId: string,
-  clerkUserId: string,
+  appUserId: string,
   status?: DspMatchStatus | 'all'
 ) {
   // Verify user owns this profile
   const [profile] = await db
-    .select({ id: creatorProfiles.id, clerkId: users.clerkId })
+    .select({ id: creatorProfiles.id, userId: creatorProfiles.userId })
     .from(creatorProfiles)
-    .innerJoin(users, eq(users.id, creatorProfiles.userId))
     .where(eq(creatorProfiles.id, profileId))
     .limit(1);
 
@@ -41,7 +39,7 @@ export async function getDspMatchesForProfile(
     throw new Error('Profile not found');
   }
 
-  if (profile.clerkId !== clerkUserId) {
+  if (profile.userId !== appUserId) {
     throw new Error('You do not have permission to view this profile');
   }
 

--- a/apps/web/tests/unit/lib/dsp-enrichment/queries.server.test.ts
+++ b/apps/web/tests/unit/lib/dsp-enrichment/queries.server.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSelect = vi.hoisted(() => vi.fn());
+
+vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => conditions,
+  eq: (left: unknown, right: unknown) => [left, right],
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { select: mockSelect },
+}));
+
+vi.mock('@/lib/db/schema/dsp-enrichment', () => ({
+  dspArtistMatches: {
+    id: 'dsp_artist_matches.id',
+    creatorProfileId: 'dsp_artist_matches.creator_profile_id',
+    providerId: 'dsp_artist_matches.provider_id',
+    externalArtistId: 'dsp_artist_matches.external_artist_id',
+    externalArtistName: 'dsp_artist_matches.external_artist_name',
+    externalArtistUrl: 'dsp_artist_matches.external_artist_url',
+    externalArtistImageUrl: 'dsp_artist_matches.external_artist_image_url',
+    confidenceScore: 'dsp_artist_matches.confidence_score',
+    confidenceBreakdown: 'dsp_artist_matches.confidence_breakdown',
+    matchingIsrcCount: 'dsp_artist_matches.matching_isrc_count',
+    matchingUpcCount: 'dsp_artist_matches.matching_upc_count',
+    totalTracksChecked: 'dsp_artist_matches.total_tracks_checked',
+    status: 'dsp_artist_matches.status',
+    createdAt: 'dsp_artist_matches.created_at',
+    updatedAt: 'dsp_artist_matches.updated_at',
+  },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: {
+    id: 'creator_profiles.id',
+    userId: 'creator_profiles.user_id',
+  },
+}));
+
+function profileQuery(profile: { id: string; userId: string }[]) {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: async () => profile,
+      }),
+    }),
+  };
+}
+
+function matchesQuery(matches: unknown[]) {
+  return {
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: async () => matches,
+        }),
+      }),
+    }),
+  };
+}
+
+describe('getDspMatchesForProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns matches when the canonical app user owns the profile', async () => {
+    const matches = [{ id: 'match_1', confidenceScore: '0.95' }];
+    mockSelect
+      .mockReturnValueOnce(
+        profileQuery([{ id: 'profile_1', userId: 'user_1' }])
+      )
+      .mockReturnValueOnce(matchesQuery(matches));
+
+    const { getDspMatchesForProfile } = await import(
+      '@/lib/dsp-enrichment/queries.server'
+    );
+
+    await expect(
+      getDspMatchesForProfile('profile_1', 'user_1')
+    ).resolves.toEqual([{ id: 'match_1', confidenceScore: 0.95 }]);
+    expect(mockSelect.mock.calls[0]?.[0]).toEqual({
+      id: 'creator_profiles.id',
+      userId: 'creator_profiles.user_id',
+    });
+  });
+
+  it('rejects a non-owner and does not load matches', async () => {
+    mockSelect.mockReturnValueOnce(
+      profileQuery([{ id: 'profile_1', userId: 'user_owner' }])
+    );
+
+    const { getDspMatchesForProfile } = await import(
+      '@/lib/dsp-enrichment/queries.server'
+    );
+
+    await expect(
+      getDspMatchesForProfile('profile_1', 'user_other')
+    ).rejects.toThrow('You do not have permission to view this profile');
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- compare DSP match ownership against `creator_profiles.user_id` using the canonical app user ID
- preserve the existing non-owner 403 route behavior
- add owner/non-owner regression coverage

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/dsp-enrichment/queries.server.test.ts`
- `pnpm exec biome check --write apps/web/lib/dsp-enrichment/queries.server.ts apps/web/tests/unit/lib/dsp-enrichment/queries.server.test.ts`
- `git diff --check`

Fixes JOV-4546