### PR TITLE
fix(mq): treat PR visual review as advisory in drain classifier

### DIFF
--- a/scripts/lib/__tests__/pr-check-failures.test.mjs
+++ b/scripts/lib/__tests__/pr-check-failures.test.mjs
@@ -84,6 +84,11 @@ describe('pr-check-failures', () => {
     expect(ADVISORY_CHECK_NAMES).toContain('Extended Smoke (Preview)');
     expect(ADVISORY_CHECK_NAMES).toContain('Classify PR taste');
     expect(ADVISORY_CHECK_NAMES).toContain('Claude Review');
+    expect(ADVISORY_CHECK_NAMES).toContain(
+      'Review screenshots and post advisory review'
+    );
+    expect(ADVISORY_CHECK_NAMES).toContain('SonarCloud Code Analysis');
+    expect(ADVISORY_CHECK_NAMES).toContain('Vercel Agent Review');
     expect(ADVISORY_CHECK_NAMES).not.toContain('Brand Scrub');
     expect(
       extractTerminalFailures([
@@ -95,6 +100,9 @@ describe('pr-check-failures', () => {
         { bucket: 'fail', name: 'E2E Smoke (PR Fast Feedback)' },
         { bucket: 'fail', name: 'Extended Smoke (Preview)' },
         { bucket: 'fail', name: 'A11y (authenticated, informational)' },
+        { bucket: 'fail', name: 'Review screenshots and post advisory review' },
+        { bucket: 'fail', name: 'SonarCloud Code Analysis' },
+        { bucket: 'fail', name: 'Vercel Agent Review' },
       ])
     ).toEqual(['Gitleaks Secret Scanning', 'Security Advisory Enforcement']);
   });

--- a/scripts/lib/pr-check-failures.mjs
+++ b/scripts/lib/pr-check-failures.mjs
@@ -57,6 +57,13 @@ export const ADVISORY_CHECK_NAMES = Object.freeze(
     'Taste Label Guard',
     'Claude Review',
     'Seer Code Review',
+    // PR Visual Review is explicitly advisory (workflow header + job name).
+    // Terminal red must not dequeue green native-MQ members.
+    'Review screenshots and post advisory review',
+    'PR Visual Review',
+    // Hosted quality signals — not branch-protection required contexts.
+    'SonarCloud Code Analysis',
+    'Vercel Agent Review',
     'scope-judge',
     'Scope Alignment Check',
     // Folded into ci-fast's Structural Contract; retained for old PR heads


### PR DESCRIPTION
## Summary
- Autoenroll/drain treated `Review screenshots and post advisory review` as a hard failure and dequeued otherwise-green native MQ members (thrash on #15097).
- Allowlist that PR Visual Review job name (workflow is explicitly advisory) plus SonarCloud Code Analysis and Vercel Agent Review as non-blocking signals.
- Tests updated so terminal advisory reds do not appear in extractTerminalFailures.

## Proof
- Local smoke: advisory names ignored; ci-fast / secret scan still fail closed.
- After land: re-enroll orphans should stop bouncing on screenshot-review FAILURE.

## Test plan
- [x] Module smoke for allowlist + terminal failure filter
- [ ] CI on this PR green
- [ ] Native enroll this PR
- [ ] Confirm #15097 no longer dequeued solely for advisory screenshot review
