### PR TITLE
fix(chat): remove attachment-only double carding

### DIFF
--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -157,6 +157,24 @@ export const ChatMessage = memo(function ChatMessage({
     attachmentChips.length === 0 &&
     !messageText.includes('\n') &&
     messageText.length <= 44;
+  const userAttachmentContent = attachmentChips.map(chip =>
+    chip.isImage ? (
+      <ImageAttachmentChip
+        key={chip.dedupeKey}
+        url={chip.url}
+        name={chip.name}
+        tone='onLight'
+      />
+    ) : (
+      <FileAttachmentChip
+        key={chip.dedupeKey}
+        url={chip.url}
+        name={chip.name}
+        mediaType={chip.mediaType}
+        tone='onLight'
+      />
+    )
+  );
 
   return (
     <motion.div
@@ -171,42 +189,35 @@ export const ChatMessage = memo(function ChatMessage({
       transition={{ duration: 0.2, ease: 'easeOut' }}
     >
       {isUser ? (
-        <div
-          data-testid='chat-user-bubble'
-          data-bubble-shape={useUserPillBubble ? 'pill' : 'rectangle'}
-          className='system-b-chat-user-bubble'
-        >
-          {attachmentChips.length > 0 && (
-            <div
-              className='system-b-chat-user-attachments'
-              data-has-message={messageText ? 'true' : 'false'}
-            >
-              {attachmentChips.map(chip =>
-                chip.isImage ? (
-                  <ImageAttachmentChip
-                    key={chip.dedupeKey}
-                    url={chip.url}
-                    name={chip.name}
-                    tone='onLight'
-                  />
-                ) : (
-                  <FileAttachmentChip
-                    key={chip.dedupeKey}
-                    url={chip.url}
-                    name={chip.name}
-                    mediaType={chip.mediaType}
-                    tone='onLight'
-                  />
-                )
-              )}
-            </div>
-          )}
-          {messageText && (
-            <div className='system-b-chat-user-text'>
-              <TokenizedText content={messageText} tone='onLight' />
-            </div>
-          )}
-        </div>
+        attachmentChips.length > 0 && !messageText ? (
+          <div
+            className='system-b-chat-user-attachments'
+            data-testid='chat-user-attachment-frame'
+            data-has-message='false'
+          >
+            {userAttachmentContent}
+          </div>
+        ) : (
+          <div
+            data-testid='chat-user-bubble'
+            data-bubble-shape={useUserPillBubble ? 'pill' : 'rectangle'}
+            className='system-b-chat-user-bubble'
+          >
+            {attachmentChips.length > 0 && (
+              <div
+                className='system-b-chat-user-attachments'
+                data-has-message={messageText ? 'true' : 'false'}
+              >
+                {userAttachmentContent}
+              </div>
+            )}
+            {messageText && (
+              <div className='system-b-chat-user-text'>
+                <TokenizedText content={messageText} tone='onLight' />
+              </div>
+            )}
+          </div>
+        )
       ) : (
         <div className='system-b-chat-assistant-frame'>
           {showThinkingIndicator ? (

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -192,6 +192,30 @@ describe('ChatMessage', () => {
     expect(bubble.textContent).not.toContain('blob.vercel-storage.com');
   });
 
+  it('renders an attachment-only message on its chip surface without a redundant user bubble (JOV-4556)', () => {
+    const messageProps = {
+      id: 'user-file-only',
+      role: 'user' as const,
+      parts: [
+        {
+          type: 'file' as const,
+          mediaType: 'text/markdown',
+          url: 'https://example.com/release-notes.md',
+          name: 'release-notes.md',
+        },
+      ],
+    };
+
+    fastRender(<ChatMessage {...messageProps} />);
+
+    const attachmentFrame = screen.getByTestId('chat-user-attachment-frame');
+    expect(attachmentFrame).toHaveClass('system-b-chat-user-attachments');
+    expect(
+      within(attachmentFrame).getByTestId('file-attachment-chip')
+    ).toHaveTextContent('release-notes.md');
+    expect(screen.queryByTestId('chat-user-bubble')).toBeNull();
+  });
+
   it('renders thinking with stable System B loading hooks', () => {
     const messageProps = {
       id: 'assistant-thinking',


### PR DESCRIPTION
## Summary

- Remove the redundant user-message bubble around attachment-only chat rows; the existing file/image chip is now the single intentional surface.
- Preserve the existing bubble when a message includes text.
- Add a regression test for a markdown attachment-only row.

## Verification

- `pnpm exec biome check apps/web/components/jovie/components/ChatMessage.tsx apps/web/tests/unit/chat/ChatMessage.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatMessage.test.tsx tests/unit/chat/streamdown-config.test.ts` (25 tests)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

Linear: JOV-4556
Source artifact: #15102

<!-- linear-issue-id:JOV-4556 -->