### PR TITLE
fix(shell): coordinate rail allocation motion

### DIFF
--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -69,20 +69,24 @@ export const AppShellFrame = memo(function AppShellFrame({
       <DesktopTitlebar />
       <div
         data-app-shell-body='true'
+        data-shell-rail-motion='coordinated'
         className={cn(
-          'flex min-h-0 min-w-0 flex-1 overflow-hidden lg:gap-(--app-shell-gap) lg:p-(--app-shell-gap)'
+          // Allocation belongs to the shell, not individual routes. Keeping the
+          // side slots and main plane on the same motion contract means a rail
+          // can yield canvas without its content or adjacent route snapping.
+          'flex min-h-0 min-w-0 flex-1 overflow-hidden transition-[gap,padding] duration-cinematic ease-cinematic motion-reduce:transition-none lg:gap-(--app-shell-gap) lg:p-(--app-shell-gap)'
         )}
       >
         <div
           data-testid='app-shell-sidebar-mount'
-          className='flex h-full min-h-0 shrink-0 flex-col transition-opacity duration-cinematic ease-cinematic motion-reduce:transition-none'
+          className='flex h-full min-h-0 shrink-0 flex-col transition-[flex-basis,width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none'
         >
           {sidebar}
         </div>
 
         <div
           data-app-shell-content-column='true'
-          className='flex min-h-0 min-w-0 flex-1 flex-col'
+          className='flex min-h-0 min-w-0 flex-1 flex-col transition-[flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none'
         >
           <main
             id='main-content'
@@ -115,7 +119,7 @@ export const AppShellFrame = memo(function AppShellFrame({
             {header}
             <div
               className={cn(
-                'flex flex-1 min-h-0 min-w-0 overflow-hidden lg:gap-(--app-shell-gap)'
+                'flex flex-1 min-h-0 min-w-0 overflow-hidden transition-[gap] duration-cinematic ease-cinematic motion-reduce:transition-none lg:gap-(--app-shell-gap)'
               )}
             >
               <div
@@ -123,7 +127,7 @@ export const AppShellFrame = memo(function AppShellFrame({
                 className={cn(
                   // Shell-level pane never owns vertical scroll — routes and table
                   // surfaces scroll inside this clip so the right rail stays fixed.
-                  'flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden overflow-x-auto overscroll-contain pb-[var(--dev-toolbar-height,0px)]',
+                  'flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden overflow-x-auto overscroll-contain transition-[flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none pb-[var(--dev-toolbar-height,0px)]',
                   contentClassName
                 )}
               >

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -465,11 +465,14 @@ export function UnifiedSidebar({
   return (
     <Sidebar
       variant='sidebar'
+      data-shell-rail-motion='left'
       collapsible='offcanvas'
       className={cn(
         'bg-base',
         '[--sidebar-width:var(--app-shell-sidebar-width)]',
-        'transition-[width,transform] duration-cinematic ease-cinematic',
+        // The left rail owns its internal label/icon staging while
+        // AppShellFrame owns the adjacent main-plane allocation (#4522).
+        'transition-[flex-basis,width,transform,opacity] duration-cinematic ease-cinematic motion-reduce:transition-none',
         // OV brand skin: class-based token override, same mechanism as `.dark`
         // (see design-system.css → OV MODE). Zero layout impact.
         variant === 'ov' && 'ov-mode'

--- a/apps/web/components/shell/AppShellRightRail.tsx
+++ b/apps/web/components/shell/AppShellRightRail.tsx
@@ -28,6 +28,7 @@ export function AppShellRightRail({
   return (
     <aside
       data-testid='app-shell-right-rail'
+      data-shell-rail-motion='right'
       aria-label='Context Panel'
       className={cn(
         // Mobile drawers are fixed descendants of this stacking context, so the
@@ -38,7 +39,7 @@ export function AppShellRightRail({
         'sticky top-0 z-30 lg:z-10 flex h-full min-h-0 shrink-0 flex-col self-stretch overflow-hidden',
         // Mirror the left sidebar mount language so inner drawer width changes
         // reclaim canvas space with the same cinematic timing.
-        'transition-[width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none',
+        'transition-[flex-basis,width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none',
         'lg:rounded-(--linear-app-shell-radius)',
         className
       )}

--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -13,6 +13,7 @@ describe('AppShellRightRail', () => {
     const rail = screen.getByTestId('app-shell-right-rail');
 
     expect(rail).toHaveAttribute('aria-label', 'Context Panel');
+    expect(rail).toHaveAttribute('data-shell-rail-motion', 'right');
     expect(rail).toHaveClass(
       'sticky',
       'top-0',
@@ -25,6 +26,7 @@ describe('AppShellRightRail', () => {
       'duration-cinematic',
       'ease-cinematic'
     );
+    expect(rail).toHaveClass('transition-[flex-basis,width,opacity,transform]');
     expect(rail).not.toHaveClass('self-start');
     expect(rail).not.toHaveClass('z-10');
     expect(rail).toContainElement(screen.getByTestId('fixture-panel'));

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -17,6 +17,14 @@ describe('AppShellFrame', () => {
     expect(mainContent).toHaveAttribute('id', 'main-content');
     expect(mainContent).not.toHaveAttribute('tabindex');
     expect(mainContent.closest('[data-app-shell-frame]')).toBeInTheDocument();
+    const shellBody = mainContent.closest('[data-app-shell-body]');
+    expect(shellBody).toHaveAttribute('data-shell-rail-motion', 'coordinated');
+    expect(shellBody).toHaveClass(
+      'transition-[gap,padding]',
+      'duration-cinematic',
+      'ease-cinematic',
+      'motion-reduce:transition-none'
+    );
     expect(mainContent).toHaveClass('lg:shadow-(--linear-app-shell-shadow)');
     // #main-content keeps its full rounded shell radius — no Electron override
     // strips the top corners now that the header lives inside the card.
@@ -98,7 +106,44 @@ describe('AppShellFrame', () => {
 
     const mount = screen.getByTestId('app-shell-sidebar-mount');
     expect(mount).toHaveClass('h-full', 'min-h-0', 'flex', 'flex-col');
+    expect(mount).toHaveClass(
+      'transition-[flex-basis,width,opacity,transform]',
+      'duration-cinematic',
+      'ease-cinematic',
+      'motion-reduce:transition-none'
+    );
     expect(mount).toContainElement(screen.getByTestId('fixture-sidebar'));
+  });
+
+  it('keeps main-plane geometry on the same reduced-motion-safe rail contract', () => {
+    render(
+      <AppShellFrame
+        sidebar={<aside>Sidebar</aside>}
+        header={<header>Header</header>}
+        main={<div>Main Content</div>}
+        rightPanel={<div>Right rail</div>}
+      />
+    );
+
+    expect(screen.getByTestId('app-shell-scroll').parentElement).toHaveClass(
+      'transition-[gap]',
+      'duration-cinematic',
+      'motion-reduce:transition-none'
+    );
+    expect(screen.getByTestId('app-shell-scroll')).toHaveClass(
+      'transition-[flex-basis,width]',
+      'duration-cinematic',
+      'motion-reduce:transition-none'
+    );
+    expect(
+      screen
+        .getByTestId('app-shell-scroll')
+        .closest('[data-app-shell-content-column]')
+    ).toHaveClass(
+      'transition-[flex-basis,width]',
+      'duration-cinematic',
+      'motion-reduce:transition-none'
+    );
   });
 
   it('renders the chat ambient gradient full-bleed behind the header on chat routes', () => {

--- a/apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts
+++ b/apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts
@@ -68,4 +68,35 @@ describe('shell UX regressions source contracts (JOV-3958/3959/3960)', () => {
     expect(source).not.toContain('hover:border-default');
     expect(source).not.toContain('rounded-md border');
   });
+
+  it('keeps left allocation, main-plane geometry, and right allocation on one rail-motion contract (JOV-4522)', () => {
+    const frame = readFileSync(
+      path.join(webRoot, 'components/organisms/AppShellFrame.tsx'),
+      'utf8'
+    );
+    const unified = readFileSync(
+      path.join(webRoot, 'components/organisms/UnifiedSidebar.tsx'),
+      'utf8'
+    );
+    const rail = readFileSync(
+      path.join(webRoot, 'components/shell/AppShellRightRail.tsx'),
+      'utf8'
+    );
+
+    expect(frame).toContain("data-shell-rail-motion='coordinated'");
+    expect(frame).toContain(
+      'transition-[flex-basis,width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none'
+    );
+    expect(frame).toContain(
+      'transition-[flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none'
+    );
+    expect(unified).toContain("data-shell-rail-motion='left'");
+    expect(unified).toContain(
+      'transition-[flex-basis,width,transform,opacity] duration-cinematic ease-cinematic motion-reduce:transition-none'
+    );
+    expect(rail).toContain("data-shell-rail-motion='right'");
+    expect(rail).toContain(
+      'transition-[flex-basis,width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none'
+    );
+  });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4522 -->

## Summary
- coordinate sidebar allocation, main-plane geometry, and the right rail on the shared cinematic motion contract
- preserve direct final-state behavior for reduced motion
- add source and component regression coverage for the shared shell contract

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/organisms/AppShellFrame.test.tsx components/shell/__tests__/AppShellRightRail.test.tsx tests/unit/shell/shell-ux-regressions-source.test.ts` (17/17)
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/organisms/UnifiedSidebar.library.test.tsx` (11/11)
- `pnpm biome check --write <6 changed files>`
- `git diff --check`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable; shell consistency improvement)

No browser or advisory review gate; normal source CI and native queue determine admission.