### PR TITLE
test(ci): isolate full-suite timeout budget

### DIFF
--- a/apps/web/lib/turnstile/single-source.test.ts
+++ b/apps/web/lib/turnstile/single-source.test.ts
@@ -47,5 +47,5 @@ describe('turnstile siteverify single source of truth', () => {
       offenders,
       `siteverify must only be called from ${CANONICAL_FILE}; found inline call(s) in: ${offenders.join(', ')}`
     ).toEqual([]);
-  });
+  }, 15_000);
 });

--- a/apps/web/tests/unit/api/dashboard/social-links-cas.test.ts
+++ b/apps/web/tests/unit/api/dashboard/social-links-cas.test.ts
@@ -431,7 +431,7 @@ describe('social link compare-and-swap routes', () => {
       PROFILE_ID,
       'artist'
     );
-  });
+  }, 15_000);
 
   it('returns VERSION_CONFLICT from PATCH before mutating a stale link', async () => {
     const { PATCH } = await import(


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4585 -->

## Summary
- scope the timeout budget to the two deterministic tests that exceed the 5s suite safety net only under full-shard load
- prevent JOV-4510 native-queue recovery from being blocked by a test-harness timeout; no product code changed

## Verification
- CI-config focused Vitest: 9/9
- Biome (2 files), diff check, bug-to-test classification
- Full hook-equivalent pre-push shard validation running locally; source CI will provide independent coverage.