### PR TITLE
fix(qa): follow test-auth redirects explicitly

### DIFF
--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -93,6 +93,12 @@ interface CaptureFailure {
   readonly message: string;
 }
 
+interface CaptureTestAuthRedirect {
+  status: number | null;
+  location: string | null;
+  currentUrl: string;
+}
+
 interface CaptureTeardown {
   page: TeardownStatus;
   context: TeardownStatus;
@@ -106,6 +112,7 @@ export interface AuthenticatedRouteCaptureReceipt {
   readonly requestedPath: string;
   readonly persona: AuthenticatedCapturePersona;
   readonly targetUrl: string;
+  readonly testAuthRedirect: CaptureTestAuthRedirect;
   finalUrl: string;
   title: string;
   readonly startedAt: string;
@@ -1061,6 +1068,11 @@ export async function runAuthenticatedRouteCapture(
     requestedPath: options.requestedPath,
     persona,
     targetUrl,
+    testAuthRedirect: {
+      status: null,
+      location: null,
+      currentUrl: targetUrl,
+    },
     finalUrl: targetUrl,
     title: '',
     startedAt: now(),
@@ -1193,6 +1205,11 @@ export async function runAuthenticatedRouteCapture(
         errorText: request.failure()?.errorText ?? 'unknown request failure',
       });
     });
+    page.on('response', response => {
+      if (response.url() !== targetUrl) return;
+      receipt.testAuthRedirect.status = response.status();
+      receipt.testAuthRedirect.location = response.headers().location ?? null;
+    });
     await checkpoint('page-created');
 
     await checkpoint('navigation-started');
@@ -1203,7 +1220,27 @@ export async function runAuthenticatedRouteCapture(
         timeout: Math.min(timeoutMs, 45_000),
       })
     );
+    receipt.testAuthRedirect.currentUrl = page.url() || receipt.finalUrl;
+    receipt.finalUrl = receipt.testAuthRedirect.currentUrl;
     await checkpoint('navigation-committed');
+    if (receipt.testAuthRedirect.status === null) {
+      throw new Error(
+        'Test-auth response was not observed before the authenticated route readiness wait.'
+      );
+    }
+    if (receipt.testAuthRedirect.status !== 303) {
+      throw new Error(
+        `Test-auth returned HTTP ${receipt.testAuthRedirect.status}; expected HTTP 303.`
+      );
+    }
+    if (!receipt.testAuthRedirect.location) {
+      throw new Error('Test-auth 303 did not include a redirect location.');
+    }
+    if (receipt.finalUrl === 'about:blank') {
+      throw new Error(
+        `Test-auth redirected to ${receipt.testAuthRedirect.location}, but navigation ended at about:blank before readiness.`
+      );
+    }
 
     await checkpoint('stability-wait-started');
     await runBounded(

--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -1205,29 +1205,16 @@ export async function runAuthenticatedRouteCapture(
         errorText: request.failure()?.errorText ?? 'unknown request failure',
       });
     });
-    page.on('response', response => {
-      if (response.url() !== targetUrl) return;
-      receipt.testAuthRedirect.status = response.status();
-      receipt.testAuthRedirect.location = response.headers().location ?? null;
-    });
     await checkpoint('page-created');
 
     await checkpoint('navigation-started');
-    await runBounded(
-      'Authenticated route navigation',
-      page.goto(targetUrl, {
-        waitUntil: 'commit',
-        timeout: Math.min(timeoutMs, 45_000),
-      })
+    const bootstrapResponse = await runBounded(
+      'Test-auth bootstrap request',
+      context.request.get(targetUrl, { maxRedirects: 0 })
     );
-    receipt.testAuthRedirect.currentUrl = page.url() || receipt.finalUrl;
-    receipt.finalUrl = receipt.testAuthRedirect.currentUrl;
-    await checkpoint('navigation-committed');
-    if (receipt.testAuthRedirect.status === null) {
-      throw new Error(
-        'Test-auth response was not observed before the authenticated route readiness wait.'
-      );
-    }
+    receipt.testAuthRedirect.status = bootstrapResponse.status();
+    receipt.testAuthRedirect.location =
+      bootstrapResponse.headers().location ?? null;
     if (receipt.testAuthRedirect.status !== 303) {
       throw new Error(
         `Test-auth returned HTTP ${receipt.testAuthRedirect.status}; expected HTTP 303.`
@@ -1236,6 +1223,21 @@ export async function runAuthenticatedRouteCapture(
     if (!receipt.testAuthRedirect.location) {
       throw new Error('Test-auth 303 did not include a redirect location.');
     }
+    const destinationUrl = new URL(
+      receipt.testAuthRedirect.location,
+      baseUrl
+    ).toString();
+    await checkpoint('test-auth-redirect-persisted');
+    await runBounded(
+      'Authenticated destination navigation',
+      page.goto(destinationUrl, {
+        waitUntil: 'commit',
+        timeout: Math.min(timeoutMs, 45_000),
+      })
+    );
+    receipt.testAuthRedirect.currentUrl = page.url() || receipt.finalUrl;
+    receipt.finalUrl = receipt.testAuthRedirect.currentUrl;
+    await checkpoint('navigation-committed');
     if (receipt.finalUrl === 'about:blank') {
       throw new Error(
         `Test-auth redirected to ${receipt.testAuthRedirect.location}, but navigation ended at about:blank before readiness.`

--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -1187,6 +1187,27 @@ export async function runAuthenticatedRouteCapture(
     );
     await checkpoint('context-created');
 
+    await checkpoint('page-bootstrap-pending');
+    await checkpoint('navigation-started');
+    const bootstrapResponse = await runBounded(
+      'Test-auth bootstrap request',
+      context.request.get(targetUrl, { maxRedirects: 0 })
+    );
+    receipt.testAuthRedirect.status = bootstrapResponse.status();
+    receipt.testAuthRedirect.location =
+      bootstrapResponse.headers().location ?? null;
+    if (receipt.testAuthRedirect.status !== 303)
+      throw new Error(
+        `Test-auth returned HTTP ${receipt.testAuthRedirect.status}; expected HTTP 303.`
+      );
+    if (!receipt.testAuthRedirect.location)
+      throw new Error('Test-auth 303 did not include a redirect location.');
+    const destinationUrl = new URL(
+      receipt.testAuthRedirect.location,
+      baseUrl
+    ).toString();
+    await checkpoint('test-auth-redirect-persisted');
+
     page = await runBounded('Page creation', context.newPage());
     page.setDefaultNavigationTimeout(timeoutMs);
     page.setDefaultTimeout(Math.min(timeoutMs, 15_000));
@@ -1206,28 +1227,6 @@ export async function runAuthenticatedRouteCapture(
       });
     });
     await checkpoint('page-created');
-
-    await checkpoint('navigation-started');
-    const bootstrapResponse = await runBounded(
-      'Test-auth bootstrap request',
-      context.request.get(targetUrl, { maxRedirects: 0 })
-    );
-    receipt.testAuthRedirect.status = bootstrapResponse.status();
-    receipt.testAuthRedirect.location =
-      bootstrapResponse.headers().location ?? null;
-    if (receipt.testAuthRedirect.status !== 303) {
-      throw new Error(
-        `Test-auth returned HTTP ${receipt.testAuthRedirect.status}; expected HTTP 303.`
-      );
-    }
-    if (!receipt.testAuthRedirect.location) {
-      throw new Error('Test-auth 303 did not include a redirect location.');
-    }
-    const destinationUrl = new URL(
-      receipt.testAuthRedirect.location,
-      baseUrl
-    ).toString();
-    await checkpoint('test-auth-redirect-persisted');
     await runBounded(
       'Authenticated destination navigation',
       page.goto(destinationUrl, {

--- a/apps/web/tests/scripts/route-qa-auth-capture.test.ts
+++ b/apps/web/tests/scripts/route-qa-auth-capture.test.ts
@@ -163,7 +163,7 @@ describe('route-qa authenticated capture', () => {
       status: 'fail',
       finalUrl: 'http://localhost:3220/app',
       failure: {
-        stage: 'test-auth-redirect-persisted',
+        stage: 'page-created',
         message: 'Authenticated destination navigation timed out after 5ms.',
       },
       teardown: {
@@ -261,6 +261,15 @@ describe('route-qa authenticated capture', () => {
       'http://localhost:3220/app/contacts',
       expect.objectContaining({ waitUntil: 'commit' })
     );
+    expect(
+      persisted
+        .find(value =>
+          value.checkpoints.some(
+            checkpoint => checkpoint.stage === 'test-auth-redirect-persisted'
+          )
+        )
+        ?.checkpoints.map(checkpoint => checkpoint.stage)
+    ).not.toContain('page-created');
   });
 
   it.each([

--- a/apps/web/tests/scripts/route-qa-auth-capture.test.ts
+++ b/apps/web/tests/scripts/route-qa-auth-capture.test.ts
@@ -22,14 +22,6 @@ function createFakeRuntime(options?: {
       listeners.set(event, listener);
     }),
     goto: vi.fn(async (url: string) => {
-      if (options?.delayedTestAuthResponse) {
-        await Promise.resolve();
-      }
-      listeners.get('response')?.({
-        url: () => url,
-        status: () => options?.testAuthStatus ?? 303,
-        headers: () => ({ location: options?.testAuthLocation ?? '/app' }),
-      } as never);
       if (options?.consoleError) {
         listeners.get('console')?.({
           type: () => 'error',
@@ -63,6 +55,15 @@ function createFakeRuntime(options?: {
     close: vi.fn().mockResolvedValue(undefined),
   };
   const context = {
+    request: {
+      get: vi.fn(async () => {
+        if (options?.delayedTestAuthResponse) await Promise.resolve();
+        return {
+          status: () => options?.testAuthStatus ?? 303,
+          headers: () => ({ location: options?.testAuthLocation ?? '/app' }),
+        };
+      }),
+    },
     newPage: vi.fn().mockResolvedValue(page),
     close: vi.fn().mockResolvedValue(undefined),
   };
@@ -162,8 +163,8 @@ describe('route-qa authenticated capture', () => {
       status: 'fail',
       finalUrl: 'http://localhost:3220/app',
       failure: {
-        stage: 'navigation-started',
-        message: 'Authenticated route navigation timed out after 5ms.',
+        stage: 'test-auth-redirect-persisted',
+        message: 'Authenticated destination navigation timed out after 5ms.',
       },
       teardown: {
         page: 'closed',
@@ -252,6 +253,44 @@ describe('route-qa authenticated capture', () => {
       currentUrl: 'http://localhost:3220/app/contacts',
     });
     expect(runtime.page.waitForLoadState).toHaveBeenCalled();
+    expect(runtime.context.request.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/dev/test-auth/enter'),
+      { maxRedirects: 0 }
+    );
+    expect(runtime.page.goto).toHaveBeenCalledWith(
+      'http://localhost:3220/app/contacts',
+      expect.objectContaining({ waitUntil: 'commit' })
+    );
+  });
+
+  it.each([
+    [
+      'non-303',
+      { testAuthStatus: 200 },
+      'Test-auth returned HTTP 200; expected HTTP 303.',
+    ],
+    [
+      'missing Location',
+      { testAuthLocation: '' },
+      'Test-auth 303 did not include a redirect location.',
+    ],
+  ])('persists a %s bootstrap failure without navigating the page', async (_name, options, message) => {
+    const runtime = createFakeRuntime(options);
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-invalid-redirect',
+        timeoutMs: 50,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        persistReceipt: vi.fn().mockResolvedValue(undefined),
+      }
+    );
+    expect(receipt.failure?.message).toBe(message);
+    expect(runtime.page.goto).not.toHaveBeenCalled();
   });
 
   it('turns an aborted destination ending at about:blank into a persisted redirect failure', async () => {

--- a/apps/web/tests/scripts/route-qa-auth-capture.test.ts
+++ b/apps/web/tests/scripts/route-qa-auth-capture.test.ts
@@ -9,6 +9,10 @@ function createFakeRuntime(options?: {
   readonly consoleError?: string;
   readonly pageError?: string;
   readonly failedRequest?: string;
+  readonly testAuthStatus?: number;
+  readonly testAuthLocation?: string;
+  readonly currentUrl?: string;
+  readonly delayedTestAuthResponse?: boolean;
 }) {
   const listeners = new Map<string, (value: never) => void>();
   const page = {
@@ -17,7 +21,15 @@ function createFakeRuntime(options?: {
     on: vi.fn((event: string, listener: (value: never) => void) => {
       listeners.set(event, listener);
     }),
-    goto: vi.fn(async () => {
+    goto: vi.fn(async (url: string) => {
+      if (options?.delayedTestAuthResponse) {
+        await Promise.resolve();
+      }
+      listeners.get('response')?.({
+        url: () => url,
+        status: () => options?.testAuthStatus ?? 303,
+        headers: () => ({ location: options?.testAuthLocation ?? '/app' }),
+      } as never);
       if (options?.consoleError) {
         listeners.get('console')?.({
           type: () => 'error',
@@ -39,7 +51,7 @@ function createFakeRuntime(options?: {
       return options?.navigation;
     }),
     waitForLoadState: vi.fn().mockResolvedValue(undefined),
-    url: vi.fn(() => 'http://localhost:3220/app'),
+    url: vi.fn(() => options?.currentUrl ?? 'http://localhost:3220/app'),
     title: vi.fn().mockResolvedValue('Jovie'),
     locator: vi.fn((selector: string) => ({
       first: () => ({
@@ -90,6 +102,11 @@ describe('route-qa authenticated capture', () => {
       screenshotPath:
         '/tmp/route-qa-auth-capture-success/authenticated-route-capture.png',
       failure: null,
+      testAuthRedirect: {
+        status: 303,
+        location: '/app',
+        currentUrl: 'http://localhost:3220/app',
+      },
       teardown: {
         page: 'closed',
         context: 'closed',
@@ -195,6 +212,96 @@ describe('route-qa authenticated capture', () => {
         errorText: 'net::ERR_FAILED',
       },
     ]);
+  });
+
+  it('persists a delayed test-auth 303 before waiting for app readiness', async () => {
+    const runtime = createFakeRuntime({
+      testAuthLocation: '/app/contacts',
+      currentUrl: 'http://localhost:3220/app/contacts',
+      delayedTestAuthResponse: true,
+    });
+    const persisted: AuthenticatedRouteCaptureReceipt[] = [];
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app/contacts',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-delayed-303',
+        timeoutMs: 50,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: async value => {
+          persisted.push(structuredClone(value));
+        },
+      }
+    );
+
+    expect(receipt.status).toBe('pass');
+    expect(
+      persisted.find(value =>
+        value.checkpoints.some(
+          checkpoint => checkpoint.stage === 'navigation-committed'
+        )
+      )?.testAuthRedirect
+    ).toEqual({
+      status: 303,
+      location: '/app/contacts',
+      currentUrl: 'http://localhost:3220/app/contacts',
+    });
+    expect(runtime.page.waitForLoadState).toHaveBeenCalled();
+  });
+
+  it('turns an aborted destination ending at about:blank into a persisted redirect failure', async () => {
+    const runtime = createFakeRuntime({
+      testAuthLocation: '/app/contacts',
+      currentUrl: 'about:blank',
+      failedRequest: 'http://localhost:3220/app/contacts',
+    });
+    const persisted: AuthenticatedRouteCaptureReceipt[] = [];
+
+    const receipt = await runAuthenticatedRouteCapture(
+      {
+        requestedPath: '/app/contacts',
+        baseUrl: 'http://localhost:3220',
+        outputRoot: '/tmp/route-qa-auth-capture-aborted-destination',
+        timeoutMs: 50,
+        closeTimeoutMs: 50,
+      },
+      {
+        launchBrowser: vi.fn().mockResolvedValue(runtime.browser as never),
+        now: () => '2026-07-29T00:00:00.000Z',
+        persistReceipt: async value => {
+          persisted.push(structuredClone(value));
+        },
+      }
+    );
+
+    expect(receipt).toMatchObject({
+      status: 'fail',
+      finalUrl: 'about:blank',
+      testAuthRedirect: {
+        status: 303,
+        location: '/app/contacts',
+        currentUrl: 'about:blank',
+      },
+      failure: {
+        stage: 'navigation-committed',
+        message:
+          'Test-auth redirected to /app/contacts, but navigation ended at about:blank before readiness.',
+      },
+    });
+    expect(receipt.failedRequests).toEqual([
+      {
+        method: 'GET',
+        url: 'http://localhost:3220/app/contacts',
+        errorText: 'net::ERR_FAILED',
+      },
+    ]);
+    expect(persisted.at(-1)).toEqual(receipt);
+    expect(runtime.page.waitForLoadState).not.toHaveBeenCalled();
   });
 
   it('does not skip teardown when persisting a cleanup checkpoint fails', async () => {


### PR DESCRIPTION
Fixes JOV-4552.

<!-- linear-issue-id:JOV-4552 -->

Persists the test-auth 303 and Location through the shared BrowserContext request API with redirects disabled before browser page creation, then explicitly navigates to the resolved destination.

Verification:
- focused route-capture tests pass
- Biome and diff checks pass
- normal pre-push affected gate passes: 2,422 passed, 9 skipped, 2 todo
- exact runtime receipt persisted the 303 and /app/settings/account destination before page creation

Known separate runtime boundary: destination page navigation can still time out under the local cold Webpack harness; this PR does not claim application-route visual acceptance.