### PR TITLE
ci(security): audit privileged workflow execution

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -244,3 +244,20 @@ jobs:
             printf '⚠️ Unsigned commit merged to main (reason: %s)\n' "$reason"
             echo "::warning title=Unsigned commit::SHA ${COMMIT_SHA} reached main without a cryptographic signature (reason: ${reason}). Enable branch-protection \"Require signed commits\" to block unsigned merges — see https://github.com/${REPO}/settings/branches"
           fi
+
+  workflow-execution-posture:
+    name: Workflow Execution Trust-Boundary Audit
+    # Keep this report post-merge/nightly and advisory so it cannot slow source
+    # PRs or the queue. Configure GitHub Actions policy in Evaluate mode before enforcement.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Report privileged workflow trust boundaries
+        run: node scripts/security/audit-workflow-execution.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Privileged workflow trust-boundary reporting:** post-merge and nightly security scans now inventory `pull_request_target` and `workflow_run` workflows, warn when a privileged pull-request workflow checks out contributor code, and remain advisory while GitHub policy is evaluated.
 - [internal] **macOS desktop packaging accepts the secured XML parser:** Electron Builder's property-list dependency now supplies the MIME type required by the repository's security-patched xmldom floor, so signed and notarized desktop releases can reach artifact creation again.
 - **Desktop recovery stays quiet and actionable (JOV-4539):** the renderer-failure fallback now keeps just the recovery action and browser escape hatch on a calm System B canvas, without diagnostic runtime chrome or a heavy error card.
 - **macOS sign-in cancellation returns to Jovie:** if a native auth redirect leaves the hidden desktop window blank, canceling sign-in now restores the canonical sign-in shell instead of showing a black window.

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -833,6 +833,27 @@ describe('merge_group workflow contract', () => {
     }
   });
 
+  it('keeps workflow execution posture reporting post-merge and advisory', () => {
+    const workflowHeader = SECURITY_WORKFLOW.slice(
+      0,
+      SECURITY_WORKFLOW.indexOf('\njobs:')
+    );
+    const posture = getJobBlock(
+      SECURITY_WORKFLOW,
+      'workflow-execution-posture'
+    );
+
+    expect(workflowHeader).not.toMatch(/^  pull_request:\s*$/m);
+    expect(workflowHeader).not.toMatch(/^  merge_group:\s*$/m);
+    expect(posture).toContain('continue-on-error: true');
+    expect(posture).toContain('contents: read');
+    expect(posture).toContain('persist-credentials: false');
+    expect(posture).toContain(
+      'node scripts/security/audit-workflow-execution.mjs'
+    );
+    expect(posture).not.toContain('secrets.');
+  });
+
   it('reserves each exact required context for its active event producer', () => {
     const mergeReady = getJobBlock(CI_WORKFLOW, 'ci-merge-group-ready');
     const sourceReady = getJobBlock(CI_WORKFLOW, 'ci-pr-ready');

--- a/scripts/security/audit-workflow-execution.mjs
+++ b/scripts/security/audit-workflow-execution.mjs
@@ -1,0 +1,139 @@
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WORKFLOW_DIRECTORY = '.github/workflows';
+const TRUSTED_BASE_REF = /github\.event\.pull_request\.base\.(?:ref|sha)/;
+const UNTRUSTED_PULL_REQUEST_REF =
+  /github\.event\.pull_request\.(?:head\.(?:ref|sha)|head\.repo)/;
+const WORKFLOW_RUN_HEAD_REF = /github\.event\.workflow_run\.head_sha/;
+
+function checkoutRefs(workflow) {
+  const lines = workflow.split('\n');
+  const refs = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/uses:\s+actions\/checkout@/.test(lines[index])) continue;
+
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (/^\s*-\s/.test(lines[cursor])) break;
+      const ref = lines[cursor].match(/^\s*ref:\s*(.+)$/);
+      if (ref) refs.push(ref[1].trim());
+    }
+  }
+
+  return refs;
+}
+
+export function auditWorkflowExecution(workflowFiles) {
+  const findings = [];
+  const privilegedWorkflows = [];
+
+  for (const [name, workflow] of Object.entries(workflowFiles)) {
+    const hasPullRequestTarget = /^\s*pull_request_target:\s*$/m.test(workflow);
+    const hasWorkflowRun = /^\s*workflow_run:\s*$/m.test(workflow);
+    if (!hasPullRequestTarget && !hasWorkflowRun) continue;
+
+    const refs = checkoutRefs(workflow);
+    const unsafePullRequestRefs = hasPullRequestTarget
+      ? refs.filter(ref => UNTRUSTED_PULL_REQUEST_REF.test(ref))
+      : [];
+    const workflowRunHeadRefs = hasWorkflowRun
+      ? refs.filter(ref => WORKFLOW_RUN_HEAD_REF.test(ref))
+      : [];
+
+    for (const ref of unsafePullRequestRefs) {
+      findings.push({
+        level: 'warning',
+        workflow: name,
+        message: `pull_request_target checks out untrusted pull request code (${ref})`,
+      });
+    }
+
+    privilegedWorkflows.push({
+      name,
+      hasPullRequestTarget,
+      hasWorkflowRun,
+      usesTrustedPullRequestBase: refs.some(ref => TRUSTED_BASE_REF.test(ref)),
+      unsafePullRequestRefs,
+      workflowRunHeadRefs,
+    });
+  }
+
+  return { findings, privilegedWorkflows };
+}
+
+function emitAnnotation(level, title, message) {
+  const escaped = message
+    .replaceAll('%', '%25')
+    .replaceAll('\r', '%0D')
+    .replaceAll('\n', '%0A');
+  console.log(`::${level} title=${title}::${escaped}`);
+}
+
+function writeSummary(audit) {
+  const lines = [
+    '## Workflow execution trust-boundary audit',
+    '',
+    'Advisory only. This job is intentionally not a required PR or merge-queue check.',
+    '',
+    `Privileged-event workflows inspected: ${audit.privilegedWorkflows.length}`,
+  ];
+
+  for (const workflow of audit.privilegedWorkflows) {
+    const events = [
+      workflow.hasPullRequestTarget && 'pull_request_target',
+      workflow.hasWorkflowRun && 'workflow_run',
+    ]
+      .filter(Boolean)
+      .join(', ');
+    const workflowRunDetail = workflow.workflowRunHeadRefs.length
+      ? ', exact triggering head checkout'
+      : '';
+    lines.push(`- \`${workflow.name}\` (${events}${workflowRunDetail})`);
+  }
+
+  lines.push('', '### Findings');
+  if (audit.findings.length === 0) {
+    lines.push(
+      '- No `pull_request_target` workflow checks out an untrusted pull-request ref.'
+    );
+  } else {
+    for (const finding of audit.findings) {
+      lines.push(
+        `- **${finding.level}** \`${finding.workflow}\`: ${finding.message}`
+      );
+    }
+  }
+
+  lines.push(
+    '',
+    'GitHub Actions workflow execution protections remain an administrator-configured policy. Start in **Evaluate** mode before enforcing actor or event allowlists.'
+  );
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+  }
+
+  console.log(lines.join('\n'));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const root = process.cwd();
+  const workflowsPath = resolve(root, WORKFLOW_DIRECTORY);
+  const workflowFiles = Object.fromEntries(
+    readdirSync(workflowsPath)
+      .filter(file => file.endsWith('.yml') || file.endsWith('.yaml'))
+      .sort()
+      .map(file => [file, readFileSync(resolve(workflowsPath, file), 'utf8')])
+  );
+  const audit = auditWorkflowExecution(workflowFiles);
+
+  for (const finding of audit.findings) {
+    emitAnnotation(
+      finding.level,
+      'Workflow execution posture',
+      `${finding.workflow}: ${finding.message}`
+    );
+  }
+  writeSummary(audit);
+}

--- a/scripts/security/audit-workflow-execution.test.mjs
+++ b/scripts/security/audit-workflow-execution.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { auditWorkflowExecution } from './audit-workflow-execution.mjs';
+
+test('warns when a privileged pull_request_target workflow checks out PR head code', () => {
+  const audit = auditWorkflowExecution({
+    'unsafe.yml': `on:\n  pull_request_target:\njobs:\n  audit:\n    steps:\n      - uses: actions/checkout@deadbeef\n        with:\n          ref: \${{ github.event.pull_request.head.sha }}\n`,
+  });
+
+  assert.equal(audit.findings.length, 1);
+  assert.equal(audit.findings[0].level, 'warning');
+  assert.match(audit.findings[0].message, /untrusted pull request code/);
+});
+
+test('accepts a pull_request_target workflow that checks out only trusted base code', () => {
+  const audit = auditWorkflowExecution({
+    'trusted.yml': `on:\n  pull_request_target:\njobs:\n  audit:\n    steps:\n      - uses: actions/checkout@deadbeef\n        with:\n          ref: \${{ github.event.pull_request.base.sha }}\n`,
+  });
+
+  assert.deepEqual(audit.findings, []);
+  assert.equal(audit.privilegedWorkflows[0].usesTrustedPullRequestBase, true);
+});
+
+test('inventories workflow_run head checkouts without treating trusted release paths as findings', () => {
+  const audit = auditWorkflowExecution({
+    'release.yml': `on:\n  workflow_run:\njobs:\n  release:\n    steps:\n      - uses: actions/checkout@deadbeef\n        with:\n          ref: \${{ github.event.workflow_run.head_sha }}\n`,
+  });
+
+  assert.deepEqual(audit.findings, []);
+  assert.deepEqual(audit.privilegedWorkflows[0].workflowRunHeadRefs, [
+    '${{ github.event.workflow_run.head_sha }}',
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a post-merge/nightly advisory audit for `pull_request_target` and `workflow_run` trust boundaries
- warn if a privileged pull-request workflow checks out contributor-controlled code
- keep the job read-only, credentialless, `continue-on-error`, and out of PR/merge-queue required contexts

## Policy rollout
GitHub workflow-execution protections are repository-admin policy, not workflow YAML. Start with **Evaluate** mode, review actor/event observations, then decide whether enforcement is safe.

## Verification
- `pnpm ci:control:test` (216 passed)
- `node --test scripts/security/audit-workflow-execution.test.mjs` (3 passed)
- isolated rerun of the three timing-sensitive web tests (27 passed)
- web typecheck through the pre-push hook
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable)

## Full-suite boundary
`pnpm run test` completed with 17,588 passing tests but failed on an ignored Playwright artifact generated by the run and three unrelated 5-second timeouts. Each timeout passed in isolation; this change neither touches those surfaces nor adds a new required check.