### PR TITLE
fix(library): simplify row artwork fallback

### DIFF
--- a/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
@@ -51,20 +51,13 @@ function LibraryArtworkImage({
   }
 
   return (
-    <div
-      className={cn(
-        'relative overflow-hidden border border-subtle bg-surface-1',
-        sizeClasses[size]
-      )}
-    >
-      <ArtworkFallbackTile
-        seed={asset.title}
-        size={
-          size === 'row' ? 'thumbnail' : size === 'drawer' ? 'hero' : 'default'
-        }
-        iconClassName={size === 'row' ? 'h-4 w-4' : 'h-[36%] w-[36%]'}
-      />
-    </div>
+    <ArtworkFallbackTile
+      seed={asset.title}
+      size={
+        size === 'row' ? 'thumbnail' : size === 'drawer' ? 'hero' : 'default'
+      }
+      iconClassName={size === 'row' ? 'h-4 w-4' : 'h-[36%] w-[36%]'}
+    />
   );
 }
 
@@ -95,6 +88,7 @@ export function LibraryMediaThumbnail({
     <div
       className={cn(
         'system-b-library-media-thumbnail relative h-full w-full overflow-hidden',
+        size === 'row' && 'rounded-sm',
         className
       )}
       data-testid={`library-media-thumbnail-${asset.id}`}

--- a/apps/web/components/atoms/ArtworkFallbackTile.tsx
+++ b/apps/web/components/atoms/ArtworkFallbackTile.tsx
@@ -27,6 +27,8 @@ export function ArtworkFallbackTile({
   iconClassName = 'h-[42%] w-[42%]',
   accentClassName = 'h-1',
 }: ArtworkFallbackTileProps) {
+  const isThumbnail = size === 'thumbnail';
+
   return (
     <div
       className={cn(
@@ -34,34 +36,36 @@ export function ArtworkFallbackTile({
         className
       )}
       data-artwork-fallback='true'
+      data-artwork-fallback-compact={isThumbnail || undefined}
       style={getArtworkFallbackSurfaceStyle(seed)}
     >
-      <span
-        aria-hidden='true'
-        className={cn(
-          'absolute inset-[8%] bg-[linear-gradient(135deg,rgba(255,255,255,0.09),rgba(255,255,255,0.012)_52%,rgba(0,0,0,0.13))] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_-24px_48px_rgba(0,0,0,0.14)]',
-          size === 'thumbnail'
-            ? 'rounded-[3%]'
-            : size === 'hero'
-              ? 'rounded-[10%]'
-              : 'rounded-[7%]'
-        )}
-        data-artwork-fallback-sleeve='true'
-      />
+      {!isThumbnail ? (
+        <span
+          aria-hidden='true'
+          className={cn(
+            'absolute inset-[8%] bg-[linear-gradient(135deg,rgba(255,255,255,0.09),rgba(255,255,255,0.012)_52%,rgba(0,0,0,0.13))] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_-24px_48px_rgba(0,0,0,0.14)]',
+            size === 'hero' ? 'rounded-[10%]' : 'rounded-[7%]'
+          )}
+          data-artwork-fallback-sleeve='true'
+        />
+      ) : null}
       <Disc3
         aria-hidden='true'
         className={cn(
-          'relative z-10 drop-shadow-[0_8px_28px_rgba(0,0,0,0.28)]',
+          'relative z-10',
+          !isThumbnail && 'drop-shadow-[0_8px_28px_rgba(0,0,0,0.28)]',
           iconClassName
         )}
         data-artwork-fallback-icon='true'
         strokeWidth={2.1}
       />
-      <span
-        aria-hidden='true'
-        className={cn('absolute inset-x-0 bottom-0 z-10', accentClassName)}
-        style={getArtworkFallbackAccentStyle(seed)}
-      />
+      {!isThumbnail ? (
+        <span
+          aria-hidden='true'
+          className={cn('absolute inset-x-0 bottom-0 z-10', accentClassName)}
+          style={getArtworkFallbackAccentStyle(seed)}
+        />
+      ) : null}
       {label ? <span className='sr-only'>{label}</span> : null}
     </div>
   );

--- a/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
+++ b/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
@@ -68,7 +68,6 @@ describe('LibraryMediaThumbnail', () => {
   });
 
   it.each([
-    ['row', 'rounded-[3%]'],
     ['card', 'rounded-[7%]'],
     ['drawer', 'rounded-[10%]'],
   ] as const)('maps the %s fallback to the appropriate artwork corner radius', (size, expectedRadius) => {
@@ -86,6 +85,47 @@ describe('LibraryMediaThumbnail', () => {
     expect(
       container.querySelector('[data-artwork-fallback-sleeve="true"]')
     ).toHaveClass(expectedRadius);
+  });
+
+  it('uses a flat, subtly rounded fallback for row thumbnails', () => {
+    render(
+      <LibraryMediaThumbnail
+        asset={buildAsset({
+          artworkUrl: null,
+          previewUrl: null,
+          videoUrl: null,
+        })}
+        size='row'
+      />
+    );
+
+    const thumbnail = screen.getByTestId('library-media-thumbnail-release-1');
+    expect(thumbnail).toHaveClass('rounded-sm');
+    expect(
+      thumbnail.querySelector('[data-artwork-fallback="true"]')
+    ).toHaveAttribute('data-artwork-fallback-compact', 'true');
+    expect(
+      thumbnail.querySelector('[data-artwork-fallback-sleeve="true"]')
+    ).toBeNull();
+  });
+
+  it('preserves the real artwork image for row thumbnails', () => {
+    const { container } = render(
+      <LibraryMediaThumbnail
+        asset={buildAsset({ previewUrl: null, videoUrl: null })}
+        size='row'
+      />
+    );
+
+    expect(container.querySelector('img')).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/artwork.jpg'
+    );
+    expect(
+      screen
+        .queryByTestId('library-media-thumbnail-release-1')
+        ?.querySelector('[data-artwork-fallback="true"]')
+    ).toBeNull();
   });
 
   it('reveals an audio waveform scrub overlay on hover', () => {


### PR DESCRIPTION
JOV-4563

Simplifies fallback artwork only at Library row-thumbnail scale. Real artwork remains unchanged; the shared thumbnail fallback removes the nested sleeve, accent stripe, and drop shadow, while the Library wrapper removes redundant local border/background chrome. Existing seed-based palette/hash logic and card/hero treatment are preserved.

## Verification

- pnpm --filter web exec vitest run tests/unit/library/LibraryMediaThumbnail.test.tsx (8/8)
- pnpm biome check --write on modified files
- git diff --check

## Hold

Runtime desktop/mobile proof and Kimi design review are intentionally held pending the serialized runtime slot. This PR remains draft, gated, and unqueued.