### PR TITLE
test(qa): persist authenticated route capture receipts

### DIFF
--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -73,6 +73,71 @@ interface TestAuthAvailability {
   readonly reason: string | null;
 }
 
+type AuthenticatedCapturePersona = 'creator-ready' | 'creator' | 'admin';
+type CaptureStatus = 'running' | 'pass' | 'fail';
+type TeardownStatus = 'not-created' | 'closed' | 'timed-out' | 'failed';
+
+interface CaptureCheckpoint {
+  readonly stage: string;
+  readonly at: string;
+}
+
+interface CaptureFailedRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly errorText: string;
+}
+
+interface CaptureFailure {
+  readonly stage: string;
+  readonly message: string;
+}
+
+interface CaptureTeardown {
+  page: TeardownStatus;
+  context: TeardownStatus;
+  browser: TeardownStatus;
+}
+
+export interface AuthenticatedRouteCaptureReceipt {
+  readonly schemaVersion: 1;
+  status: CaptureStatus;
+  readonly baseUrl: string;
+  readonly requestedPath: string;
+  readonly persona: AuthenticatedCapturePersona;
+  readonly targetUrl: string;
+  finalUrl: string;
+  title: string;
+  readonly startedAt: string;
+  finishedAt: string | null;
+  readonly checkpoints: CaptureCheckpoint[];
+  readonly consoleErrors: string[];
+  readonly pageErrors: string[];
+  readonly failedRequests: CaptureFailedRequest[];
+  screenshotPath: string | null;
+  screenshotError: string | null;
+  failure: CaptureFailure | null;
+  readonly teardown: CaptureTeardown;
+}
+
+interface AuthenticatedRouteCaptureOptions {
+  readonly requestedPath: string;
+  readonly persona?: AuthenticatedCapturePersona;
+  readonly baseUrl?: string;
+  readonly outputRoot?: string;
+  readonly timeoutMs?: number;
+  readonly closeTimeoutMs?: number;
+  readonly signal?: AbortSignal;
+}
+
+interface AuthenticatedRouteCaptureDependencies {
+  readonly launchBrowser?: () => Promise<Browser>;
+  readonly now?: () => string;
+  readonly persistReceipt?: (
+    receipt: Readonly<AuthenticatedRouteCaptureReceipt>
+  ) => Promise<void>;
+}
+
 const APP_DIR = resolveAppPath('app');
 const OUTPUT_SEGMENT = process.env.ROUTE_QA_OUTPUT_DIR?.trim() || 'latest';
 const OUTPUT_BASE = resolveAppPath('test-results', 'route-qa');
@@ -84,6 +149,10 @@ const OUTPUT_ROOT = resolveOwnedOutputDirectory(
 const SCREENSHOT_DIR = path.join(OUTPUT_ROOT, 'screenshots');
 const BASE_URL =
   process.env.ROUTE_QA_BASE_URL?.trim() || 'http://localhost:3000';
+const AUTH_CAPTURE_PATH =
+  process.env.ROUTE_QA_AUTH_CAPTURE_PATH?.trim() || null;
+const AUTH_CAPTURE_PERSONA =
+  process.env.ROUTE_QA_AUTH_CAPTURE_PERSONA?.trim() || 'creator-ready';
 const ROUTE_FILTER = process.env.ROUTE_QA_FILTER?.trim().toLowerCase() || null;
 const ROUTE_LIMIT = Number.parseInt(process.env.ROUTE_QA_LIMIT || '', 10);
 const CANONICAL_RELEASE_TASKS_ROUTE = `${APP_ROUTES.RELEASES}/[releaseId]/tasks`;
@@ -864,6 +933,356 @@ export async function settleWithTimeout<T>(
   }
 }
 
+function validateCapturePersona(
+  persona: string
+): asserts persona is AuthenticatedCapturePersona {
+  if (!['creator-ready', 'creator', 'admin'].includes(persona)) {
+    throw new Error(
+      'ROUTE_QA_AUTH_CAPTURE_PERSONA must be creator-ready, creator, or admin.'
+    );
+  }
+}
+
+function buildAuthenticatedCaptureTargetUrl(
+  baseUrl: string,
+  requestedPath: string,
+  persona: AuthenticatedCapturePersona
+) {
+  if (!requestedPath.startsWith('/') || requestedPath.startsWith('//')) {
+    throw new Error(
+      'ROUTE_QA_AUTH_CAPTURE_PATH must be an absolute application path.'
+    );
+  }
+
+  const resolvedBaseUrl = new URL(baseUrl);
+  const requestedUrl = new URL(requestedPath, resolvedBaseUrl);
+  if (requestedUrl.origin !== resolvedBaseUrl.origin) {
+    throw new Error(
+      'ROUTE_QA_AUTH_CAPTURE_PATH must stay on ROUTE_QA_BASE_URL.'
+    );
+  }
+
+  const bootstrapUrl = new URL('/api/dev/test-auth/enter', resolvedBaseUrl);
+  bootstrapUrl.searchParams.set('persona', persona);
+  bootstrapUrl.searchParams.set(
+    'redirect',
+    `${requestedUrl.pathname}${requestedUrl.search}${requestedUrl.hash}`
+  );
+  return bootstrapUrl.toString();
+}
+
+function cloneCaptureReceipt(
+  receipt: Readonly<AuthenticatedRouteCaptureReceipt>
+) {
+  return JSON.parse(
+    JSON.stringify(receipt)
+  ) as AuthenticatedRouteCaptureReceipt;
+}
+
+async function writeCaptureReceiptAtomically(
+  outputRoot: string,
+  receipt: Readonly<AuthenticatedRouteCaptureReceipt>
+) {
+  await fs.mkdir(outputRoot, { recursive: true });
+  const receiptPath = path.join(outputRoot, 'authenticated-route-capture.json');
+  const temporaryPath = `${receiptPath}.tmp`;
+  await fs.writeFile(
+    temporaryPath,
+    `${JSON.stringify(receipt, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.rename(temporaryPath, receiptPath);
+}
+
+function withAbortSignal<T>(
+  operation: Promise<T>,
+  signal: AbortSignal | undefined
+): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) {
+    return Promise.reject(
+      signal.reason instanceof Error
+        ? signal.reason
+        : new Error('Authenticated route capture aborted.')
+    );
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error('Authenticated route capture aborted.')
+      );
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      result => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(result);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+export async function runAuthenticatedRouteCapture(
+  options: Readonly<AuthenticatedRouteCaptureOptions>,
+  dependencies: Readonly<AuthenticatedRouteCaptureDependencies> = {}
+): Promise<AuthenticatedRouteCaptureReceipt> {
+  const baseUrl = options.baseUrl ?? BASE_URL;
+  const persona = options.persona ?? 'creator-ready';
+  const outputRoot = options.outputRoot ?? OUTPUT_ROOT;
+  const timeoutMs = options.timeoutMs ?? resolveRouteCaseTimeoutMs();
+  const closeTimeoutMs = options.closeTimeoutMs ?? 5_000;
+  const now = dependencies.now ?? (() => new Date().toISOString());
+  const launchBrowser =
+    dependencies.launchBrowser ?? (() => chromium.launch({ headless: true }));
+  const persistReceipt =
+    dependencies.persistReceipt ??
+    (receipt => writeCaptureReceiptAtomically(outputRoot, receipt));
+  validateCapturePersona(persona);
+  const targetUrl = buildAuthenticatedCaptureTargetUrl(
+    baseUrl,
+    options.requestedPath,
+    persona
+  );
+  const screenshotPath = path.join(
+    outputRoot,
+    'authenticated-route-capture.png'
+  );
+  const receipt: AuthenticatedRouteCaptureReceipt = {
+    schemaVersion: 1,
+    status: 'running',
+    baseUrl,
+    requestedPath: options.requestedPath,
+    persona,
+    targetUrl,
+    finalUrl: targetUrl,
+    title: '',
+    startedAt: now(),
+    finishedAt: null,
+    checkpoints: [],
+    consoleErrors: [],
+    pageErrors: [],
+    failedRequests: [],
+    screenshotPath: null,
+    screenshotError: null,
+    failure: null,
+    teardown: {
+      page: 'not-created',
+      context: 'not-created',
+      browser: 'not-created',
+    },
+  };
+  let activeStage = 'initializing';
+  let browser: Browser | null = null;
+  let context: BrowserContext | null = null;
+  let page: Page | null = null;
+
+  const persist = async () => {
+    await persistReceipt(cloneCaptureReceipt(receipt));
+  };
+  const checkpoint = async (stage: string) => {
+    activeStage = stage;
+    receipt.checkpoints.push({ stage, at: now() });
+    await persist();
+  };
+  const markCaptureFailure = (stage: string, message: string) => {
+    receipt.status = 'fail';
+    receipt.failure ??= { stage, message };
+  };
+  const bestEffortCheckpoint = async (stage: string) => {
+    try {
+      await checkpoint(stage);
+    } catch (error) {
+      const message = `Receipt checkpoint ${stage} failed: ${(error as Error).message}`;
+      receipt.pageErrors.push(message);
+      markCaptureFailure(stage, message);
+    }
+  };
+  const readPageTitle = async (currentPage: Page, titleTimeoutMs: number) => {
+    try {
+      const settledTitle = await settleWithTimeout(
+        currentPage.title(),
+        titleTimeoutMs
+      );
+      return settledTitle.timedOut ? receipt.title : settledTitle.result;
+    } catch {
+      return receipt.title;
+    }
+  };
+  const runBounded = async <T>(
+    label: string,
+    operation: Promise<T>,
+    operationTimeoutMs = timeoutMs
+  ) => {
+    const settled = await settleWithTimeout(
+      withAbortSignal(operation, options.signal),
+      operationTimeoutMs
+    );
+    if (settled.timedOut) {
+      throw new Error(`${label} timed out after ${operationTimeoutMs}ms.`);
+    }
+    return settled.result;
+  };
+  const closeResource = async (
+    resource: keyof CaptureTeardown,
+    close: (() => Promise<unknown>) | null
+  ) => {
+    if (!close) return;
+    await bestEffortCheckpoint(`${resource}-close-started`);
+    try {
+      const settledClose = await settleWithTimeout(
+        Promise.resolve().then(close),
+        closeTimeoutMs
+      );
+      receipt.teardown[resource] = settledClose.timedOut
+        ? 'timed-out'
+        : 'closed';
+      if (settledClose.timedOut) {
+        markCaptureFailure(
+          `${resource}-close-started`,
+          `${resource} teardown timed out after ${closeTimeoutMs}ms.`
+        );
+      }
+    } catch (error) {
+      receipt.teardown[resource] = 'failed';
+      const message = `${resource} teardown failed: ${(error as Error).message}`;
+      receipt.pageErrors.push(message);
+      markCaptureFailure(`${resource}-close-started`, message);
+    }
+    await bestEffortCheckpoint(
+      `${resource}-close-${receipt.teardown[resource]}`
+    );
+  };
+
+  try {
+    await checkpoint('browser-launch-started');
+    const launchedBrowser = await runBounded('Browser launch', launchBrowser());
+    browser = launchedBrowser;
+    await checkpoint('browser-launched');
+
+    context = await runBounded(
+      'Browser context creation',
+      browser.newContext({
+        viewport: { width: 1440, height: 960 },
+        colorScheme: 'dark',
+      })
+    );
+    await checkpoint('context-created');
+
+    page = await runBounded('Page creation', context.newPage());
+    page.setDefaultNavigationTimeout(timeoutMs);
+    page.setDefaultTimeout(Math.min(timeoutMs, 15_000));
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        receipt.consoleErrors.push(message.text());
+      }
+    });
+    page.on('pageerror', error => {
+      receipt.pageErrors.push(error.message);
+    });
+    page.on('requestfailed', request => {
+      receipt.failedRequests.push({
+        method: request.method(),
+        url: request.url(),
+        errorText: request.failure()?.errorText ?? 'unknown request failure',
+      });
+    });
+    await checkpoint('page-created');
+
+    await checkpoint('navigation-started');
+    await runBounded(
+      'Authenticated route navigation',
+      page.goto(targetUrl, {
+        waitUntil: 'commit',
+        timeout: Math.min(timeoutMs, 45_000),
+      })
+    );
+    await checkpoint('navigation-committed');
+
+    await checkpoint('stability-wait-started');
+    await runBounded(
+      'Authenticated route stability wait',
+      waitForStablePage(page)
+    );
+    receipt.finalUrl = page.url();
+    receipt.title = await readPageTitle(page, Math.min(timeoutMs, 15_000));
+    receipt.pageErrors.push(
+      ...(await runBounded(
+        'Page error collection',
+        collectPageErrors(page),
+        Math.min(timeoutMs, 15_000)
+      ))
+    );
+    await checkpoint('stability-wait-completed');
+
+    const mainVisible = await page
+      .locator('main')
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (!mainVisible) {
+      throw new Error(
+        'Authenticated route did not render visible main content.'
+      );
+    }
+    if (
+      receipt.consoleErrors.length > 0 ||
+      receipt.pageErrors.length > 0 ||
+      receipt.failedRequests.length > 0
+    ) {
+      throw new Error(
+        'Authenticated route emitted console, page, or failed-request evidence.'
+      );
+    }
+    receipt.status = 'pass';
+    await checkpoint('capture-passed');
+  } catch (error) {
+    markCaptureFailure(activeStage, (error as Error).message);
+    await checkpoint('capture-failed').catch(() => undefined);
+  } finally {
+    if (page) {
+      receipt.finalUrl = page.url() || receipt.finalUrl;
+      receipt.title = await readPageTitle(page, closeTimeoutMs);
+      await bestEffortCheckpoint('screenshot-started');
+      try {
+        await fs.mkdir(outputRoot, { recursive: true });
+        const screenshot = await settleWithTimeout(
+          page.screenshot({ path: screenshotPath, fullPage: true }),
+          closeTimeoutMs
+        );
+        if (screenshot.timedOut) {
+          const message = `Screenshot timed out after ${closeTimeoutMs}ms.`;
+          receipt.screenshotError = message;
+          markCaptureFailure('screenshot-started', message);
+          await bestEffortCheckpoint('screenshot-timed-out');
+        } else {
+          receipt.screenshotPath = screenshotPath;
+          await bestEffortCheckpoint('screenshot-written');
+        }
+      } catch (error) {
+        receipt.screenshotError = (error as Error).message;
+        markCaptureFailure('screenshot-started', receipt.screenshotError);
+        await bestEffortCheckpoint('screenshot-failed');
+      }
+    }
+
+    await closeResource('page', page ? () => page.close() : null);
+    await closeResource('context', context ? () => context.close() : null);
+    await closeResource('browser', browser ? () => browser.close() : null);
+    receipt.finishedAt = now();
+    await bestEffortCheckpoint('receipt-finalized');
+    await persist();
+  }
+
+  return cloneCaptureReceipt(receipt);
+}
+
 async function runRouteCase(
   context: BrowserContext,
   routeCase: RouteCase
@@ -1135,6 +1554,38 @@ async function main() {
     OUTPUT_SEGMENT,
     'ROUTE_QA_OUTPUT_DIR'
   );
+  if (AUTH_CAPTURE_PATH) {
+    validateCapturePersona(AUTH_CAPTURE_PERSONA);
+    const abortController = new AbortController();
+    const handleSignal = (signal: NodeJS.Signals) => {
+      abortController.abort(
+        new Error(`Authenticated route capture received ${signal}.`)
+      );
+    };
+    const handleInterrupt = () => handleSignal('SIGINT');
+    const handleTermination = () => handleSignal('SIGTERM');
+    process.once('SIGINT', handleInterrupt);
+    process.once('SIGTERM', handleTermination);
+
+    let receipt: AuthenticatedRouteCaptureReceipt;
+    try {
+      receipt = await runAuthenticatedRouteCapture({
+        requestedPath: AUTH_CAPTURE_PATH,
+        persona: AUTH_CAPTURE_PERSONA,
+        signal: abortController.signal,
+      });
+    } finally {
+      process.removeListener('SIGINT', handleInterrupt);
+      process.removeListener('SIGTERM', handleTermination);
+    }
+    console.log(
+      `Authenticated route capture ${receipt.status}: ${receipt.finalUrl}`
+    );
+    console.log(`Artifacts: ${OUTPUT_ROOT}`);
+    await flushStandardStreams();
+    process.exit(receipt.status === 'pass' ? 0 : 1);
+  }
+
   const authAvailability = await getTestAuthAvailability();
   const routeCases = applyAuthAvailability(
     await buildRouteMatrix(),

--- a/apps/web/tests/scripts/route-qa-auth-capture.test.ts
+++ b/apps/web/tests/scripts/route-qa-auth-capture.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type AuthenticatedRouteCaptureReceipt,
+  runAuthenticatedRouteCapture,
+} from '../../scripts/route-qa';
+
+function createFakeRuntime(options?: {
+  readonly navigation?: Promise<unknown>;
+  readonly consoleError?: string;
+  readonly pageError?: string;
+  readonly failedRequest?: string;
+}) {
+  const listeners = new Map<string, (value: never) => void>();
+  const page = {
+    setDefaultNavigationTimeout: vi.fn(),
+    setDefaultTimeout: vi.fn(),
+    on: vi.fn((event: string, listener: (value: never) => void) => {
+      listeners.set(event, listener);
+    }),
+    goto: vi.fn(async () => {
+      if (options?.consoleError) {
+        listeners.get('console')?.({
+          type: () => 'error',
+          text: () => options.consoleError,
+        } as never);
+      }
+      if (options?.pageError) {
+        listeners.get('pageerror')?.({
+          message: options.pageError,
+        } as never);
+      }
+      if (options?.failedRequest) {
+        listeners.get('requestfailed')?.({
+          method: () => 'GET',
+          url: () => options.failedRequest,
+          failure: () => ({ errorText: 'net::ERR_FAILED' }),
+        } as never);
+      }
+      return options?.navigation;
+    }),
+    waitForLoadState: vi.fn().mockResolvedValue(undefined),
+    url: vi.fn(() => 'http://localhost:3220/app'),
+    title: vi.fn().mockResolvedValue('Jovie'),
+    locator: vi.fn((selector: string) => ({
+      first: () => ({
+        isVisible: vi.fn().mockResolvedValue(selector === 'main'),
+      }),
+      innerText: vi.fn().mockResolvedValue('Jovie authenticated shell'),
+    })),
+    screenshot: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const context = {
+    newPage: vi.fn().mockResolvedValue(page),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const browser = {
+    newContext: vi.fn().mockResolvedValue(context),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return { browser, context, page };
+}
+
+describe('route-qa authenticated capture', () => {
+  it('persists checkpoints and a clean final receipt while closing every resource', async () => {
+    const runtime = createFakeRuntime();
+    const persisted: AuthenticatedRouteCaptureReceipt[] = [];
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-success',
+        timeoutMs: 50,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: async value => {
+          persisted.push(structuredClone(value));
+        },
+      }
+    );
+
+    expect(receipt).toMatchObject({
+      status: 'pass',
+      finalUrl: 'http://localhost:3220/app',
+      screenshotPath:
+        '/tmp/route-qa-auth-capture-success/authenticated-route-capture.png',
+      failure: null,
+      teardown: {
+        page: 'closed',
+        context: 'closed',
+        browser: 'closed',
+      },
+    });
+    expect(receipt.checkpoints.map(checkpoint => checkpoint.stage)).toEqual(
+      expect.arrayContaining([
+        'browser-launch-started',
+        'navigation-started',
+        'screenshot-written',
+        'receipt-finalized',
+      ])
+    );
+    expect(
+      persisted.find(value =>
+        value.checkpoints.some(
+          checkpoint => checkpoint.stage === 'navigation-started'
+        )
+      )
+    ).toBeDefined();
+    expect(persisted.at(-1)).toEqual(receipt);
+    expect(runtime.page.close).toHaveBeenCalledOnce();
+    expect(runtime.context.close).toHaveBeenCalledOnce();
+    expect(runtime.browser.close).toHaveBeenCalledOnce();
+  });
+
+  it('writes a deterministic timeout receipt in finally and still tears down', async () => {
+    const runtime = createFakeRuntime({
+      navigation: new Promise(() => undefined),
+    });
+    runtime.page.goto.mockReturnValue(new Promise(() => undefined) as never);
+    const persisted: AuthenticatedRouteCaptureReceipt[] = [];
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-timeout',
+        timeoutMs: 5,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: async value => {
+          persisted.push(structuredClone(value));
+        },
+      }
+    );
+
+    expect(receipt).toMatchObject({
+      status: 'fail',
+      finalUrl: 'http://localhost:3220/app',
+      failure: {
+        stage: 'navigation-started',
+        message: 'Authenticated route navigation timed out after 5ms.',
+      },
+      teardown: {
+        page: 'closed',
+        context: 'closed',
+        browser: 'closed',
+      },
+    });
+    expect(receipt.screenshotPath).toBe(
+      '/tmp/route-qa-auth-capture-timeout/authenticated-route-capture.png'
+    );
+    expect(persisted.at(-1)).toEqual(receipt);
+    expect(runtime.page.close).toHaveBeenCalledOnce();
+    expect(runtime.context.close).toHaveBeenCalledOnce();
+    expect(runtime.browser.close).toHaveBeenCalledOnce();
+  });
+
+  it('records console, page, and failed-request evidence before failing', async () => {
+    const runtime = createFakeRuntime({
+      consoleError: 'console exploded',
+      pageError: 'page exploded',
+      failedRequest: 'http://localhost:3220/api/dsp/matches',
+    });
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-errors',
+        timeoutMs: 50,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: vi.fn().mockResolvedValue(undefined),
+      }
+    );
+
+    expect(receipt.status).toBe('fail');
+    expect(receipt.consoleErrors).toEqual(['console exploded']);
+    expect(receipt.pageErrors).toContain('page exploded');
+    expect(receipt.failedRequests).toEqual([
+      {
+        method: 'GET',
+        url: 'http://localhost:3220/api/dsp/matches',
+        errorText: 'net::ERR_FAILED',
+      },
+    ]);
+  });
+
+  it('does not skip teardown when persisting a cleanup checkpoint fails', async () => {
+    const runtime = createFakeRuntime();
+    let failedCheckpoint = false;
+    const persisted: AuthenticatedRouteCaptureReceipt[] = [];
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-persist-failure',
+        timeoutMs: 50,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: async value => {
+          const stage = value.checkpoints.at(-1)?.stage;
+          if (!failedCheckpoint && stage === 'page-close-started') {
+            failedCheckpoint = true;
+            throw new Error('disk unavailable');
+          }
+          persisted.push(structuredClone(value));
+        },
+      }
+    );
+
+    expect(receipt.status).toBe('fail');
+    expect(receipt.failure).toMatchObject({
+      stage: 'page-close-started',
+      message: 'Receipt checkpoint page-close-started failed: disk unavailable',
+    });
+    expect(receipt.teardown).toEqual({
+      page: 'closed',
+      context: 'closed',
+      browser: 'closed',
+    });
+    expect(runtime.page.close).toHaveBeenCalledOnce();
+    expect(runtime.context.close).toHaveBeenCalledOnce();
+    expect(runtime.browser.close).toHaveBeenCalledOnce();
+    expect(persisted.at(-1)).toEqual(receipt);
+  });
+
+  it('bounds a stuck screenshot and still closes every resource', async () => {
+    const runtime = createFakeRuntime();
+    runtime.page.screenshot.mockReturnValue(
+      new Promise(() => undefined) as never
+    );
+    const persisted: AuthenticatedRouteCaptureReceipt[] = [];
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-screenshot-timeout',
+        timeoutMs: 50,
+        closeTimeoutMs: 5,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: async value => {
+          persisted.push(structuredClone(value));
+        },
+      }
+    );
+
+    expect(receipt).toMatchObject({
+      status: 'fail',
+      screenshotPath: null,
+      screenshotError: 'Screenshot timed out after 5ms.',
+      failure: {
+        stage: 'screenshot-started',
+        message: 'Screenshot timed out after 5ms.',
+      },
+      teardown: {
+        page: 'closed',
+        context: 'closed',
+        browser: 'closed',
+      },
+    });
+    expect(
+      receipt.checkpoints.some(
+        checkpoint => checkpoint.stage === 'screenshot-timed-out'
+      )
+    ).toBe(true);
+    expect(runtime.page.close).toHaveBeenCalledOnce();
+    expect(runtime.context.close).toHaveBeenCalledOnce();
+    expect(runtime.browser.close).toHaveBeenCalledOnce();
+    expect(persisted.at(-1)).toEqual(receipt);
+  });
+
+  it('bounds hanging title reads and preserves teardown', async () => {
+    const runtime = createFakeRuntime();
+    runtime.page.title.mockReturnValue(new Promise(() => undefined) as never);
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-title-timeout',
+        timeoutMs: 5,
+        closeTimeoutMs: 5,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: vi.fn().mockResolvedValue(undefined),
+      }
+    );
+
+    expect(receipt.title).toBe('');
+    expect(receipt.teardown).toEqual({
+      page: 'closed',
+      context: 'closed',
+      browser: 'closed',
+    });
+    expect(runtime.page.close).toHaveBeenCalledOnce();
+    expect(runtime.context.close).toHaveBeenCalledOnce();
+    expect(runtime.browser.close).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- add an opt-in, one-route authenticated capture mode to the existing route QA harness
- atomically persist checkpoints before browser waits and a deterministic final receipt from `finally`
- record final URL, title, console/page errors, failed requests, screenshot or screenshot failure, and page/context/browser teardown
- bound browser launch, context/page creation, navigation, stability, title reads, screenshots, and teardown without owning server startup

## Linear
- JOV-4549: https://linear.app/jovie/issue/JOV-4549/testqa-persist-bounded-authenticated-route-proof-receipts

## Verification
- `pnpm --filter web exec vitest run tests/scripts/route-qa-auth-capture.test.ts tests/scripts/route-qa.test.ts tests/scripts/route-qa-auth-probe.test.ts` — 3 files, 13 tests passed
- `pnpm biome check apps/web/scripts/route-qa.ts apps/web/tests/scripts/route-qa-auth-capture.test.ts` — 2 files clean
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `git diff --check` — passed
- normal `git push` — passed

## Runtime boundary
- No server or browser was started for this PR.
- Port 3224 was preserved.
- Runtime use remains gated pending coordinator authorization.

## Risk
- Harness-only, opt-in through `ROUTE_QA_AUTH_CAPTURE_PATH`.
- No product or UI files changed.
