### PR TITLE
fix(settings): unify pixel toggle grouping

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsAdPixelsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsAdPixelsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, Button, Input, Switch } from '@jovie/ui';
+import { Badge, Button, Input } from '@jovie/ui';
 import { ExternalLink, Eye, EyeOff } from 'lucide-react';
 import {
   type FormEvent,
@@ -455,20 +455,16 @@ export function SettingsAdPixelsSection({
       <SettingsPanel
         title='Pixel tracking'
         description='Integrate Facebook, Google, and TikTok conversion tracking pixels.'
-        actions={
-          <div className='flex items-center gap-2'>
-            <span className='text-app font-caption tracking-normal text-secondary-token'>
-              {pixelData.enabled ? 'Enabled' : 'Disabled'}
-            </span>
-            <Switch
-              checked={pixelData.enabled}
-              onCheckedChange={checked => handleInputChange('enabled', checked)}
-              aria-label='Enable pixel tracking'
-            />
-          </div>
-        }
       >
         <div className='space-y-3 px-4 py-4 sm:px-5'>
+          <SettingsToggleRow
+            title='Enable pixel tracking'
+            description='Route fan actions to your Facebook, Google, and TikTok pixels for conversion tracking.'
+            checked={pixelData.enabled}
+            onCheckedChange={checked => handleInputChange('enabled', checked)}
+            ariaLabel='Enable pixel tracking'
+          />
+
           <ContentSurfaceCard className='bg-surface-0 px-4 py-3.5'>
             <p className='text-app leading-[18px] text-secondary-token'>
               Configure each retargeting destination independently.

--- a/apps/web/tests/unit/dashboard/SettingsAdPixelsSection.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsAdPixelsSection.test.tsx
@@ -84,6 +84,16 @@ const { usePixelSettingsQueryMock } = vi.hoisted(() => {
   };
 });
 
+const { SettingsToggleRowMock } = vi.hoisted(() => ({
+  SettingsToggleRowMock: ({ title }: { title: string }) => (
+    <div data-testid='shared-settings-toggle'>{title}</div>
+  ),
+}));
+
+vi.mock('@/features/dashboard/molecules/SettingsToggleRow', () => ({
+  SettingsToggleRow: SettingsToggleRowMock,
+}));
+
 vi.mock('@/lib/queries', () => ({
   usePixelSettingsMutation: () => ({
     mutate: vi.fn(),
@@ -125,5 +135,13 @@ describe('SettingsAdPixelsSection', () => {
     fastRender(<SettingsAdPixelsSection isPro />);
 
     expect(usePixelSettingsQueryMock).toHaveBeenCalled();
+  });
+
+  it('uses the shared settings toggle row for the pixel enable control', () => {
+    const { getByTestId } = fastRender(<SettingsAdPixelsSection isPro />);
+
+    expect(getByTestId('shared-settings-toggle')).toHaveTextContent(
+      'Enable pixel tracking'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Linear: JOV-4555
- Move the pixel enable control into the shared `SettingsToggleRow` primitive used by audience verification.
- Keep the existing optimistic form state and save path unchanged while removing duplicate header control chrome.

## Verification
- `pnpm exec biome check --write apps/web/components/features/dashboard/organisms/SettingsAdPixelsSection.tsx apps/web/tests/unit/dashboard/SettingsAdPixelsSection.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/SettingsAdPixelsSection.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

## Test coverage
- Adds a focused regression test that the pro pixel section renders its enable control through the shared settings-toggle primitive.

<!-- linear-issue-id:JOV-4555 -->