### PR TITLE
fix(shell): reserve header Search geometry (JOV-4566)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -12,11 +12,7 @@ export interface DashboardHeaderProps {
   readonly breadcrumbSuffix?: ReactNode;
   /** Content shown on right side */
   readonly action?: ReactNode;
-  /**
-   * Shell-owned search surface. When set, the closed trigger renders inline
-   * beside the breadcrumb; when `isSearchActive` is true, the breadcrumb
-   * collapses and the search takes over the leading area to avoid layout shift.
-   */
+  /** Shell-owned search surface with a persistent header slot. */
   readonly searchSurface?: ReactNode;
   readonly isSearchActive?: boolean;
   /** Profile button slot shown on the far right of the mobile header */
@@ -85,7 +81,6 @@ export function DashboardHeader({
     breadcrumbs.length > 1 ? (breadcrumbs[0]?.label ?? 'Jovie') : 'Jovie';
   const usesSectionTitleLayout = breadcrumbs.length === 1 && !breadcrumbSuffix;
   const showInlineSearch = Boolean(searchSurface);
-  const searchTakesOver = showInlineSearch && isSearchActive;
 
   return (
     <header
@@ -121,33 +116,24 @@ export function DashboardHeader({
         ) : null}
         <div
           className='flex min-w-0 flex-1 items-center gap-2 tracking-[-0.012em]'
-          data-search-active={searchTakesOver ? 'true' : 'false'}
+          data-search-active={isSearchActive ? 'true' : 'false'}
         >
-          {searchTakesOver ? (
-            <div className='flex min-w-0 flex-1 items-center justify-start'>
+          <HeaderTitle
+            usesSectionTitleLayout={usesSectionTitleLayout}
+            currentLabel={currentLabel}
+            rootLabel={rootLabel}
+            breadcrumbSuffix={breadcrumbSuffix}
+          />
+          {showInlineSearch ? (
+            <div className='ml-auto flex min-w-0 shrink-0 items-center justify-start sm:ml-1.5'>
               {searchSurface}
             </div>
-          ) : (
-            <>
-              <HeaderTitle
-                usesSectionTitleLayout={usesSectionTitleLayout}
-                currentLabel={currentLabel}
-                rootLabel={rootLabel}
-                breadcrumbSuffix={breadcrumbSuffix}
-              />
-              {showInlineSearch ? (
-                <div className='ml-auto flex min-w-0 items-center justify-start sm:ml-1.5'>
-                  {searchSurface}
-                </div>
-              ) : null}
-            </>
-          )}
+          ) : null}
         </div>
         {action ? (
           <div
             className={cn(
               'ml-auto flex items-center gap-1',
-              searchTakesOver && 'max-sm:hidden',
               'max-sm:[&_button]:h-8 max-sm:[&_button]:rounded-full max-sm:[&_button]:shadow-none max-sm:[&_button>svg]:h-4 max-sm:[&_button>svg]:w-4'
             )}
           >

--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -93,7 +93,7 @@ function AuthShellInner({
   );
   const searchSurface = useMemo(() => {
     return headerActionsState ? (
-      <HeaderSearchSurfaceFromContext className='w-full sm:w-auto' />
+      <HeaderSearchSurfaceFromContext className='w-full sm:w-55 lg:w-65' />
     ) : null;
   }, [headerActionsState]);
   const audioPlayer = useMemo(() => <PersistentAudioBar />, []);

--- a/apps/web/components/shell/HeaderSearchSurface.test.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.test.tsx
@@ -68,6 +68,9 @@ describe('HeaderSearchSurface', () => {
     expect(surface?.className).toContain('items-center');
     expect(surface?.className).toContain('justify-start');
     expect(surface?.className).toContain('text-left');
+    expect(surface?.className).toContain('w-[13.5rem]');
+    expect(surface?.className).toContain('sm:w-55');
+    expect(surface?.className).toContain('lg:w-65');
     expect(
       screen.getByRole('combobox', { name: 'Search Jovie' })
     ).toBeVisible();
@@ -75,6 +78,29 @@ describe('HeaderSearchSurface', () => {
     expect(
       screen.getByRole('button', { name: 'Filter Current View' })
     ).toBeVisible();
+  });
+
+  it('reserves the same width before and after activation', () => {
+    const props = {
+      adapter: createAdapter(),
+      onOpen: vi.fn(),
+      onClose: vi.fn(),
+    };
+    const { rerender } = render(
+      <HeaderSearchSurface {...props} isOpen={false} />
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Search' });
+    expect(trigger).toHaveClass('w-[13.5rem]', 'sm:w-55', 'lg:w-65');
+
+    rerender(<HeaderSearchSurface {...props} isOpen />);
+
+    const field = screen.getByRole('combobox', { name: 'Search Jovie' });
+    expect(field.parentElement?.parentElement?.parentElement).toHaveClass(
+      'w-[13.5rem]',
+      'sm:w-55',
+      'lg:w-65'
+    );
   });
 
   it('focuses the search field inside a tokenized focus-within ring', async () => {

--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -54,6 +54,8 @@ const MIN_REMOTE_QUERY_LENGTH = 2;
 
 const headerSearchSurfaceChrome =
   'rounded-xl border border-subtle bg-surface-0 shadow-[0_0_0_1px_color-mix(in_oklab,var(--color-border-subtle)_18%,transparent)]';
+const headerSearchSurfaceWidth =
+  'w-[13.5rem] max-w-[calc(100vw-2rem)] sm:w-55 lg:w-65';
 
 function flattenGroups(groups: readonly HeaderSearchResultGroup[]) {
   return groups.flatMap(group => group.items);
@@ -492,6 +494,7 @@ export function HeaderSearchSurface({
         onClick={onOpen}
         className={cn(
           headerSearchSurfaceChrome,
+          headerSearchSurfaceWidth,
           'inline-flex h-7 min-h-7 min-w-0 items-center justify-start gap-1.5 px-2.5 text-left text-xs text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle ease-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-ring-themed',
           className
         )}
@@ -508,7 +511,8 @@ export function HeaderSearchSurface({
     <div
       className={cn(
         headerSearchSurfaceChrome,
-        'relative flex h-7 min-h-7 w-full max-w-[min(560px,calc(100vw-2rem))] items-center justify-start px-2 py-0 text-left shadow-popover transition-[border-color,box-shadow,background-color] duration-subtle focus-within:border-focus focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14 sm:w-110 lg:w-130',
+        headerSearchSurfaceWidth,
+        'relative flex h-7 min-h-7 min-w-0 items-center justify-start px-2 py-0 text-left shadow-popover transition-[border-color,box-shadow,background-color] duration-subtle focus-within:border-focus focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14',
         className
       )}
     >

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -138,7 +138,7 @@ describe('DashboardHeader', () => {
     ).toBeNull();
   });
 
-  it('collapses the breadcrumb when the search surface takes over', () => {
+  it('keeps the breadcrumb in its slot when search activates', () => {
     const { container } = render(
       <DashboardHeader
         breadcrumbs={[{ label: 'Releases', href: '/app/dashboard/releases' }]}
@@ -153,7 +153,7 @@ describe('DashboardHeader', () => {
       '[data-search-active="true"]'
     ) as HTMLElement | null;
     expect(desktopRow).not.toBeNull();
-    expect(within(desktopRow!).queryByText('Releases')).not.toBeInTheDocument();
+    expect(within(desktopRow!).getByText('Releases')).toBeInTheDocument();
     expect(
       within(desktopRow!).getByRole('searchbox', { name: 'Filter releases' })
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Reserve one shared width for the Search control before and after activation.
- Keep the page title/header slot stable while Search is active.
- Preserve Search and / shortcut copy plus existing focus behavior.

## Verification
- `HeaderSearchSurface` + `DashboardHeader`: 19/19 passing.
- Biome and `git diff --check` clean.

## Admission
- Draft and `gated`. Seeded desktop/mobile activation, focus, overflow proof and Kimi review remain required before ready or queue.