### PR TITLE
fix(ops): harden Symphony backlog admission

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -12,6 +12,7 @@ const scorer = await import('../scorer.mjs');
 const workstreamer = await import('../workstreamer.mjs');
 const reporter = await import('../reporter.mjs');
 const staleLease = await import('../stale-lease-guard.mjs');
+const admitter = await import('../admitter.mjs');
 
 function makeIssue(overrides = {}) {
   return {
@@ -363,5 +364,182 @@ describe('entrypoint contract', () => {
     assert.match(wrapperSource, /exec node backlog-orchestrator\.mjs \"\$@\"/);
     assert.match(await readFile(executable, 'utf8'), /Deterministic-first/);
     assert.equal(JSON.parse(await readFile(config, 'utf8')).version, 1);
+  });
+});
+
+describe('deterministic Symphony admission boundary', () => {
+  function admissionIssue(overrides = {}) {
+    return makeIssue({
+      id: overrides.id || `${overrides.identifier || 'JOV-900'}-id`,
+      identifier: overrides.identifier || 'JOV-900',
+      title: overrides.title || 'Fix the real thing',
+      state: overrides.state || 'Triage',
+      labels: overrides.labels || ['plan-approved', 'admission-approved'],
+      assignee: overrides.assignee || null,
+      comments: overrides.comments || [],
+      ...overrides,
+    });
+  }
+
+  function classification(issue) {
+    return {
+      identifier: issue.identifier,
+      title: issue.title,
+      category: 'triageable',
+      mrrCategory: 'reliability',
+      mrrConfidence: 'high',
+      effort: 'small',
+      relatedIssues: [],
+      labels: issue.labels.nodes.map(label => label.name),
+      issue,
+    };
+  }
+
+  function fakeClient(issue, rereads = []) {
+    const reads = [...rereads];
+    const calls = { transitions: [], labels: [], comments: [], rereads: 0 };
+    return {
+      calls,
+      async fetchIssue() {
+        calls.rereads += 1;
+        return reads.shift() || issue;
+      },
+      async transitionIssue(id, stateId) {
+        calls.transitions.push({ id, stateId });
+        return { issueUpdate: { success: true } };
+      },
+      async fetchTeamLabel() {
+        return { id: 'symphony-label-id', name: 'symphony' };
+      },
+      async setIssueLabels(id, labelIds) {
+        calls.labels.push({ id, labelIds });
+        return { issueUpdate: { success: true } };
+      },
+      async addComment(id, body) {
+        calls.comments.push({ id, body });
+        return { commentCreate: { success: true } };
+      },
+    };
+  }
+
+  it('rejects synthetic workstream bundles and admits no member', async () => {
+    const real = admissionIssue({ identifier: 'JOV-4513' });
+    const result = await admitter.selectNextToAdmit(
+      [classification(real)],
+      [
+        {
+          id: 'unknown-bundle-931',
+          name: 'unknown cleanup bundle',
+          issueIds: ['JOV-4513'],
+        },
+      ],
+      { currentlyShipping: 0, productionRed: false }
+    );
+    assert.equal(result.admit.length, 0);
+    assert.match(result.reason, /synthetic|no eligible/i);
+  });
+
+  it('selects exactly one concrete eligible JOV issue deterministically', async () => {
+    const first = admissionIssue({
+      identifier: 'JOV-4513',
+      title: 'Fix crash',
+    });
+    const second = admissionIssue({
+      identifier: 'JOV-4396',
+      title: 'Fix typo',
+    });
+    const result = await admitter.selectNextToAdmit(
+      [classification(first), classification(second)],
+      [],
+      { currentlyShipping: 0, productionRed: false }
+    );
+    assert.equal(result.admit.length, 1);
+    assert.equal(result.admit[0].identifier, 'JOV-4396');
+    assert.equal(result.admit[0].type, 'issue');
+  });
+
+  it('excludes protected and Tim-owned issues', async () => {
+    const protectedIssue = admissionIssue({
+      identifier: 'JOV-4513',
+      labels: ['plan-approved', 'admission-approved', 'needs-human'],
+    });
+    const timOwned = admissionIssue({
+      identifier: 'JOV-4396',
+      assignee: { id: 'tim', name: 'Tim White' },
+    });
+    const result = await admitter.selectNextToAdmit(
+      [classification(protectedIssue), classification(timOwned)],
+      [],
+      { currentlyShipping: 0, productionRed: false }
+    );
+    assert.equal(result.admit.length, 0);
+  });
+
+  it('records an idempotent lease receipt without duplicate mutations', async () => {
+    const issue = admissionIssue({
+      state: 'Todo',
+      labels: ['plan-approved', 'admission-approved', 'symphony'],
+    });
+    issue.comments.nodes.push({
+      body: admitter.buildAdmissionReceipt(issue, {
+        now: '2026-07-29T00:00:00.000Z',
+      }),
+      createdAt: '2026-07-29T00:00:00.000Z',
+    });
+    const client = fakeClient(issue);
+    const result = await admitter.admitIssue({
+      issue,
+      classification: classification(issue),
+      client,
+      now: '2026-07-29T00:00:00.000Z',
+    });
+    assert.equal(result.status, 'already-admitted');
+    assert.deepEqual(client.calls.transitions, []);
+    assert.deepEqual(client.calls.labels, []);
+    assert.deepEqual(client.calls.comments, []);
+  });
+
+  it('verifies state, labels, and receipt by reread after mutation', async () => {
+    const issue = admissionIssue({
+      state: 'Triage',
+      labels: ['plan-approved', 'admission-approved'],
+    });
+    const afterTransition = admissionIssue({
+      state: 'Todo',
+      labels: ['plan-approved', 'admission-approved'],
+    });
+    const afterLabel = admissionIssue({
+      state: 'Todo',
+      labels: ['plan-approved', 'admission-approved', 'symphony'],
+    });
+    const afterReceipt = admissionIssue({
+      state: 'Todo',
+      labels: ['plan-approved', 'admission-approved', 'symphony'],
+      comments: [
+        {
+          body: admitter.buildAdmissionReceipt(issue, {
+            now: '2026-07-29T00:00:00.000Z',
+          }),
+          createdAt: '2026-07-29T00:00:00.000Z',
+        },
+      ],
+    });
+    const client = fakeClient(issue, [
+      afterTransition,
+      afterLabel,
+      afterReceipt,
+      afterReceipt,
+    ]);
+    const result = await admitter.admitIssue({
+      issue,
+      classification: classification(issue),
+      client,
+      now: '2026-07-29T00:00:00.000Z',
+    });
+    assert.equal(result.status, 'admitted');
+    assert.equal(client.calls.transitions.length, 1);
+    assert.equal(client.calls.labels.length, 1);
+    assert.equal(client.calls.comments.length, 1);
+    assert.equal(client.calls.rereads, 4);
   });
 });

--- a/scripts/backlog-orchestrator/admitter.mjs
+++ b/scripts/backlog-orchestrator/admitter.mjs
@@ -1,117 +1,272 @@
 /**
- * Admission control for backlog orchestrator.
+ * Deterministic admission boundary for Symphony.
  *
- * Determines how many items to admit and the handoff mechanism to Gem shippers.
+ * Workstream bundles are useful reports, but only one concrete JOV issue may
+ * cross this boundary. Admission is fail-closed on ownership, plan evidence,
+ * and mutation read-back.
  */
 
 import { isProductionRed, scoreIssue } from './scorer.mjs';
 
-export const MAX_CONCURRENT_SHIPPING = 1; // v0: one item at a time
+export const MAX_CONCURRENT_SHIPPING = 1;
+export const SYMPHONY_LABEL = 'symphony';
+export const TODO_STATE_ID = 'c6c00506-dc9f-4910-8ff7-3874dd77174c';
+export const ADMISSION_RECEIPT_PREFIX = '<!-- symphony-admission:v1 ';
 
-const FOUNDER_FAST_TRACK_LABEL = 'founder-fast-track';
+const PROTECTED_LABELS = new Set([
+  'human-review-required',
+  'needs-human',
+  'no-auto',
+  'protected',
+  'tim-approved',
+  'tim-owned',
+]);
+const PLAN_LABELS = new Set(['plan-approved', 'approved-plan']);
+const ADMISSION_LABELS = new Set([
+  'admission-approved',
+  'symphony-admission-approved',
+]);
+
+function namesOf(issueOrClassification) {
+  if (Array.isArray(issueOrClassification?.labels))
+    return issueOrClassification.labels;
+  return (issueOrClassification?.labels?.nodes || []).map(label => label.name);
+}
+
+function commentsOf(issue) {
+  return issue?.comments?.nodes || issue?.comments || [];
+}
+
+function commentText(issue) {
+  return commentsOf(issue)
+    .map(comment =>
+      typeof comment === 'string'
+        ? comment
+        : `${comment.body || ''} ${comment.event || ''}`
+    )
+    .join('\n');
+}
+
+export function isConcreteJovieIssue(issue) {
+  return Boolean(issue?.id && /^JOV-\d+$/.test(issue.identifier || ''));
+}
+
+function isTimOwned(issue) {
+  const assignee = issue?.assignee;
+  if (!assignee) return false;
+  const text =
+    `${assignee.id || ''} ${assignee.name || ''} ${assignee.email || ''} ${assignee.displayName || ''}`.toLowerCase();
+  return /tim(?:\s|-|_)*white|itstimwhite|^tim$/.test(text);
+}
+
+export function hasAdmissionEvidence(issue, classification = issue) {
+  const labels = new Set([...namesOf(issue), ...namesOf(classification)]);
+  const text = commentText(issue).toLowerCase();
+  const planApproved =
+    [...PLAN_LABELS].some(label => labels.has(label)) ||
+    /plan[- ]approved|approved[- ]plan/.test(text);
+  const admissionApproved =
+    [...ADMISSION_LABELS].some(label => labels.has(label)) ||
+    /admission[- ]approved|symphony[- ]admission[- ]approved/.test(text);
+  return {
+    planApproved,
+    admissionApproved,
+    eligible: planApproved && admissionApproved,
+  };
+}
+
+export function buildAdmissionReceipt(
+  issue,
+  { now = new Date().toISOString(), fingerprint = '' } = {}
+) {
+  return `${ADMISSION_RECEIPT_PREFIX}${JSON.stringify({ issue: issue.identifier, fingerprint, action: 'lease', at: now })} -->`;
+}
+
+function hasReceipt(issue, receipt) {
+  return commentsOf(issue).some(comment =>
+    (comment.body || comment).includes(receipt)
+  );
+}
+
+function issueForClassification(classification) {
+  return classification.issue || classification;
+}
+
+function eligibleCandidate(classification, bundledIds) {
+  const issue = issueForClassification(classification);
+  const evidence = hasAdmissionEvidence(issue, classification);
+  const state = issue.state?.name || classification.state;
+  return (
+    isConcreteJovieIssue(issue) &&
+    !bundledIds.has(classification.identifier) &&
+    classification.category === 'triageable' &&
+    ['Triage', 'Backlog', 'Todo'].includes(state) &&
+    !namesOf(issue).some(label => PROTECTED_LABELS.has(label)) &&
+    !isTimOwned(issue) &&
+    !issue.pullRequestUrl &&
+    evidence.eligible
+  );
+}
 
 /**
- * Determine the next item(s) to admit into To Do.
- *
- * @param {object} classifications
- * @param {object} workstreams
- * @param {object} state - current shipping state
- * @returns {Promise<{ admit: Array, reason: string }>}
+ * Select exactly one real, evidence-backed issue. `workstreams` is deliberately
+ * not admitted: its member IDs remain report-only.
  */
 export async function selectNextToAdmit(
   classifications,
   workstreams,
   state = {}
 ) {
-  const prodRed = await isProductionRed();
-
-  // Check for founder fast-track
-  const fastTracked = classifications.filter(
-    c =>
-      c.labels?.includes?.(FOUNDER_FAST_TRACK_LABEL) &&
-      c.category !== 'duplicate'
-  );
-
-  if (fastTracked.length > 0 && !prodRed) {
-    // Score and pick highest
-    const scored = fastTracked.map(c => ({ c, ...scoreIssue(c) }));
-    scored.sort((a, b) => b.score - a.score);
-    return {
-      admit: [scored[0].c],
-      reason: `founder-fast-track: ${scored[0].c.identifier}`,
-    };
-  }
-
-  // If production is red, only admit production/reliability items
-  if (prodRed) {
-    const remediation = classifications.filter(
-      c =>
-        c.mrrCategory === 'reliability' ||
-        c.mrrCategory === 'revenue-protection'
-    );
-    if (remediation.length > 0) {
-      const scored = remediation.map(c => ({ c, ...scoreIssue(c) }));
-      scored.sort((a, b) => b.score - a.score);
-      return {
-        admit: [scored[0].c],
-        reason: `prod-red remediation priority: ${scored[0].c.identifier}`,
-      };
-    }
-    return {
-      admit: [],
-      reason: 'production is red — blocking all non-remediation work',
-    };
-  }
-
-  // Check current load
-  const capacity = MAX_CONCURRENT_SHIPPING - (state.currentlyShipping || 0);
-  if (capacity <= 0) {
+  const prodRed = state.productionRed ?? (await isProductionRed());
+  if (prodRed)
+    return { admit: [], reason: 'production is red — blocking admission' };
+  if ((state.currentlyShipping || 0) >= MAX_CONCURRENT_SHIPPING) {
     return {
       admit: [],
       reason: `at capacity (${state.currentlyShipping}/${MAX_CONCURRENT_SHIPPING})`,
     };
   }
 
-  // Score all triageable workstreams and issues
-  const candidates = [];
-
-  for (const ws of workstreams) {
-    // Use the max score of member issues
-    const memberScores = ws.issueIds
-      .map(id => classifications.find(c => c.identifier === id))
-      .filter(Boolean)
-      .map(c => scoreIssue(c).score);
-    candidates.push({
-      id: ws.id,
-      name: ws.name,
-      score: Math.max(...memberScores, 0),
-      type: 'workstream',
-      items: ws.issueIds,
-    });
-  }
-
-  // Add individual issues not in workstreams
-  const inWorkstreams = new Set(workstreams.flatMap(ws => ws.issueIds));
-  for (const c of classifications) {
-    if (!inWorkstreams.has(c.identifier) && c.category === 'triageable') {
-      candidates.push({
-        id: c.identifier,
-        name: c.title,
-        score: scoreIssue(c).score,
-        type: 'issue',
-        items: [c.identifier],
-      });
-    }
-  }
+  const bundledIds = new Set(
+    (workstreams || []).flatMap(workstream => workstream.issueIds || [])
+  );
+  const candidates = classifications
+    .filter(classification => eligibleCandidate(classification, bundledIds))
+    .map(classification => ({
+      ...classification,
+      type: 'issue',
+      issue: issueForClassification(classification),
+      score: scoreIssue(classification).score,
+    }))
+    .sort(
+      (a, b) => b.score - a.score || a.identifier.localeCompare(b.identifier)
+    );
 
   if (candidates.length === 0) {
-    return { admit: [], reason: 'no eligible candidates' };
+    return {
+      admit: [],
+      reason: bundledIds.size
+        ? 'no concrete evidence-backed issue (synthetic bundles are report-only)'
+        : 'no eligible candidates',
+    };
+  }
+  const selected = candidates[0];
+  return {
+    admit: [selected],
+    reason: `selected: ${selected.identifier} (score ${selected.score})`,
+  };
+}
+
+function mutationSucceeded(result) {
+  return (
+    result?.success === true ||
+    result?.issueUpdate?.success === true ||
+    result?.commentCreate?.success === true
+  );
+}
+
+function labelIds(issue, symphonyLabelId) {
+  return [
+    ...new Set([
+      ...(issue.labels?.nodes || []).map(label => label.id).filter(Boolean),
+      symphonyLabelId,
+    ]),
+  ];
+}
+
+async function rereadOrThrow(client, identifier, predicate, reason) {
+  const reread = await client.fetchIssue(identifier);
+  if (!reread || !predicate(reread))
+    throw new Error(`${reason}-verification-failed`);
+  return reread;
+}
+
+/**
+ * Apply one admission lease. Every mutation is followed by a Linear reread;
+ * the stable receipt makes retries no-ops.
+ */
+export async function admitIssue({
+  issue,
+  classification = issue,
+  client,
+  teamId = null,
+  todoStateId = TODO_STATE_ID,
+  now = new Date().toISOString(),
+}) {
+  if (!isConcreteJovieIssue(issue))
+    return { status: 'rejected', reason: 'not-concrete-jovie-issue' };
+  if (!hasAdmissionEvidence(issue, classification).eligible) {
+    return { status: 'rejected', reason: 'plan-or-admission-evidence-missing' };
+  }
+  const receipt = buildAdmissionReceipt(issue, {
+    now,
+    fingerprint: classification.fingerprint || '',
+  });
+  if (
+    hasReceipt(issue, receipt) ||
+    (issue.state?.name === 'Todo' &&
+      namesOf(issue).includes(SYMPHONY_LABEL) &&
+      commentsOf(issue).some(comment =>
+        (comment.body || comment).startsWith(ADMISSION_RECEIPT_PREFIX)
+      ))
+  ) {
+    return { status: 'already-admitted', identifier: issue.identifier };
   }
 
-  candidates.sort((a, b) => b.score - a.score);
+  let current = issue;
+  if (current.state?.name !== 'Todo') {
+    const result = await client.transitionIssue(current.id, todoStateId);
+    if (!mutationSucceeded(result))
+      throw new Error('transition-mutation-failed');
+    current = await rereadOrThrow(
+      client,
+      current.identifier,
+      reread => reread.state?.name === 'Todo',
+      'state'
+    );
+  }
 
-  return {
-    admit: [candidates[0]],
-    reason: `admitted: ${candidates[0].name} (score ${candidates[0].score})`,
-  };
+  if (!namesOf(current).includes(SYMPHONY_LABEL)) {
+    const existing = (current.labels?.nodes || []).find(
+      label => label.name === SYMPHONY_LABEL
+    );
+    const teamLabel =
+      existing || (await client.fetchTeamLabel?.(teamId, SYMPHONY_LABEL));
+    if (!teamLabel?.id) throw new Error('symphony-label-not-found');
+    const result = await client.setIssueLabels(
+      current.id,
+      labelIds(current, teamLabel.id)
+    );
+    if (!mutationSucceeded(result)) throw new Error('label-mutation-failed');
+    current = await rereadOrThrow(
+      client,
+      current.identifier,
+      reread => namesOf(reread).includes(SYMPHONY_LABEL),
+      'label'
+    );
+  }
+
+  const result = await client.addComment(current.id, receipt);
+  if (!mutationSucceeded(result)) throw new Error('receipt-mutation-failed');
+  current = await rereadOrThrow(
+    client,
+    current.identifier,
+    reread =>
+      commentsOf(reread).some(comment =>
+        (comment.body || comment).includes(receipt)
+      ),
+    'receipt'
+  );
+  await rereadOrThrow(
+    client,
+    current.identifier,
+    reread =>
+      reread.state?.name === 'Todo' &&
+      namesOf(reread).includes(SYMPHONY_LABEL) &&
+      commentsOf(reread).some(comment =>
+        (comment.body || comment).includes(receipt)
+      ),
+    'admission'
+  );
+  return { status: 'admitted', identifier: current.identifier, receipt };
 }

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -222,6 +222,7 @@ async function runAdmitNext(cache, isDryRun) {
     const stored = classifier.parseStoredClassification(issue);
     const c = classifier.classifyDeterministic(issue, allIssues);
     if (stored) c.preexisting = stored;
+    c.issue = issue;
     classifications.push(c);
   }
 
@@ -242,30 +243,21 @@ async function runAdmitNext(cache, isDryRun) {
 
   if (result.admit.length > 0 && !isDryRun) {
     const item = result.admit[0];
-    if (item.type === 'workstream') {
-      // Move all issues in the workstream to Todo
-      for (const id of item.items) {
-        const issue = allIssues.find(i => i.identifier === id);
-        if (issue && issue.state?.name === 'Triage') {
-          try {
-            await linear.transitionIssue(issue.id, TODO_STATE_ID);
-            console.log(`  → Moved ${id} to Todo`);
-          } catch (err) {
-            console.error(`  → Failed to move ${id}: ${err.message}`);
-          }
-        }
-      }
-    } else {
-      // Single issue
-      const issue = allIssues.find(i => i.identifier === item.id);
-      if (issue && issue.state?.name === 'Triage') {
-        try {
-          await linear.transitionIssue(issue.id, TODO_STATE_ID);
-          console.log(`  → Moved ${item.id} to Todo`);
-        } catch (err) {
-          console.error(`  → Failed to move ${item.id}: ${err.message}`);
-        }
-      }
+    try {
+      const receipt = await admitter.admitIssue({
+        issue: item.issue,
+        classification: item,
+        client: linear,
+        teamId: TEAM_ID,
+        todoStateId: TODO_STATE_ID,
+      });
+      console.log(`  ${receipt.status}: ${item.identifier}`);
+    } catch (err) {
+      console.error(
+        `  Admission failed for ${item.identifier}: ${err.message}`
+      );
+      result.admit = [];
+      result.reason = `admission failed: ${err.message}`;
     }
   } else if (result.admit.length > 0) {
     console.log('  (dry-run — no mutations performed)');

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -125,6 +125,7 @@ export async function fetchTeamActiveIssues(teamId, maxResults = 1000) {
               children { nodes { id identifier title } }
               relations { nodes { type relatedIssue { id identifier title } } }
               state { id name type }
+              comments { nodes { id body createdAt } }
             }
             pageInfo { hasNextPage endCursor }
           }
@@ -267,6 +268,22 @@ export async function transitionIssue(issueId, stateId) {
   `,
     { id: issueId, stateId }
   );
+}
+
+export async function fetchTeamLabel(teamId, name) {
+  const data = await graphql(
+    `
+    query($teamId: String!, $name: String!) {
+      team(id: $teamId) {
+        labels(filter: { name: { eq: $name } }, first: 1) {
+          nodes { id name }
+        }
+      }
+    }
+  `,
+    { teamId, name }
+  );
+  return data.team.labels.nodes[0] || null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Prevents synthetic cleanup bundles from crossing the `admit-next` mutation boundary.
- Selects exactly one concrete, evidence-backed `JOV-*` issue with deterministic tie-breaking.
- Excludes protected and Tim-owned work, moves the selected issue to Todo, applies `symphony`, and writes an idempotent lease receipt.
- Verifies every mutation and the final combined Linear state by reread.

## Test plan
- `node --test scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` (20 passing)
- `node --check` on all three changed implementation modules
- `git diff --check`
- Pre-commit secret scans, repository hygiene, skill governance, and proxy guard passed.

## Scope
Bounded backlog-orchestrator change only. No Linear production mutation was run and this PR is not being merged.
