### PR TITLE
fix(ci): retain live typecheck singleflight owner

### DIFF
--- a/scripts/lib/__tests__/typecheck-singleflight.test.mjs
+++ b/scripts/lib/__tests__/typecheck-singleflight.test.mjs
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
+const wrapper = resolve(repoRoot, 'scripts/typecheck-singleflight.mjs');
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function runWrapper(stateDir, marker) {
+  const script =
+    "const fs=require('node:fs');" +
+    "fs.appendFileSync(process.argv[1], 'owner\\n');" +
+    'setTimeout(() => process.exit(0), 700);';
+  return new Promise(resolveRun => {
+    const child = spawn(
+      process.execPath,
+      [wrapper, '--', process.execPath, '-e', script, marker],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          TYPECHECK_SINGLEFLIGHT_DIR: stateDir,
+          TYPECHECK_SINGLEFLIGHT_POLL_MS: '25',
+          TYPECHECK_SINGLEFLIGHT_STALE_MS: '100',
+          TYPECHECK_SINGLEFLIGHT_REUSE_WINDOW_MS: '5000',
+        },
+        stdio: 'ignore',
+      }
+    );
+    child.once('exit', code => resolveRun(code));
+  });
+}
+
+describe('typecheck singleflight', () => {
+  it('never evicts a live owner solely because its lock is old', async () => {
+    const stateDir = mkdtempSync(resolve(tmpdir(), 'jovie-singleflight-'));
+    temporaryDirectories.push(stateDir);
+    const marker = resolve(stateDir, 'owners.txt');
+
+    const first = runWrapper(stateDir, marker);
+    await new Promise(resolveWait => setTimeout(resolveWait, 250));
+    const second = runWrapper(stateDir, marker);
+
+    expect(await Promise.all([first, second])).toEqual([0, 0]);
+    expect(readFileSync(marker, 'utf8').trim().split('\n')).toEqual(['owner']);
+  });
+});

--- a/scripts/typecheck-singleflight.mjs
+++ b/scripts/typecheck-singleflight.mjs
@@ -258,12 +258,14 @@ function isRecoverableLock(lock) {
     return lockFileAgeMs() > Math.min(staleMs, 5000);
   }
 
-  const ageMs = Date.now() - Number(lock.startedAtMs ?? 0);
-  if (Number.isFinite(ageMs) && ageMs > staleMs) {
-    return true;
+  // A live owner is authoritative. Long typechecks routinely exceed the stale
+  // threshold under host pressure; age alone must never permit a second owner.
+  if (typeof lock.pid === 'number') {
+    return !isProcessAlive(lock.pid);
   }
 
-  return typeof lock.pid === 'number' && !isProcessAlive(lock.pid);
+  const ageMs = Date.now() - Number(lock.startedAtMs ?? 0);
+  return Number.isFinite(ageMs) && ageMs > staleMs;
 }
 
 function lockFileAgeMs() {


### PR DESCRIPTION
## Summary
- retain a live typecheck singleflight owner even after its stale-age threshold
- recover only locks whose recorded process is no longer alive
- add a concurrency regression test proving one owner executes

## Verification
- `pnpm exec vitest run scripts/lib/__tests__/typecheck-singleflight.test.mjs`
- `pnpm biome check scripts/typecheck-singleflight.mjs scripts/lib/__tests__/typecheck-singleflight.test.mjs`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm run test:bug-to-test`
- normal pre-push gate

## Tracking
No Linear issue — ad-hoc recovery of Codex task `019faf63-40ac-7672-bb91-4a0287d9ee1c`. Linear creation was attempted via the configured client but the remote request failed; it is not treated as an admission hold.

## Risk
Low: lock recovery remains enabled for dead or PID-less stale owners; only live PIDs are protected from age-only eviction.