### PR TITLE
fix(chat): preserve mobile header title space [JOV-4544]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -125,7 +125,7 @@ export function DashboardHeader({
             breadcrumbSuffix={breadcrumbSuffix}
           />
           {showInlineSearch ? (
-            <div className='ml-auto flex min-w-0 shrink-0 items-center justify-start max-sm:w-(--linear-app-control-height-sm) sm:ml-1.5'>
+            <div className='ml-auto flex min-w-0 shrink-0 items-center justify-start max-sm:w-app-control-sm sm:ml-1.5'>
               {searchSurface}
             </div>
           ) : null}

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -125,7 +125,7 @@ export function DashboardHeader({
             breadcrumbSuffix={breadcrumbSuffix}
           />
           {showInlineSearch ? (
-            <div className='ml-auto flex min-w-0 shrink-0 items-center justify-start sm:ml-1.5'>
+            <div className='ml-auto flex min-w-0 shrink-0 items-center justify-start max-sm:w-(--linear-app-control-height-sm) sm:ml-1.5'>
               {searchSurface}
             </div>
           ) : null}

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -132,9 +132,7 @@ describe('DashboardHeader', () => {
     const searchButton = screen.getByRole('button', { name: 'Search chats' });
 
     expect(title).toHaveClass('min-w-0', 'truncate');
-    expect(searchButton.parentElement).toHaveClass(
-      'max-sm:w-(--linear-app-control-height-sm)'
-    );
+    expect(searchButton.parentElement).toHaveClass('max-sm:w-app-control-sm');
     expect(
       container.querySelectorAll('[data-testid="dashboard-header"] h1')
     ).toHaveLength(1);

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -116,6 +116,30 @@ describe('DashboardHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('reserves only the compact control width for mobile search beside a chat title', () => {
+    const longTitle =
+      'Release planning for the summer residency announcement and launch';
+    const { container } = render(
+      <DashboardHeader
+        breadcrumbs={[{ label: 'New Chat', href: '/app/chat/conv-123' }]}
+        breadcrumbSuffix={<span title={longTitle}>{longTitle}</span>}
+        searchSurface={<button type='button'>Search chats</button>}
+        action={<button type='button'>Thread options</button>}
+      />
+    );
+
+    const title = screen.getByRole('heading', { name: longTitle, level: 1 });
+    const searchButton = screen.getByRole('button', { name: 'Search chats' });
+
+    expect(title).toHaveClass('min-w-0', 'truncate');
+    expect(searchButton.parentElement).toHaveClass(
+      'max-sm:w-(--linear-app-control-height-sm)'
+    );
+    expect(
+      container.querySelectorAll('[data-testid="dashboard-header"] h1')
+    ).toHaveLength(1);
+  });
+
   it('prefers the breadcrumb suffix for the mobile title when present', () => {
     const { container } = render(
       <DashboardHeader


### PR DESCRIPTION
## Summary
- reserve the compact mobile action slot so long chat titles retain useful width at 375px
- preserve the existing single-line truncation contract without reintroducing duplicate header chrome
- add a 375px long-title regression

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/DashboardHeader.test.tsx` — 10/10
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/components/features/dashboard/organisms/DashboardHeader.tsx apps/web/tests/unit/dashboard/DashboardHeader.test.tsx`
- normal pre-push gate — 12/12 affected tests, Tailwind guard, typecheck, lint, CI harness/docs

Visual review is advisory under the non-blocking taste policy.

Closes JOV-4544