### PR TITLE
fix(contacts): consolidate empty-state add action

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -109,7 +109,7 @@ export const ContactsTable = memo(function ContactsTable({
           ariaLabel='Add contact'
           onClick={() => onAddContactRef.current()}
           icon={<Plus className='h-3.5 w-3.5' />}
-          label='Add contact'
+          label='Add Contact'
         />
       </DashboardHeaderActionGroup>
     ),
@@ -215,12 +215,8 @@ export const ContactsTable = memo(function ContactsTable({
           {isEmpty ? (
             <EmptyState
               icon={<UserPlus className='h-6 w-6' aria-hidden='true' />}
-              heading='No Contacts Yet'
-              description='Add a contact to keep your team connected.'
-              action={{
-                label: 'Add contact',
-                onClick: () => onAddContact(),
-              }}
+              heading='No Contacts'
+              description='Add a contact to manage bookings, management, and press.'
             />
           ) : (
             <UnifiedTable

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { rowState } from '@/components/organisms/table/table.styles';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
 import { ContactsTable } from '@/features/dashboard/organisms/contacts-table/ContactsTable';
@@ -16,8 +16,11 @@ vi.mock('@/contexts/HeaderActionsContext', () => ({
 
 vi.mock('@/contexts/TableMetaContext', () => ({
   useTableMeta: () => ({
+    tableMeta: {
+      rightPanelWidth: 0,
+      toggle: null,
+    },
     setTableMeta,
-    tableMeta: { rightPanelWidth: 0 },
   }),
 }));
 
@@ -113,11 +116,6 @@ const contacts: EditableContact[] = [
 ];
 
 describe('ContactsTable', () => {
-  beforeEach(() => {
-    setHeaderActions.mockClear();
-    setTableMeta.mockClear();
-  });
-
   it('uses shell-selected row chrome and keeps the detail surface flat', () => {
     render(
       <ContactsTable
@@ -177,7 +175,7 @@ describe('ContactsTable', () => {
     expect(screen.queryByText('No Contacts Yet')).not.toBeInTheDocument();
   });
 
-  it('uses one concise add-contact action in the empty state and header', () => {
+  it('keeps the empty state informational and exposes the only add action in the header', async () => {
     const onAddContact = vi.fn();
 
     render(
@@ -191,29 +189,27 @@ describe('ContactsTable', () => {
       />
     );
 
-    expect(screen.getByText('No Contacts Yet')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No Contacts' })).toBeVisible();
     expect(
-      screen.getByText('Add a contact to keep your team connected.')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Add contact' })
-    ).toBeInTheDocument();
-    expect(screen.queryByText('Add Bookings Contact')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Add Management Contact')
-    ).not.toBeInTheDocument();
+      screen.getByText(
+        'Add a contact to manage bookings, management, and press.'
+      )
+    ).toBeVisible();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add contact' }));
-    expect(onAddContact).toHaveBeenCalledWith();
+    await waitFor(() => {
+      expect(setHeaderActions).toHaveBeenCalledWith(expect.anything());
+    });
 
-    const headerActions = setHeaderActions.mock.calls.find(
-      ([actions]) => actions
-    )?.[0];
-    expect(headerActions).toBeTruthy();
+    const headerActions = setHeaderActions.mock.calls.at(-1)?.[0];
     render(headerActions);
 
-    expect(screen.getAllByRole('button', { name: 'Add contact' })).toHaveLength(
-      2
-    );
+    const addContactButton = screen.getByRole('button', {
+      name: 'Add contact',
+    });
+    expect(addContactButton).toHaveTextContent('Add Contact');
+
+    fireEvent.click(addContactButton);
+    expect(onAddContact).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4516 -->

## Summary
- Normalize the Contacts empty state to an informational No Contacts state with no embedded CTA.
- Keep the single accessible Add Contact action in the header.
- Stabilize coverage around delayed header-action registration and current table metadata.

## Verification
- `pnpm exec biome check apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx apps/web/tests/unit/dashboard/ContactsTable.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/dashboard/ContactsTable.test.tsx` (3 passed)
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

No browser or advisory-review run was required for this bounded source-gated slice; no Kimi review was used.