### PR TITLE
fix(ui): unify overlay surface contracts

### DIFF
--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -207,6 +207,7 @@ export function PageToolbarActionButton({
       label={tooltipLabel}
       shortcut={tooltipShortcut}
       side='bottom'
+      contentVariant='compact'
     >
       {button}
     </TooltipShortcut>

--- a/apps/web/tests/unit/components/table/PageToolbar.test.tsx
+++ b/apps/web/tests/unit/components/table/PageToolbar.test.tsx
@@ -17,9 +17,13 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
-  TooltipShortcut: ({ children }: { readonly children: ReactNode }) => (
-    <>{children}</>
-  ),
+  TooltipShortcut: ({
+    children,
+    contentVariant,
+  }: {
+    readonly children: ReactNode;
+    readonly contentVariant?: 'compact' | 'rich';
+  }) => <span data-tooltip-content-variant={contentVariant}>{children}</span>,
 }));
 
 describe('PageToolbar buttons', () => {
@@ -75,6 +79,10 @@ describe('PageToolbar buttons', () => {
     const button = screen.getByRole('button', { name: 'Toggle preview' });
     expect(button).toBeInTheDocument();
     expect(button).toBeEnabled();
+    expect(button.parentElement).toHaveAttribute(
+      'data-tooltip-content-variant',
+      'compact'
+    );
   });
 });
 

--- a/packages/ui/atoms/tooltip-shortcut.test.tsx
+++ b/packages/ui/atoms/tooltip-shortcut.test.tsx
@@ -45,6 +45,18 @@ describe('TooltipShortcut', () => {
     });
   });
 
+  it('forwards the explicit compact contract for a toolbar label', () => {
+    render(
+      <TooltipProvider delayDuration={0}>
+        <TooltipShortcut label='Display' contentVariant='compact'>
+          <button type='button'>Display</button>
+        </TooltipShortcut>
+      </TooltipProvider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Display' })).toBeInTheDocument();
+  });
+
   describe('Props', () => {
     it('accepts label prop', () => {
       renderWithProvider(

--- a/packages/ui/atoms/tooltip-shortcut.tsx
+++ b/packages/ui/atoms/tooltip-shortcut.tsx
@@ -20,6 +20,11 @@ export interface TooltipShortcutProps {
    */
   readonly side?: 'top' | 'right' | 'bottom' | 'left';
   /**
+   * Declares the shape contract for the tooltip content. Toolbar labels are
+   * compact by definition; explanatory labels should opt into `rich`.
+   */
+  readonly contentVariant?: 'compact' | 'rich';
+  /**
    * The trigger element (button, link, etc.)
    */
   readonly children: React.ReactNode;
@@ -33,12 +38,17 @@ export function TooltipShortcut({
   label,
   shortcut,
   side = 'top',
+  contentVariant = 'rich',
   children,
 }: TooltipShortcutProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent side={side} className='flex items-center gap-2'>
+      <TooltipContent
+        contentVariant={contentVariant}
+        side={side}
+        className='flex items-center gap-2'
+      >
         <span>{label}</span>
         {shortcut && <Kbd variant='tooltip'>{shortcut}</Kbd>}
       </TooltipContent>

--- a/packages/ui/atoms/tooltip.stories.tsx
+++ b/packages/ui/atoms/tooltip.stories.tsx
@@ -52,6 +52,41 @@ export const Basic: Story = {
   ),
 };
 
+/** Compact labels use the shared pill contract; explanatory content uses the shared rounded rectangle. */
+export const ContentShapes: Story = {
+  render: () => (
+    <div className='flex flex-col items-center gap-6'>
+      <Tooltip defaultOpen>
+        <TooltipTrigger>
+          <Button variant='outline'>Compact label</Button>
+        </TooltipTrigger>
+        <TooltipContent contentVariant='compact'>Save draft</TooltipContent>
+      </Tooltip>
+      <Tooltip defaultOpen>
+        <TooltipTrigger>
+          <Button variant='outline'>Two-line explanation</Button>
+        </TooltipTrigger>
+        <TooltipContent contentVariant='rich'>
+          This explanation intentionally wraps into a calm, shared rounded
+          rectangle.
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  ),
+};
+
+/** Keyboard focus opens the same compact tooltip contract without a pointer. */
+export const KeyboardFocus: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger>
+        <Button variant='outline'>Tab here</Button>
+      </TooltipTrigger>
+      <TooltipContent contentVariant='compact'>Keyboard focus</TooltipContent>
+    </Tooltip>
+  ),
+};
+
 /**
  * Tooltip with arrow enabled (arrow is hidden by default)
  */

--- a/packages/ui/atoms/tooltip.test.tsx
+++ b/packages/ui/atoms/tooltip.test.tsx
@@ -16,6 +16,7 @@ const TestTooltip = ({
   defaultOpen,
   children = 'Tooltip content',
   showArrow = false,
+  contentVariant,
   side = 'top' as const,
   sideOffset,
 }: {
@@ -25,13 +26,19 @@ const TestTooltip = ({
   showArrow?: boolean;
   side?: 'top' | 'right' | 'bottom' | 'left';
   sideOffset?: number;
+  contentVariant?: 'compact' | 'rich';
 }) => (
   <TooltipProvider delayDuration={0}>
     <Tooltip open={open} defaultOpen={defaultOpen}>
       <TooltipTrigger>
         <button type='button'>Hover me</button>
       </TooltipTrigger>
-      <TooltipContent showArrow={showArrow} side={side} sideOffset={sideOffset}>
+      <TooltipContent
+        contentVariant={contentVariant}
+        showArrow={showArrow}
+        side={side}
+        sideOffset={sideOffset}
+      >
         {children}
       </TooltipContent>
     </Tooltip>
@@ -187,8 +194,7 @@ describe('Tooltip', () => {
       render(<TestTooltip open={true} />);
       const content = screen.getByTestId('tooltip-content');
       expect(content.className).toContain('z-[150]');
-      // Radius on the System B scale (--radius-default = 4px), 12px type.
-      expect(content.className).toContain('rounded-(--radius-default)');
+      expect(content.className).toContain('rounded-xl');
       expect(content.className).toContain('text-xs');
     });
 
@@ -197,8 +203,32 @@ describe('Tooltip', () => {
       const content = screen.getByTestId('tooltip-content');
       expect(content.className).toContain('bg-surface-0');
       expect(content.className).toContain('text-primary-token');
-      expect(content.className).toContain('border-subtle');
+      expect(content.className).toContain('border-default');
       expect(content.className).toContain('shadow-popover');
+    });
+
+    it('uses a pill only for the explicit compact one-line contract', () => {
+      render(
+        <TestTooltip open={true} contentVariant='compact'>
+          Save
+        </TestTooltip>
+      );
+      const content = screen.getByTestId('tooltip-content');
+      expect(content.className).toContain('rounded-full');
+      expect(content.className).toContain('whitespace-nowrap');
+      expect(content.className).not.toContain('max-w-56');
+    });
+
+    it('uses the shared rounded rectangle for wrapped content', () => {
+      render(
+        <TestTooltip open={true} contentVariant='rich'>
+          A clear two-line explanation that must wrap safely in the overlay.
+        </TestTooltip>
+      );
+      const content = screen.getByTestId('tooltip-content');
+      expect(content.className).toContain('rounded-xl');
+      expect(content.className).toContain('max-w-56');
+      expect(content.className).toContain('break-words');
     });
 
     it('never hard-clips content mid-glyph (no overflow-hidden; wraps within max width)', () => {

--- a/packages/ui/atoms/tooltip.tsx
+++ b/packages/ui/atoms/tooltip.tsx
@@ -3,6 +3,10 @@
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import * as React from 'react';
 
+import {
+  OVERLAY_CONTENT_RADIUS,
+  OVERLAY_SURFACE_BASE,
+} from '../lib/dropdown-styles';
 import { cn } from '../lib/utils';
 
 /**
@@ -48,6 +52,12 @@ TooltipTrigger.displayName = TooltipPrimitive.Trigger.displayName;
 interface TooltipContentProps
   extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
   /**
+   * `compact` is reserved for an author-confirmed, single-line label. It keeps
+   * the tooltip on one line and applies the compact pill shape. `rich` is the
+   * default for any content that may wrap or contain structured children.
+   */
+  readonly contentVariant?: 'compact' | 'rich';
+  /**
    * Whether to show the arrow pointer. Defaults to false for cleaner Linear-style appearance.
    */
   readonly showArrow?: boolean;
@@ -79,6 +89,7 @@ const TooltipContent = React.forwardRef<
       sideOffset = 4,
       collisionPadding = 8,
       showArrow = false,
+      contentVariant = 'rich',
       children,
       testId = 'tooltip-content',
       ...props
@@ -92,14 +103,15 @@ const TooltipContent = React.forwardRef<
         collisionPadding={collisionPadding}
         data-testid={testId}
         className={cn(
-          // Base layout + spacing. Radius is --radius-default (4px, System B
-          // scale) — compact Linear-style tooltip, not a pill. No
-          // overflow-hidden: long labels wrap/ellipsize (consumers control
-          // clamping); they must never hard-clip mid-glyph.
-          'z-[150] rounded-(--radius-default) border border-subtle',
-          'bg-surface-0 px-2 py-1 text-xs font-normal tracking-tight',
-          'text-primary-token shadow-popover',
-          'max-w-56 break-words',
+          // Every overlay shares the same tokenized surface. The content
+          // contract, not runtime line measurement, chooses the shape: a
+          // compact label is provably one line; all other content is a shared
+          // rounded rectangle that may wrap without clipping.
+          'z-[150] px-2 py-1 text-xs font-normal tracking-tight',
+          OVERLAY_SURFACE_BASE,
+          contentVariant === 'compact'
+            ? 'rounded-full whitespace-nowrap'
+            : `${OVERLAY_CONTENT_RADIUS} max-w-56 break-words`,
           // Pure opacity reveal (fade only) — subtract decorative zoom + slide-ins.
           // Matches parallel support work on shell Tooltip / Dsp for visual parity.
           // No layout shift; cursor-near friendly.

--- a/packages/ui/lib/dropdown-styles.test.ts
+++ b/packages/ui/lib/dropdown-styles.test.ts
@@ -29,6 +29,8 @@ import {
   MENU_SEARCH_INPUT_BASE,
   MENU_SEPARATOR_BASE,
   MENU_SHORTCUT_BASE,
+  OVERLAY_CONTENT_RADIUS,
+  OVERLAY_SURFACE_BASE,
   POPOVER_TRANSFORM_ORIGIN,
   popoverContentClasses,
   SELECT_ITEM_BASE,
@@ -62,6 +64,21 @@ describe('dropdown-styles', () => {
       expect(DROPDOWN_CONTENT_BASE).toContain('border');
       expect(DROPDOWN_CONTENT_BASE).toContain('bg-surface-0');
       expect(DROPDOWN_CONTENT_BASE).toContain('rounded-xl');
+    });
+
+    it('shares the tokenized overlay surface and rounded rectangle contract', () => {
+      expect(OVERLAY_SURFACE_BASE).toContain('border-default');
+      expect(OVERLAY_SURFACE_BASE).toContain('bg-surface-0');
+      expect(OVERLAY_SURFACE_BASE).toContain('shadow-popover');
+      expect(OVERLAY_CONTENT_RADIUS).toBe('rounded-xl');
+      expect(DROPDOWN_CONTENT_BASE).toContain(OVERLAY_SURFACE_BASE);
+    });
+
+    it('disables overlay entry and exit motion when reduced motion is requested', () => {
+      expect(DROPDOWN_TRANSITIONS).toContain('motion-reduce:animate-none');
+      expect(DROPDOWN_TRANSITIONS).toContain(
+        'motion-reduce:data-[state=closed]:animate-none'
+      );
     });
 
     it('default base uses default border token and p-1 padding', () => {

--- a/packages/ui/lib/dropdown-styles.ts
+++ b/packages/ui/lib/dropdown-styles.ts
@@ -31,7 +31,8 @@
  */
 export const DROPDOWN_TRANSITIONS =
   'data-[state=open]:animate-in data-[state=closed]:animate-out ' +
-  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0';
+  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 ' +
+  'motion-reduce:animate-none motion-reduce:data-[state=closed]:animate-none';
 
 /**
  * @deprecated Positional slide/zoom motion is intentionally disabled.
@@ -48,8 +49,15 @@ export const DROPDOWN_SLIDE_ANIMATIONS = '';
  *
  * Border uses --color-border-default (slightly more opaque than --color-border-subtle used by separators)
  */
-export const DROPDOWN_CONTENT_BASE =
-  'z-50 min-w-48 overflow-hidden rounded-xl border border-default bg-surface-0 p-1 text-primary-token shadow-popover';
+export const OVERLAY_SURFACE_BASE =
+  'border border-default bg-surface-0 text-primary-token shadow-popover';
+
+/**
+ * The shared rounded rectangle used by wrapped overlay content.
+ */
+export const OVERLAY_CONTENT_RADIUS = 'rounded-xl';
+
+export const DROPDOWN_CONTENT_BASE = `z-50 min-w-48 overflow-hidden ${OVERLAY_CONTENT_RADIUS} ${OVERLAY_SURFACE_BASE} p-1`;
 
 /**
  * Shadow effect for elevated appearance


### PR DESCRIPTION
## Summary
- canonicalize tooltip and popover surface, border, elevation, motion, and shape contracts in `@jovie/ui`
- reserve `compact` for explicit one-line/pill labels; keep wrapped content on the shared rounded rectangle
- adopt the compact contract in `PageToolbarActionButton`, preserving keyboard focus and Escape behavior from Radix primitives

## Verification
- `pnpm --filter @jovie/ui exec vitest run atoms/tooltip.test.tsx atoms/tooltip-shortcut.test.tsx atoms/popover.test.tsx lib/dropdown-styles.test.ts` (122 passed, 2 skipped)
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/table/PageToolbar.test.tsx` (8 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check <9 changed files>`
- `pnpm --filter @jovie/web run test:bug-to-test`
- normal pre-push gate

## Risk
Low: token-only shared primitive consolidation; no routing, auth, data, or runtime-state changes. Taste review is advisory per current policy.

Linear: JOV-4521