### PR TITLE
fix(calendar): remove redundant toolbar subtitle

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -26,10 +26,7 @@ import {
 } from '@/app/app/(shell)/dashboard/tour-dates/events-actions';
 import { NavigationDestinationReady } from '@/components/features/dashboard/NavigationDestinationReady';
 import { PageContent, PageShell } from '@/components/organisms/PageShell';
-import {
-  PAGE_TOOLBAR_META_TEXT_CLASS,
-  PageToolbar,
-} from '@/components/organisms/table';
+import { PageToolbar } from '@/components/organisms/table';
 import { getEventLocalDateKey } from '@/lib/events/date';
 import { normalizeTicketUrl } from '@/lib/events/ticket-url';
 import { queryKeys } from '@/lib/queries';
@@ -425,11 +422,6 @@ export function CalendarPageClient() {
       data-testid='calendar-workspace'
       toolbar={
         <PageToolbar
-          start={
-            <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
-              Releases and events at a glance.
-            </span>
-          }
           end={
             <div className='flex flex-wrap items-center justify-end gap-1'>
               <FilterPill

--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -422,6 +422,7 @@ export function CalendarPageClient() {
       data-testid='calendar-workspace'
       toolbar={
         <PageToolbar
+          start={null}
           end={
             <div className='flex flex-wrap items-center justify-end gap-1'>
               <FilterPill

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -145,6 +145,9 @@ describe('CalendarPageClient', () => {
     expect(mocks.useReleasesQuery).toHaveBeenCalledWith('profile-1');
     expect(screen.getByText('May Release')).toBeInTheDocument();
     expect(screen.getByText('Movement Festival')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Releases and events at a glance.')
+    ).not.toBeInTheDocument();
   });
 
   it('keeps event review filtering backed by the event query', () => {


### PR DESCRIPTION
Resolves JOV-4562.

## Scope
- removes the redundant Calendar toolbar subtitle to tighten header-to-toolbar spacing
- retains the existing Calendar header and controls

## Local verification
- `biome check` on the 2 changed files: passed
- `git diff --check origin/main...HEAD`: passed
- focused `CalendarPageClient.test.tsx`: blocked before test collection by the existing Vite dependency-resolution error `Failed to resolve import "ws" from apps/web/lib/db/client/connection.ts`; no assertions ran and this slice does not modify that dependency path

## Admission
Draft and gated. No server/browser/Kimi capture, ready state, queue, or merge action has been taken.