### PR TITLE
fix(releases): reserve import banner space

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrixNotices.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrixNotices.tsx
@@ -47,13 +47,12 @@ export function ReleaseImportProgressNotice({
   readonly importedCount: number;
   readonly totalCount: number;
 }) {
-  if (!visible) {
-    return null;
-  }
-
   return (
-    <div className='mx-3 lg:mx-4 mt-3'>
-      <Suspense fallback={null}>
+    <div
+      className='mx-3 lg:mx-4 mt-3 min-h-15'
+      data-testid='release-import-progress-slot'
+    >
+      <Suspense fallback={<div className='h-15' aria-hidden />}>
         <ImportProgressBanner
           artistName={artistName}
           importedCount={importedCount}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx
@@ -46,16 +46,17 @@ export function ReleaseStateBanners({
 
   return (
     <>
-      {showImportProgress && (
-        <div className='mx-3 lg:mx-4 mt-3'>
-          <ImportProgressBanner
-            artistName={artistName}
-            importedCount={importedCount}
-            totalCount={totalCount}
-            visible={showImportProgress}
-          />
-        </div>
-      )}
+      <div
+        className='mx-3 lg:mx-4 mt-3 min-h-15'
+        data-testid='release-import-progress-slot'
+      >
+        <ImportProgressBanner
+          artistName={artistName}
+          importedCount={importedCount}
+          totalCount={totalCount}
+          visible={showImportProgress}
+        />
+      </div>
 
       {showReleasesTable &&
         firstProfileId &&

--- a/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
@@ -693,7 +693,7 @@ describe('ReleaseProviderMatrix', () => {
       expect(screen.getByTestId('release-subheader')).toBeInTheDocument();
     });
 
-    it('does not render spotify import banner when import is idle', () => {
+    it('keeps the spotify import banner footprint when import is idle', () => {
       renderWithProviders(
         <ReleaseProviderMatrix
           releases={[makeRelease()]}
@@ -704,9 +704,12 @@ describe('ReleaseProviderMatrix', () => {
         />
       );
 
+      expect(screen.getByTestId('release-import-progress-slot')).toHaveClass(
+        'min-h-15'
+      );
       expect(
-        screen.queryByTestId('spotify-import-progress-banner')
-      ).not.toBeInTheDocument();
+        screen.getByTestId('spotify-import-progress-banner')
+      ).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('shows spotify import banner when import is active', async () => {

--- a/apps/web/tests/unit/dashboard/ReleaseStateBanners.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseStateBanners.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReleaseStateBanners } from '@/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners';
+
+describe('ReleaseStateBanners', () => {
+  it('keeps the import banner slot mounted across import state changes', () => {
+    const props = {
+      rows: [],
+      showReleasesTable: false,
+      artistName: 'The 1975',
+      importedCount: 0,
+      totalCount: 10,
+      isAppleMusicConnected: false,
+      isImporting: false,
+      isSpotifyConnected: true,
+      isPro: true,
+      canAccessFutureReleases: true,
+      releasedCount: 0,
+      unreleasedCount: 0,
+      onAppleMusicMatchStatusChange: () => {},
+    };
+
+    const { rerender } = render(
+      <ReleaseStateBanners {...props} showImportProgress={false} />
+    );
+
+    const slot = screen.getByTestId('release-import-progress-slot');
+    expect(slot).toHaveClass('min-h-15');
+    expect(
+      screen.getByTestId('spotify-import-progress-banner')
+    ).toHaveAttribute('aria-hidden', 'true');
+
+    rerender(<ReleaseStateBanners {...props} showImportProgress />);
+
+    expect(screen.getByTestId('release-import-progress-slot')).toBe(slot);
+    expect(
+      screen.getByTestId('spotify-import-progress-banner')
+    ).toHaveAttribute('aria-hidden', 'false');
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4160 -->

## Summary
- keep the import-progress slot mounted in both release shells
- reserve the banner footprint through lazy loading and idle/active transitions
- add regression coverage for stable banner geometry

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/ImportProgressBanner.test.tsx tests/unit/dashboard/ReleaseStateBanners.test.tsx tests/unit/dashboard/ReleaseProviderMatrix.test.tsx` (20/20)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm tailwind:check`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable: layout-stability issue)
- `git diff --check`
- normal protected pre-push gate

Taste review is advisory; no Kimi used.