### PR TITLE
fix(backlog): make classification comments idempotent

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -8,6 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ORCHESTRATOR_DIR = resolve(__dirname, '..');
 
 const classifier = await import('../classifier.mjs');
+const { reconcileIssues } = await import('../reconcile.mjs');
 const scorer = await import('../scorer.mjs');
 const workstreamer = await import('../workstreamer.mjs');
 const reporter = await import('../reporter.mjs');
@@ -91,6 +92,31 @@ describe('classifier', () => {
     const c = new classifier.IssueClassification(makeIssue());
     c.category = 'duplicate';
     assert.equal(scorer.scoreIssue(c).score, 0);
+  });
+});
+
+describe('reconciliation idempotency', () => {
+  it('does not repost a classification when only the persisted comment changes updatedAt', async () => {
+    const issue = makeIssue({ identifier: 'JOV-4530' });
+    let nextUpdatedAt = issue.updatedAt;
+    const calls = { comments: [] };
+    const client = {
+      async addComment(issueId, body) {
+        calls.comments.push({ issueId, body });
+        issue.comments.nodes.push({
+          id: `comment-${calls.comments.length}`,
+          body,
+          createdAt: `2026-07-01T12:0${calls.comments.length}:00Z`,
+        });
+        nextUpdatedAt = `2026-07-01T12:0${calls.comments.length}:30Z`;
+      },
+    };
+
+    const reread = () => ({ ...issue, updatedAt: nextUpdatedAt });
+    await reconcileIssues({ issues: [reread()], client });
+    await reconcileIssues({ issues: [reread()], client });
+
+    assert.equal(calls.comments.length, 1);
   });
 });
 

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -26,6 +26,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // ----- Local imports -----
 const linear = await import(resolve(__dirname, 'linear-client.mjs'));
 const classifier = await import(resolve(__dirname, 'classifier.mjs'));
+const reconciler = await import(resolve(__dirname, 'reconcile.mjs'));
 const scorer = await import(resolve(__dirname, 'scorer.mjs'));
 const workstreamer = await import(resolve(__dirname, 'workstreamer.mjs'));
 const admitter = await import(resolve(__dirname, 'admitter.mjs'));
@@ -148,44 +149,12 @@ async function runReconcile(cache, isDryRun, issueArg) {
 
   console.log(`Processing ${issues.length} issues`);
 
-  for (const issue of issues) {
-    const stored = classifier.parseStoredClassification(issue);
-    const c = classifier.classifyDeterministic(issue, issues);
-
-    if (stored && stored.fp === c.fingerprint) {
-      console.log(`  SKIP ${issue.identifier} — unchanged`);
-      continue;
-    }
-
-    console.log(
-      `  ${c.category}: ${issue.identifier} — ${(issue.title || '').slice(0, 50)}`
-    );
-
-    if (isDryRun) {
-      console.log(
-        `    (dry-run) would classify as ${c.category}, score ${c.valueScore}`
-      );
-      continue;
-    }
-
-    // Persist classification as machine comment
-    const commentBody = classifier.buildStoredClassification(c);
-    try {
-      await linear.addComment(issue.id, commentBody);
-    } catch (err) {
-      console.error(`    Failed to add comment: ${err.message}`);
-    }
-
-    // If duplicate/obsolete, move to Backlog
-    if (c.category === 'duplicate' || c.category === 'obsolete') {
-      try {
-        await linear.transitionIssue(issue.id, BACKLOG_STATE_ID);
-        console.log(`    Moved to Backlog`);
-      } catch (err) {
-        console.error(`    Failed to transition: ${err.message}`);
-      }
-    }
-  }
+  await reconciler.reconcileIssues({
+    issues,
+    client: linear,
+    isDryRun,
+    backlogStateId: BACKLOG_STATE_ID,
+  });
 
   console.log('Reconciliation complete.');
 }

--- a/scripts/backlog-orchestrator/classifier.mjs
+++ b/scripts/backlog-orchestrator/classifier.mjs
@@ -44,7 +44,6 @@ export class IssueClassification {
         ?.map(l => l.name)
         .sort()
         .join(',') || '',
-      issue.updatedAt,
     ].join('|');
     return createHash('sha256').update(canonical).digest('hex').slice(0, 16);
   }

--- a/scripts/backlog-orchestrator/reconcile.mjs
+++ b/scripts/backlog-orchestrator/reconcile.mjs
@@ -1,0 +1,52 @@
+/**
+ * Reconcile deterministic classifications against persisted machine comments.
+ */
+
+import * as classifier from './classifier.mjs';
+
+export async function reconcileIssues({
+  issues,
+  client,
+  isDryRun = false,
+  backlogStateId = null,
+}) {
+  for (const issue of issues) {
+    const stored = classifier.parseStoredClassification(issue);
+    const c = classifier.classifyDeterministic(issue, issues);
+
+    if (stored && stored.fp === c.fingerprint) {
+      console.log(`  SKIP ${issue.identifier} — unchanged`);
+      continue;
+    }
+
+    console.log(
+      `  ${c.category}: ${issue.identifier} — ${(issue.title || '').slice(0, 50)}`
+    );
+
+    if (isDryRun) {
+      console.log(
+        `    (dry-run) would classify as ${c.category}, score ${c.valueScore}`
+      );
+      continue;
+    }
+
+    const commentBody = classifier.buildStoredClassification(c);
+    try {
+      await client.addComment(issue.id, commentBody);
+    } catch (err) {
+      console.error(`    Failed to add comment: ${err.message}`);
+    }
+
+    if (
+      backlogStateId &&
+      (c.category === 'duplicate' || c.category === 'obsolete')
+    ) {
+      try {
+        await client.transitionIssue(issue.id, backlogStateId);
+        console.log('    Moved to Backlog');
+      } catch (err) {
+        console.error(`    Failed to transition: ${err.message}`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove mutable Linear `updatedAt` from classification fingerprints
- isolate reconciliation and add a two-run regression proving one machine comment

## Verification
- `node --test scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` (21 passed)
- `node --check` on changed `.mjs` files
- `pnpm exec biome check --formatter-enabled=true --linter-enabled=false scripts/backlog-orchestrator/classifier.mjs scripts/backlog-orchestrator/backlog-orchestrator.mjs scripts/backlog-orchestrator/reconcile.mjs scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs`
- `git diff --check`

No Linear mutations were performed. Do not merge.