### PR TITLE
fix(contacts): consolidate empty-state actions

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -109,8 +109,7 @@ export const ContactsTable = memo(function ContactsTable({
           ariaLabel='Add contact'
           onClick={() => onAddContactRef.current()}
           icon={<Plus className='h-3.5 w-3.5' />}
-          iconOnly
-          tooltipLabel='Add contact'
+          label='Add contact'
         />
       </DashboardHeaderActionGroup>
     ),
@@ -217,14 +216,10 @@ export const ContactsTable = memo(function ContactsTable({
             <EmptyState
               icon={<UserPlus className='h-6 w-6' aria-hidden='true' />}
               heading='No Contacts Yet'
-              description='Add bookings, management, and press contacts so fans and industry know who to reach.'
+              description='Add a contact to keep your team connected.'
               action={{
-                label: 'Add Bookings Contact',
-                onClick: () => onAddContact('bookings'),
-              }}
-              secondaryAction={{
-                label: 'Add Management Contact',
-                onClick: () => onAddContact('management'),
+                label: 'Add contact',
+                onClick: () => onAddContact(),
               }}
             />
           ) : (

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { rowState } from '@/components/organisms/table/table.styles';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
 import { ContactsTable } from '@/features/dashboard/organisms/contacts-table/ContactsTable';
@@ -17,6 +17,7 @@ vi.mock('@/contexts/HeaderActionsContext', () => ({
 vi.mock('@/contexts/TableMetaContext', () => ({
   useTableMeta: () => ({
     setTableMeta,
+    tableMeta: { rightPanelWidth: 0 },
   }),
 }));
 
@@ -112,6 +113,11 @@ const contacts: EditableContact[] = [
 ];
 
 describe('ContactsTable', () => {
+  beforeEach(() => {
+    setHeaderActions.mockClear();
+    setTableMeta.mockClear();
+  });
+
   it('uses shell-selected row chrome and keeps the detail surface flat', () => {
     render(
       <ContactsTable
@@ -169,5 +175,45 @@ describe('ContactsTable', () => {
       'true'
     );
     expect(screen.queryByText('No Contacts Yet')).not.toBeInTheDocument();
+  });
+
+  it('uses one concise add-contact action in the empty state and header', () => {
+    const onAddContact = vi.fn();
+
+    render(
+      <ContactsTable
+        contacts={[]}
+        artistName='Tim White'
+        onUpdate={() => undefined}
+        onSave={async () => undefined}
+        onDelete={() => undefined}
+        onAddContact={onAddContact}
+      />
+    );
+
+    expect(screen.getByText('No Contacts Yet')).toBeInTheDocument();
+    expect(
+      screen.getByText('Add a contact to keep your team connected.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add contact' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Add Bookings Contact')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Add Management Contact')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add contact' }));
+    expect(onAddContact).toHaveBeenCalledWith();
+
+    const headerActions = setHeaderActions.mock.calls.find(
+      ([actions]) => actions
+    )?.[0];
+    expect(headerActions).toBeTruthy();
+    render(headerActions);
+
+    expect(screen.getAllByRole('button', { name: 'Add contact' })).toHaveLength(
+      2
+    );
   });
 });


### PR DESCRIPTION
JOV-4565

Simplifies the Contacts empty state to one concise Add contact CTA and makes the existing header action an explicit Add contact control. Removes the Bookings/Management CTA split while preserving existing no-role add behavior and all contact forms.

## Verification

- pnpm --filter web exec vitest run tests/unit/dashboard/ContactsTable.test.tsx (3/3)
- pnpm biome check --write on modified files
- git diff --check

## Hold

Runtime desktop/mobile proof and Kimi design review are intentionally held pending the serialized runtime slot. This PR remains draft, gated, and unqueued.