### PR TITLE
docs(investors): add Closed-Loop Creator thesis

### DIFF
--- a/apps/web/components/features/pitch/InvestorBrief.tsx
+++ b/apps/web/components/features/pitch/InvestorBrief.tsx
@@ -67,6 +67,11 @@ export function InvestorBrief({
           <Button asChild variant='secondary'>
             <a href='#brief'>Read The Brief</a>
           </Button>
+          <Button asChild variant='ghost'>
+            <Link href='/investor-portal/closed-loop-creator'>
+              Read The Closed-Loop Creator Thesis
+            </Link>
+          </Button>
         </div>
       </header>
 

--- a/apps/web/content/investors/closed-loop-creator.md
+++ b/apps/web/content/investors/closed-loop-creator.md
@@ -1,0 +1,149 @@
+# The Closed-Loop Creator
+
+Jovie's long-term opportunity is not another destination for creator links. It is a
+closed-loop operating layer for the business a creator is already trying to run:
+bring attention in, turn attention into owned relationships, choose the next
+high-value action, get approval where judgment matters, execute, and learn from the
+outcome.
+
+This is a thesis and product direction—not a claim that every part of the loop is
+already shipped, automated, or proven at scale.
+
+## The owned-asset graph
+
+A creator's business is spread across assets that rarely share a useful operating
+context: a Jovie profile, social accounts, streaming destinations, email and SMS
+lists, stores, ticketing pages, releases, tour dates, brand contacts, and the
+creative files behind each campaign. The creator may own or control some of these
+assets, have limited access to others, and rent distribution on the rest.
+
+Jovie's wedge is to make the relationships between those assets explicit. A release
+can be connected to its smart links, the audience actions that followed, the offers
+available in a city, and the tasks required to keep the moment moving. A contact can
+be connected to a team role, a thread, a rate card, and the next follow-up. An
+opportunity can be connected to the source signal, the recommended task, its
+approval decision, and the downstream result.
+
+That graph is valuable even before sophisticated automation: it gives a creator one
+place to see what exists, what is missing, and what deserves attention next. It also
+creates the substrate for learning across moments without pretending that a
+creator's data should be pooled indiscriminately across people.
+
+## The observability gap is the product gap
+
+Most creator tools report activity in isolated dashboards. They can show a click,
+a follower, a sale, or a message send, but not reliably answer the operating
+questions underneath:
+
+- Which owned asset produced this opportunity?
+- Which task was suggested, by what evidence, and when?
+- Was the task done manually, approved and automated, or merely drafted?
+- What happened after it shipped?
+- Which parts of the result are measured revenue, a directional proxy, or still
+  unknown?
+
+A closed loop needs an event spine, not a prettier dashboard. Jovie should preserve
+source evidence, task state, approval state, execution state, and downstream
+outcomes as separate facts. Attribution should be time-bounded and labeled. When a
+link between an action and an outcome cannot be established, the honest answer is
+"unknown," not a stronger-sounding conversion story.
+
+## ROI-ranked work, with a human in the loop
+
+The system should turn the graph into a ranked work queue. A useful task is not
+simply an AI suggestion; it is a bounded action with an owner, an objective, an
+estimated upside or cost avoided, evidence, dependencies, and a clear completion
+signal.
+
+Examples might include following up with a qualified booking inquiry, fixing a
+broken destination link before a release moment, asking for permission to use a
+fan asset, packaging a merch offer for a relevant city, or preparing a campaign
+brief from an artist-approved release plan. The ranking should consider expected
+value, confidence, time sensitivity, effort, and reversibility. A low-confidence,
+high-consequence action should not outrank a small, well-supported fix merely
+because an LLM wrote a persuasive explanation.
+
+Human approval is part of the product contract. A creator or authorized teammate
+must approve external communications, pricing, commitments, rights-sensitive use
+of assets, and anything that could materially change a public presence. Jovie can
+prepare the work, explain the evidence, and make the approval decision easy; it
+should not silently impersonate the creator. Reversible, low-risk internal steps
+may become automatic only after their boundaries and failure handling are explicit.
+
+## Manual to automated maturity
+
+Automation is earned through repeated, observable success—not switched on because a
+model is available.
+
+1. **Observe:** collect the asset, event, and outcome facts with provenance.
+2. **Suggest:** produce a ranked task and show the evidence and uncertainty.
+3. **Prepare:** draft the copy, payload, or checklist without sending or publishing.
+4. **Approve:** let the creator accept, edit, reject, or defer it.
+5. **Execute:** run the approved task with an idempotency key and an audit trail.
+6. **Automate narrowly:** allow a proven class of reversible task to run within an
+   explicit budget and policy.
+7. **Re-evaluate:** compare outcomes, overrides, failures, and time saved before
+   widening the boundary.
+
+This progression keeps the product useful on day one. A creator does not need to
+hand over the business to get value; the first win can be better visibility and a
+shorter path from signal to approved action.
+
+## Creator Deal Desk and rate-card floors
+
+Creator work also has a commercial operating layer. A deal should not be treated as
+an email thread that disappears after the reply. Jovie can help organize inbound
+opportunities, capture deliverables and dates, compare an offer with the creator's
+approved rate-card floors, and prepare a response for review.
+
+Rate-card floors are guardrails, not a promise that every deal should be rejected
+below a number. A creator may intentionally trade price for access, strategic value,
+rights, speed, or a relationship. The system should make the deviation visible,
+record who approved it, and avoid presenting an inferred rate as an authoritative
+commercial term. No deal should be accepted, negotiated, or committed externally
+without the creator's explicit approval.
+
+## Privacy and externalization boundaries
+
+The graph is only useful if creators trust it. Private contacts, unpublished work,
+negotiation details, fan identifiers, and sensitive performance data should remain
+scoped to the creator and authorized collaborators. External systems should receive
+only the minimum approved payload needed for the task, with consent, purpose, and
+retention rules appropriate to the destination.
+
+Jovie should separate private operating context from sanitized, aggregate product
+learning. Cross-creator learning may use explicit, de-identified patterns—such as
+which task types are commonly useful—not a hidden exchange of one creator's
+contacts, rates, messages, or audience records with another. The product must expose
+what will leave Jovie, where it will go, and what can be revoked. Privacy is a
+launch constraint, not a later compliance paragraph.
+
+## Tim's dogfood loop and the PMF test
+
+Founder dogfood is a fast way to find the sharp edges: Tim can use Jovie against
+real creator work, notice where context is missing, approve or reject suggested
+actions, and record whether the result saved time or created value. That loop is
+important because the product must survive real deadlines, messy contacts, changing
+assets, and judgment calls—not just a polished demo.
+
+Dogfood is evidence of usability and problem discovery, not proof of broad
+product-market fit. Each observation should become a testable hypothesis: a task
+category, a measurable time-to-value or outcome, and a cohort or customer path that
+can confirm or falsify it. The next proof is not a larger claim; it is repeated use
+by independent creators, with permissioned data and attributable outcomes.
+
+## What would make the thesis true
+
+The thesis earns credibility if creators repeatedly use Jovie to move from a real
+signal to a better approved action, return because the system remembers the work,
+and can see enough outcome evidence to decide what to do next. The key measures are
+therefore not just generated tasks. They include task acceptance and override
+rates, time from signal to approved execution, completion reliability, creator
+retention around meaningful work, and attributable lift where a defensible baseline
+exists.
+
+Until those measurements exist, Jovie should describe the Closed-Loop Creator as a
+coherent direction with a staged implementation plan. The promise is ambitious:
+help creators operate the business behind the content. The evidence standard should
+be equally ambitious: explicit ownership, visible uncertainty, human control, and
+proof earned one loop at a time.

--- a/apps/web/content/investors/investor-memo.md
+++ b/apps/web/content/investors/investor-memo.md
@@ -28,6 +28,8 @@ Music creation is easier than ever, but attention and monetization are harder th
 
 Jovie is an AI growth engine for music creators. It turns a creator's link in bio into a personalized funnel that identifies high-value fans and routes each visitor to the next best action—streaming, subscribing, merch, or tickets—then follows up automatically to increase lifetime value.
 
+For the broader operating thesis behind this loop, read [The Closed-Loop Creator Thesis](/investor-portal/closed-loop-creator).
+
 **Product:** AI flywheel for fan value extraction
 
 Jovie runs an always-on decision loop on every profile view:

--- a/apps/web/content/investors/manifest.json
+++ b/apps/web/content/investors/manifest.json
@@ -5,6 +5,12 @@
       "file": "investor-memo.md",
       "title": "Investor Memo",
       "nav": true
+    },
+    {
+      "slug": "closed-loop-creator",
+      "file": "closed-loop-creator.md",
+      "title": "The Closed-Loop Creator",
+      "nav": true
     }
   ],
   "deck": {

--- a/docs/product/closed-loop-creator.md
+++ b/docs/product/closed-loop-creator.md
@@ -1,0 +1,180 @@
+---
+title: Closed-Loop Creator — Canonical Product Contract
+status: thesis-and-architecture
+owner: Product
+source_of_truth: This document is the agent-facing contract for the Closed-Loop Creator direction.
+evidence_boundary: Proposed architecture and roadmap; do not represent planned behavior as shipped or proven.
+---
+
+# Closed-Loop Creator
+
+## Purpose and evidence boundary
+
+The Closed-Loop Creator is a product direction for operating a creator's business
+across owned assets, audience signals, opportunities, approved tasks, execution, and
+outcomes. This document is canonical for the vocabulary and boundaries below. It is
+not evidence that every component exists, that automation is enabled, or that Jovie
+has broad creator PMF. Agents must label each statement as **shipped**, **manual**,
+**planned**, **proxy**, or **unknown** when writing product or investor copy.
+
+## Canonical architecture
+
+```text
+owned assets + external signals
+  -> normalized asset graph and provenance
+  -> observable opportunity / task candidates
+  -> ROI-ranked task contract
+  -> prepare -> human approval boundary
+  -> bounded execution with audit/idempotency
+  -> downstream outcome events
+  -> attribution + operator feedback
+  -> updated ranking and next task
+```
+
+### Owned-asset graph
+
+The graph may represent creator profiles, smart links, releases, campaigns, fan
+identifiers, offers, merch, tickets, tour dates, contacts, team roles, deal terms,
+rate-card floors, and creative assets. Every edge needs a source, timestamp, scope,
+and confidence. Ownership and access are distinct: an external platform may be
+connected without becoming an owned Jovie asset.
+
+### Observability spine
+
+Keep these states separate and queryable:
+
+- source signal and provenance;
+- candidate task and ranking explanation;
+- preparation/draft state;
+- approval decision and approver;
+- execution request, idempotency key, and result;
+- downstream outcome and attribution window;
+- override, failure, cost, and human feedback.
+
+Never infer shipped execution from a generated draft. Never call a modeled value
+settled revenue. If temporal linkage or a baseline is missing, classify the outcome
+as `unknown` or `proxy`.
+
+## Privacy and externalization rules
+
+1. Private contacts, fan identifiers, unpublished creative, negotiations, and
+   creator-specific rates remain scoped to that creator and authorized collaborators.
+2. Externalize the minimum payload needed for an approved task, only to the named
+   destination and for the stated purpose.
+3. Require creator/team consent before sending messages, publishing content, sharing
+   identifiers, or using rights-sensitive assets.
+4. Keep cross-creator learning de-identified and aggregate. Do not train or expose
+   one creator's contacts, rates, messages, or audience records to another.
+5. Show what leaves Jovie, where it goes, why it is needed, retention expectations,
+   and how access can be revoked.
+6. Do not use private dogfood observations as public traction or customer proof.
+
+## Task contract
+
+Every task candidate must be representable as a bounded record with at least:
+
+```yaml
+id: stable-task-id
+creator_scope: creator-or-workspace-scope
+kind: stable-task-kind
+objective: measurable desired outcome
+source_evidence: [{source, observed_at, excerpt_or_reference}]
+rank:
+  expected_value: measured-or-labeled-proxy
+  confidence: low|medium|high
+  urgency: low|medium|high
+effort: estimate-or-unknown
+draft: payload-or-checklist
+approval:
+  required: true|false
+  boundary: internal|external-communication|pricing|rights|public-change
+execution:
+  mode: manual|approved-automation
+  idempotency_key: stable-key-or-null
+outcome:
+  status: unknown|success|failure|proxy
+  attribution_window: explicit-window-or-null
+```
+
+A task is not complete until its execution and outcome state are recorded. Ranking
+must be explainable in terms of expected value, confidence, urgency, effort, and
+reversibility. A task with high consequence and low confidence defaults to
+prepare-only or human approval.
+
+## Approval boundaries
+
+Human approval is mandatory before:
+
+- any external communication or public publication;
+- accepting, negotiating, or committing to a deal;
+- changing a creator's rate-card floor or approving a deviation from it;
+- sending fan identifiers or sensitive data to an external system;
+- using unpublished or rights-sensitive creative;
+- actions that materially spend money, change access, or alter a public presence.
+
+The approver may edit, reject, or defer. Approval must be bound to the exact draft,
+recipient/destination, scope, and relevant data. Execution must fail closed when the
+approved payload has changed, the approval is stale, or the destination is outside
+scope.
+
+Low-risk, reversible internal steps may become automated only after repeated
+successful manual/approved runs, explicit policy, bounded budgets, idempotency, and
+a rollback path. Model confidence alone is never an approval substitute.
+
+## Manual-to-automated maturity
+
+1. **Observe** — capture source facts and provenance.
+2. **Suggest** — rank a task with evidence and uncertainty.
+3. **Prepare** — draft without sending or publishing.
+4. **Approve** — creator/team accepts, edits, rejects, or defers.
+5. **Execute** — run the approved task and record the result.
+6. **Automate narrowly** — only a proven, reversible class within policy.
+7. **Re-evaluate** — measure outcomes, overrides, failures, and time saved.
+
+Agents must not skip a maturity stage in copy, implementation plans, or demos.
+
+## Creator Deal Desk
+
+Deal tasks may include intake, deliverable/date extraction, rate-card comparison,
+response preparation, and follow-up reminders. Rate-card floors are creator-owned
+guardrails, not automatically binding rejection rules. A below-floor exception must
+show the tradeoff and require explicit approval. No agent may accept or negotiate a
+deal externally.
+
+## Roadmap
+
+- **P0 — observable substrate:** canonical asset/task vocabulary, provenance,
+  manual task ledger, explicit unknown/proxy labels, and approval audit trail.
+- **P1 — operator loop:** owned-asset graph views, ROI-ranked suggestions, draft
+  preparation, creator/team approvals, outcome capture, and Tim dogfood.
+- **P2 — repeatable workflows:** Deal Desk, rate-card floors, release/tour/offer
+  playbooks, bounded integrations, and attribution windows with baselines.
+- **P3 — narrow automation:** automate only task classes with repeated evidence,
+  reliable execution, clear rollback, privacy policy, and creator opt-in.
+- **P4 — learning system:** aggregate, de-identified patterns improve ranking;
+  independent creator cohorts validate time-to-value, retention, and attributable
+  outcomes.
+
+These are sequencing hypotheses, not committed delivery dates.
+
+## PMF and dogfood loop
+
+Tim dogfood is an internal discovery loop: use real creator work, record missing
+context and approval friction, turn observations into falsifiable hypotheses, and
+validate them with independent creators. It is not broad traction. The evidence
+ladder is: repeated approved use, reliable execution, measurable time or outcome
+improvement, then attributable cohort evidence with a stated baseline.
+
+## Unknowns and decision gates
+
+- Which asset graph entities produce the highest repeatable creator value?
+- Which tasks are frequent, reversible, and valuable enough to automate?
+- What minimum provenance is needed for defensible attribution?
+- Which integrations can honor consent, deletion, and scope reliably?
+- What does a creator consider a meaningful time-to-value?
+- Which Deal Desk exceptions are common enough to model without replacing judgment?
+- What independent cohort size and baseline are needed before quoting lift?
+
+Do not resolve these unknowns by inventing metrics, customer counts, automation
+coverage, or revenue claims. Add evidence, an owner, and a falsifiable acceptance
+condition before promoting a hypothesis to product truth.


### PR DESCRIPTION
## Summary
- Add the public Closed-Loop Creator investor thesis covering the owned-asset graph, observability, ROI-ranked tasks, approvals, maturity, Deal Desk/rate-card floors, privacy, and founder dogfood/PMF evidence boundaries.
- Add the agent-facing canonical product contract with architecture, privacy/externalization rules, task contract, approval boundaries, roadmap, and unknowns.
- Link the thesis from the investor memo and InvestorBrief, and register the page in the investor manifest.

## Scope
- Five files only; no pricing, backend, or unrelated roadmap changes.
- Claims are explicitly qualified; founder dogfood is not presented as broad traction or PMF.

## Verification
- `git diff --cached --check` — pass before commit
- Independent manifest/file/link/frontmatter contract — pass
- Biome on changed TSX/JSON — pass
- Focused investor manifest Vitest — blocked at startup: isolated worktree dependency layout is unavailable (`@vitejs/plugin-react`/`dotenv` unresolved); Node `v22.22.3` is also below the repo-required `>=22.23.1`.

## Evidence boundary
This is a bounded documentation/copy update. Do not merge as part of this task; leave the PR draft for the canonical workflow and CI feedback.
