### PR TITLE
fix(drawer): eliminate collapsed avatar image warning

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebarSections.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebarSections.tsx
@@ -234,6 +234,7 @@ export function ProfileSidebarHeaderCard({
             <DrawerMediaThumb
               src={previewData.avatarUrl}
               alt={primaryLabel}
+              dimension={60}
               sizeClassName='h-15 w-15 rounded-xl'
               sizes='60px'
               fallback={

--- a/apps/web/components/molecules/drawer/DrawerMediaThumb.test.tsx
+++ b/apps/web/components/molecules/drawer/DrawerMediaThumb.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DrawerMediaThumb } from './DrawerMediaThumb';
+
+const { nextImage } = vi.hoisted(() => ({ nextImage: vi.fn() }));
+
+vi.mock('next/image', () => ({
+  default: ({
+    fill: _fill,
+    ...props
+  }: {
+    readonly src: string;
+    readonly alt: string;
+    readonly fill?: boolean;
+    readonly [key: string]: unknown;
+  }) => {
+    nextImage(props);
+    return <img {...props} />;
+  },
+}));
+
+describe('DrawerMediaThumb', () => {
+  it('uses explicit dimensions for the 60px profile header avatar without fill', () => {
+    nextImage.mockClear();
+
+    render(
+      <DrawerMediaThumb
+        src='/avatars/default-user.png'
+        alt='Artist profile'
+        dimension={60}
+        sizeClassName='h-15 w-15 rounded-xl'
+        fallback={<span>AP</span>}
+      />
+    );
+
+    const image = screen.getByRole('img', { name: 'Artist profile' });
+    expect(image).toHaveAttribute('width', '60');
+    expect(image).toHaveAttribute('height', '60');
+    expect(image).not.toHaveAttribute('fill');
+    expect(image).toHaveClass('h-full', 'w-full', 'object-cover');
+    expect(nextImage).toHaveBeenCalledWith(
+      expect.objectContaining({ height: 60, width: 60 })
+    );
+    expect(nextImage.mock.calls[0]?.[0]).not.toHaveProperty('fill');
+  });
+});

--- a/apps/web/components/molecules/drawer/DrawerMediaThumb.tsx
+++ b/apps/web/components/molecules/drawer/DrawerMediaThumb.tsx
@@ -8,6 +8,8 @@ export interface DrawerMediaThumbProps {
   readonly src?: string | null;
   readonly alt: string;
   readonly fallback: ReactNode;
+  /** Intrinsic image dimensions; keeps Next Image stable while the drawer is collapsed. */
+  readonly dimension?: number;
   readonly sizeClassName?: string;
   readonly sizes?: string;
   readonly className?: string;
@@ -18,6 +20,7 @@ export function DrawerMediaThumb({
   src,
   alt,
   fallback,
+  dimension = 64,
   sizeClassName = 'h-16 w-16',
   sizes = '64px',
   className,
@@ -35,8 +38,9 @@ export function DrawerMediaThumb({
         <Image
           src={src}
           alt={alt}
-          fill
-          className={cn('object-cover', imageClassName)}
+          width={dimension}
+          height={dimension}
+          className={cn('h-full w-full object-cover', imageClassName)}
           sizes={sizes}
         />
       ) : (

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
@@ -285,6 +285,7 @@ export function ReleaseEntityHeader({
                   <DrawerMediaThumb
                     src={release.artworkUrl}
                     alt={artworkAlt}
+                    dimension={68}
                     sizeClassName='h-17 w-17 rounded-xl'
                     sizes='68px'
                     fallback={

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -348,6 +348,7 @@ export function TrackSidebar({
                   <DrawerMediaThumb
                     src={track.releaseArtworkUrl}
                     alt={`${track.releaseTitle} artwork`}
+                    dimension={72}
                     sizeClassName='h-18 w-18 rounded-xl'
                     sizes='72px'
                     fallback={


### PR DESCRIPTION
## Summary
- replace `DrawerMediaThumb` fill-mode images with explicit intrinsic dimensions
- preserve each non-default drawer thumbnail size and cover geometry
- add a 60px profile-header regression proving `fill` is absent

## Verification
- `pnpm --filter web exec vitest run components/molecules/drawer/DrawerMediaThumb.test.tsx`
- `pnpm biome check --write <five changed paths>`
- `git diff --check`

## Deferred visual proof
Authenticated browser capture is intentionally deferred until #15089 has merged, this branch is rebased onto current main, and the serialized runtime lane is available.