### PR TITLE
fix(shell): elevate New Chat in canonical rail

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -273,7 +273,7 @@ export function NavMenuItem({
     : undefined;
   const shellNavClassName = getSidebarNavRowClassName({
     active: isActive,
-    tone: 'default',
+    tone: item.tone,
     className:
       'group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0',
   });

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -7,8 +7,8 @@ import {
 } from './config';
 
 const CANONICAL_SIX = [
+  ['chat', 'New Chat', APP_ROUTES.CHAT],
   ['inbox', 'Inbox', APP_ROUTES.DASHBOARD],
-  ['chat', 'Chat', APP_ROUTES.CHAT],
   ['library', 'Library', APP_ROUTES.LIBRARY],
   ['contacts', 'Contacts', APP_ROUTES.CONTACTS],
   ['calendar', 'Calendar', APP_ROUTES.CALENDAR],
@@ -20,8 +20,9 @@ function toContract(items: readonly (typeof primaryNavigation)[number][]) {
 }
 
 describe('canonical customer shell navigation', () => {
-  it('keeps the founder-approved six destinations in exact order', () => {
+  it('keeps New Chat as the elevated first action in the exact customer order', () => {
     expect(toContract(primaryNavigation)).toEqual(CANONICAL_SIX);
+    expect(primaryNavigation[0].tone).toBe('primary');
   });
 
   it('detects missing and reordered canonical destinations', () => {

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -43,10 +43,11 @@ export const inboxNavItem: NavItem = {
 };
 
 export const chatNavItem: NavItem = {
-  name: 'Chat',
+  name: 'New Chat',
   href: APP_ROUTES.CHAT,
   id: 'chat',
   icon: SquarePen,
+  tone: 'primary',
   description: 'Start a new conversation',
 };
 
@@ -87,8 +88,8 @@ export const tasksNavItem: NavItem = {
  * consumed by desktop and mobile navigation (JOV-3763).
  */
 export const primaryNavigation = [
-  inboxNavItem,
   chatNavItem,
+  inboxNavItem,
   libraryNavItem,
   contactsNavItem,
   calendarNavItem,

--- a/apps/web/components/features/dashboard/dashboard-nav/types.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/types.ts
@@ -5,6 +5,8 @@ export interface NavItem {
   href: string;
   id: string;
   icon: ComponentType<SVGProps<SVGSVGElement>>;
+  /** Gives the one primary sidebar action the shared elevated row treatment. */
+  tone?: 'default' | 'primary';
   description?: string;
   badge?: ReactNode;
   children?: NavItem[];

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -23,8 +23,8 @@ vi.mock('@/lib/queries/prefetch-dashboard', () => ({
 }));
 
 const PRIMARY_LABELS = [
+  'New Chat',
   'Inbox',
-  'Chat',
   'Library',
   'Contacts',
   'Calendar',
@@ -174,8 +174,8 @@ describe('DashboardNav interactions', () => {
       renderFn: render,
     });
 
-    expect(screen.getAllByRole('link', { name: 'Chat' })).toHaveLength(1);
-    expect(screen.queryByRole('button', { name: 'Chat' })).toBeNull();
+    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'New Chat' })).toBeNull();
   });
 
   it('marks an active thread read without changing primary navigation', async () => {
@@ -203,7 +203,7 @@ describe('DashboardNav interactions', () => {
         JSON.parse(localStorage.getItem('jovie:sidebar-thread-read-at')!)
       ).toMatchObject({ 'thread-1': '2026-05-12T00:00:00.000Z' });
     });
-    expect(screen.getByRole('link', { name: 'Chat' })).not.toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'New Chat' })).not.toHaveAttribute(
       'aria-current'
     );
   });

--- a/apps/web/tests/scripts/performance-route-manifest.test.ts
+++ b/apps/web/tests/scripts/performance-route-manifest.test.ts
@@ -112,14 +112,14 @@ const RELEASE_BUDGET_CREATOR_SHELL_ROUTE_IDS = [
 
 const CANONICAL_SHELL_PERF_PAIRS = [
   {
-    itemId: 'inbox',
-    coldRouteId: 'creator-app-home',
-    warmRouteId: 'creator-inbox-nav',
-  },
-  {
     itemId: 'chat',
     coldRouteId: 'creator-chat',
     warmRouteId: 'creator-chat-nav',
+  },
+  {
+    itemId: 'inbox',
+    coldRouteId: 'creator-app-home',
+    warmRouteId: 'creator-inbox-nav',
   },
   {
     itemId: 'library',

--- a/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
@@ -38,8 +38,8 @@ vi.mock('@/lib/tracking/navigation-telemetry', () => ({
 }));
 
 const CANONICAL_LABELS = [
+  'New Chat',
   'Inbox',
-  'Chat',
   'Library',
   'Contacts',
   'Calendar',
@@ -64,8 +64,8 @@ describe('DashboardMobileTabs', () => {
     const directLinks = within(tabs).getAllByRole('link');
 
     expect(directLinks.map(link => link.textContent?.trim())).toEqual([
+      'New Chat',
       'Inbox',
-      'Chat',
       'Library',
     ]);
     expect(
@@ -81,7 +81,7 @@ describe('DashboardMobileTabs', () => {
     render(<DashboardMobileTabs />);
 
     expect(mockTrackNavigationImpressions).toHaveBeenCalledWith(
-      ['inbox', 'chat', 'library'],
+      ['chat', 'inbox', 'library'],
       APP_ROUTES.CHAT,
       expect.objectContaining({
         isMobile: true,
@@ -118,8 +118,8 @@ describe('DashboardMobileTabs', () => {
       CANONICAL_LABELS
     );
     expect(links.slice(0, 6).map(link => link.getAttribute('href'))).toEqual([
-      APP_ROUTES.DASHBOARD,
       APP_ROUTES.CHAT,
+      APP_ROUTES.DASHBOARD,
       APP_ROUTES.LIBRARY,
       APP_ROUTES.CONTACTS,
       APP_ROUTES.CALENDAR,
@@ -168,7 +168,7 @@ describe('DashboardMobileTabs', () => {
       within(chatTabs).getByRole('link', { name: 'Inbox' })
     ).not.toHaveAttribute('aria-current');
     expect(
-      within(chatTabs).getByRole('link', { name: 'Chat' })
+      within(chatTabs).getByRole('link', { name: 'New Chat' })
     ).toHaveAttribute('aria-current', 'page');
     chat.unmount();
 

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -17,8 +17,8 @@ vi.mock('@/app/app/(shell)/chat/ChatPageClient', () => ({
 }));
 
 const CANONICAL_NAV = [
+  ['New Chat', APP_ROUTES.CHAT],
   ['Inbox', APP_ROUTES.DASHBOARD],
-  ['Chat', APP_ROUTES.CHAT],
   ['Library', APP_ROUTES.LIBRARY],
   ['Contacts', APP_ROUTES.CONTACTS],
   ['Calendar', APP_ROUTES.CALENDAR],
@@ -87,7 +87,7 @@ describe('DashboardNav', () => {
     });
 
     expect(queryByRole('link', { name: 'Inbox' })).toBeNull();
-    expect(getByRole('link', { name: 'Chat' })).toBeInTheDocument();
+    expect(getByRole('link', { name: 'New Chat' })).toBeInTheDocument();
   });
 
   it('keeps a settled-empty Inbox visible while its root destination is active', () => {
@@ -186,7 +186,7 @@ describe('DashboardNav', () => {
     }
   });
 
-  it('uses Chat as the nav label while preserving the New Chat page title', async () => {
+  it('uses New Chat consistently for the elevated nav action and page title', async () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.CHAT);
     const { generateMetadata } = await import('@/app/app/(shell)/chat/page');
     const metadata = await generateMetadata();
@@ -202,7 +202,7 @@ describe('DashboardNav', () => {
     });
 
     expect(title).toBe('New Chat');
-    expect(getByRole('link', { name: 'Chat' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'New Chat' })).toHaveAttribute(
       'aria-current',
       'page'
     );
@@ -212,23 +212,26 @@ describe('DashboardNav', () => {
     expect(getAllByRole('heading', { name: title, level: 1 })).toHaveLength(1);
   });
 
-  it('does not mark Chat active on a chat thread', () => {
+  it('does not mark New Chat active on a chat thread', () => {
     mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.CHAT}/thread-123`);
     const { getByRole } = renderDashboardNav({ renderFn: fastRender });
 
     expect(
-      getByRole('link', { name: 'Chat' }).getAttribute('aria-current')
+      getByRole('link', { name: 'New Chat' }).getAttribute('aria-current')
     ).toBeNull();
   });
 
-  it('keeps inactive Chat on the default shell tone', () => {
+  it('keeps inactive New Chat on the shared primary shell tone', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.CALENDAR);
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
     });
 
-    const chatLink = getByRole('link', { name: 'Chat' });
-    expect(chatLink).toHaveClass('text-sidebar-item-foreground');
+    const chatLink = getByRole('link', { name: 'New Chat' });
+    expect(chatLink).toHaveClass('text-primary-token');
+    expect(chatLink).toHaveClass(
+      'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)]'
+    );
     expect(chatLink).not.toHaveAttribute('aria-current');
   });
 
@@ -285,7 +288,7 @@ describe('DashboardNav', () => {
     });
 
     expect(primaryLinks(container)).toHaveLength(6);
-    expect(getByRole('link', { name: 'Chat' }).className).toContain(
+    expect(getByRole('link', { name: 'New Chat' }).className).toContain(
       'group-data-[collapsible=icon]:justify-center'
     );
     expect(mockUseChatConversationsQuery).toHaveBeenCalledWith({


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4510 -->

## Summary

- moves the canonical New Chat action to the first position in the shared navigation tuple
- gives that one action the existing shared primary sidebar tone
- keeps desktop and mobile navigation derived from the same objects

## Verification

- `pnpm --filter @jovie/web exec vitest run components/features/dashboard/dashboard-nav/config.test.ts tests/unit/dashboard/DashboardNav.test.tsx --config=vitest.config.mts` — 23 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed via the singleflight result
- `pnpm --filter @jovie/web run test:bug-to-test` — not applicable; IA parity change
- `pnpm biome check --write ...` and `git diff --check` — passed

## Scope

This is the first JOV-4510 shared-rail slice only. Inbox visibility and row fade were already merged. Search relocation and profile/header consolidation stay separate shared-surface work.