### PR TITLE
fix(library): compact dates and status pills

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -543,6 +543,23 @@ const ApprovalStatusCell = memo(function ApprovalStatusCell({
   );
 });
 
+const ReleaseDateCell = memo(function ReleaseDateCell({
+  asset,
+}: {
+  readonly asset: LibraryReleaseAsset;
+}) {
+  return (
+    <span
+      className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'
+      title={formatLibraryReleaseDateTitle(asset.releaseDate)}
+    >
+      {asset.releaseDate
+        ? formatLibraryReleaseDate(asset.releaseDate)
+        : 'No date'}
+    </span>
+  );
+});
+
 /**
  * Neutral fallback avatar color for provider keys missing from
  * `PROVIDER_CONFIG`. Points at a System B text token — no raw hex here.
@@ -661,16 +678,7 @@ const LIBRARY_CATALOG_COLUMNS = [
   libraryColumnHelper.display({
     id: 'releaseDate',
     header: 'Release Date',
-    cell: ({ row }) => (
-      <span
-        className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'
-        title={formatLibraryReleaseDateTitle(row.original.releaseDate)}
-      >
-        {row.original.releaseDate
-          ? formatLibraryReleaseDate(row.original.releaseDate)
-          : 'No date'}
-      </span>
-    ),
+    cell: ({ row }) => <ReleaseDateCell asset={row.original} />,
     size: 112,
     minSize: 96,
     meta: { className: 'pl-2 pr-3' },
@@ -704,16 +712,7 @@ const LIBRARY_TABLE_COLUMNS = [
   libraryColumnHelper.display({
     id: 'releaseDate',
     header: 'Release Date',
-    cell: ({ row }) => (
-      <span
-        className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'
-        title={formatLibraryReleaseDateTitle(row.original.releaseDate)}
-      >
-        {row.original.releaseDate
-          ? formatLibraryReleaseDate(row.original.releaseDate)
-          : 'No date'}
-      </span>
-    ),
+    cell: ({ row }) => <ReleaseDateCell asset={row.original} />,
     size: 112,
     minSize: 96,
     meta: { className: 'pl-2 pr-3' },

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -128,6 +128,7 @@ import { LibraryMediaThumbnail } from './LibraryMediaThumbnail';
 import {
   formatLibraryDuration,
   formatLibraryReleaseDate,
+  formatLibraryReleaseDateTitle,
   getLibraryAspectRatioClass,
   getLibraryAssetAspectRatio,
   getLibraryDrawerHeroClass,
@@ -511,7 +512,7 @@ const StatusCell = memo(function StatusCell({
     <span
       role='status'
       className={cn(
-        'system-b-library-status-pill inline-flex h-6 w-fit items-center whitespace-nowrap border px-2 leading-4',
+        'system-b-library-status-pill inline-flex h-6 w-fit max-w-full items-center truncate rounded-full border px-2 leading-4',
         releaseStatusClasses(asset.status)
       )}
       data-testid={`library-release-status-${asset.id}`}
@@ -531,7 +532,7 @@ const ApprovalStatusCell = memo(function ApprovalStatusCell({
     <span
       role='status'
       className={cn(
-        'system-b-library-status-pill inline-flex h-6 w-fit items-center whitespace-nowrap border px-2 leading-4',
+        'system-b-library-status-pill inline-flex h-6 w-fit max-w-full items-center truncate rounded-full border px-2 leading-4',
         libraryApprovalStatusClasses(asset.approvalStatus)
       )}
       data-testid={`library-approval-status-${asset.id}`}
@@ -661,7 +662,10 @@ const LIBRARY_CATALOG_COLUMNS = [
     id: 'releaseDate',
     header: 'Release Date',
     cell: ({ row }) => (
-      <span className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'>
+      <span
+        className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'
+        title={formatLibraryReleaseDateTitle(row.original.releaseDate)}
+      >
         {row.original.releaseDate
           ? formatLibraryReleaseDate(row.original.releaseDate)
           : 'No date'}
@@ -701,7 +705,10 @@ const LIBRARY_TABLE_COLUMNS = [
     id: 'releaseDate',
     header: 'Release Date',
     cell: ({ row }) => (
-      <span className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'>
+      <span
+        className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'
+        title={formatLibraryReleaseDateTitle(row.original.releaseDate)}
+      >
         {row.original.releaseDate
           ? formatLibraryReleaseDate(row.original.releaseDate)
           : 'No date'}
@@ -1512,7 +1519,7 @@ const AssetCard = memo(function AssetCard({
               <span
                 role='status'
                 className={cn(
-                  'system-b-library-card-status border px-1.5 py-0.5 leading-4',
+                  'system-b-library-card-status inline-flex max-w-full truncate rounded-full border px-1.5 py-0.5 leading-4',
                   releaseStatusClasses(asset.status)
                 )}
                 data-testid={`library-release-status-${asset.id}`}
@@ -1523,7 +1530,7 @@ const AssetCard = memo(function AssetCard({
               <span
                 role='status'
                 className={cn(
-                  'system-b-library-card-status border px-1.5 py-0.5 leading-4',
+                  'system-b-library-card-status inline-flex max-w-full truncate rounded-full border px-1.5 py-0.5 leading-4',
                   libraryApprovalStatusClasses(asset.approvalStatus)
                 )}
                 data-testid={`library-approval-status-${asset.id}`}
@@ -1973,7 +1980,7 @@ function ApprovalStatusEditor({
           aria-label='Approval Status'
           data-testid={`library-approval-status-select-${asset.id}`}
           className={cn(
-            'system-b-library-status-pill inline-flex h-6 items-center gap-1 whitespace-nowrap border px-2',
+            'system-b-library-status-pill inline-flex h-6 max-w-full items-center gap-1 truncate rounded-full border px-2',
             libraryApprovalStatusClasses(asset.approvalStatus),
             LIBRARY_BUTTON_FOCUS_CLASS
           )}
@@ -2197,7 +2204,7 @@ function AssetDrawer({
                     <span
                       role='status'
                       className={cn(
-                        'system-b-library-status-pill inline-flex h-6 items-center whitespace-nowrap border px-2',
+                        'system-b-library-status-pill inline-flex h-6 max-w-full items-center truncate rounded-full border px-2',
                         releaseStatusClasses(current.status)
                       )}
                       data-testid={`library-release-status-${current.id}`}
@@ -2310,7 +2317,15 @@ function AssetDrawer({
                       />
                       <MetadataRow
                         label={isMerch ? 'Updated' : 'Release Date'}
-                        value={formatLibraryReleaseDate(current.releaseDate)}
+                        value={
+                          <span
+                            title={formatLibraryReleaseDateTitle(
+                              current.releaseDate
+                            )}
+                          >
+                            {formatLibraryReleaseDate(current.releaseDate)}
+                          </span>
+                        }
                       />
                       <MetadataRow
                         label='Type'

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -320,6 +320,19 @@ export function formatLibraryReleaseDate(value: string | null): string {
   return new Intl.DateTimeFormat('en', {
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+export function formatLibraryReleaseDateTitle(value: string | null): string {
+  if (!value) return 'No Release Date';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'No Release Date';
+
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
     year: 'numeric',
     timeZone: 'UTC',
   }).format(date);

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -279,7 +279,8 @@ describe('LibrarySurface', () => {
 
     expect(statusPillClasses).toHaveLength(4);
     for (const className of statusPillClasses ?? []) {
-      expect(className).toContain('whitespace-nowrap');
+      expect(className).toContain('truncate');
+      expect(className).toContain('rounded-full');
     }
   });
 
@@ -320,7 +321,7 @@ describe('LibrarySurface', () => {
     renderLibrary([buildAsset()]);
 
     expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getByText('Apr 28, 2026')).toBeInTheDocument();
+    expect(screen.getByText('Apr 28')).toHaveAttribute('title', 'Apr 28, 2026');
     expect(
       screen.getByTestId('library-release-row-release-1')
     ).toBeInTheDocument();
@@ -666,7 +667,7 @@ describe('LibrarySurface', () => {
       }).length
     ).toBeGreaterThan(0);
     fireEvent.click(drawer.getByRole('button', { name: 'Details' }));
-    expect(drawer.getByText('Apr 28, 2026')).toBeDefined();
+    expect(drawer.getByText('Apr 28')).toHaveAttribute('title', 'Apr 28, 2026');
     expect(drawer.getByText('68/100')).toBeDefined();
     expect(drawer.getByText('Progressive House')).toBeDefined();
 

--- a/apps/web/tests/unit/library/library-data.test.ts
+++ b/apps/web/tests/unit/library/library-data.test.ts
@@ -5,6 +5,7 @@ import {
   buildLibraryReleaseAssets,
   formatLibraryDuration,
   formatLibraryReleaseDate,
+  formatLibraryReleaseDateTitle,
   getLibraryAspectRatioClass,
   getLibraryAssetAspectRatio,
   getLibraryDrawerHeroClass,
@@ -190,7 +191,8 @@ describe('library data', () => {
   });
 
   it('formats release dates without local timezone drift', () => {
-    expect(formatLibraryReleaseDate('2026-04-28T00:00:00.000Z')).toBe(
+    expect(formatLibraryReleaseDate('2026-04-28T00:00:00.000Z')).toBe('Apr 28');
+    expect(formatLibraryReleaseDateTitle('2026-04-28T00:00:00.000Z')).toBe(
       'Apr 28, 2026'
     );
     expect(formatLibraryReleaseDate(null)).toBe('No Release Date');


### PR DESCRIPTION
Resolves JOV-4560.

## Scope
- render compact library dates while preserving the full date in a native tooltip
- make release and approval status labels consistently rounded, bounded, and truncating across list, card, drawer, and editor surfaces

## Verification
- Biome on 4 changed files: passed
- focused Vitest: LibrarySurface 35/35; library-data 14/14
- git diff --check: passed
- JSDOM logs existing HTMLMediaElement.pause not-implemented noise during LibrarySurface, but suite passed

## Admission
Draft + gated; no runtime capture, Kimi, ready, queue, or merge action.