### PR TITLE
fix(chat): disambiguate pitch copy labels

### DIFF
--- a/apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx
+++ b/apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx
@@ -68,6 +68,12 @@ describe('ChatGenerationArtifactSurface', () => {
     expect(
       document.querySelector('.system-b-chat-pitch-block-text[data-clamped]')
     ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Copy Pitch pitch' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Copy full pitch draft' })
+    ).toBeInTheDocument();
   });
 
   it('keeps artifact visuals and shimmer on System B classes', () => {

--- a/apps/web/components/jovie/components/ChatPitchCard.tsx
+++ b/apps/web/components/jovie/components/ChatPitchCard.tsx
@@ -51,7 +51,8 @@ interface ChatPitchCardProps {
 function CopyButton({
   text,
   platform,
-}: Readonly<{ text: string; platform: string }>) {
+  ariaLabel,
+}: Readonly<{ text: string; platform: string; ariaLabel?: string }>) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
@@ -79,7 +80,7 @@ function CopyButton({
       size='icon'
       onClick={handleCopy}
       className='h-6 w-6 rounded-md focus-ring'
-      aria-label={`Copy ${platform} pitch`}
+      aria-label={ariaLabel ?? `Copy ${platform} pitch`}
     >
       <CopyToggleIcon copied={copied} size='system-b-chat-pitch-copy-icon' />
     </Button>
@@ -193,7 +194,11 @@ export function ChatPitchCard({
             <span className='system-b-chat-pitch-full-draft-label'>
               Full draft
             </span>
-            <CopyButton text={copyText} platform='Pitch' />
+            <CopyButton
+              text={copyText}
+              platform='Pitch'
+              ariaLabel='Copy full pitch draft'
+            />
           </div>
         </div>
       </ChatGenerationArtifactSurface>


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4402 -->

## Summary
- give the full-draft copy action its own accessible name
- retain the existing platform copy labels
- add a focused regression assertion for the distinct controls

## Verification
- `pnpm --filter web exec vitest run components/jovie/components/ChatGenerationArtifactSurface.test.tsx`
- `pnpm biome check --write apps/web`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

## Changelog
Not required: this is a narrow accessibility-label correction tracked in JOV-4402.