### PR TITLE
fix(table): unify keyboard row interaction [JOV-4518]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -7,7 +7,6 @@ import {
   convertToCommonDropdownItems,
   PAGE_TOOLBAR_META_TEXT_CLASS,
   PageToolbar,
-  rowState,
   UnifiedTable,
 } from '@/components/organisms/table';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
@@ -181,13 +180,6 @@ export const ContactsTable = memo(function ContactsTable({
     [selectedContactId, contacts]
   );
 
-  const getRowClassName = useCallback(
-    (contact: EditableContact) => {
-      return selectedContactId === contact.id ? rowState.selected : '';
-    },
-    [selectedContactId]
-  );
-
   const isEmpty = !isLoading && contacts.length === 0;
 
   return (
@@ -226,7 +218,7 @@ export const ContactsTable = memo(function ContactsTable({
               getRowId={contact => contact.id}
               minWidth={`${TABLE_MIN_WIDTHS.MEDIUM}px`}
               className='text-app'
-              getRowClassName={getRowClassName}
+              isRowSelected={contact => selectedContactId === contact.id}
               onRowClick={handleRowClick}
               onFocusedRowChange={handleFocusedRowChange}
               getContextMenuItems={getContextMenuItems}

--- a/apps/web/components/organisms/table/organisms/UnifiedTable.keyboard.test.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTable.keyboard.test.tsx
@@ -1,0 +1,106 @@
+import type { ColumnDef } from '@tanstack/react-table';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UnifiedTable } from './UnifiedTable';
+
+type TestRow = { id: string; name: string };
+
+const data: TestRow[] = [
+  { id: 'one', name: 'One' },
+  { id: 'two', name: 'Two' },
+  { id: 'three', name: 'Three' },
+];
+
+const columns: ColumnDef<TestRow, unknown>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+  },
+];
+
+describe('UnifiedTable keyboard interaction', () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+  });
+
+  it('uses instant scrolling when reduced motion is requested', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    render(
+      <UnifiedTable
+        data={data}
+        columns={columns}
+        hideHeader
+        enableVirtualization={false}
+        getRowId={row => row.id}
+        onRowClick={vi.fn()}
+      />
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      behavior: 'auto',
+    });
+  });
+
+  it('uses roving tabindex and moves keyboard focus without changing row height', async () => {
+    const onFocusedRowChange = vi.fn();
+
+    render(
+      <UnifiedTable
+        data={data}
+        columns={columns}
+        hideHeader
+        enableVirtualization={false}
+        getRowId={row => row.id}
+        getRowTestId={row => `row-${row.id}`}
+        onRowClick={vi.fn()}
+        onFocusedRowChange={onFocusedRowChange}
+      />
+    );
+
+    const first = screen.getByTestId('row-one');
+    const second = screen.getByTestId('row-two');
+    const third = screen.getByTestId('row-three');
+
+    expect(first).toHaveAttribute('tabindex', '0');
+    expect(second).toHaveAttribute('tabindex', '-1');
+    expect(third).toHaveAttribute('tabindex', '-1');
+    expect(first).toHaveClass('system-b-table-row-height');
+
+    first.focus();
+    fireEvent.keyDown(first, { key: 'ArrowDown' });
+
+    await waitFor(() => expect(second).toHaveAttribute('tabindex', '0'));
+    expect(first).toHaveAttribute('tabindex', '-1');
+    expect(document.activeElement).toBe(second);
+    expect(onFocusedRowChange).toHaveBeenCalledWith(1);
+  });
+
+  it('exposes consumer-owned selection through the shared selected row state', () => {
+    const onRowClick = vi.fn();
+
+    render(
+      <UnifiedTable
+        data={data}
+        columns={columns}
+        hideHeader
+        enableVirtualization={false}
+        getRowId={row => row.id}
+        getRowTestId={row => `row-${row.id}`}
+        isRowSelected={row => row.id === 'two'}
+        onRowClick={onRowClick}
+      />
+    );
+
+    const selected = screen.getByTestId('row-two');
+    expect(selected).toHaveAttribute('aria-selected', 'true');
+    expect(selected).toHaveClass('system-b-table-row-selected');
+
+    fireEvent.keyDown(selected, { key: 'Enter' });
+    expect(onRowClick).toHaveBeenCalledWith(data[1]);
+  });
+});

--- a/apps/web/components/organisms/table/organisms/UnifiedTable.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTable.tsx
@@ -136,6 +136,14 @@ export interface UnifiedTableProps<TData> {
   readonly getRowClassName?: (row: TData, index: number) => string;
 
   /**
+   * Returns whether a row is selected when selection is owned by a consumer
+   * (for example, a persistent details rail rather than TanStack's checkbox
+   * selection state). The shared row then exposes the selection to assistive
+   * technology and applies the canonical selected treatment.
+   */
+  readonly isRowSelected?: (row: TData, index: number) => boolean;
+
+  /**
    * Get a stable test ID for a row when callers need selector-level targeting.
    */
   readonly getRowTestId?: (row: TData, index: number) => string | undefined;
@@ -348,6 +356,7 @@ export function UnifiedTable<TData>({
   onRowContextMenu,
   getContextMenuItems,
   getRowClassName,
+  isRowSelected,
   getRowTestId,
   className,
   containerClassName,
@@ -387,17 +396,17 @@ export function UnifiedTable<TData>({
   );
 
   // Internal focused row state (uncontrolled mode)
-  const [internalFocusedIndex, setInternalFocusedIndex] = useState<number>(-1);
+  // Roving tabindex needs a deterministic first stop. Focus-visible styling
+  // remains CSS-driven, so this does not paint a focus ring before keyboard
+  // focus actually reaches the table.
+  const [internalFocusedIndex, setInternalFocusedIndex] = useState<number>(0);
 
   // Use controlled or uncontrolled focus
-  const focusedIndex = controlledFocusedIndex ?? internalFocusedIndex;
+  const requestedFocusedIndex = controlledFocusedIndex ?? internalFocusedIndex;
   const setFocusedIndex = useCallback(
     (index: number) => {
-      if (onFocusedRowChange) {
-        onFocusedRowChange(index);
-      } else {
-        setInternalFocusedIndex(index);
-      }
+      setInternalFocusedIndex(index);
+      onFocusedRowChange?.(index);
     },
     [onFocusedRowChange]
   );
@@ -455,6 +464,11 @@ export function UnifiedTable<TData>({
   });
 
   const { rows } = table.getRowModel();
+
+  const focusedIndex = Math.max(
+    0,
+    Math.min(requestedFocusedIndex, rows.length - 1)
+  );
 
   const groupingEnabled = Boolean(groupingConfig);
   const groupingSourceData = useMemo(
@@ -530,6 +544,7 @@ export function UnifiedTable<TData>({
           shouldEnableKeyboardNav={shouldEnableKeyboardNav}
           shouldVirtualize={false}
           focusedIndex={focusedIndex}
+          isSelected={isRowSelected?.(rowData, index)}
           onRowClick={onRowClick}
           onRowContextMenu={onRowContextMenu}
           onKeyDown={handleKeyDown}
@@ -584,6 +599,7 @@ export function UnifiedTable<TData>({
       handleKeyDown,
       setFocusedIndex,
       getRowClassName,
+      isRowSelected,
       getRowTestId,
       onRowShiftClick,
       getExpandableRowId,
@@ -722,6 +738,7 @@ export function UnifiedTable<TData>({
           getContextMenuItems={getContextMenuItems}
           onRowShiftClick={onRowShiftClick}
           getRowClassName={getRowClassName}
+          isRowSelected={isRowSelected}
           getRowTestId={getRowTestId}
           renderRow={renderRow}
           getRowId={getRowId}
@@ -746,7 +763,7 @@ export function UnifiedTable<TData>({
                     <LoadingSpinner
                       size='sm'
                       tone='muted'
-                      label='Loading more'
+                      label='Loading More'
                     />
                     {' Loading more...'}
                   </span>

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableBody.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableBody.tsx
@@ -97,6 +97,12 @@ export interface VirtualizedTableBodyProps<TData> {
   readonly getRowClassName?: (row: TData, index: number) => string;
 
   /**
+   * Consumer-owned selected state for rows that do not use TanStack checkbox
+   * selection (for example, a row that owns an open details rail).
+   */
+  readonly isRowSelected?: (row: TData, index: number) => boolean;
+
+  /**
    * Get a stable test ID for a row when callers need selector-level targeting.
    */
   readonly getRowTestId?: (row: TData, index: number) => string | undefined;
@@ -181,6 +187,7 @@ export function VirtualizedTableBody<TData>({
   onRowShiftClick,
   getContextMenuItems,
   getRowClassName,
+  isRowSelected,
   getRowTestId,
   renderRow,
   getRowId,
@@ -248,6 +255,7 @@ export function VirtualizedTableBody<TData>({
             shouldVirtualize={useVirtual}
             virtualStart={virtualItem?.start}
             focusedIndex={focusedIndex}
+            isSelected={isRowSelected?.(rowData, rowIndex)}
             onRowClick={onRowClick}
             onRowContextMenu={onRowContextMenu}
             onKeyDown={onKeyDown}

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
@@ -27,6 +27,8 @@ export interface VirtualizedTableRowProps<TData> {
   readonly shouldVirtualize: boolean;
   readonly virtualStart?: number;
   readonly focusedIndex: number;
+  /** Consumer-owned selected state, composed with TanStack selection. */
+  readonly isSelected?: boolean;
   readonly onRowClick?: (row: TData) => void;
   readonly onRowContextMenu?: (row: TData, event: React.MouseEvent) => void;
   readonly onKeyDown: (
@@ -69,6 +71,7 @@ function VirtualizedTableRowComponent<TData>({
   shouldVirtualize,
   virtualStart,
   focusedIndex,
+  isSelected = false,
   onRowClick,
   onRowContextMenu,
   onKeyDown,
@@ -81,7 +84,7 @@ function VirtualizedTableRowComponent<TData>({
 }: VirtualizedTableRowProps<TData> &
   Omit<React.ComponentPropsWithoutRef<'tr'>, ManagedTrProps>) {
   const rowData = row.original as TData;
-  const isRowSelected = row.getIsSelected?.() ?? false;
+  const isRowSelected = (row.getIsSelected?.() ?? false) || isSelected;
 
   // Keep a ref to the forwarded onContextMenu so we can compose it without
   // breaking memoisation of handleContextMenu.
@@ -153,14 +156,19 @@ function VirtualizedTableRowComponent<TData>({
       ref={handleRef}
       data-index={rowIndex}
       data-testid={getRowTestId?.(rowData, rowIndex)}
-      tabIndex={shouldEnableKeyboardNav ? 0 : undefined}
+      tabIndex={
+        shouldEnableKeyboardNav
+          ? focusedIndex === rowIndex
+            ? 0
+            : -1
+          : undefined
+      }
       aria-selected={isRowSelected || htmlProps['aria-selected']}
       className={cn(
         presets.tableRow,
         onRowClick && 'cursor-pointer',
         shouldEnableKeyboardNav && rowState.focusVisible,
         isRowSelected && rowState.selected,
-        focusedIndex === rowIndex && !isRowSelected && rowState.focused,
         getRowClassName?.(rowData, rowIndex)
       )}
       onClick={handleClick}

--- a/apps/web/components/organisms/table/organisms/useTableKeyboardNav.ts
+++ b/apps/web/components/organisms/table/organisms/useTableKeyboardNav.ts
@@ -84,7 +84,13 @@ export function useTableKeyboardNav<TData>({
   useEffect(() => {
     if (focusedIndex >= 0 && enabled) {
       const rowElement = rowRefsMap.get(focusedIndex);
-      rowElement?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      const prefersReducedMotion = window.matchMedia?.(
+        '(prefers-reduced-motion: reduce)'
+      ).matches;
+      rowElement?.scrollIntoView?.({
+        block: 'nearest',
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      });
     }
   }, [focusedIndex, enabled, rowRefsMap]);
 

--- a/apps/web/components/organisms/table/table.styles.test.ts
+++ b/apps/web/components/organisms/table/table.styles.test.ts
@@ -27,6 +27,7 @@ describe('table System B style exports', () => {
     expect(alignment.rowHeight).toBe('system-b-table-row-height');
     expect(rowState.selected).toBe('system-b-table-row-selected');
     expect(rowState.focusVisible).toBe('system-b-table-row-focus-visible');
+    expect(rowState.focused).toBe('system-b-table-row-focused');
     expect(selection.checked).toBe('system-b-table-selection-checked');
     expect(columnWidths.small).toBe('system-b-table-column-small');
     expect(columnWidths.actions).toBe('system-b-table-column-actions');
@@ -44,5 +45,17 @@ describe('table System B style exports', () => {
     expect(source).not.toMatch(/\b(?:bg|shadow|ring|border|w|min-w|h)-\[/);
     expect(source).not.toMatch(/color-mix\(|rgba?\(|#[0-9a-fA-F]{3,8}\b/);
     expect(source).not.toMatch(/group-(?:hover|focus-visible)\/task-row:bg-/);
+  });
+
+  it('keeps reduced motion and the 40px row invariant in the canonical stylesheet', () => {
+    const designSystemSource = readFileSync(
+      join(process.cwd(), 'styles/design-system.css'),
+      'utf8'
+    );
+
+    expect(designSystemSource).toContain('height: 40px;');
+    expect(designSystemSource).toContain(
+      '@media (prefers-reduced-motion: reduce)'
+    );
   });
 });

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6410,6 +6410,13 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   transition-timing-function: var(--system-b-ease);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  :where(.system-b-table-row-base),
+  :where(.system-b-table-selection-unchecked) {
+    transition-duration: 0s;
+  }
+}
+
 :where(.system-b-table-row-hover):hover,
 :where(.system-b-table-row-focus-within):focus-within,
 :where(.system-b-table-row-focus-visible):focus-visible,

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { rowState } from '@/components/organisms/table/table.styles';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
 import { ContactsTable } from '@/features/dashboard/organisms/contacts-table/ContactsTable';
 
@@ -37,25 +36,22 @@ vi.mock('@/components/organisms/table', async importOriginal => {
     convertToCommonDropdownItems: vi.fn(() => []),
     UnifiedTable: ({
       data,
-      getRowClassName,
+      isRowSelected,
       isLoading,
       onRowClick,
     }: {
       readonly data: EditableContact[];
-      readonly getRowClassName?: (
-        row: EditableContact,
-        index: number
-      ) => string;
+      readonly isRowSelected?: (row: EditableContact, index: number) => boolean;
       readonly isLoading?: boolean;
       readonly onRowClick?: (row: EditableContact) => void;
     }) => {
-      const firstRowClassName = data[0]
-        ? (getRowClassName?.(data[0], 0) ?? '')
-        : '';
+      const firstRowSelected = data[0]
+        ? String(isRowSelected?.(data[0], 0) ?? false)
+        : 'false';
 
       return (
         <div
-          data-first-row-class={firstRowClassName}
+          data-first-row-selected={firstRowSelected}
           data-loading={String(isLoading)}
           data-testid='contacts-unified-table'
         >
@@ -116,7 +112,7 @@ const contacts: EditableContact[] = [
 ];
 
 describe('ContactsTable', () => {
-  it('uses shell-selected row chrome and keeps the detail surface flat', () => {
+  it('persists drawer selection through the shared table selection contract', () => {
     render(
       <ContactsTable
         contacts={contacts}
@@ -130,8 +126,8 @@ describe('ContactsTable', () => {
 
     expect(screen.getByText('1 contact')).toBeInTheDocument();
     expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
-      'data-first-row-class',
-      ''
+      'data-first-row-selected',
+      'false'
     );
 
     fireEvent.click(
@@ -147,8 +143,8 @@ describe('ContactsTable', () => {
       'contact-1'
     );
     expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
-      'data-first-row-class',
-      rowState.selected
+      'data-first-row-selected',
+      'true'
     );
     expect(setHeaderActions).toHaveBeenCalled();
     expect(setTableMeta).toHaveBeenCalled();

--- a/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
+++ b/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
@@ -145,4 +145,34 @@ describe('VirtualizedTableRow', () => {
     expect(onFocusChange).toHaveBeenCalledWith(0);
     matches.mockRestore();
   });
+
+  it('keeps only the roving row in the tab order', () => {
+    render(
+      <table>
+        <tbody>
+          <VirtualizedTableRow
+            {...baseProps}
+            shouldEnableKeyboardNav
+            focusedIndex={1}
+          />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByRole('row')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('accepts consumer-owned selection when TanStack selection is unavailable', () => {
+    render(
+      <table>
+        <tbody>
+          <VirtualizedTableRow {...baseProps} isSelected />
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByRole('row');
+    expect(row).toHaveAttribute('aria-selected', 'true');
+    expect(row).toHaveClass('system-b-table-row-selected');
+  });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4518 -->

## Summary
- establish one shared roving-row focus and consumer-owned selected-row contract in UnifiedTable
- expose semantic selection to assistive technology and apply it to Contacts drawer selection
- preserve the fixed table row height, focus-visible behavior, and reduced-motion scrolling/transition rules

## Verification
- `pnpm --filter @jovie/web exec vitest run UnifiedTable.keyboard.test.tsx VirtualizedTableRow.test.tsx table.styles.test.ts ContactsTable.test.tsx demo-releases-experience.test.tsx` (19/19)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check` and `git diff --check`
- normal pre-push affected suite (8 shards)

No browser or external-model review: ordinary UI slice admitted under the non-blocking taste policy.