### PR TITLE
ci: preflight workspace lockfile specifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,19 @@ jobs:
           echo "runner_class=$runner_class" >> "$GITHUB_OUTPUT"
           echo "::notice::Unit runner route: $runner_label — $HEARTBEAT_EVIDENCE"
 
+  ci-lockfile-preflight:
+    name: Lockfile Specifier Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Compare workspace manifest and lockfile specifiers
+        run: pnpm exec node scripts/lockfile-specifier-preflight.mjs
+
   # ── Centralized deterministic path-change detection ────────────────────
   # Source and combined heads compute their own exact diff. The former
   # Vendor queue reuse actions are intentionally absent: native queue provenance
@@ -982,11 +995,12 @@ jobs:
     name: ci-fast (typecheck)
     # JOV-4477: dedicated jobs keep structural Docker/Python action setup out of
     # the typecheck path while preserving parallel hosted fan-out.
-    needs: [ci-path-changes, ci-merge-group-admission]
+    needs: [ci-lockfile-preflight, ci-path-changes, ci-merge-group-admission]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     if: >-
       !cancelled() &&
+      needs.ci-lockfile-preflight.result == 'success' &&
       needs.ci-path-changes.result == 'success' &&
       (
         github.event_name != 'merge_group' ||
@@ -1039,11 +1053,12 @@ jobs:
     name: ci-fast (remaining)
     # JOV-4477: the structural Docker/Python actions stay isolated to the
     # remaining group, where their path-gated lane can actually run.
-    needs: [ci-path-changes, ci-merge-group-admission]
+    needs: [ci-lockfile-preflight, ci-path-changes, ci-merge-group-admission]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     if: >-
       !cancelled() &&
+      needs.ci-lockfile-preflight.result == 'success' &&
       needs.ci-path-changes.result == 'success' &&
       (
         github.event_name != 'merge_group' ||

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "ds:offscale": "node scripts/ds-offscale-report.mjs",
     "ds:llms-manifest": "node scripts/generate-llms-design-manifest.mjs",
     "ds:llms-manifest:check": "node scripts/generate-llms-design-manifest.mjs --check",
-    "ci:control:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/ci-duration-ratchet.test.mjs lib/__tests__/ci-branching-guard.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/ci-metrics-compute.test.mjs lib/__tests__/auto-ready-agent-drafts.test.mjs lib/__tests__/eval-main-health-action.test.mjs lib/__tests__/pr-check-failures.test.mjs lib/__tests__/pr-conflict-handler.test.mjs lib/__tests__/ci-fast-workflow-contract.test.mjs lib/__tests__/merge-group-workflow-contract.test.mjs",
+    "ci:control:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/ci-duration-ratchet.test.mjs lib/__tests__/ci-branching-guard.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/ci-metrics-compute.test.mjs lib/__tests__/auto-ready-agent-drafts.test.mjs lib/__tests__/eval-main-health-action.test.mjs lib/__tests__/pr-check-failures.test.mjs lib/__tests__/pr-conflict-handler.test.mjs lib/__tests__/ci-fast-workflow-contract.test.mjs lib/__tests__/merge-group-workflow-contract.test.mjs lib/__tests__/lockfile-specifier-preflight.test.mjs",
     "gate-ladder:validate": "node scripts/gate-ladder/validate.mjs",
     "gate-ladder:list": "node scripts/gate-ladder/run.mjs --list",
     "gate-ladder:test": "node --test scripts/gate-ladder/gate-ladder.test.mjs",

--- a/scripts/lib/__tests__/ci-fast-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/ci-fast-workflow-contract.test.mjs
@@ -68,8 +68,8 @@ describe('ci-fast bounded parallel workflow', () => {
       const selector = block.match(/CI_FAST_LANE_GROUP:\s*([^\s]+)/)?.[1];
       expect(selector, `missing hosted selector in ${jobId}`).toBeDefined();
       expect(block).toContain(`name: ci-fast (${selector})`);
-      expect(block).toContain(
-        'needs: [ci-path-changes, ci-merge-group-admission]'
+      expect(block).toMatch(
+        /needs: \[ci-lockfile-preflight, ci-path-changes, ci-merge-group-admission\]/
       );
       expect(block).toMatch(/if: >-\s+!cancelled\(\) &&/);
       expect(block).not.toContain('always()');
@@ -119,6 +119,24 @@ describe('ci-fast bounded parallel workflow', () => {
       structural:
         'pnpm ci:harness:check && pnpm ci:control:test && pnpm ci:merge-queue:check && pnpm next:proxy-guard && pnpm tailwind:check && pnpm --filter=@jovie/web run lint:no-native-dialogs && pnpm --filter=@jovie/web run lint:seo && pnpm --filter=@jovie/web run lint:contrast-ratchet && pnpm doc:freshness:check && pnpm test:reliability-detectors',
     });
+  });
+
+  it('runs the lockfile specifier preflight before expensive fast lanes', () => {
+    const preflight = jobBlock('ci-lockfile-preflight', 'ci-path-changes');
+    expect(preflight).toContain('name: Lockfile Specifier Preflight');
+    expect(preflight).toContain(
+      'run: pnpm exec node scripts/lockfile-specifier-preflight.mjs'
+    );
+    for (const jobId of ['ci-fast-typecheck', 'ci-fast-remaining']) {
+      expect(
+        jobBlock(
+          jobId,
+          jobId === 'ci-fast-typecheck' ? 'ci-fast-remaining' : 'ci-fast'
+        )
+      ).toMatch(
+        /needs: \[ci-lockfile-preflight, ci-path-changes, ci-merge-group-admission\]/
+      );
+    }
   });
 
   it('keeps workflow contracts in the bounded CI control suite', () => {

--- a/scripts/lib/__tests__/lockfile-specifier-preflight.test.mjs
+++ b/scripts/lib/__tests__/lockfile-specifier-preflight.test.mjs
@@ -1,0 +1,98 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  compareWorkspaceSpecifiers,
+  formatMismatches,
+} from '../../lockfile-specifier-preflight.mjs';
+
+const tempRoots = [];
+afterEach(() => {
+  for (const root of tempRoots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+function fixture(
+  lockfile,
+  manifest = { devDependencies: { typescript: '^6.0.3', vitest: '4.1.8' } }
+) {
+  const root = mkdtempSync(join(tmpdir(), 'jovie-lockfile-preflight-'));
+  tempRoots.push(root);
+  writeFileSync(
+    join(root, 'pnpm-workspace.yaml'),
+    "packages:\n  - 'packages/*'\n"
+  );
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  mkdirPackage(root, 'packages/audio-contracts', manifest);
+  return { root, lockfile };
+}
+
+function mkdirPackage(root, packagePath, manifest) {
+  const directory = join(root, packagePath);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'package.json'), JSON.stringify(manifest));
+}
+
+describe('lockfile importer specifier preflight', () => {
+  it('accepts matching workspace manifest specifiers', () => {
+    const { root, lockfile } = fixture(
+      `lockfileVersion: '9.0'\n\nimporters:\n  .:\n  packages/audio-contracts:\n    devDependencies:\n      typescript:\n        specifier: ^6.0.3\n      vitest:\n        specifier: 4.1.8\n`
+    );
+    expect(compareWorkspaceSpecifiers({ root, lockfile })).toEqual([]);
+  });
+
+  it('reports the exact package path and mismatched keys', () => {
+    const { root, lockfile } = fixture(
+      `lockfileVersion: '9.0'\n\nimporters:\n  .:\n  packages/audio-contracts:\n    devDependencies:\n      typescript:\n        specifier: ^5.9.0\n      vitest:\n        specifier: 4.1.8\n`
+    );
+    const mismatches = compareWorkspaceSpecifiers({ root, lockfile });
+    expect(mismatches).toEqual([
+      {
+        packagePath: 'packages/audio-contracts',
+        key: 'devDependencies:typescript',
+        expected: '^6.0.3',
+        actual: '^5.9.0',
+      },
+    ]);
+    expect(formatMismatches(mismatches)).toContain(
+      '- packages/audio-contracts: devDependencies:typescript (manifest="^6.0.3", lockfile="^5.9.0")'
+    );
+  });
+
+  it('fails closed when an importer dependency key is absent', () => {
+    const { root, lockfile } = fixture(
+      `lockfileVersion: '9.0'\n\nimporters:\n  .:\n  packages/audio-contracts:\n    devDependencies:\n      typescript:\n        specifier: ^6.0.3\n`
+    );
+    const mismatches = compareWorkspaceSpecifiers({ root, lockfile });
+    expect(mismatches).toEqual([
+      {
+        packagePath: 'packages/audio-contracts',
+        key: 'devDependencies:vitest',
+        expected: '4.1.8',
+        actual: 'missing',
+      },
+    ]);
+  });
+
+  it('returns a failing process with actionable output for a stale importer', () => {
+    const { root, lockfile } = fixture(
+      `lockfileVersion: '9.0'\n\nimporters:\n  .:\n  packages/audio-contracts:\n    devDependencies:\n      typescript:\n        specifier: ^5.9.0\n      vitest:\n        specifier: 4.1.8\n`
+    );
+    writeFileSync(join(root, 'pnpm-lock.yaml'), lockfile);
+    const result = spawnSync(
+      process.execPath,
+      [join(process.cwd(), 'scripts', 'lockfile-specifier-preflight.mjs')],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, JOVIE_REPO_ROOT: root },
+        encoding: 'utf8',
+      }
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '- packages/audio-contracts: devDependencies:typescript (manifest="^6.0.3", lockfile="^5.9.0")'
+    );
+  });
+});

--- a/scripts/lockfile-specifier-preflight.mjs
+++ b/scripts/lockfile-specifier-preflight.mjs
@@ -1,0 +1,161 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+];
+
+function yamlScalar(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replaceAll("''", "'");
+  }
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return JSON.parse(trimmed);
+  }
+  return trimmed;
+}
+
+export function parseImporterSpecifiers(lockfile) {
+  const lines = lockfile.split(/\r?\n/);
+  const importersIndex = lines.findIndex(line => line === 'importers:');
+  if (importersIndex === -1)
+    throw new Error('pnpm-lock.yaml is missing importers:');
+
+  const importers = new Map();
+  let importer;
+  let section;
+  let dependency;
+  for (const line of lines.slice(importersIndex + 1)) {
+    if (line && !/^\s/.test(line)) break;
+    const importerMatch = line.match(/^  (?! )(.+):(?:\s*\{\})?\s*$/);
+    if (importerMatch) {
+      importer = yamlScalar(importerMatch[1]);
+      importers.set(importer, {});
+      section = undefined;
+      dependency = undefined;
+      continue;
+    }
+    const sectionMatch = line.match(
+      /^    (dependencies|devDependencies|optionalDependencies|peerDependencies):\s*$/
+    );
+    if (sectionMatch && importer) {
+      section = sectionMatch[1];
+      dependency = undefined;
+      continue;
+    }
+    const dependencyMatch = line.match(/^      (.+):\s*$/);
+    if (dependencyMatch && importer && section) {
+      dependency = yamlScalar(dependencyMatch[1]);
+      continue;
+    }
+    const specifierMatch = line.match(/^        specifier:\s*(.+)$/);
+    if (specifierMatch && importer && section && dependency) {
+      importers.get(importer)[`${section}:${dependency}`] = yamlScalar(
+        specifierMatch[1]
+      );
+    }
+  }
+  return importers;
+}
+
+function workspacePackagePaths(root) {
+  const paths = ['.'];
+  const workspace = readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf8');
+  for (const match of workspace.matchAll(/^\s*-\s*['"]([^'"]+)['"]\s*$/gm)) {
+    const pattern = match[1];
+    if (!pattern.endsWith('/*'))
+      throw new Error(`Unsupported workspace pattern: ${pattern}`);
+    const parent = pattern.slice(0, -2);
+    for (const entry of readdirSync(join(root, parent)).sort()) {
+      const candidate = join(root, parent, entry);
+      if (
+        statSync(candidate).isDirectory() &&
+        statSync(join(candidate, 'package.json'), { throwIfNoEntry: false })
+      )
+        paths.push(relative(root, candidate));
+    }
+  }
+  return paths.sort();
+}
+
+export function compareWorkspaceSpecifiers({
+  root,
+  manifestByPath = undefined,
+  lockfile,
+}) {
+  const manifests =
+    manifestByPath ??
+    new Map(
+      workspacePackagePaths(root).map(packagePath => [
+        packagePath,
+        JSON.parse(
+          readFileSync(join(root, packagePath, 'package.json'), 'utf8')
+        ),
+      ])
+    );
+  const importers = parseImporterSpecifiers(lockfile);
+  const overrides = manifests.get('.')?.pnpm?.overrides ?? {};
+  const mismatches = [];
+  for (const [packagePath, manifest] of manifests) {
+    const importer = importers.get(packagePath);
+    if (!importer) {
+      mismatches.push({
+        packagePath,
+        key: '<importer>',
+        expected: 'present',
+        actual: 'missing',
+      });
+      continue;
+    }
+    for (const section of DEPENDENCY_SECTIONS) {
+      for (const [name, expected] of Object.entries(manifest[section] ?? {})) {
+        const key = `${section}:${name}`;
+        const effectiveExpected = overrides[name] ?? expected;
+        const actual = importer[key];
+        if (actual === undefined) {
+          mismatches.push({
+            packagePath,
+            key,
+            expected: effectiveExpected,
+            actual: 'missing',
+          });
+        } else if (actual !== effectiveExpected) {
+          mismatches.push({
+            packagePath,
+            key,
+            expected: effectiveExpected,
+            actual,
+          });
+        }
+      }
+    }
+  }
+  return mismatches;
+}
+
+export function formatMismatches(mismatches) {
+  return [
+    'Lockfile importer specifier preflight failed:',
+    ...mismatches.map(
+      ({ packagePath, key, expected, actual }) =>
+        `- ${packagePath}: ${key} (manifest=${JSON.stringify(expected)}, lockfile=${JSON.stringify(actual)})`
+    ),
+  ].join('\n');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const root = resolve(process.env.JOVIE_REPO_ROOT ?? process.cwd());
+  const mismatches = compareWorkspaceSpecifiers({
+    root,
+    lockfile: readFileSync(join(root, 'pnpm-lock.yaml'), 'utf8'),
+  });
+  if (mismatches.length) {
+    console.error(formatMismatches(mismatches));
+    process.exitCode = 1;
+  } else {
+    console.log('Lockfile importer specifier preflight passed.');
+  }
+}


### PR DESCRIPTION
## Summary
- Add an early deterministic workspace manifest/importer specifier preflight using pnpm 9.15.4 and Node.
- Fail closed with exact package paths and mismatched dependency keys before ci-fast lanes proceed.
- Add passing, mismatch, missing-key, and CLI non-zero contract coverage.

## Safety
- No dependency versions or pnpm-lock.yaml changed.
- Existing frozen-lockfile installs remain unchanged.
- PR targets `main`; do not merge.

## Verification
- `pnpm exec node scripts/lockfile-specifier-preflight.mjs`
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/lockfile-specifier-preflight.test.mjs lib/__tests__/ci-fast-workflow-contract.test.mjs`
- `pnpm ci:control:test` (12 files, 219 tests)
- `pnpm install --frozen-lockfile --ignore-scripts --offline`
- `git diff --check`
- `actionlint .github/workflows/ci.yml` reports existing unrelated ShellCheck diagnostics; no diagnostics point at the added preflight lines.