### PR TITLE
fix(account): restore full-page scrolling

### DIFF
--- a/apps/web/components/organisms/AppShellContentPanel.tsx
+++ b/apps/web/components/organisms/AppShellContentPanel.tsx
@@ -49,7 +49,11 @@ export function AppShellContentPanel({
   ...sectionProps
 }: Readonly<AppShellContentPanelProps>) {
   const panelScrollClassName =
-    scroll === 'panel' ? 'min-h-0 overflow-hidden' : 'overflow-visible';
+    scroll === 'panel'
+      ? 'min-h-0 overflow-hidden'
+      : 'min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain';
+  const panelContentConstraintClassName =
+    scroll === 'panel' ? 'min-h-0 overflow-hidden' : 'min-h-0';
   const isTableSurface = surfaceMode === 'table';
 
   return (
@@ -70,7 +74,7 @@ export function AppShellContentPanel({
           isTableSurface
             ? PANEL_TABLE_SURFACE_CLASSNAME
             : PANEL_OUTER_INSET_CLASSNAME,
-          panelScrollClassName,
+          panelContentConstraintClassName,
           surfaceClassName
         )}
       >
@@ -87,7 +91,7 @@ export function AppShellContentPanel({
           <div
             className={cn(
               'flex min-h-0 min-w-0 flex-1 flex-col',
-              panelScrollClassName,
+              panelContentConstraintClassName,
               PANEL_CONTENT_PADDING_CLASSNAME[contentPadding],
               contentClassName
             )}

--- a/apps/web/tests/unit/components/organisms/AppShellContentPanel.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellContentPanel.test.tsx
@@ -25,16 +25,24 @@ describe('AppShellContentPanel', () => {
         frame='none'
         contentPadding='compact'
         scroll='page'
+        data-testid='shell-panel'
       >
         <div>Settings content</div>
       </AppShellContentPanel>
     );
 
     expect(screen.getByText('Settings content')).toBeInTheDocument();
+    const pageScrollOwner = screen.getByTestId('shell-panel');
     const outerPanel = container.querySelector('.mx-auto');
     expect(outerPanel).toHaveClass('max-w-(--app-shell-content-max-form)');
     expect(container.innerHTML).toContain('px-3 py-3 sm:px-3.5 sm:py-3.5');
-    expect(container.innerHTML).toContain('overflow-visible');
+    expect(pageScrollOwner).toHaveClass(
+      'min-h-0',
+      'overflow-y-auto',
+      'overflow-x-hidden',
+      'overscroll-contain'
+    );
+    expect(outerPanel).not.toHaveClass('overflow-y-auto');
   });
 
   it('keeps the toolbar and content on the same outer inset contract', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4554 -->

## Summary
- restore a single vertical scroll owner for `scroll='page'` authenticated shell surfaces
- keep page-mode descendants unconstrained so Account controls cannot be clipped or form nested vertical scroll regions
- retain the shell clip and fixed right rail; page mode also explicitly hides horizontal overflow

## Verification
- `pnpm --filter web exec vitest run tests/unit/components/organisms/AppShellContentPanel.test.tsx tests/unit/app/settings-scroll-mode.test.ts tests/unit/app/settings-shell-normalization.test.ts` — 3 files, 13 tests passed
- `pnpm biome check --write apps/web/components/organisms/AppShellContentPanel.tsx apps/web/tests/unit/components/organisms/AppShellContentPanel.test.tsx` — passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `git diff --check` — passed

## Visual proof needed before ready
No dev server or browser was started for this bounded source fix. Review the authenticated `/app/settings/account` route on the exact head at desktop and 390px: verify every control is reachable by pointer and keyboard, only the content panel scrolls, no horizontal overflow, and the fixed shell/right rail remain stable.
