### PR TITLE
fix(ui): guard thumbnail radii and badge wrapping

### DIFF
--- a/apps/web/components/atoms/ReleaseArtworkThumb.tsx
+++ b/apps/web/components/atoms/ReleaseArtworkThumb.tsx
@@ -16,6 +16,10 @@ interface ReleaseArtworkThumbProps {
   readonly fallbackIconClass?: string;
 }
 
+function getArtworkRadiusClassName(size: number): string {
+  return size >= 64 ? 'rounded-lg' : 'rounded-xs';
+}
+
 /**
  * Square artwork thumbnail with rounded corners.
  * Shows a Disc3 fallback icon when:
@@ -38,7 +42,8 @@ export function ReleaseArtworkThumb({
   return (
     <div
       className={cn(
-        'relative shrink-0 overflow-hidden rounded bg-surface-2 shadow-sm outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10',
+        'relative shrink-0 overflow-hidden bg-surface-2 shadow-sm',
+        getArtworkRadiusClassName(size),
         className
       )}
       style={{ width: size, height: size }}

--- a/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
+++ b/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
@@ -87,6 +87,8 @@ describe('ReleaseArtworkThumb', () => {
     );
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper).toHaveStyle({ width: '40px', height: '40px' });
+    expect(wrapper).toHaveClass('rounded-xs');
+    expect(wrapper).not.toHaveClass('outline');
   });
 
   it('renders with custom size applied as inline style', () => {
@@ -95,5 +97,6 @@ describe('ReleaseArtworkThumb', () => {
     );
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper).toHaveStyle({ width: '64px', height: '64px' });
+    expect(wrapper).toHaveClass('rounded-lg');
   });
 });

--- a/packages/ui/atoms/badge.test.tsx
+++ b/packages/ui/atoms/badge.test.tsx
@@ -141,6 +141,7 @@ describe('Badge', () => {
       expect(badge.className).toContain('inline-flex');
       expect(badge.className).toContain('items-center');
       expect(badge.className).toContain('rounded-full');
+      expect(badge.className).toContain('whitespace-nowrap');
       expect(badge.className).toContain('font-[510]');
     });
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4527 -->

## Summary
- Use `rounded-xs` for 40px release artwork and `rounded-lg` at 64px and above.
- Remove the decorative artwork outline while retaining existing dimensions and state behavior.
- Lock the existing Badge primitive to its one-line `rounded-full` contract.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/atoms/ReleaseArtworkThumb.test.tsx` (9 passed)
- `pnpm --filter @jovie/ui exec vitest run atoms/badge.test.tsx` (23 passed)
- `pnpm biome check --write apps/web/components/atoms/ReleaseArtworkThumb.tsx apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx packages/ui/atoms/badge.test.tsx`
- `pnpm tailwind:check`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/ui run typecheck`
- `git diff --check origin/main...HEAD`