### PR TITLE
fix(releases): synchronize Apple banner first paint

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner.tsx
@@ -35,6 +35,9 @@ interface AppleMusicSyncBannerProps {
   readonly profileId: string;
   readonly spotifyConnected: boolean;
   readonly releases: ReleaseViewModel[];
+  /** Shared eligibility query result from the release shell, when available. */
+  readonly matches?: DspMatch[];
+  readonly isLoading?: boolean;
   readonly className?: string;
   readonly compact?: boolean;
   readonly onMatchStatusChange?: (
@@ -65,14 +68,20 @@ export function AppleMusicSyncBanner({
   profileId,
   spotifyConnected,
   releases,
+  matches: providedMatches,
+  isLoading: providedIsLoading,
   className,
   compact = false,
   onMatchStatusChange,
 }: AppleMusicSyncBannerProps) {
-  const { data: matches = [] as DspMatch[], isLoading } = useDspMatchesQuery({
-    profileId,
-    enabled: spotifyConnected && !!profileId,
-  });
+  const { data: queriedMatches, isLoading: isQueryLoading } =
+    useDspMatchesQuery({
+      profileId,
+      enabled:
+        providedIsLoading === undefined && spotifyConnected && !!profileId,
+    });
+  const matches = providedMatches ?? queriedMatches ?? ([] as DspMatch[]);
+  const isLoading = providedIsLoading ?? isQueryLoading;
 
   const confirmMutation = useConfirmDspMatchMutation();
   const rejectMutation = useRejectDspMatchMutation();

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ReleaseViewModel } from '@/lib/discography/types';
+import type { DspMatch } from '@/lib/queries';
 import { AppleMusicSyncBanner } from './AppleMusicSyncBanner';
 import { ImportProgressBanner } from './ImportProgressBanner';
 import { SmartLinkGateBanner } from './SmartLinkGateBanner';
@@ -8,6 +9,8 @@ import { SMART_LINK_SOFT_CAP } from './smart-link-gating';
 
 interface ReleaseStateBannersProps {
   readonly rows: ReleaseViewModel[];
+  readonly appleMusicMatches?: DspMatch[];
+  readonly isAppleMusicEligibilityLoading?: boolean;
   readonly showImportProgress: boolean;
   readonly showReleasesTable: boolean;
   readonly artistName: string | null;
@@ -28,6 +31,8 @@ interface ReleaseStateBannersProps {
 
 export function ReleaseStateBanners({
   rows,
+  appleMusicMatches,
+  isAppleMusicEligibilityLoading,
   showImportProgress,
   showReleasesTable,
   artistName,
@@ -65,6 +70,8 @@ export function ReleaseStateBanners({
             profileId={firstProfileId}
             spotifyConnected={isSpotifyConnected}
             releases={rows}
+            matches={appleMusicMatches}
+            isLoading={isAppleMusicEligibilityLoading}
             onMatchStatusChange={onAppleMusicMatchStatusChange}
             className='mx-3 lg:mx-4 mt-3'
           />

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -39,7 +39,7 @@ import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { openChatWithPrompt } from '@/lib/chat/open-chat-with-prompt';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import { useAppFlag } from '@/lib/flags/client';
-import { usePlanGate } from '@/lib/queries';
+import { useDspMatchesQuery, usePlanGate } from '@/lib/queries';
 import { buildReleasePitchChatPrompt } from '@/lib/services/pitch/targets';
 import { cn } from '@/lib/utils';
 import {
@@ -943,6 +943,15 @@ export function ShellReleasesView({
   const showEmptyState = !isConnected && !isImporting && rows.length === 0;
   const showConnectedEmptyState =
     isConnected && rows.length === 0 && !isImporting;
+  const shouldResolveAppleMusicEligibility =
+    isConnected && rows.length > 0 && !isAmConnected && !isImporting;
+  const { data: appleMusicMatches, isLoading: isAppleMusicEligibilityLoading } =
+    useDspMatchesQuery({
+      profileId: rows[0]?.profileId ?? '',
+      enabled: shouldResolveAppleMusicEligibility,
+    });
+  const shouldGateListPaint =
+    shouldResolveAppleMusicEligibility && isAppleMusicEligibilityLoading;
 
   return (
     <>
@@ -957,6 +966,8 @@ export function ShellReleasesView({
       >
         <ReleaseStateBanners
           rows={rows}
+          appleMusicMatches={appleMusicMatches}
+          isAppleMusicEligibilityLoading={isAppleMusicEligibilityLoading}
           showImportProgress={showImportProgress}
           showReleasesTable={rows.length > 0}
           artistName={artistName}
@@ -973,26 +984,28 @@ export function ShellReleasesView({
         />
 
         <div className='flex-1 min-h-0 overflow-y-auto'>
-          <ReleasesListContent
-            showEmptyState={showEmptyState}
-            showConnectedEmptyState={showConnectedEmptyState}
-            visibleReleases={visibleReleases}
-            selectedReleaseId={selectedReleaseId}
-            pills={pills}
-            canCreateManualReleases={canCreateManualReleases}
-            isSyncing={isSyncing}
-            actionMenusByReleaseId={actionMenusByReleaseId}
-            contextMenuItemsByReleaseId={contextMenuItemsByReleaseId}
-            isSmartLinkLocked={isSmartLinkLocked}
-            getSmartLinkLockReason={getSmartLinkLockReason}
-            getSyncStatus={getSyncStatus}
-            onConnectSpotify={() => setSpotifySearchOpen(true)}
-            onNewRelease={handleNewRelease}
-            onSync={handleSync}
-            onSelect={handleSelect}
-            onClearFilters={handleClearFilters}
-            listboxRef={listboxRef}
-          />
+          {!shouldGateListPaint && (
+            <ReleasesListContent
+              showEmptyState={showEmptyState}
+              showConnectedEmptyState={showConnectedEmptyState}
+              visibleReleases={visibleReleases}
+              selectedReleaseId={selectedReleaseId}
+              pills={pills}
+              canCreateManualReleases={canCreateManualReleases}
+              isSyncing={isSyncing}
+              actionMenusByReleaseId={actionMenusByReleaseId}
+              contextMenuItemsByReleaseId={contextMenuItemsByReleaseId}
+              isSmartLinkLocked={isSmartLinkLocked}
+              getSmartLinkLockReason={getSmartLinkLockReason}
+              getSyncStatus={getSyncStatus}
+              onConnectSpotify={() => setSpotifySearchOpen(true)}
+              onNewRelease={handleNewRelease}
+              onSync={handleSync}
+              onSelect={handleSelect}
+              onClearFilters={handleClearFilters}
+              listboxRef={listboxRef}
+            />
+          )}
         </div>
       </PageShell>
 

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
@@ -13,16 +13,19 @@ import {
 } from '@/contexts/RightPanelContext';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 
-const mockUsePlanGate = vi.fn(() => ({
-  isLoading: false,
-  isError: false,
-  smartLinksLimit: null as number | null,
-  isPro: true,
-  canCreateManualReleases: true,
-  canGenerateAlbumArt: false,
-  canGenerateReleasePlans: true,
-  canEditSmartLinks: true,
-  canAccessFutureReleases: true,
+const { mockUseDspMatchesQuery, mockUsePlanGate } = vi.hoisted(() => ({
+  mockUseDspMatchesQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  mockUsePlanGate: vi.fn(() => ({
+    isLoading: false,
+    isError: false,
+    smartLinksLimit: null as number | null,
+    isPro: true,
+    canCreateManualReleases: true,
+    canGenerateAlbumArt: false,
+    canGenerateReleasePlans: true,
+    canEditSmartLinks: true,
+    canAccessFutureReleases: true,
+  })),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -100,7 +103,17 @@ vi.mock(
 vi.mock(
   '@/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner',
   () => ({
-    AppleMusicSyncBanner: () => <div data-testid='apple-music-sync-banner' />,
+    AppleMusicSyncBanner: ({
+      isLoading,
+      matches,
+    }: {
+      readonly isLoading?: boolean;
+      readonly matches?: Array<{ readonly status: string }>;
+    }) =>
+      isLoading ||
+      matches?.some(match => match.status === 'confirmed') ? null : (
+        <div data-testid='apple-music-sync-banner' />
+      ),
   })
 );
 
@@ -203,6 +216,7 @@ vi.mock('@/lib/queries', () => {
     useSaveReleaseStatusMutation: () => mutation,
     useSaveReleaseTargetPlaylistsMutation: () => mutation,
     useSyncReleasesFromSpotifyMutation: () => mutation,
+    useDspMatchesQuery: () => mockUseDspMatchesQuery(),
     usePlanGate: () => mockUsePlanGate(),
   };
 });
@@ -351,6 +365,7 @@ function renderShell(
 }
 
 beforeEach(() => {
+  mockUseDspMatchesQuery.mockReturnValue({ data: [], isLoading: false });
   mockUsePlanGate.mockReturnValue({
     isLoading: false,
     isError: false,
@@ -365,6 +380,65 @@ beforeEach(() => {
 });
 
 describe('ShellReleasesView', () => {
+  it('waits to mount the list until Apple eligibility resolves, then commits banner and rows together', () => {
+    mockUseDspMatchesQuery.mockReturnValue({ data: [], isLoading: true });
+    const rendered = renderShell(
+      [fakeRelease({ id: 'release-1', title: 'Wait for eligibility' })],
+      { spotifyConnected: true }
+    );
+
+    expect(
+      screen.queryByRole('option', { name: /Wait for eligibility/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('apple-music-sync-banner')
+    ).not.toBeInTheDocument();
+
+    mockUseDspMatchesQuery.mockReturnValue({ data: [], isLoading: false });
+    rendered.rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <HeaderActionsProvider>
+          <RightPanelProvider>
+            <ShellReleasesView
+              releases={[
+                fakeRelease({ id: 'release-1', title: 'Wait for eligibility' }),
+              ]}
+              providerConfig={providerConfig}
+              primaryProviders={primaryProviders}
+              artistName='Bahamas'
+              spotifyConnected
+            />
+            <HeaderActionsProbe />
+            <RightPanelProbe />
+          </RightPanelProvider>
+        </HeaderActionsProvider>
+      </QueryClientProvider>
+    );
+
+    expect(
+      screen.getByRole('option', { name: /Wait for eligibility/ })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('apple-music-sync-banner')).toBeInTheDocument();
+  });
+
+  it('keeps the settled no-banner release list mounted', () => {
+    mockUseDspMatchesQuery.mockReturnValue({
+      data: [{ status: 'confirmed' }],
+      isLoading: false,
+    });
+
+    renderShell([fakeRelease({ id: 'release-2', title: 'Already linked' })], {
+      spotifyConnected: true,
+    });
+
+    expect(
+      screen.getByRole('option', { name: /Already linked/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('apple-music-sync-banner')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders one row per release with title + artist', () => {
     renderShell([
       fakeRelease({ id: '1', title: 'Lost in the Light' }),

--- a/apps/web/tests/unit/dashboard/AppleMusicSyncBanner.test.tsx
+++ b/apps/web/tests/unit/dashboard/AppleMusicSyncBanner.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppleMusicSyncBanner } from '@/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner';
+
+const { useDspMatchesQuery } = vi.hoisted(() => ({
+  useDspMatchesQuery: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
+vi.mock('@/lib/queries', () => ({
+  useDspMatchesQuery,
+  useConfirmDspMatchMutation: () => ({ isPending: false, mutate: vi.fn() }),
+  useRejectDspMatchMutation: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+describe('AppleMusicSyncBanner', () => {
+  it('does not enable its standalone eligibility query when the shell owns loading state', () => {
+    render(
+      <AppleMusicSyncBanner
+        profileId='profile-1'
+        spotifyConnected
+        releases={[]}
+        matches={[]}
+        isLoading={false}
+      />
+    );
+
+    expect(useDspMatchesQuery).toHaveBeenCalledWith({
+      profileId: 'profile-1',
+      enabled: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve Apple Music eligibility in the release shell and commit the banner and release list together on first paint.
- Preserve the settled no-banner layout without a skeleton, spinner, reserved gap, or overlay.
- Prevent the child banner from duplicating the eligibility query when the shell supplies state.

## Bug-to-Test

- [x] The list stays unmounted while shell-owned eligibility is unresolved, then the banner and rows appear together.
- [x] The settled no-banner list remains mounted.
- [x] The child banner disables its standalone query when the shell owns loading state.

## Verification

- [x] `pnpm exec biome check` on the five changed files
- [x] Focused Vitest: 26 passed
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `git diff --check origin/main...HEAD`

Linear follow-ups: none.

Advisory review only: browser, Grok, and Codex reviews were not run; no Kimi review requested.