### PR TITLE
fix(tasks): tighten desktop task split (JOV-4525)

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
@@ -13,7 +13,7 @@ export const TASK_DATA_TABLE_CONTAINER_CLASSNAME =
   'h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5';
 
 export const TASK_DATA_TABLE_ROW_CLASSNAME =
-  'group/row group/task-row !bg-transparent !shadow-none hover:!bg-transparent hover:!shadow-none focus-within:!bg-transparent focus-within:!shadow-none';
+  'group/row group/task-row !bg-transparent !shadow-none hover:!bg-transparent hover:!shadow-none focus-visible:!bg-transparent focus-visible:!shadow-none focus-within:!bg-transparent focus-within:!shadow-none';
 
 export type TaskDataTableProps<TData> = UnifiedTableProps<TData>;
 

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -175,7 +175,7 @@ export const TaskListRow = memo(function TaskListRow({
       isSelected={isSelected}
       interaction='task-row-group'
       className={cn(
-        'group/row flex h-full items-center gap-2.5 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
+        'group/row flex h-full w-full items-center gap-2.5 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
         isDone && !isSelected && 'opacity-75',
         isCancelled && !isSelected && 'opacity-60'
       )}

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -2232,7 +2232,7 @@ export function TasksPageClient() {
                   ? selectedTask
                     ? 'lg:grid-cols-[minmax(0,1fr)_minmax(18rem,20rem)] xl:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]'
                     : 'lg:grid-cols-1'
-                  : 'lg:grid-cols-[minmax(20rem,0.9fr)_minmax(0,1.1fr)]'
+                  : 'lg:grid-cols-[minmax(24rem,28rem)_minmax(0,1fr)]'
               )}
             >
               <div

--- a/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
@@ -70,6 +70,9 @@ describe('TaskDataTable', () => {
     expect(TASK_DATA_TABLE_ROW_CLASSNAME).not.toContain(
       'focus-visible:!ring-0'
     );
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).toContain(
+      'focus-visible:!shadow-none'
+    );
   });
 
   it('allows callers to extend task table chrome without losing row defaults', () => {

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -67,6 +67,7 @@ describe('TaskListRow', () => {
     );
 
     expect(getByTestId('task-list-row-task-1').className).toContain('py-1');
+    expect(getByTestId('task-list-row-task-1').className).toContain('w-full');
   });
 
   it('keeps the release link clickable and marks the selected state on the row shell', () => {

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -816,7 +816,7 @@ describe('TasksPageClient', () => {
 
     expect(screen.getByLabelText('Task Title')).toHaveValue(mockTaskTwo.title);
     expect(screen.getByTestId('task-list-pane').parentElement).toHaveClass(
-      'lg:grid-cols-[minmax(20rem,0.9fr)_minmax(0,1.1fr)]'
+      'lg:grid-cols-[minmax(24rem,28rem)_minmax(0,1fr)]'
     );
   });
 


### PR DESCRIPTION
## Summary
- Reserve a 24–28rem task-list column so task detail owns the remaining canvas.
- Make task-row surfaces span their allocated width.
- Keep keyboard focus on the interactive row rather than the outer table shell.

## Verification
- `TaskDataTable`, `TaskListRow`, and `TasksPageClient`: 63/63 passing.
- Biome and `git diff --check` clean.

## Admission
- Draft and `gated`. Seeded desktop/mobile split and focus proof plus Kimi review remain required before ready or queue admission.