### PR TITLE
fix(ui): unify mobile bottom surface and starter actions [JOV-4568]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
@@ -110,6 +110,7 @@ export function DashboardMobileTabs({
           currentPathname.startsWith(`${item.href}/`)
         );
       }}
+      inFlow
       className={cn('lg:hidden', className)}
     />
   );

--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -39,6 +39,11 @@ export interface LiquidGlassMenuProps {
   readonly navigationLabel?: string;
   readonly expandedNavigationLabel?: string;
   readonly className?: string;
+  /**
+   * Render inside the authenticated shell's shared bottom surface instead of
+   * creating a second fixed/elevated layer.
+   */
+  readonly inFlow?: boolean;
   readonly onItemActivate?: (
     item: LiquidGlassMenuItem,
     inputMethod: NavigationInputMethod
@@ -244,6 +249,7 @@ export function LiquidGlassMenu({
   navigationLabel = 'Dashboard Tabs',
   expandedNavigationLabel = 'Expanded Navigation Menu',
   className,
+  inFlow = false,
   onItemActivate,
   onExpandedItemsVisible,
   isItemActive,
@@ -301,8 +307,13 @@ export function LiquidGlassMenu({
     <div
       ref={menuRef}
       data-mobile-navigation='true'
-      data-layout='overlay'
-      className={cn('fixed bottom-0 inset-x-0 z-40 lg:hidden', className)}
+      data-layout={inFlow ? 'in-flow' : 'overlay'}
+      className={cn(
+        inFlow
+          ? 'relative z-0 shrink-0 lg:hidden'
+          : 'fixed bottom-0 inset-x-0 z-40 lg:hidden',
+        className
+      )}
     >
       {/* Closed menu content is unmounted so hidden links cannot receive focus. */}
       {isExpanded ? (
@@ -408,9 +419,12 @@ export function LiquidGlassMenu({
         aria-label={navigationLabel}
         className='relative z-50'
         style={{
-          background: 'var(--liquid-glass-bg-solid)',
-          boxShadow: isExpanded ? 'none' : 'var(--liquid-glass-shadow)',
-          borderTop: '1px solid var(--liquid-glass-border)',
+          background: inFlow ? 'transparent' : 'var(--liquid-glass-bg-solid)',
+          boxShadow:
+            inFlow || isExpanded ? 'none' : 'var(--liquid-glass-shadow)',
+          borderTop: inFlow
+            ? '1px solid transparent'
+            : '1px solid var(--liquid-glass-border)',
         }}
       >
         <GlassHighlight subtle rounded={false} />

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -755,7 +755,7 @@ export function JovieChat({
                       />
                     ) : showEmptyActionCards ? (
                       <div
-                        className='mx-auto flex min-h-full w-full max-w-[46rem] items-center py-3'
+                        className='mx-auto flex min-h-full w-full max-w-[46rem] items-start py-2 sm:items-center sm:py-3'
                         data-testid='chat-empty-state-action-card-slot'
                       >
                         <ChatStarterActionsRail

--- a/apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
+++ b/apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
@@ -73,6 +73,32 @@ describe('ChatStarterActionsRail', () => {
     ).toHaveLength(3);
   });
 
+  it('shows one complete mobile card with an explicit More control', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatStarterActionsRail
+        cards={cards}
+        onAct={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByTestId('chat-action-card')).toHaveLength(1);
+    const more = screen.getByRole('button', {
+      name: 'Show More Starter Actions',
+    });
+    expect(more).toHaveClass('focus-visible:ring-2');
+    expect(more.parentElement).toHaveClass('sm:hidden', 'min-h-11');
+    expect(screen.getByText('1 of 3')).toHaveClass('tabular-nums');
+
+    await user.click(more);
+
+    expect(
+      screen.getByRole('group', { name: '2 of 3: Review Signals' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('2 of 3')).toBeInTheDocument();
+  });
+
   it('keeps endpoint controls mounted and retains dot focus at the boundary', async () => {
     const user = userEvent.setup();
     render(

--- a/apps/web/components/jovie/components/ChatStarterActionsRail.tsx
+++ b/apps/web/components/jovie/components/ChatStarterActionsRail.tsx
@@ -107,28 +107,51 @@ export function ChatStarterActionsRail({
         />
       </button>
       {cards.length > 1 ? (
-        <fieldset className='mt-2 flex min-h-5 items-center justify-center border-0 p-0'>
-          <legend className='sr-only'>Choose Starter Action</legend>
-          {visiblePaginationIndexes.map(index => (
-            <button
-              key={cards[index]?.id ?? index}
-              type='button'
-              aria-label={`Show Starter Action ${index + 1} Of ${cards.length}: ${cards[index]?.title ?? ''}`}
-              aria-current={index === boundedIndex ? 'true' : undefined}
-              onClick={() => setActiveIndex(index)}
-              onKeyDown={handlePaginationKeyDown}
-              className='group relative grid size-8 place-items-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-0'
+        <>
+          <div className='mt-2 flex min-h-11 items-center justify-between gap-3 sm:hidden'>
+            <span
+              className='text-xs tabular-nums text-tertiary-token'
+              aria-live='polite'
             >
-              <span
-                className='size-1 rounded-full bg-quaternary-token/65 transition-[transform,background-color] duration-subtle group-hover:bg-tertiary-token group-aria-[current=true]:scale-125 group-aria-[current=true]:bg-secondary-token motion-reduce:transition-none'
-                aria-hidden='true'
-              />
+              {boundedIndex + 1} of {cards.length}
+            </span>
+            <button
+              type='button'
+              aria-label='Show More Starter Actions'
+              onClick={() =>
+                setActiveIndex(current =>
+                  current >= lastIndex ? 0 : current + 1
+                )
+              }
+              className='inline-flex min-h-11 items-center gap-1.5 rounded-full px-3 text-xs font-medium text-secondary-token transition-[background-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-0 motion-reduce:transition-none'
+            >
+              More
+              <ChevronRight className='size-4' aria-hidden='true' />
             </button>
-          ))}
-          <span className='sr-only' aria-live='polite'>
-            Starter Action {boundedIndex + 1} Of {cards.length}
-          </span>
-        </fieldset>
+          </div>
+          <fieldset className='mt-2 hidden min-h-5 items-center justify-center border-0 p-0 sm:flex'>
+            <legend className='sr-only'>Choose Starter Action</legend>
+            {visiblePaginationIndexes.map(index => (
+              <button
+                key={cards[index]?.id ?? index}
+                type='button'
+                aria-label={`Show Starter Action ${index + 1} Of ${cards.length}: ${cards[index]?.title ?? ''}`}
+                aria-current={index === boundedIndex ? 'true' : undefined}
+                onClick={() => setActiveIndex(index)}
+                onKeyDown={handlePaginationKeyDown}
+                className='group relative grid size-8 place-items-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-0'
+              >
+                <span
+                  className='size-1 rounded-full bg-quaternary-token/65 transition-[transform,background-color] duration-subtle group-hover:bg-tertiary-token group-aria-[current=true]:scale-125 group-aria-[current=true]:bg-secondary-token motion-reduce:transition-none'
+                  aria-hidden='true'
+                />
+              </button>
+            ))}
+            <span className='sr-only' aria-live='polite'>
+              Starter Action {boundedIndex + 1} Of {cards.length}
+            </span>
+          </fieldset>
+        </>
       ) : null}
     </section>
   );

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -145,7 +145,14 @@ export const AppShellFrame = memo(function AppShellFrame({
         </div>
       </div>
 
-      {mobileBottomNav}
+      {mobileBottomNav ? (
+        <div
+          className='system-b-app-mobile-bottom-surface shrink-0 lg:hidden'
+          data-testid='app-shell-mobile-bottom-surface'
+        >
+          {mobileBottomNav}
+        </div>
+      ) : null}
     </div>
   );
 });

--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -39,7 +39,7 @@ export interface AuthShellProps {
 
 function getContentClassName(showMobileTabs: boolean, isTableRoute: boolean) {
   if (!showMobileTabs) return undefined;
-  return isTableRoute ? 'pb-20 lg:pb-0' : 'pb-20 lg:pb-6';
+  return isTableRoute ? undefined : 'lg:pb-6';
 }
 
 function AuthShellInner({

--- a/apps/web/components/organisms/OperatorMobileNavigation.tsx
+++ b/apps/web/components/organisms/OperatorMobileNavigation.tsx
@@ -27,6 +27,7 @@ export function OperatorMobileNavigation(): React.JSX.Element {
       isItemActive={(item, pathname) =>
         isOperatorNavigationHrefActive(pathname, item.href)
       }
+      inFlow
       className='lg:hidden'
     />
   );

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -271,11 +271,17 @@ export function PersistentAudioBar() {
         aria-label='Playback Controls'
         inert={idleTrayOpen ? undefined : true}
         className={cn(
-          'shrink-0 overflow-hidden border-t border-(--app-shell-border) bg-(--app-shell-content-surface)',
+          'shrink-0 overflow-hidden bg-(--app-shell-content-surface)',
+          idleTrayOpen
+            ? 'border-t border-(--app-shell-border)'
+            : 'border-t border-transparent',
           SHELL_AUDIO_CHROME_TRANSITION_CLASSNAME,
           className
         )}
         data-testid={testId}
+        data-mobile-audio-surface={
+          testId === 'audio-surface-idle-shell-mobile' ? 'true' : undefined
+        }
         style={{
           maxHeight: idleTrayOpen ? 'var(--app-shell-audio-bar-max-height)' : 0,
           opacity: idleTrayOpen ? 1 : 0,
@@ -304,7 +310,7 @@ export function PersistentAudioBar() {
               <p className='text-sm font-medium text-secondary-token'>
                 Nothing playing
               </p>
-              <p className='truncate text-xs text-tertiary-token'>
+              <p className='text-pretty text-xs leading-4 text-tertiary-token'>
                 {isLibraryRoute
                   ? 'Choose a track to start playback.'
                   : 'Choose a track from Library to start playback.'}
@@ -337,10 +343,7 @@ export function PersistentAudioBar() {
     return (
       <>
         {idleTray('audio-surface-idle-shell-desktop', 'hidden lg:block')}
-        {idleTray(
-          'audio-surface-idle-shell-mobile',
-          'max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))] lg:hidden'
-        )}
+        {idleTray('audio-surface-idle-shell-mobile', 'lg:hidden')}
       </>
     );
   }
@@ -371,8 +374,10 @@ export function PersistentAudioBar() {
   const mobileBar = (className?: string) => (
     <section
       aria-label='Audio Player'
+      aria-hidden='false'
+      data-mobile-audio-surface='true'
       className={cn(
-        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--app-shell-content-surface) backdrop-blur-xl px-3 py-2 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]',
+        'animate-in fade-in slide-in-from-bottom-2 duration-cinematic shrink-0 border-t border-subtle bg-(--app-shell-content-surface) backdrop-blur-xl px-3 py-2',
         className
       )}
     >

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -7955,6 +7955,29 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   box-shadow: none;
 }
 
+/* Mobile shell chrome is one in-flow bottom plane: the nav owns the quiet
+   elevation when playback is closed; an open player takes over the same seam
+   without introducing an internal border or overlaying route content. */
+:where(.system-b-app-mobile-bottom-surface) {
+  position: relative;
+  z-index: 40;
+  border-top: 1px solid var(--liquid-glass-border);
+  background: var(--liquid-glass-bg-solid);
+  box-shadow: var(--liquid-glass-shadow);
+}
+
+@media (max-width: 1023px) {
+  :where(
+    [data-app-shell-frame]:has(
+        [data-mobile-audio-surface="true"][aria-hidden="false"]
+      )
+      .system-b-app-mobile-bottom-surface
+  ) {
+    border-top-color: transparent;
+    box-shadow: none;
+  }
+}
+
 @media (min-width: 640px) {
   :where(.system-b-chat-action-card) {
     min-height: var(--system-b-chat-action-card-min-height-compact);

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -178,6 +178,13 @@ describe('PersistentAudioBar', () => {
     // instead of covering the main canvas or right rail.
     expect(idleSurfaces[0]).not.toHaveClass('absolute');
     expect(idleSurfaces[0]).toHaveClass('shrink-0');
+    expect(idleSurfaces[1]).toHaveAttribute(
+      'data-mobile-audio-surface',
+      'true'
+    );
+    expect(idleSurfaces[1]).not.toHaveClass(
+      'max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]'
+    );
   });
 
   it('opens and closes the idle playback tray with the global toggle shortcuts', () => {
@@ -192,6 +199,17 @@ describe('PersistentAudioBar', () => {
     expect(idleSurface).toHaveTextContent(
       'Choose a track from Library to start playback.'
     );
+    const mobileSurface = screen.getByTestId('audio-surface-idle-shell-mobile');
+    expect(
+      within(mobileSurface).getByText(
+        'Choose a track from Library to start playback.'
+      )
+    ).toHaveClass('text-pretty', 'leading-4');
+    expect(
+      within(mobileSurface).getByText(
+        'Choose a track from Library to start playback.'
+      )
+    ).not.toHaveClass('truncate');
     expect(
       screen.getAllByRole('button', { name: 'Open Library' })
     ).toHaveLength(2);
@@ -395,6 +413,13 @@ describe('PersistentAudioBar', () => {
     expect(
       screen.getAllByRole('region', { name: 'Audio Player' })
     ).toHaveLength(2);
+    const mobileSurface = screen.getAllByRole('region', {
+      name: 'Audio Player',
+    })[1];
+    expect(mobileSurface).toHaveAttribute('data-mobile-audio-surface', 'true');
+    expect(mobileSurface).not.toHaveClass(
+      'max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]'
+    );
   });
 
   it('renders the extracted canonical audio bar when requested', () => {

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -270,6 +270,10 @@ describe('JovieChat empty state', () => {
     expect(
       screen.getByTestId('chat-empty-state-centered-composer')
     ).toBeTruthy();
+    expect(screen.getByTestId('chat-empty-state-action-card-slot')).toHaveClass(
+      'items-start',
+      'sm:items-center'
+    );
     // Docked layout: cards scroll above, composer at bottom of usable area.
     const region = screen.getByTestId('chat-empty-state-composer-region');
     expect(region.getAttribute('data-layout')).toBe('docked');
@@ -281,6 +285,12 @@ describe('JovieChat empty state', () => {
     ).toBe('bottom');
     expect(screen.queryByTestId('suggested-prompts-rail')).toBeNull();
     expect(screen.getAllByTestId('chat-action-card')).toHaveLength(1);
+    expect(
+      within(screen.getByTestId('chat-starter-actions-rail')).getByRole(
+        'button',
+        { name: 'Show More Starter Actions' }
+      )
+    ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('chat-starter-actions-rail')).getAllByRole(
         'button',

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -166,4 +166,25 @@ describe('AppShellFrame', () => {
     );
     expect(tray).toHaveClass('shrink-0');
   });
+
+  it('mounts mobile navigation in the shared in-flow bottom surface', () => {
+    render(
+      <AppShellFrame
+        sidebar={<aside>Sidebar</aside>}
+        main={<div>Main Content</div>}
+        mobileBottomNav={<nav aria-label='Mobile Navigation'>Nav</nav>}
+      />
+    );
+
+    const surface = screen.getByTestId('app-shell-mobile-bottom-surface');
+    expect(surface).toHaveClass(
+      'system-b-app-mobile-bottom-surface',
+      'shrink-0',
+      'lg:hidden'
+    );
+    expect(surface).toContainElement(
+      screen.getByRole('navigation', { name: 'Mobile Navigation' })
+    );
+    expect(surface).not.toHaveClass('fixed', 'absolute');
+  });
 });

--- a/apps/web/tests/unit/components/organisms/AuthShell.flag.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AuthShell.flag.test.tsx
@@ -145,10 +145,7 @@ describe('AuthShell canonical wiring', () => {
     ).not.toBeInTheDocument();
 
     const customerRender = screen.getByTestId('app-shell-frame');
-    expect(customerRender).toHaveAttribute(
-      'data-content-class',
-      'pb-20 lg:pb-6'
-    );
+    expect(customerRender).toHaveAttribute('data-content-class', 'lg:pb-6');
 
     unmount();
     renderOvAuthShell();
@@ -161,7 +158,7 @@ describe('AuthShell canonical wiring', () => {
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('app-shell-frame')).toHaveAttribute(
       'data-content-class',
-      'pb-20 lg:pb-6'
+      'lg:pb-6'
     );
   });
 

--- a/apps/web/tests/unit/components/organisms/OperatorMobileNavigation.test.tsx
+++ b/apps/web/tests/unit/components/organisms/OperatorMobileNavigation.test.tsx
@@ -83,14 +83,14 @@ describe('OperatorMobileNavigation', () => {
     }
   });
 
-  it('opens without moving content and keeps the canonical sign-out action keyboard reachable', async () => {
+  it('uses the shared in-flow bottom surface and keeps the canonical sign-out action keyboard reachable', async () => {
     const user = userEvent.setup();
     render(<OperatorMobileNavigation />);
 
     const mobileNavigation = screen
       .getByRole('navigation', { name: 'OV Mobile Navigation' })
       .closest('[data-mobile-navigation]');
-    expect(mobileNavigation).toHaveAttribute('data-layout', 'overlay');
+    expect(mobileNavigation).toHaveAttribute('data-layout', 'in-flow');
 
     const more = screen.getByRole('button', { name: 'More options' });
     more.focus();

--- a/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
@@ -59,6 +59,8 @@ describe('DashboardMobileTabs', () => {
     render(<DashboardMobileTabs />);
 
     const tabs = screen.getByRole('navigation', { name: 'Dashboard Tabs' });
+    expect(tabs.parentElement).toHaveAttribute('data-layout', 'in-flow');
+    expect(tabs.parentElement).not.toHaveClass('fixed');
     const directLinks = within(tabs).getAllByRole('link');
 
     expect(directLinks.map(link => link.textContent?.trim())).toEqual([


### PR DESCRIPTION
## Summary
- unify the mobile audio player and bottom navigation as one shared-elevation System B surface
- keep idle playback guidance readable without ellipsis
- replace mobile starter-card peek theater with one complete option plus an explicit More action
- preserve desktop carousel controls and focus-visible/reduced-motion behavior

Linear: https://linear.app/jovie/issue/JOV-4568/mobile-bottom-surface-readable-playback-copy-and-unoccluded-starter

## Bug-to-Test
bug-to-test: satisfied

Regression coverage:
- apps/web/components/jovie/components/ChatStarterActionsRail.test.tsx
- apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
- apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
- apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
- apps/web/tests/unit/components/organisms/AuthShell.flag.test.tsx
- apps/web/tests/unit/components/organisms/OperatorMobileNavigation.test.tsx
- apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx

## Deterministic verification
- Node 22.23.1 / pnpm 9.15.4
- focused Vitest after merge-group feedback: 7 files, 74/74 passed
- stale OperatorMobileNavigation overlay assertion updated to the intended in-flow shared-surface contract
- Biome: changed files clean
- Tailwind configuration guard passed
- @jovie/web typecheck passed
- git diff --check passed

## Visual review
Advisory hosted capture failed on the prior head. A local browser/Grok run was not started because the host had 766.5 MiB swap free, below the established 1 GiB safe floor, and port 3224 is a protected preview. Per lane-owner instruction this advisory review does not block native queue admission.

## Scope
Mobile authenticated shell only. No route, schema, auth, data, dependency, or release changes.

## Linear follow-ups
None.