### PR TITLE
fix(ci): keep visual capture advisory in queue

### DIFF
--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -7,7 +7,11 @@ const UI_FILE =
   /^(apps\/web\/(app|components|features|lib|public|styles|tests\/visual-qa)|packages\/ui|apps\/console\/.*screenshot|apps\/ios\/.*(View|Screen|Snapshot)|.*\.(css|scss|tsx|jsx))\//;
 const SECRET =
   /(api[_-]?key|secret|password|token|private[_-]?key|database[_-]?url|authorization)\s*[:=]\s*[^\s,;]+/gi;
-const ALLOWED_MODELS = /(?:glm[-_ ]?5(?:\.2)?|kimi[-_ ]?k3)/i;
+const GROK_MODEL = /grok[-_ ]?4(?:[._ -]?5)?/i;
+const CODEX_MODEL =
+  /(?:gpt[-_ ]?5(?:[._ -]?\d+)?(?:[-_ ]?codex)?|codex[-_ ]?[\w.-]+)/i;
+
+/** @typedef {{ apiKey?: string, baseUrl?: string, model?: string }} ReviewBackend */
 
 export function sanitizeForPrompt(value) {
   return String(value ?? '')
@@ -87,17 +91,23 @@ export function buildReviewPrompt({ diff, changedFiles, screenshots }) {
   const safeDiff = sanitizeForPrompt(diff).slice(0, MAX_DIFF);
   const files = changedFiles.map(sanitizeForPrompt).slice(0, 80).join('\n');
   const images = screenshots.map(sanitizeForPrompt).join(', ');
-  return `You are reviewing a Jovie UI PR. Return ONLY JSON matching this shape: {"summary":string,"findings":[{"title":string,"category":"layout|accessibility|responsive|functional|taste|preference|brand|identity|composition|copy-tone","severity":"high|medium|low","kind":"objective|subjective","evidence":string,"recommendation":string}],"backend":"glm-5.2|kimi-k3"}.\n\nRules: objective means an observable defect (overflow, clipping, inaccessible contrast/focus, broken interaction, missing content, desktop/mobile regression). Subjective means taste, preference, brand, identity, composition, or copy tone. Never turn a subjective finding into an auto-fix. Mention only evidence visible in the screenshots or grounded in the diff. Do not repeat secrets or credentials.\n\nChanged files:\n${files}\n\nDiff context:\n${safeDiff}\n\nScreenshots (desktop and mobile are paired per route): ${images}`;
+  return `You are reviewing a Jovie UI PR. Return ONLY JSON matching this shape: {"summary":string,"findings":[{"title":string,"category":"layout|accessibility|responsive|functional|taste|preference|brand|identity|composition|copy-tone","severity":"high|medium|low","kind":"objective|subjective","evidence":string,"recommendation":string}],"backend":"grok-4.5|codex"}.\n\nRules: objective means an observable defect (overflow, clipping, inaccessible contrast/focus, broken interaction, missing content, desktop/mobile regression). Subjective means taste, preference, brand, identity, composition, or copy tone. Never turn a subjective finding into an auto-fix. Mention only evidence visible in the screenshots or grounded in the diff. Do not repeat secrets or credentials.\n\nChanged files:\n${files}\n\nDiff context:\n${safeDiff}\n\nScreenshots (desktop and mobile are paired per route): ${images}`;
 }
 
-function requireBackend({ apiKey, baseUrl, model }) {
+function requireBackend({ apiKey, baseUrl, model, provider }) {
+  const prefix = provider === 'grok' ? 'GROK' : 'CODEX';
   if (!apiKey)
-    throw new Error('backend_unconfigured: VISUAL_REVIEW_API_KEY is missing');
-  if (!baseUrl)
-    throw new Error('backend_unconfigured: VISUAL_REVIEW_BASE_URL is missing');
-  if (!ALLOWED_MODELS.test(model ?? ''))
     throw new Error(
-      'backend_unconfigured: VISUAL_REVIEW_MODEL must be GLM 5.2 or Kimi K3'
+      `backend_unconfigured: ${prefix}_VISUAL_REVIEW_API_KEY is missing`
+    );
+  if (!baseUrl)
+    throw new Error(
+      `backend_unconfigured: ${prefix}_VISUAL_REVIEW_BASE_URL is missing`
+    );
+  const allowed = provider === 'grok' ? GROK_MODEL : CODEX_MODEL;
+  if (!allowed.test(model ?? ''))
+    throw new Error(
+      `backend_unconfigured: ${prefix}_VISUAL_REVIEW_MODEL is invalid`
     );
 }
 
@@ -105,12 +115,13 @@ export async function reviewWithBackend({
   apiKey,
   baseUrl,
   model,
+  provider = 'grok',
   prompt,
   images,
   timeoutMs = 90_000,
   fetchImpl = fetch,
 }) {
-  requireBackend({ apiKey, baseUrl, model });
+  requireBackend({ apiKey, baseUrl, model, provider });
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -148,6 +159,51 @@ export async function reviewWithBackend({
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * @param {{ prompt: string, images: string[], timeoutMs?: number, fetchImpl?: typeof fetch, grok?: ReviewBackend, codex?: ReviewBackend }} options
+ */
+export async function reviewWithConfiguredBackends({
+  prompt,
+  images,
+  timeoutMs = 90_000,
+  fetchImpl = fetch,
+  grok = {
+    apiKey: process.env.GROK_VISUAL_REVIEW_API_KEY,
+    baseUrl: process.env.GROK_VISUAL_REVIEW_BASE_URL,
+    model: process.env.GROK_VISUAL_REVIEW_MODEL,
+  },
+  codex = {
+    apiKey: process.env.CODEX_VISUAL_REVIEW_API_KEY,
+    baseUrl: process.env.CODEX_VISUAL_REVIEW_BASE_URL,
+    model: process.env.CODEX_VISUAL_REVIEW_MODEL,
+  },
+}) {
+  /** @type {Array<['grok' | 'codex', ReviewBackend]>} */
+  const attempts = [
+    ['grok', grok],
+    ['codex', codex],
+  ];
+  const errors = [];
+  for (const [provider, backend] of attempts) {
+    try {
+      const review = await reviewWithBackend({
+        apiKey: backend.apiKey ?? '',
+        baseUrl: backend.baseUrl ?? '',
+        model: backend.model ?? '',
+        provider,
+        prompt,
+        images,
+        timeoutMs,
+        fetchImpl,
+      });
+      return { review: { ...review, backend: provider }, provider };
+    } catch (error) {
+      errors.push(`${provider}: ${String(error.message ?? error)}`);
+    }
+  }
+  throw new Error(`backend_unavailable: ${errors.join('; ')}`);
 }
 
 export function normalizeFindings(review) {
@@ -229,10 +285,7 @@ async function main() {
           .map(c => c.path) ?? [],
     });
     try {
-      const review = await reviewWithBackend({
-        apiKey: process.env.VISUAL_REVIEW_API_KEY,
-        baseUrl: process.env.VISUAL_REVIEW_BASE_URL,
-        model: process.env.VISUAL_REVIEW_MODEL,
+      const { review, provider } = await reviewWithConfiguredBackends({
         prompt,
         images: screenshots,
       });
@@ -243,6 +296,7 @@ async function main() {
             status: 'completed',
             review_status: 'advisory',
             review,
+            provider,
             promptLength: prompt.length,
           },
           null,

--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -31,7 +31,9 @@ env:
 
 jobs:
   capture:
-    name: Capture changed UI (desktop + mobile)
+    # Failures remain visible in Actions, but the native queue treats this exact
+    # evidence check as advisory. Deterministic CI is the merge gate.
+    name: Capture changed UI (desktop + mobile) (advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -143,9 +145,12 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      VISUAL_REVIEW_API_KEY: ${{ secrets.VISUAL_REVIEW_API_KEY || secrets.AI_GATEWAY_API_KEY }}
-      VISUAL_REVIEW_BASE_URL: ${{ vars.VISUAL_REVIEW_BASE_URL || 'https://ai-gateway.vercel.sh/v1' }}
-      VISUAL_REVIEW_MODEL: ${{ vars.VISUAL_REVIEW_MODEL || 'zai/glm-5.2' }}
+      GROK_VISUAL_REVIEW_API_KEY: ${{ secrets.GROK_VISUAL_REVIEW_API_KEY }}
+      GROK_VISUAL_REVIEW_BASE_URL: ${{ vars.GROK_VISUAL_REVIEW_BASE_URL || 'https://api.x.ai/v1' }}
+      GROK_VISUAL_REVIEW_MODEL: ${{ vars.GROK_VISUAL_REVIEW_MODEL || 'grok-4.5' }}
+      CODEX_VISUAL_REVIEW_API_KEY: ${{ secrets.CODEX_VISUAL_REVIEW_API_KEY }}
+      CODEX_VISUAL_REVIEW_BASE_URL: ${{ vars.CODEX_VISUAL_REVIEW_BASE_URL || 'https://api.openai.com/v1' }}
+      CODEX_VISUAL_REVIEW_MODEL: ${{ vars.CODEX_VISUAL_REVIEW_MODEL || 'gpt-5.2-codex' }}
     steps:
       - name: Checkout trusted base helpers
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -186,7 +191,7 @@ jobs:
           await writeFile('review-input.json', JSON.stringify({ artifactDir: 'pr-visual-artifacts', changedFiles: routing.files, diff, reviewStatus: routing.review_status, output: 'review-result.json' }));
           NODE
 
-      - name: Call configured GLM 5.2 / Kimi K3 backend
+      - name: Call Grok 4.5 with Codex fallback
         if: steps.routed.outputs.review == 'true'
         run: node .github/scripts/pr-visual-review.mjs review review-input.json
 

--- a/scripts/lib/__tests__/pr-check-failures.test.mjs
+++ b/scripts/lib/__tests__/pr-check-failures.test.mjs
@@ -85,6 +85,9 @@ describe('pr-check-failures', () => {
     expect(ADVISORY_CHECK_NAMES).toContain('Classify PR taste');
     expect(ADVISORY_CHECK_NAMES).toContain('Claude Review');
     expect(ADVISORY_CHECK_NAMES).toContain(
+      'Capture changed UI (desktop + mobile) (advisory)'
+    );
+    expect(ADVISORY_CHECK_NAMES).toContain(
       'Review screenshots and post advisory review'
     );
     expect(ADVISORY_CHECK_NAMES).toContain('SonarCloud Code Analysis');
@@ -100,6 +103,10 @@ describe('pr-check-failures', () => {
         { bucket: 'fail', name: 'E2E Smoke (PR Fast Feedback)' },
         { bucket: 'fail', name: 'Extended Smoke (Preview)' },
         { bucket: 'fail', name: 'A11y (authenticated, informational)' },
+        {
+          bucket: 'fail',
+          name: 'Capture changed UI (desktop + mobile) (advisory)',
+        },
         { bucket: 'fail', name: 'Review screenshots and post advisory review' },
         { bucket: 'fail', name: 'SonarCloud Code Analysis' },
         { bucket: 'fail', name: 'Vercel Agent Review' },

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -4,6 +4,7 @@ import {
   buildReviewPrompt,
   classifyFinding,
   classifyReviewOutcome,
+  reviewWithConfiguredBackends,
   routeChangedFiles,
   sanitizeForPrompt,
 } from '../../../.github/scripts/pr-visual-review.mjs';
@@ -77,6 +78,44 @@ describe('bounded PR visual review contract', () => {
       '[redacted-secret]'
     );
     expect(prompt).not.toContain('secret-value');
+    expect(prompt).toContain('grok-4.5|codex');
+    expect(prompt.toLowerCase()).not.toContain('kimi');
+  });
+
+  it('uses Grok 4.5 first and independently falls back to Codex', async () => {
+    const calls = [];
+    const fetchImpl = async url => {
+      calls.push(url);
+      if (String(url).startsWith('https://grok.example'))
+        return new Response(null, { status: 503 });
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"summary":"ok","findings":[]}' } }],
+        }),
+        { status: 200 }
+      );
+    };
+    const result = await reviewWithConfiguredBackends({
+      prompt: 'review',
+      images: [],
+      fetchImpl,
+      grok: {
+        apiKey: 'grok-key',
+        baseUrl: 'https://grok.example/v1',
+        model: 'grok-4.5',
+      },
+      codex: {
+        apiKey: 'codex-key',
+        baseUrl: 'https://codex.example/v1',
+        model: 'gpt-5.2-codex',
+      },
+    });
+    expect(result.provider).toBe('codex');
+    expect(result.review.backend).toBe('codex');
+    expect(calls).toEqual([
+      'https://grok.example/v1/chat/completions',
+      'https://codex.example/v1/chat/completions',
+    ]);
   });
 
   it('separates objective findings from taste and never auto-fixes taste', () => {
@@ -110,6 +149,13 @@ describe('bounded PR visual review contract', () => {
     );
     expect(workflow).toContain('Do not alter subjective/taste findings.');
     expect(workflow).toContain('review_status');
+    expect(workflow).toContain(
+      'Capture changed UI (desktop + mobile) (advisory)'
+    );
+    expect(workflow).toContain('GROK_VISUAL_REVIEW_API_KEY');
+    expect(workflow).toContain('CODEX_VISUAL_REVIEW_API_KEY');
+    expect(workflow).toContain('Call Grok 4.5 with Codex fallback');
+    expect(workflow).not.toContain('Kimi');
     expect(workflow).toContain("'unavailable'");
     expect(workflow).toContain("'skipped'");
     expect(workflow).not.toContain('pr-visual-review-capture.mjs || true');

--- a/scripts/lib/pr-check-failures.mjs
+++ b/scripts/lib/pr-check-failures.mjs
@@ -59,6 +59,7 @@ export const ADVISORY_CHECK_NAMES = Object.freeze(
     'Seer Code Review',
     // PR Visual Review is explicitly advisory (workflow header + job name).
     // Terminal red must not dequeue green native-MQ members.
+    'Capture changed UI (desktop + mobile) (advisory)',
     'Review screenshots and post advisory review',
     'PR Visual Review',
     // Hosted quality signals — not branch-protection required contexts.


### PR DESCRIPTION
Fixes #15096

## What changed
- Keeps routed visual capture fail-closed and visible, but names its exact check as advisory for native queue classification.
- Replaces Kimi/GLM visual-review configuration with Grok 4.5 primary and independently configured Codex/OpenAI-compatible fallback.
- Adds regression coverage for capture advisory handling and provider fallback order.

## Verification
- `vitest run --config scripts/vitest.config.mts scripts/lib/__tests__/pr-visual-review.test.mjs scripts/lib/__tests__/pr-check-failures.test.mjs` (21 passed)
- `biome check` on changed JS/test files
- `node --check .github/scripts/pr-visual-review.mjs`
- YAML parse + `git diff --check`

Visual capture failures remain red in Actions; only their queue classification is advisory.