### PR TITLE
fix(chat): restore file-drop image-chip contrast

### DIFF
--- a/apps/web/components/jovie/components/ChatFileChips.tsx
+++ b/apps/web/components/jovie/components/ChatFileChips.tsx
@@ -54,6 +54,7 @@ export function ChatFileChips({ files, onRemove }: ChatFileChipsProps) {
             exit={{ opacity: 0, scale: 0.8 }}
             transition={{ duration: 0.15 }}
             className='system-b-chat-file-chip'
+            data-upload-state={f.status}
           >
             <span className='system-b-chat-file-chip-icon'>
               {f.previewUrl ? (
@@ -67,9 +68,7 @@ export function ChatFileChips({ files, onRemove }: ChatFileChipsProps) {
                 fileKindIcon(f.kind, 'h-3 w-3')
               )}
             </span>
-            <span className='max-w-30 truncate text-xs text-secondary-token'>
-              {f.name}
-            </span>
+            <span className='system-b-chat-file-chip-label'>{f.name}</span>
             <Check
               className='h-3 w-3 shrink-0 text-accent-green'
               strokeWidth={2.5}
@@ -79,10 +78,10 @@ export function ChatFileChips({ files, onRemove }: ChatFileChipsProps) {
               variant='ghost'
               size='icon'
               onClick={() => onRemove(f.id)}
-              className='ml-0.5 h-4 w-4 rounded-full'
+              className='system-b-chat-file-chip-remove'
               aria-label={`Remove ${f.name}`}
             >
-              <X className='h-3 w-3 text-tertiary-token' />
+              <X className='h-3 w-3' />
             </Button>
           </motion.span>
         ))}

--- a/apps/web/styles/chat-file-upload.css
+++ b/apps/web/styles/chat-file-upload.css
@@ -205,11 +205,6 @@
   background: var(--system-b-bg-surface-2);
 }
 
-:where(.system-b-chat-file-chip:focus-within) {
-  border-color: var(--color-focus-ring);
-  box-shadow: 0 0 0 var(--focus-ring-width) var(--color-focus-ring);
-}
-
 :where(.system-b-chat-file-chip-icon) {
   width: 24px;
   height: 24px;

--- a/apps/web/styles/chat-file-upload.css
+++ b/apps/web/styles/chat-file-upload.css
@@ -193,8 +193,21 @@
   gap: var(--space-2);
   padding: var(--space-1) var(--space-3) var(--space-1) var(--space-1);
   border-radius: 9999px;
-  background: color-mix(in oklab, white 4%, transparent);
+  background: var(--system-b-bg-surface-1);
   border: 1px solid var(--system-b-app-frame-seam);
+  color: var(--color-text-primary-token);
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-chat-file-chip:hover) {
+  background: var(--system-b-bg-surface-2);
+}
+
+:where(.system-b-chat-file-chip:focus-within) {
+  border-color: var(--color-focus-ring);
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--color-focus-ring);
 }
 
 :where(.system-b-chat-file-chip-icon) {
@@ -208,6 +221,32 @@
   align-items: center;
   justify-content: center;
   color: var(--color-text-secondary-token);
+}
+
+:where(.system-b-chat-file-chip-label) {
+  max-width: 7.5rem;
+  overflow: hidden;
+  color: inherit;
+  font-size: var(--text-app);
+  line-height: var(--space-4);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-chat-file-chip-remove) {
+  width: var(--space-4);
+  height: var(--space-4);
+  margin-left: var(--space-0-5);
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary-token);
+}
+
+:where(.system-b-chat-file-chip-remove:hover) {
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-chat-file-chip-remove:focus-visible) {
+  color: var(--color-text-primary-token);
 }
 
 /* ── Chat Upload Pay Gate ─────────────────────────────────────────────── */

--- a/apps/web/tests/unit/chat/chat-file-drop-chip-contrast-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-file-drop-chip-contrast-guard.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8');
+
+describe('chat file-drop image chip contrast guard (JOV-4557)', () => {
+  it('keeps the completed chip on canonical surfaces with a visible keyboard state', () => {
+    const chip = readSource('components/jovie/components/ChatFileChips.tsx');
+    const styles = readSource('styles/chat-file-upload.css');
+
+    expect(chip).toContain('data-upload-state={f.status}');
+    expect(chip).toContain('system-b-chat-file-chip-label');
+    expect(chip).toContain('system-b-chat-file-chip-remove');
+
+    expect(styles).toContain(
+      ':where(.system-b-chat-file-chip) {\n  display: inline-flex;'
+    );
+    expect(styles).toContain('background: var(--system-b-bg-surface-1);');
+    expect(styles).toContain('color: var(--color-text-primary-token);');
+    expect(styles).toContain(':where(.system-b-chat-file-chip:focus-within)');
+    expect(styles).toContain('border-color: var(--color-focus-ring);');
+    expect(styles).toContain(
+      ':where(.system-b-chat-file-chip-remove:focus-visible)'
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/chat-file-drop-chip-contrast-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-file-drop-chip-contrast-guard.test.ts
@@ -6,9 +6,14 @@ const readSource = (path: string) =>
   readFileSync(resolve(process.cwd(), path), 'utf8');
 
 describe('chat file-drop image chip contrast guard (JOV-4557)', () => {
-  it('keeps the completed chip on canonical surfaces with a visible keyboard state', () => {
+  it('keeps the completed chip on canonical surfaces and leaves keyboard focus to its Button primitive', () => {
     const chip = readSource('components/jovie/components/ChatFileChips.tsx');
     const styles = readSource('styles/chat-file-upload.css');
+    const contrastPairs = JSON.parse(
+      readSource('contrast-pairs.config.json')
+    ) as {
+      pairs: Array<{ fg: string; bg: string; minRatio: number }>;
+    };
 
     expect(chip).toContain('data-upload-state={f.status}');
     expect(chip).toContain('system-b-chat-file-chip-label');
@@ -19,10 +24,16 @@ describe('chat file-drop image chip contrast guard (JOV-4557)', () => {
     );
     expect(styles).toContain('background: var(--system-b-bg-surface-1);');
     expect(styles).toContain('color: var(--color-text-primary-token);');
-    expect(styles).toContain(':where(.system-b-chat-file-chip:focus-within)');
-    expect(styles).toContain('border-color: var(--color-focus-ring);');
+    expect(styles).not.toContain('.system-b-chat-file-chip:focus-within');
     expect(styles).toContain(
       ':where(.system-b-chat-file-chip-remove:focus-visible)'
+    );
+    expect(contrastPairs.pairs).toContainEqual(
+      expect.objectContaining({
+        fg: '--color-text-primary-token',
+        bg: '--color-bg-surface-1',
+        minRatio: 4.5,
+      })
     );
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:e09ece94-54ec-47d4-906f-e23e5a7fdcd3 -->
<!-- linear-issue-identifier:JOV-4557 -->

## Summary
- place completed file-drop image chips on the canonical surface token and use the primary text token
- add hover and focus-within treatments through the existing focus tokens
- add a narrow guard for the real chat file-chip primitive so the generic token-pair gate cannot silently miss it

## Verification
- `pnpm biome check --write apps/web/components/jovie/components/ChatFileChips.tsx apps/web/styles/chat-file-upload.css apps/web/tests/unit/chat/chat-file-drop-chip-contrast-guard.test.ts`
- `pnpm --filter web exec vitest run tests/unit/chat/chat-file-drop-chip-contrast-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push affected verify bundle and staged a11y check

## Bug-to-test
- Regression test added: `chat-file-drop-chip-contrast-guard.test.ts` validates the completed image-chip primitive uses canonical surface/text/focus tokens rather than its former translucent-only surface.

## Visual proof
- Remaining: exact-head desktop and 390px dark/light capture, including hover/focus-visible and uploading/error/completed states. No dev server or browser was started in this bounded slice.