### PR TITLE
fix(shell): simplify dashboard fatal error

### DIFF
--- a/apps/web/app/app/(shell)/layout.ov-mode.test.tsx
+++ b/apps/web/app/app/(shell)/layout.ov-mode.test.tsx
@@ -11,6 +11,7 @@ const {
   headersMock,
   redirectMock,
   suspendShellContentMock,
+  unstableRethrowMock,
 } = vi.hoisted(() => ({
   dashboardShellContentMock: vi.fn(),
   getAppFlagValueMock: vi.fn(),
@@ -21,6 +22,7 @@ const {
     throw new Error(`NEXT_REDIRECT:${href}`);
   }),
   suspendShellContentMock: { value: false },
+  unstableRethrowMock: vi.fn(),
 }));
 
 vi.mock('server-only', () => ({}));
@@ -30,7 +32,10 @@ vi.mock('next/headers', () => ({ headers: headersMock }));
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,
   unstable_rethrow: (error: unknown) => {
-    throw error;
+    unstableRethrowMock(error);
+    if (error instanceof Error && error.message.startsWith('NEXT_REDIRECT:')) {
+      throw error;
+    }
   },
 }));
 
@@ -51,8 +56,10 @@ vi.mock('@/components/shell/LyricsRouteSkeleton', () => ({
 vi.mock('@/components/shell/TasksRouteSkeleton', () => ({
   TasksRouteSkeleton: () => <div data-testid='tasks-route-skeleton' />,
 }));
+const errorBannerMock = vi.hoisted(() => vi.fn((_props: unknown) => null));
+
 vi.mock('@/features/feedback/ErrorBanner', () => ({
-  ErrorBanner: () => null,
+  ErrorBanner: errorBannerMock,
 }));
 
 vi.mock('@/lib/admin/page-access', () => ({
@@ -102,6 +109,7 @@ describe('AppShellLayout OV mode', () => {
     getCachedAuthMock.mockResolvedValue({ userId: 'user_test' });
     getAppFlagValueMock.mockResolvedValue(true);
     suspendShellContentMock.value = false;
+    unstableRethrowMock.mockReset();
   });
 
   it('terminates unauthorized OV requests before shell or flag data loads', async () => {
@@ -189,5 +197,26 @@ describe('AppShellLayout OV mode', () => {
 
     expect(screen.getByTestId('app-shell-skeleton')).toBeInTheDocument();
     expect(screen.queryByTestId('chat-route-skeleton')).toBeNull();
+  });
+
+  it('keeps the fatal recovery action primary and the return path secondary', async () => {
+    const failure = new Error('workspace query failed');
+    getCachedAuthMock.mockRejectedValueOnce(failure);
+
+    render(await AppShellLayout({ children: <div>Unavailable content</div> }));
+
+    expect(unstableRethrowMock).toHaveBeenCalledWith(failure);
+    expect(errorBannerMock.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        title: 'Dashboard failed to load',
+        actions: [
+          expect.objectContaining({ label: 'Retry', variant: 'primary' }),
+          expect.objectContaining({
+            label: 'Return to Jovie',
+            variant: 'secondary',
+          }),
+        ],
+      })
+    );
   });
 });

--- a/apps/web/app/app/(shell)/layout.tsx
+++ b/apps/web/app/app/(shell)/layout.tsx
@@ -170,20 +170,20 @@ export default async function AppShellLayout({
     // as it would break context provider expectations (DashboardDataProvider, etc.)
     return (
       <div className='min-h-screen bg-base flex items-center justify-center px-6'>
-        <div className='w-full max-w-lg space-y-4'>
+        <div className='w-full max-w-md'>
           <ErrorBanner
             title='Dashboard failed to load'
-            description='We could not load your workspace data; refresh to try again or return to your profile.'
+            description='We could not load your workspace data. Try again, or return to Jovie.'
             actions={[
-              { label: 'Retry', href: APP_ROUTES.DASHBOARD },
-              { label: 'Go To My Profile', href: '/' },
+              {
+                label: 'Retry',
+                href: APP_ROUTES.DASHBOARD,
+                variant: 'primary',
+              },
+              { label: 'Return to Jovie', href: '/', variant: 'secondary' },
             ]}
             testId='dashboard-error'
           />
-          <p className='text-sm text-secondary-token text-center'>
-            If this keeps happening, please reach out to support so we can help
-            restore access.
-          </p>
         </div>
       </div>
     );

--- a/apps/web/components/features/feedback/ErrorBanner.tsx
+++ b/apps/web/components/features/feedback/ErrorBanner.tsx
@@ -9,9 +9,14 @@ import { toast } from '@/components/feedback';
 import { cn } from '@/lib/utils';
 
 export interface ErrorBannerAction {
-  label: string;
-  onClick?: () => void;
-  href?: string;
+  readonly label: string;
+  readonly onClick?: () => void;
+  readonly href?: string;
+  /**
+   * Error states have one recovery path. Additional exits remain quiet so the
+   * alert does not give equal visual weight to every action.
+   */
+  readonly variant?: 'primary' | 'secondary';
 }
 
 export interface ErrorBannerProps {
@@ -57,40 +62,38 @@ export function ErrorBanner({
         toast.error('Failed to copy error details');
       });
   };
-  const actionClass =
-    'inline-flex w-full items-center justify-center rounded-lg px-3 py-2 text-sm font-medium transition-colors sm:w-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-error-subtle';
+  const actionClass = 'w-full sm:w-auto';
 
   const renderAction = (action: ErrorBannerAction, index: number) => {
+    const variant = action.variant ?? (index === 0 ? 'primary' : 'secondary');
+
     if (action.href) {
       const isInternal = action.href.startsWith('/');
 
       if (isInternal && !action.onClick) {
         return (
-          <Link
+          <Button
             key={`${action.label}-${index}`}
-            href={action.href}
-            className={cn(
-              actionClass,
-              'border border-error/50 bg-error/15 text-error-foreground shadow-lg hover:bg-error/25 hover:border-error/70'
-            )}
+            asChild
+            variant={variant}
+            className={actionClass}
           >
-            {action.label}
-          </Link>
+            <Link href={action.href}>{action.label}</Link>
+          </Button>
         );
       }
 
       return (
-        <a
+        <Button
           key={`${action.label}-${index}`}
-          href={action.href}
-          onClick={action.onClick}
-          className={cn(
-            actionClass,
-            'border border-error/50 bg-error/15 text-error-foreground shadow-lg hover:bg-error/25 hover:border-error/70'
-          )}
+          asChild
+          variant={variant}
+          className={actionClass}
         >
-          {action.label}
-        </a>
+          <a href={action.href} onClick={action.onClick}>
+            {action.label}
+          </a>
+        </Button>
       );
     }
 
@@ -98,12 +101,9 @@ export function ErrorBanner({
       <Button
         key={`${action.label}-${index}`}
         type='button'
-        variant='ghost'
+        variant={variant}
         onClick={action.onClick}
-        className={cn(
-          actionClass,
-          'h-auto border border-error/50 bg-error/15 text-error-foreground shadow-lg hover:bg-error/25 hover:border-error/70'
-        )}
+        className={actionClass}
       >
         {action.label || 'Action'}
       </Button>

--- a/apps/web/tests/unit/feedback/ErrorBanner.test.tsx
+++ b/apps/web/tests/unit/feedback/ErrorBanner.test.tsx
@@ -43,6 +43,26 @@ describe('ErrorBanner', () => {
     expect(link).toHaveAttribute('href', '/support');
   });
 
+  it('uses shared button variants to keep secondary exits quiet', () => {
+    render(
+      <ErrorBanner
+        title='Action hierarchy'
+        actions={[
+          { label: 'Retry', onClick: vi.fn(), variant: 'primary' },
+          { label: 'Return to Jovie', href: '/', variant: 'secondary' },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toHaveAttribute(
+      'data-variant',
+      'primary'
+    );
+    expect(
+      screen.getByRole('link', { name: 'Return to Jovie' })
+    ).toHaveAttribute('data-variant', 'secondary');
+  });
+
   describe('dismiss functionality', () => {
     it('renders close button when onDismiss is provided', () => {
       const onDismiss = vi.fn();


### PR DESCRIPTION
Resolves JOV-4564.

## Scope
- simplify the dashboard fatal recovery state to one compact panel
- make Retry the sole primary recovery action and keep Return to Jovie secondary
- remove redundant support copy and reuse shared Button variants

## Verification
- Biome on 4 changed files: passed
- focused Vitest: layout OV mode 6/6; ErrorBanner 8/8
- git diff --check: passed

## Admission
Draft + gated. No runtime capture, Kimi, ready, queue, or merge action.