### PR TITLE
fix(ci): validate workflow references and package filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,8 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - name: Verify workflow references
+        run: node scripts/verify-workflow-references.mjs
       - uses: ./.github/actions/setup-node-pnpm
       - name: Compare workspace manifest and lockfile specifiers
         run: pnpm exec node scripts/lockfile-specifier-preflight.mjs

--- a/.github/workflows/test-coverage-audit.yml
+++ b/.github/workflows/test-coverage-audit.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ZHVtbXktdGVzdC1jb3ZlcmFnZS5jbGVyay5hY2NvdW50cy5kZXYk
           CLERK_SECRET_KEY: sk_test_dummy_secret_for_coverage_run_only
-        run: pnpm --filter web test:coverage
+        run: pnpm --filter @jovie/web test:coverage
 
       - name: Generate heatmap
         run: pnpm exec tsx scripts/audit-test-coverage.ts

--- a/.github/workflows/visual-a11y.yml
+++ b/.github/workflows/visual-a11y.yml
@@ -52,10 +52,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter web exec playwright install chromium --with-deps
+      - run: pnpm --filter @jovie/web exec playwright install chromium --with-deps
       - name: Run Storybook A11y Tests
         id: a11y-test
-        run: pnpm --filter web test:a11y
+        run: pnpm --filter @jovie/web test:a11y
       - name: A11y Results Summary
         if: always()
         run: |
@@ -64,7 +64,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "FAIL: Accessibility violations detected - blocking this PR." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "To run locally: pnpm --filter web test:a11y" >> "$GITHUB_STEP_SUMMARY"
+            echo "To run locally: pnpm --filter @jovie/web test:a11y" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "## A11y Check Results" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "dev:web:local": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run dev:local",
     "dev:web:browse": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run dev:local:browse",
     "dev:web:fast": "bash scripts/dev-web-fast.sh",
+    "verify:workflow-references": "node scripts/verify-workflow-references.mjs",
+    "test:workflow-references": "node --test scripts/verify-workflow-references.test.mjs",
     "dev:console": "pnpm --filter @jovie/console run dev",
     "sweep:taste-inbox": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/console run sweep",
     "ios:open": "open apps/ios/Jovie.xcodeproj",

--- a/scripts/lib/__tests__/merge-queue-guard.test.mjs
+++ b/scripts/lib/__tests__/merge-queue-guard.test.mjs
@@ -456,7 +456,7 @@ describe('aggregate required checks', () => {
     // The duplicate manual ci-storybook-a11y job was removed (JOV-4326); the
     // scheduled visual-a11y.yml storybook-a11y lane is the single owner.
     expect(ciWorkflowYaml).not.toContain('ci-storybook-a11y:');
-    expect(storybookBlock).toMatch(/pnpm --filter web test:a11y/);
+    expect(storybookBlock).toMatch(/pnpm --filter @jovie\/web test:a11y/);
     expect(prReadyBlock).not.toMatch(/ci-storybook-a11y|STORYBOOK_A11Y_RESULT/);
     expect(visualWorkflowYaml).not.toMatch(/^\s+pull_request:/m);
     expect(visualWorkflowYaml).not.toMatch(/^\s+push:/m);

--- a/scripts/verify-workflow-references.mjs
+++ b/scripts/verify-workflow-references.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const WORKFLOW_EXTENSIONS = new Set(['.yml', '.yaml']);
+const LOCAL_PATH_PREFIXES = ['./', '.github/', 'apps/', 'scripts/'];
+const COMMANDS_WITH_PATH =
+  /(?<![-\w])(?:bash|sh|node|python3?|ruby)(?:\s+--[^\s]+)*\s+(['"]?)([^\s'"`;&|)]+)\1/g;
+const FILTER_PATTERN = /--filter(?:=|\s+)([^\s]+)/g;
+const IOS_SCRIPT_PATH_PATTERN =
+  /(?:apps\/ios\/scripts|\.github\/scripts)\/[A-Za-z0-9._/-]+\.(?:mjs|js|ts|sh|cjs|rb)\b/g;
+
+function walkFiles(directory, predicate) {
+  const result = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (
+      entry.isDirectory() &&
+      (entry.name === 'node_modules' || entry.name === '.git')
+    )
+      continue;
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) result.push(...walkFiles(entryPath, predicate));
+    else if (predicate(entryPath)) result.push(entryPath);
+  }
+  return result;
+}
+
+function isRepoPath(value) {
+  return (
+    LOCAL_PATH_PREFIXES.some(prefix => value.startsWith(prefix)) &&
+    !value.includes('${') &&
+    !value.includes('$')
+  );
+}
+
+function resolveWorkspaceNames(root) {
+  const names = new Set();
+  const workspaceRoots = [root, 'apps', 'packages', 'workers'].map(relative =>
+    path.join(root, relative)
+  );
+  for (const workspaceRoot of workspaceRoots) {
+    if (!fs.existsSync(workspaceRoot)) continue;
+    const packageFiles = walkFiles(
+      workspaceRoot,
+      file => path.basename(file) === 'package.json'
+    );
+    for (const packagePath of packageFiles) {
+      try {
+        const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+        if (typeof packageJson.name === 'string') names.add(packageJson.name);
+      } catch {
+        // Package JSON validity is owned by the package-manager/lint gates.
+      }
+    }
+  }
+  return names;
+}
+
+export function validateWorkflowReferences(root = process.cwd()) {
+  const workflowRoot = path.join(root, '.github', 'workflows');
+  const errors = [];
+  const workflowFiles = fs.existsSync(workflowRoot)
+    ? walkFiles(workflowRoot, file =>
+        WORKFLOW_EXTENSIONS.has(path.extname(file))
+      )
+    : [];
+  const workspaceNames = resolveWorkspaceNames(root);
+
+  for (const workflowFile of workflowFiles) {
+    const relativeWorkflow = path.relative(root, workflowFile);
+    const source = fs.readFileSync(workflowFile, 'utf8');
+    const lines = source.split(/\r?\n/);
+
+    for (const [index, line] of lines.entries()) {
+      const localAction = line.match(/\buses:\s*(['"]?)(\.\/[^\s#'"}]+)\1/);
+      if (localAction) {
+        const actionPath = localAction[2];
+        if (actionPath.startsWith('./.github/workflows/')) {
+          if (!fs.existsSync(path.join(root, actionPath))) {
+            errors.push(
+              `${relativeWorkflow}:${index + 1}: local workflow does not resolve: ${actionPath}`
+            );
+          }
+          continue;
+        }
+        const actionFile = path.join(root, actionPath, 'action.yml');
+        const actionYaml = path.join(root, actionPath, 'action.yaml');
+        const dockerfile = path.join(root, actionPath, 'Dockerfile');
+        if (
+          !fs.existsSync(actionFile) &&
+          !fs.existsSync(actionYaml) &&
+          !fs.existsSync(dockerfile)
+        ) {
+          errors.push(
+            `${relativeWorkflow}:${index + 1}: local action does not resolve: ${actionPath}`
+          );
+        }
+      }
+
+      for (const match of line.matchAll(COMMANDS_WITH_PATH)) {
+        const referencedPath = match[2].replace(/[),]+$/, '');
+        if (!isRepoPath(referencedPath)) continue;
+        if (!fs.existsSync(path.join(root, referencedPath))) {
+          errors.push(
+            `${relativeWorkflow}:${index + 1}: command path does not resolve: ${referencedPath}`
+          );
+        }
+      }
+
+      for (const referencedPath of line.matchAll(IOS_SCRIPT_PATH_PATTERN)) {
+        const scriptPath = referencedPath[0];
+        if (!fs.existsSync(path.join(root, scriptPath))) {
+          errors.push(
+            `${relativeWorkflow}:${index + 1}: command path does not resolve: ${scriptPath}`
+          );
+        }
+      }
+
+      for (const match of line.matchAll(FILTER_PATTERN)) {
+        const filter = match[1].replace(/[),`]+$/, '');
+        if (
+          filter.startsWith('!') ||
+          filter.includes('*') ||
+          filter.includes('${')
+        )
+          continue;
+        if (!workspaceNames.has(filter)) {
+          errors.push(
+            `${relativeWorkflow}:${index + 1}: pnpm workspace filter does not resolve: ${filter}`
+          );
+        }
+      }
+    }
+  }
+
+  return [...new Set(errors)].sort();
+}
+
+function main() {
+  const rootFlag = process.argv.indexOf('--root');
+  const root =
+    rootFlag === -1 ? process.cwd() : path.resolve(process.argv[rootFlag + 1]);
+  const errors = validateWorkflowReferences(root);
+  if (errors.length > 0) {
+    console.error(
+      `Workflow reference validation failed (${errors.length} issue${errors.length === 1 ? '' : 's'}):`
+    );
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log('Workflow reference validation passed.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/verify-workflow-references.test.mjs
+++ b/scripts/verify-workflow-references.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+import { validateWorkflowReferences } from './verify-workflow-references.mjs';
+
+const temporaryRoots = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0))
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('reports missing local actions, command paths, and workspace filters', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-refs-'));
+  temporaryRoots.push(root);
+  fs.mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.github', 'workflows', 'broken.yml'),
+    `
+name: broken
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing
+      - run: node scripts/missing.mjs
+      - run: pnpm --filter=@missing/app test
+`
+  );
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'root' })
+  );
+
+  assert.deepEqual(validateWorkflowReferences(root), [
+    '.github/workflows/broken.yml:7: local action does not resolve: ./.github/actions/missing',
+    '.github/workflows/broken.yml:8: command path does not resolve: scripts/missing.mjs',
+    '.github/workflows/broken.yml:9: pnpm workspace filter does not resolve: @missing/app',
+  ]);
+});
+
+test('passes when workflow references resolve', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-refs-'));
+  temporaryRoots.push(root);
+  fs.mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+  fs.mkdirSync(path.join(root, '.github', 'actions', 'setup'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.github', 'actions', 'setup', 'action.yml'),
+    'name: setup\nruns:\n  using: composite\n  steps: []\n'
+  );
+  fs.writeFileSync(path.join(root, 'scripts', 'check.mjs'), '');
+  fs.writeFileSync(path.join(root, 'apps.json'), '');
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'root' })
+  );
+  fs.mkdirSync(path.join(root, 'apps', 'web'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'apps', 'web', 'package.json'),
+    JSON.stringify({ name: '@actual/web' })
+  );
+  fs.writeFileSync(
+    path.join(root, '.github', 'workflows', 'valid.yml'),
+    `
+name: valid
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup
+      - run: node scripts/check.mjs
+      - run: pnpm --filter=@actual/web test
+`
+  );
+
+  assert.deepEqual(validateWorkflowReferences(root), []);
+});


### PR DESCRIPTION
## Summary
- Add a deterministic workflow-reference validator covering local actions, local command scripts, iOS/TestFlight script paths, and pnpm workspace filters.
- Run the validator before the existing lockfile preflight in the required CI DAG; it fails closed without changing release/launch gates.
- Correct the remaining unscoped `web` filters to the actual current workspace package `@jovie/web`.
- Add focused fixture tests for missing and resolving references.

## LYB/iOS release-path verification
- Current `origin/main` resolves the existing `apps/ios/Jovie` project and TestFlight validation script; no destructive path rewrite was needed.
- The validator independently checks those local references on every CI run.

## Tests
- `node scripts/verify-workflow-references.mjs`
- `node --test scripts/verify-workflow-references.test.mjs`
- `git diff --check`

## Scope
- PR only; do not merge.
