### PR TITLE
fix(agents): distinguish context from ownership

### DIFF
--- a/scripts/agent/PREFLIGHT.md
+++ b/scripts/agent/PREFLIGHT.md
@@ -38,7 +38,10 @@ source (`ledger` / `keyword` / `semantic`) is recorded in
 `gbrain-timeout`. Unreachable/empty GBrain keeps the existing policy:
 soft by default, hard block with `AGENT_PREFLIGHT_REQUIRE_GBRAIN=1`.
 
-The ownership receipt also records requested/resolved slug, engine/CLI/MCP
+Free-text lookup results never fabricate an owner or lease:
+`receipt.ownership.owner` remains `null` and
+`receipt.ownership.context_available` reports whether coordination context was
+retrieved. The ownership receipt also records requested/resolved slug, engine/CLI/MCP
 latency when available, timeout tier, and lookup health. Nullable DB lock and
 session signal fields only report signatures seen in command stderr; `null`
 means no signal was observed, not that a database health probe passed. This
@@ -87,6 +90,7 @@ Exit `0` = `verdict: go`. Exit `1` = `verdict: blocked`. Exit `2` = script error
     "scope": "string|null",
     "source": "ledger|keyword|semantic|gbrain|gbrain-timeout|gbrain-empty|gbrain-missing|none",
     "reachable": true,
+    "context_available": true,
     "ms": 12
   },
   "worktree": {

--- a/scripts/agent/preflight-lib.mjs
+++ b/scripts/agent/preflight-lib.mjs
@@ -107,6 +107,7 @@ export function evaluateOwnership(input) {
         scope: task || null,
         source: 'gbrain-missing',
         reachable: false,
+        context_available: false,
         ms: input.ms ?? 0,
         diagnostics: input.diagnostics ?? null,
       },
@@ -131,6 +132,7 @@ export function evaluateOwnership(input) {
         scope: task || null,
         source: timedOut ? 'gbrain-timeout' : 'gbrain-empty',
         reachable: false,
+        context_available: false,
         ms: input.ms ?? 0,
         diagnostics: input.diagnostics ?? null,
       },
@@ -138,13 +140,15 @@ export function evaluateOwnership(input) {
     };
   }
 
-  // Do not invent owner names from free-text hits — mark presence only.
+  // Free-text context is not an ownership claim. Expose availability without
+  // fabricating an owner that downstream agents could mistake for a lease.
   return {
     ownership: {
-      owner: 'available',
+      owner: null,
       scope: task || 'repo',
       source: input.source || 'gbrain',
       reachable: true,
+      context_available: true,
       ms: input.ms ?? 0,
       diagnostics: input.diagnostics ?? null,
     },

--- a/scripts/agent/preflight.test.mjs
+++ b/scripts/agent/preflight.test.mjs
@@ -115,14 +115,15 @@ test('evaluateOwnership: empty gbrain hard when required', () => {
   assert.equal(r.ownership.source, 'gbrain-empty');
 });
 
-test('evaluateOwnership: reachable marks presence only (no invented names)', () => {
+test('evaluateOwnership: reachable context does not invent an owner', () => {
   const r = evaluateOwnership({
     gbrainOnPath: true,
     gbrainOutput: 'Owner: Alice the CEO of everything scope: whole company',
     task: 'JOV-4183',
   });
   assert.equal(r.ownership.reachable, true);
-  assert.equal(r.ownership.owner, 'available');
+  assert.equal(r.ownership.owner, null);
+  assert.equal(r.ownership.context_available, true);
   assert.equal(r.ownership.scope, 'JOV-4183');
   assert.equal(r.ownership.source, 'gbrain');
   assert.deepEqual(r.blockers, []);
@@ -190,7 +191,8 @@ test('buildReceipt / assembleReceipt schema and merge', () => {
   assert.equal(receipt.verdict, 'go');
   assert.equal(receipt.ms_total, 42);
   assert.equal(receipt.worktree.branch, 'feat');
-  assert.equal(receipt.ownership.owner, 'available');
+  assert.equal(receipt.ownership.owner, null);
+  assert.equal(receipt.ownership.context_available, true);
   assert.equal(receipt.gstack.installed, true);
   assert.deepEqual(receipt.blockers, []);
 


### PR DESCRIPTION
## Summary
- report free-text coordination lookup as available context, never an ownership lease
- return `owner: null` with `context_available: true` when GBrain is reachable
- make unavailable and empty lookup receipts explicitly report `context_available: false`

## Verification
- `node --test scripts/agent/preflight.test.mjs` (29/29)
- `pnpm biome check scripts/agent/preflight-lib.mjs scripts/agent/preflight.test.mjs`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm run test:bug-to-test`
- normal pre-push gate

## Tracking
No Linear issue — ad-hoc recovery of Codex task `019faf63-40ac-7672-bb91-4a0287d9ee1c`. Linear creation was attempted via the configured client but the remote request failed; it is not treated as an admission hold.

## Risk
Low: this changes receipt truthfulness only. It does not alter the existing go/block verdict policy.