### PR TITLE
fix(release): prove staging deployment SHA provenance

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -286,7 +286,8 @@ jobs:
                 --env SESSION_SECRET \
                 --env AI_GATEWAY_API_KEY \
                 --env NEXT_PUBLIC_TURNSTILE_SITE_KEY \
-                --env TURNSTILE_SECRET_KEY; then
+                --env TURNSTILE_SECRET_KEY \
+                --meta "githubCommitSha=${VERCEL_GIT_COMMIT_SHA}"; then
                 break
               fi
               echo "Vercel deploy attempt $i failed, retrying in 10s..."
@@ -533,8 +534,12 @@ jobs:
               >/dev/null 2>&1 <<<"$alias_json"; then
               alias_id="$(jq -r '.id' <<<"$alias_json")"
               alias_state="$(jq -r '.readyState | ascii_upcase' <<<"$alias_json")"
-              if [ "$alias_id" = "$EXPECTED_DEPLOYMENT_ID" ] && [ "$alias_state" = "READY" ]; then
-                echo "staging.jov.ie owns exact READY deployment $alias_id at $EXPECTED_COMMIT_SHA."
+              alias_commit_sha="$(jq -r '.meta.githubCommitSha // ""' <<<"$alias_json")"
+              if [ "$alias_id" = "$EXPECTED_DEPLOYMENT_ID" ] &&
+                [ "$alias_state" = "READY" ] &&
+                [[ "$alias_commit_sha" =~ ^[0-9a-f]{40}$ ]] &&
+                [ "$alias_commit_sha" = "$EXPECTED_COMMIT_SHA" ]; then
+                echo "staging.jov.ie owns exact READY deployment $alias_id at $alias_commit_sha."
                 break
               fi
             fi

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1461,6 +1461,9 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
 
     expect(deployStep).not.toContain('VERCEL_FORCE_SOURCE_DEPLOY');
     expect(deployStep).toContain("VERCEL_ENABLE_SOURCE_FALLBACK: 'false'");
+    expect(deployStep).toContain(
+      '--meta "githubCommitSha=${VERCEL_GIT_COMMIT_SHA}"'
+    );
     expect(stagingJob).not.toContain('download_vercel_build');
     expect(stagingJob).not.toContain('restore_vercel_build');
     expect(buildStep).toContain('jovie-generated-public-files');
@@ -2216,6 +2219,19 @@ describe('canary health gate workflow', () => {
     expect(canary).not.toContain('staging.jov.ie');
     expect(aliasStep).toContain(
       'vercel alias set "$deployment_url" staging.jov.ie'
+    );
+    const aliasProofStep = getStepBlock(
+      aliasJob,
+      'Prove staging alias owns the exact deployment and full SHA'
+    );
+    expect(aliasProofStep).toContain(
+      'alias_commit_sha="$(jq -r \'.meta.githubCommitSha // ""\' <<<"$alias_json")"'
+    );
+    expect(aliasProofStep).toContain(
+      '[[ "$alias_commit_sha" =~ ^[0-9a-f]{40}$ ]]'
+    );
+    expect(aliasProofStep).toContain(
+      '[ "$alias_commit_sha" = "$EXPECTED_COMMIT_SHA" ]'
     );
     expect(oauthStep).toContain('BASE_URL: https://staging.jov.ie');
     expect(oauthStep).toContain(


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4579 -->

## Summary
- tag the staging prebuilt deployment with the authorized full Git SHA
- fail alias verification unless `staging.jov.ie` resolves to the exact READY deployment and exposes the same full SHA

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts tests/unit/ci/supply-chain-provenance.test.ts` (100 passed)
- `pnpm exec biome check .github/workflows/production-release.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `pnpm exec actionlint .github/workflows/production-release.yml`
- normal pre-commit hooks (secret scans, hygiene, Turbo warm/typecheck)

Closes JOV-4579.