### PR TITLE
fix(settings): remove duplicate navigation

### DIFF
--- a/apps/web/app/app/(shell)/settings/layout.tsx
+++ b/apps/web/app/app/(shell)/settings/layout.tsx
@@ -1,5 +1,4 @@
 import { PageShell } from '@/components/organisms/PageShell';
-import { SettingsSidebar } from '@/features/settings/SettingsSidebar';
 
 export default function SettingsLayout({
   children,
@@ -15,13 +14,8 @@ export default function SettingsLayout({
       surfaceClassName='pb-10'
       data-testid='settings-shell-content'
     >
-      <div className='flex items-start gap-8'>
-        {/* Grouped settings navigation — hidden on mobile, where the app
-            shell sidebar already exposes the settings sections. */}
-        <SettingsSidebar className='max-md:hidden' />
-        <div className='min-w-0 max-w-(--app-shell-content-max-form) flex-1 space-y-6'>
-          {children}
-        </div>
+      <div className='min-w-0 max-w-(--app-shell-content-max-form) space-y-6'>
+        {children}
       </div>
     </PageShell>
   );

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -11,6 +11,11 @@ const SETTINGS_LAYOUT = findSourceFile(
   resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/layout.tsx')
 );
 
+const UNIFIED_SIDEBAR = findSourceFile(
+  resolve(process.cwd(), 'components/organisms/UnifiedSidebar.tsx'),
+  resolve(process.cwd(), 'apps/web/components/organisms/UnifiedSidebar.tsx')
+);
+
 const RETARGETING_ROUTE_FILES = [
   findSourceFile(
     resolve(process.cwd(), 'app/app/(shell)/settings/retargeting-ads/page.tsx'),
@@ -170,6 +175,36 @@ describe('settings shell normalization', () => {
     const layoutSource = readFileSync(SETTINGS_LAYOUT, 'utf8');
     expect(layoutSource).toContain('<PageShell');
     expect(layoutSource).toContain("data-testid='settings-shell-content'");
+  });
+
+  it('uses the global shell settings navigation instead of mounting a second in-content sidebar', () => {
+    expect(SETTINGS_LAYOUT).toBeDefined();
+
+    if (!SETTINGS_LAYOUT) {
+      throw new Error('Could not find settings layout source');
+    }
+
+    const layoutSource = readFileSync(SETTINGS_LAYOUT, 'utf8');
+    expect(layoutSource).not.toContain('@/features/settings/SettingsSidebar');
+    expect(layoutSource).not.toContain('<SettingsSidebar');
+    expect(layoutSource).toContain('{children}');
+  });
+
+  it('keeps global settings navigation and deep links independent of the content layout on every viewport', () => {
+    expect(UNIFIED_SIDEBAR).toBeDefined();
+
+    if (!UNIFIED_SIDEBAR) {
+      throw new Error('Could not find UnifiedSidebar source');
+    }
+
+    const sidebarSource = readFileSync(UNIFIED_SIDEBAR, 'utf8');
+    expect(sidebarSource).toContain(
+      "const isInSettings = section === 'settings';"
+    );
+    expect(sidebarSource).toContain(
+      '<SettingsNavigation pathname={pathname} section={section} />'
+    );
+    expect(sidebarSource).toContain('function SettingsNavigation');
   });
 
   it('keeps focused settings subroutes inside the parent shell', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4573 -->

## Summary
- remove the redundant in-content desktop SettingsSidebar
- retain the unified shell as the sole Settings navigation composition
- add regression coverage for the single-navigation and global settings-route contracts

## Verification
- `pnpm --filter web exec vitest run tests/unit/app/settings-shell-normalization.test.ts`
- `pnpm biome check --write apps/web`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

## Risk
Small layout-only subtraction. No routes, mobile navigation logic, or global Settings navigation implementation changed.