### PR TITLE
fix(ci): make PR visual review advisory and failure-transparent

### DIFF
--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -23,7 +23,12 @@ export function routeChangedFiles(files) {
     file => UI_FILE.test(file) || /(^|\/)DESIGN\.md$/.test(file)
   );
   if (changed.length === 0)
-    return { shouldReview: false, routes: [], reason: 'no-ui-change' };
+    return {
+      shouldReview: false,
+      routes: [],
+      reason: 'no-ui-change',
+      review_status: 'skipped',
+    };
   const routes = new Set();
   for (const file of changed) {
     if (/admin|console|ops/i.test(file)) routes.add('/demo/admin');
@@ -49,7 +54,20 @@ export function routeChangedFiles(files) {
               : a.localeCompare(b)
     ),
     reason: 'ui-change',
+    review_status: 'advisory',
   };
+}
+
+export function classifyReviewOutcome({
+  shouldReview,
+  mergeBaseAvailable = true,
+  backendAvailable = true,
+  timedOut = false,
+}) {
+  if (!shouldReview) return 'skipped';
+  if (!mergeBaseAvailable || !backendAvailable || timedOut)
+    return 'unavailable';
+  return 'advisory';
 }
 
 export function classifyFinding(finding) {
@@ -176,6 +194,25 @@ async function main() {
     const manifest = JSON.parse(
       await readFile(join(artifactDir, 'manifest.json'), 'utf8')
     );
+    const reviewStatus = input.reviewStatus ?? 'advisory';
+    if (reviewStatus === 'skipped' || reviewStatus === 'unavailable') {
+      await writeFile(
+        input.output,
+        JSON.stringify(
+          {
+            status: reviewStatus,
+            review_status: reviewStatus,
+            error:
+              reviewStatus === 'skipped'
+                ? 'No UI surface changed; visual review skipped.'
+                : 'Merge base unavailable; visual review evidence is unavailable.',
+          },
+          null,
+          2
+        )
+      );
+      return;
+    }
     const screenshots = [];
     for (const capture of manifest.captures ?? []) {
       if (capture.status !== 'captured') continue;
@@ -202,7 +239,12 @@ async function main() {
       await writeFile(
         input.output,
         JSON.stringify(
-          { status: 'completed', review, promptLength: prompt.length },
+          {
+            status: 'completed',
+            review_status: 'advisory',
+            review,
+            promptLength: prompt.length,
+          },
           null,
           2
         )
@@ -212,7 +254,8 @@ async function main() {
         input.output,
         JSON.stringify(
           {
-            status: error.name === 'AbortError' ? 'timed_out' : 'blocked',
+            status: 'unavailable',
+            review_status: 'unavailable',
             error: String(error.message ?? error),
           },
           null,

--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -56,16 +56,32 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          git diff --name-only "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/changed-files.txt"
+          merge_base_available=true
+          if ! git diff --name-only "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/changed-files.txt" 2> "$RUNNER_TEMP/merge-base-error.txt"; then
+            merge_base_available=false
+            # Divergent/stacked history is unavailable evidence, not a UI defect.
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/changed-files.txt" || :
+          fi
+          export MERGE_BASE_AVAILABLE="$merge_base_available"
           mkdir -p "$PR_VISUAL_OUT"
           node --input-type=module - <<'NODE'
           import { readFile, writeFile } from 'node:fs/promises';
           import { routeChangedFiles } from './.github/scripts/pr-visual-review.mjs';
           const files = (await readFile(process.env.RUNNER_TEMP + '/changed-files.txt', 'utf8')).split('\n').filter(Boolean);
           const route = routeChangedFiles(files);
-          await writeFile(process.env.PR_VISUAL_OUT + '/routing.json', JSON.stringify({ ...route, files }, null, 2));
-          await writeFile(process.env.GITHUB_OUTPUT, `should_review=${route.shouldReview}\nroutes<<ROUTES\n${JSON.stringify(route.routes)}\nROUTES\n`, { flag: 'a' });
-          console.log(JSON.stringify(route));
+          const output = {
+            ...route,
+            review_status: route.shouldReview
+              ? process.env.MERGE_BASE_AVAILABLE === 'true'
+                ? route.review_status
+                : 'unavailable'
+              : 'skipped',
+            merge_base_available: process.env.MERGE_BASE_AVAILABLE === 'true',
+            files,
+          };
+          await writeFile(process.env.PR_VISUAL_OUT + '/routing.json', JSON.stringify(output, null, 2));
+          await writeFile(process.env.GITHUB_OUTPUT, `should_review=${route.shouldReview}\nreview_status=${output.review_status}\nroutes<<ROUTES\n${JSON.stringify(route.routes)}\nROUTES\n`, { flag: 'a' });
+          console.log(JSON.stringify(output));
           NODE
 
       - name: Build web app for deterministic capture
@@ -97,7 +113,7 @@ jobs:
           PR_VISUAL_ROUTES: ${{ steps.route.outputs.routes }}
         run: |
           set -euo pipefail
-          PR_VISUAL_ROUTES="$(node -p "JSON.stringify(require('./pr-visual-artifacts/routing.json').routes)")" node .github/scripts/pr-visual-review-capture.mjs || true
+          PR_VISUAL_ROUTES="$(node -p "JSON.stringify(require('./pr-visual-artifacts/routing.json').routes)")" node .github/scripts/pr-visual-review-capture.mjs
           test -f pr-visual-artifacts/manifest.json
 
       - name: Stop server
@@ -153,6 +169,7 @@ jobs:
           else
             echo "review=true" >> "$GITHUB_OUTPUT"
           fi
+          echo "review_status=$(node -p "require('./pr-visual-artifacts/routing.json').review_status")" >> "$GITHUB_OUTPUT"
 
       - name: Prepare bounded diff context
         if: steps.routed.outputs.review == 'true'
@@ -161,12 +178,12 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git fetch --no-tags --depth=2 origin "$BASE_SHA" "$HEAD_SHA"
-          git diff --no-ext-diff "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr.diff"
+          git diff --no-ext-diff "$BASE_SHA...$HEAD_SHA" > "$RUNNER_TEMP/pr.diff" 2>/dev/null || git diff --no-ext-diff "$BASE_SHA" "$HEAD_SHA" > "$RUNNER_TEMP/pr.diff" || :
           node --input-type=module - <<'NODE'
           import { readFile, writeFile } from 'node:fs/promises';
           const routing = JSON.parse(await readFile('pr-visual-artifacts/routing.json', 'utf8'));
           const diff = await readFile(process.env.RUNNER_TEMP + '/pr.diff', 'utf8');
-          await writeFile('review-input.json', JSON.stringify({ artifactDir: 'pr-visual-artifacts', changedFiles: routing.files, diff, output: 'review-result.json' }));
+          await writeFile('review-input.json', JSON.stringify({ artifactDir: 'pr-visual-artifacts', changedFiles: routing.files, diff, reviewStatus: routing.review_status, output: 'review-result.json' }));
           NODE
 
       - name: Call configured GLM 5.2 / Kimi K3 backend
@@ -184,7 +201,7 @@ jobs:
           const run = process.env.GITHUB_RUN_ID;
           const body = result.status === 'completed'
             ? formatReviewBody({ review: result.review, runId: run, artifactUrl: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${run}` })
-            : `## Visual review (${run})\n\n**Status: ${result.status}**\n\n${result.error}\n\nNo findings were generated; rerun after configuring a GLM 5.2 or Kimi K3 backend.`;
+            : `## Visual review (${run})\n\n**review_status: ${result.review_status}**\n\n${result.error}\n\nNo findings were generated and this advisory lane does not block merging.`;
           process.stdout.write(body);
           NODE
           )

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildReviewPrompt,
   classifyFinding,
+  classifyReviewOutcome,
   routeChangedFiles,
   sanitizeForPrompt,
 } from '../../../.github/scripts/pr-visual-review.mjs';
@@ -19,6 +20,7 @@ describe('bounded PR visual review contract', () => {
       shouldReview: true,
       routes: ['/', '/demo'],
       reason: 'ui-change',
+      review_status: 'advisory',
     });
   });
 
@@ -29,12 +31,28 @@ describe('bounded PR visual review contract', () => {
       shouldReview: true,
       routes: ['/demo', '/demo/profile'],
       reason: 'ui-change',
+      review_status: 'advisory',
     });
     expect(routeChangedFiles(['scripts/format.mjs'])).toEqual({
       shouldReview: false,
       routes: [],
       reason: 'no-ui-change',
+      review_status: 'skipped',
     });
+  });
+
+  it('classifies unavailable evidence and model output as successful advisory states', () => {
+    expect(classifyReviewOutcome({ shouldReview: false })).toBe('skipped');
+    expect(
+      classifyReviewOutcome({ shouldReview: true, mergeBaseAvailable: false })
+    ).toBe('unavailable');
+    expect(
+      classifyReviewOutcome({ shouldReview: true, backendAvailable: false })
+    ).toBe('unavailable');
+    expect(classifyReviewOutcome({ shouldReview: true, timedOut: true })).toBe(
+      'unavailable'
+    );
+    expect(classifyReviewOutcome({ shouldReview: true })).toBe('advisory');
   });
 
   it('routes chat and shell changes through the seeded authenticated surface', () => {
@@ -44,6 +62,7 @@ describe('bounded PR visual review contract', () => {
       shouldReview: true,
       routes: ['/demo', '/app/chat'],
       reason: 'ui-change',
+      review_status: 'advisory',
     });
   });
 
@@ -90,6 +109,11 @@ describe('bounded PR visual review contract', () => {
       'Existing visual review found; idempotent no-op.'
     );
     expect(workflow).toContain('Do not alter subjective/taste findings.');
+    expect(workflow).toContain('review_status');
+    expect(workflow).toContain("'unavailable'");
+    expect(workflow).toContain("'skipped'");
+    expect(workflow).not.toContain('pr-visual-review-capture.mjs || true');
+    expect(workflow).not.toContain('requested_reviewers');
   });
 
   it('fails visual capture closed on runtime console, page, and server errors', () => {


### PR DESCRIPTION
## Summary
- classify no-merge-base, unavailable/timeout backend, no-UI, and model findings with machine-readable `review_status`
- keep advisory/unavailable/skipped outcomes successful and non-blocking
- preserve real screenshot/manifest failures for routed UI surfaces
- add focused control-plane contract coverage

## Verification
- `pnpm exec vitest run scripts/lib/__tests__/pr-visual-review.test.mjs` (8 passed)
- `actionlint .github/workflows/pr-visual-review.yml`
- `node --check .github/scripts/pr-visual-review.mjs`
- `git diff --check`
- repository pre-push gate passed, including web typecheck/lint and CI harness checks

No merge or merge-queue enrollment requested.
