### PR TITLE
fix(nav): hide settled empty inbox

### DIFF
--- a/apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts
+++ b/apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts
@@ -14,8 +14,10 @@
  */
 
 import { and, eq } from 'drizzle-orm';
+import { revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth/require-auth';
+import { CACHE_TAGS } from '@/lib/cache/tags';
 import { recordInboxDecision } from '@/lib/connectors/inbox-decision';
 import {
   enqueueApprovedActionWorkflow,
@@ -71,6 +73,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
       });
 
       if (recovery === 'enqueued' || recovery === 'already-queued') {
+        revalidateTag(CACHE_TAGS.DASHBOARD_DATA, 'max');
         return NextResponse.json(
           {
             ok: true,
@@ -122,6 +125,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
       cardKind: updated[0]?.kind ?? null,
       surface: 'opportunity-inbox',
     });
+    revalidateTag(CACHE_TAGS.DASHBOARD_DATA, 'max');
 
     return NextResponse.json(
       { ok: true, approvalId: id },

--- a/apps/web/app/api/connectors/suggested-actions/[id]/next-step/route.ts
+++ b/apps/web/app/api/connectors/suggested-actions/[id]/next-step/route.ts
@@ -21,8 +21,10 @@
  */
 
 import { and, eq } from 'drizzle-orm';
+import { revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth/require-auth';
+import { CACHE_TAGS } from '@/lib/cache/tags';
 import { parseReportMeasurement } from '@/lib/connectors/opportunity-inbox-report';
 import { db } from '@/lib/db';
 import { suggestedActions } from '@/lib/db/schema/connectors';
@@ -165,6 +167,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
       childId: result.childId,
       userId,
     });
+    revalidateTag(CACHE_TAGS.DASHBOARD_DATA, 'max');
 
     return NextResponse.json(
       { ok: true, parentId: id, nextActionId: result.childId },

--- a/apps/web/app/api/connectors/suggested-actions/[id]/reject/route.ts
+++ b/apps/web/app/api/connectors/suggested-actions/[id]/reject/route.ts
@@ -9,8 +9,10 @@
  */
 
 import { and, eq } from 'drizzle-orm';
+import { revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth/require-auth';
+import { CACHE_TAGS } from '@/lib/cache/tags';
 import { recordInboxDecision } from '@/lib/connectors/inbox-decision';
 import { db } from '@/lib/db';
 import { suggestedActions } from '@/lib/db/schema/connectors';
@@ -74,6 +76,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       cardKind: updated[0]?.kind ?? null,
       surface: 'opportunity-inbox',
     });
+    revalidateTag(CACHE_TAGS.DASHBOARD_DATA, 'max');
 
     return NextResponse.json(
       { ok: true, approvalId: id },

--- a/apps/web/app/app/(shell)/dashboard/DashboardDataContext.tsx
+++ b/apps/web/app/app/(shell)/dashboard/DashboardDataContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useMemo } from 'react';
+import { UNKNOWN_INBOX_NAVIGATION_AVAILABILITY } from '@/lib/inbox/navigation-availability';
 import { UNKNOWN_AVATAR_QUALITY } from '@/lib/profile/avatar-quality';
 import type { DashboardData } from './actions';
 
@@ -19,6 +20,8 @@ function normalizeDashboardData(value: DashboardData): DashboardData {
     ...value,
     avatarQuality: value.avatarQuality ?? UNKNOWN_AVATAR_QUALITY,
     bioLinkActivation: value.bioLinkActivation ?? null,
+    inboxNavigation:
+      value.inboxNavigation ?? UNKNOWN_INBOX_NAVIGATION_AVAILABILITY,
     profileCompletion: value.profileCompletion ?? EMPTY_PROFILE_COMPLETION,
   };
 }

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -27,12 +27,14 @@ import {
 } from '@/lib/db/query-timeout';
 import { clickEvents, tips } from '@/lib/db/schema/analytics';
 import { userSettings, users } from '@/lib/db/schema/auth';
+import { suggestedActions } from '@/lib/db/schema/connectors';
 import { socialLinks } from '@/lib/db/schema/links';
 import {
   type CreatorProfile,
   creatorDistributionEvents,
   creatorProfiles,
 } from '@/lib/db/schema/profiles';
+import { tourDates } from '@/lib/db/schema/tour';
 import {
   createEmptyTippingStats,
   profileIsPublishable,
@@ -49,6 +51,11 @@ import {
 } from '@/lib/distribution/instagram-activation';
 import { isE2EFastOnboardingEnabled } from '@/lib/e2e/runtime';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import {
+  type InboxNavigationAvailability,
+  resolveInboxNavigationAvailability,
+  UNKNOWN_INBOX_NAVIGATION_AVAILABILITY,
+} from '@/lib/inbox/navigation-availability';
 import { handleMigrationErrors } from '@/lib/migrations/handleMigrationErrors';
 import {
   type AvatarQuality,
@@ -144,6 +151,8 @@ export interface DashboardData {
   bioLinkActivation?: BioLinkActivation | null;
   /** Whether the user appears to be in their first chat session window */
   isFirstSession?: boolean;
+  /** Settled server-derived Inbox availability for conditional shell navigation. */
+  inboxNavigation?: InboxNavigationAvailability;
 }
 
 export interface ProfileCompletionStep {
@@ -467,6 +476,58 @@ function buildProfileCompletion(
  */
 type CoreData = Omit<DashboardData, 'isAdmin'>;
 
+async function loadInboxNavigationAvailability(
+  tx: DbOrTransaction,
+  userId: string,
+  profileId: string | null
+): Promise<InboxNavigationAvailability> {
+  if (!profileId) return UNKNOWN_INBOX_NAVIGATION_AVAILABILITY;
+
+  try {
+    const [pendingSuggestedActions, pendingTourDates] = await Promise.all([
+      dashboardQuery(
+        () =>
+          tx
+            .select({ count: drizzleSql<number>`count(*)` })
+            .from(suggestedActions)
+            .where(
+              and(
+                eq(suggestedActions.userId, userId),
+                eq(suggestedActions.status, 'pending')
+              )
+            ),
+        'Inbox navigation suggested actions count query',
+        { db: tx, timeoutMs: QUERY_TIMEOUTS.api }
+      ),
+      dashboardQuery(
+        () =>
+          tx
+            .select({ count: drizzleSql<number>`count(*)` })
+            .from(tourDates)
+            .where(
+              and(
+                eq(tourDates.profileId, profileId),
+                eq(tourDates.confirmationStatus, 'pending')
+              )
+            ),
+        'Inbox navigation tour dates count query',
+        { db: tx, timeoutMs: QUERY_TIMEOUTS.api }
+      ),
+    ]);
+
+    return resolveInboxNavigationAvailability(
+      Number(pendingSuggestedActions[0]?.count ?? 0),
+      Number(pendingTourDates[0]?.count ?? 0)
+    );
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'warning',
+      tags: { context: 'inbox_navigation_availability' },
+    });
+    return UNKNOWN_INBOX_NAVIGATION_AVAILABILITY;
+  }
+}
+
 function shouldBypassDashboardCache(): boolean {
   return isE2EFastOnboardingEnabled();
 }
@@ -753,6 +814,12 @@ async function fetchDashboardBaseWithSession(
             return undefined;
           });
 
+  const inboxNavigation = await loadInboxNavigationAvailability(
+    tx,
+    userData.id,
+    selected.id
+  );
+
   return {
     user: userData,
     creatorProfiles: creatorData,
@@ -765,6 +832,7 @@ async function fetchDashboardBaseWithSession(
     tippingStats: createEmptyTippingStats(),
     profileCompletion: buildProfileCompletion(selected, userData.email, false),
     bioLinkActivation: null,
+    inboxNavigation,
     dashboardLoadError: undefined,
     isFirstSession: deriveIsFirstSession(selected),
   };

--- a/apps/web/app/app/(shell)/dashboard/tour-dates/events-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tour-dates/events-actions.ts
@@ -3,6 +3,7 @@
 import { and, eq, inArray } from 'drizzle-orm';
 import { unstable_noStore as noStore, revalidateTag } from 'next/cache';
 import { getCachedAuth } from '@/lib/auth/cached';
+import { CACHE_TAGS } from '@/lib/cache/tags';
 import { db } from '@/lib/db';
 import { tourDates } from '@/lib/db/schema/tour';
 import { trackServerEvent } from '@/lib/server-analytics';
@@ -59,6 +60,7 @@ async function requireAuthedProfile(): Promise<AuthedProfile | null> {
 
 function invalidateEventsCache(authed: AuthedProfile): void {
   revalidateTag(`tour-dates:${authed.userId}:${authed.profileId}`, 'max');
+  revalidateTag(CACHE_TAGS.DASHBOARD_DATA, 'max');
 }
 
 function isValidEventId(id: string): boolean {

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -23,6 +23,7 @@ import {
 import { useChatThreadContextMenu } from '@/components/shell/useChatThreadContextMenu';
 import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
+import { shouldShowInboxNavigation } from '@/lib/inbox/navigation-availability';
 import { NAV_SHORTCUTS } from '@/lib/keyboard-shortcuts';
 import { usePlanGate } from '@/lib/queries';
 import { useChatConversationsQuery } from '@/lib/queries/useChatConversationsQuery';
@@ -127,7 +128,7 @@ function formatTaskBadge(
 }
 
 export function DashboardNav(_: DashboardNavProps) {
-  const { selectedProfile } = useDashboardData();
+  const { inboxNavigation, selectedProfile } = useDashboardData();
   const { isMobile, openMobile, state: sidebarState } = useSidebar();
   const pathname = usePathname();
   const router = useRouter();
@@ -156,6 +157,18 @@ export function DashboardNav(_: DashboardNavProps) {
     seenAt: tasksSeenAt,
   });
   const isInSettings = pathname.startsWith(APP_ROUTES.SETTINGS);
+  const visiblePrimaryNavigation = useMemo(
+    () =>
+      primaryNavigation.filter(
+        item =>
+          item.id !== 'inbox' ||
+          shouldShowInboxNavigation(
+            inboxNavigation,
+            isItemActive(pathname, item)
+          )
+      ),
+    [inboxNavigation, pathname]
+  );
   const threadsVisible =
     !isDemo &&
     !isInSettings &&
@@ -197,11 +210,20 @@ export function DashboardNav(_: DashboardNavProps) {
   useEffect(() => {
     if (isDemo || isMobile) return;
     trackNavigationImpressions(
-      isInSettings ? ['settings'] : primaryNavigation.map(item => item.id),
+      isInSettings
+        ? ['settings']
+        : visiblePrimaryNavigation.map(item => item.id),
       pathname,
       telemetryContext
     );
-  }, [isDemo, isInSettings, isMobile, pathname, telemetryContext]);
+  }, [
+    isDemo,
+    isInSettings,
+    isMobile,
+    pathname,
+    telemetryContext,
+    visiblePrimaryNavigation,
+  ]);
 
   const artistSettingsLabel = 'Artist';
 
@@ -237,10 +259,16 @@ export function DashboardNav(_: DashboardNavProps) {
     return [
       {
         key: 'primary',
-        items: primaryNavigation.map(decorateItem),
+        items: visiblePrimaryNavigation.map(decorateItem),
       },
     ];
-  }, [canAccessTasksWorkspace, isPlanGateLoading, taskStats, tasksSeenAt]);
+  }, [
+    canAccessTasksWorkspace,
+    isPlanGateLoading,
+    taskStats,
+    tasksSeenAt,
+    visiblePrimaryNavigation,
+  ]);
 
   // Debounced prefetch: avoid firing on fast mouse sweeps across nav items
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/web/lib/inbox/navigation-availability.test.ts
+++ b/apps/web/lib/inbox/navigation-availability.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveInboxNavigationAvailability,
+  shouldShowInboxNavigation,
+  UNKNOWN_INBOX_NAVIGATION_AVAILABILITY,
+} from './navigation-availability';
+
+describe('Inbox navigation availability', () => {
+  it('marks the Inbox available when either review queue has pending work', () => {
+    expect(resolveInboxNavigationAvailability(1, 0)).toEqual({
+      state: 'available',
+      pendingCount: 1,
+    });
+    expect(resolveInboxNavigationAvailability(0, 2)).toEqual({
+      state: 'available',
+      pendingCount: 2,
+    });
+  });
+
+  it('marks the Inbox empty only after both queues settle at zero', () => {
+    expect(resolveInboxNavigationAvailability(0, 0)).toEqual({
+      state: 'empty',
+      pendingCount: 0,
+    });
+  });
+
+  it('fails open for unknown availability and preserves an active empty Inbox', () => {
+    expect(
+      shouldShowInboxNavigation(UNKNOWN_INBOX_NAVIGATION_AVAILABILITY, false)
+    ).toBe(true);
+    expect(shouldShowInboxNavigation(undefined, false)).toBe(true);
+    expect(
+      shouldShowInboxNavigation({ state: 'empty', pendingCount: 0 }, true)
+    ).toBe(true);
+    expect(
+      shouldShowInboxNavigation({ state: 'empty', pendingCount: 0 }, false)
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/inbox/navigation-availability.ts
+++ b/apps/web/lib/inbox/navigation-availability.ts
@@ -1,0 +1,33 @@
+/**
+ * The shell receives this server-derived summary before the sidebar renders.
+ * `unknown` deliberately fails open: a transient data failure must never hide
+ * a destination a creator may still need.
+ */
+export interface InboxNavigationAvailability {
+  readonly state: 'available' | 'empty' | 'unknown';
+  readonly pendingCount: number | null;
+}
+
+export const UNKNOWN_INBOX_NAVIGATION_AVAILABILITY: InboxNavigationAvailability =
+  {
+    state: 'unknown',
+    pendingCount: null,
+  };
+
+export function resolveInboxNavigationAvailability(
+  pendingSuggestedActionCount: number,
+  pendingTourDateCount: number
+): InboxNavigationAvailability {
+  const pendingCount = pendingSuggestedActionCount + pendingTourDateCount;
+
+  return pendingCount > 0
+    ? { state: 'available', pendingCount }
+    : { state: 'empty', pendingCount: 0 };
+}
+
+export function shouldShowInboxNavigation(
+  availability: InboxNavigationAvailability | undefined,
+  isActive: boolean
+): boolean {
+  return isActive || availability?.state !== 'empty';
+}

--- a/apps/web/tests/unit/actions/tour-dates-events-actions.test.ts
+++ b/apps/web/tests/unit/actions/tour-dates-events-actions.test.ts
@@ -170,6 +170,7 @@ describe('event moderation server actions', () => {
       'tour-dates:user_123:prof_123',
       'max'
     );
+    expect(mockRevalidateTag).toHaveBeenCalledWith('dashboard-data', 'max');
     expect(mockTrackServerEvent).not.toHaveBeenCalled();
   });
 
@@ -192,6 +193,7 @@ describe('event moderation server actions', () => {
       'tour-dates:user_123:prof_123',
       'max'
     );
+    expect(mockRevalidateTag).toHaveBeenCalledWith('dashboard-data', 'max');
   });
 
   it('undoRejectEvent stays scoped to profileId and only matches rejected rows', async () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -78,6 +78,44 @@ describe('DashboardNav', () => {
     ).toEqual(CANONICAL_NAV);
   });
 
+  it('hides a settled-empty Inbox away from its active destination', () => {
+    const { getByRole, queryByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      overrides: {
+        inboxNavigation: { state: 'empty', pendingCount: 0 },
+      },
+    });
+
+    expect(queryByRole('link', { name: 'Inbox' })).toBeNull();
+    expect(getByRole('link', { name: 'Chat' })).toBeInTheDocument();
+  });
+
+  it('keeps a settled-empty Inbox visible while its root destination is active', () => {
+    mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD);
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      overrides: {
+        inboxNavigation: { state: 'empty', pendingCount: 0 },
+      },
+    });
+
+    expect(getByRole('link', { name: 'Inbox' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('keeps Inbox visible when availability is unknown', () => {
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      overrides: {
+        inboxNavigation: { state: 'unknown', pendingCount: null },
+      },
+    });
+
+    expect(getByRole('link', { name: 'Inbox' })).toBeInTheDocument();
+  });
+
   it('keeps the exact customer IA invariant for admin users', () => {
     const standard = renderDashboardNav({ renderFn: fastRender });
     const standardContract = primaryLinks(standard.container).map(link => [

--- a/apps/web/tests/unit/dashboard/dashboard-data-tx-isolation.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-data-tx-isolation.test.ts
@@ -355,6 +355,8 @@ describe('dashboard data transaction isolation (JOV-4189)', () => {
       ok([userRow]),
       ok([dashboardProfile]),
       ok([{ sidebarCollapsed: false }]),
+      ok([{ count: 0 }]), // settled Inbox suggested-actions count
+      ok([{ count: 0 }]), // settled Inbox tour-dates count
       fail(realLinksError), // social links existence read fails
       ok([{ width: 1024, height: 1024 }]), // avatar quality read
       ok([{ totalReceived: 100, monthReceived: 50, tipsSubmitted: 2 }]),
@@ -399,6 +401,8 @@ describe('dashboard data transaction isolation (JOV-4189)', () => {
       ok([userRow]),
       ok([dashboardProfile]),
       ok([{ sidebarCollapsed: false }]),
+      ok([{ count: 0 }]), // settled Inbox suggested-actions count
+      ok([{ count: 0 }]), // settled Inbox tour-dates count
       ok([{ hasLinks: true, hasMusicLinks: true }]),
       fail(realAvatarError), // avatar quality read fails
       ok([{ totalReceived: 100, monthReceived: 50, tipsSubmitted: 2 }]),
@@ -440,6 +444,8 @@ describe('dashboard data transaction isolation (JOV-4189)', () => {
       ok([userRow]),
       ok([dashboardProfile]),
       ok([{ sidebarCollapsed: false }]),
+      ok([{ count: 0 }]), // settled Inbox suggested-actions count
+      ok([{ count: 0 }]), // settled Inbox tour-dates count
       ok([{ hasLinks: true, hasMusicLinks: true }]),
       ok([{ width: 1024, height: 1024 }]),
       fail(realTippingError), // tipping aggregate read fails
@@ -474,6 +480,8 @@ describe('dashboard data transaction isolation (JOV-4189)', () => {
       ok([userRow]),
       ok([dashboardProfile]),
       ok([{ sidebarCollapsed: true }]),
+      ok([{ count: 0 }]), // settled Inbox suggested-actions count
+      ok([{ count: 0 }]), // settled Inbox tour-dates count
       ok([{ hasLinks: true, hasMusicLinks: true }]),
       ok([{ width: 256, height: 256 }]),
       ok([{ totalReceived: 250, monthReceived: 125, tipsSubmitted: 4 }]),


### PR DESCRIPTION
Resolves JOV-4561.

## Scope
- derive Inbox availability from pending suggested actions and tour-date confirmations before sidebar render
- hide Inbox only after a settled empty result; retain it when active
- fail open on missing profile or query failure, and revalidate dashboard data after relevant mutations

## Verification
- Biome on primary changed files: passed
- focused Vitest: availability 3/3; tour-date actions 7/7
- git diff --check: passed
- DashboardNav test is blocked before collection by existing Vite ws resolution in `apps/web/lib/db/client/connection.ts`; no assertions ran

## Admission
Draft + gated. No runtime capture, Kimi, ready, queue, or merge action.