### PR TITLE
fix(shell): hide developer toolbar outside local dev

### DIFF
--- a/apps/web/components/features/dev/DevToolbarGate.tsx
+++ b/apps/web/components/features/dev/DevToolbarGate.tsx
@@ -7,6 +7,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import {
   isDemoRecordingClient,
   isDevChromeDisabledClient,
+  isLocalDevelopmentDevChrome,
 } from '@/lib/demo-recording';
 
 const DevToolbar = dynamic(
@@ -55,7 +56,9 @@ export function shouldDefaultDevToolbarHidden(pathname: string): boolean {
 }
 
 /**
- * Production customer sessions never render development controls.
+ * Customer-facing deployments never render development controls. The toolbar
+ * is intentionally limited to a local `next dev` runtime; staging is a real
+ * customer review surface, not an internal control plane.
  */
 export function shouldRenderDevToolbar({
   env,
@@ -76,12 +79,14 @@ export function shouldRenderDevToolbar({
   readonly isElectron?: boolean;
   readonly nodeEnv?: string | undefined;
 }): boolean {
+  // Kept in the public contract for existing test callers; environment itself
+  // is the source of truth because Vercel previews compile with production.
+  void nodeEnv;
   if (disabled) return false;
   if (isDemoRecording || isDevChromeDisabled || isElectron) return false;
   if (isDevToolbarSuppressedPath(pathname)) return false;
 
-  const isProduction = nodeEnv === 'production' && env === 'production';
-  if (isProduction) return false;
+  if (!isLocalDevelopmentDevChrome(env)) return false;
 
   return true;
 }

--- a/apps/web/lib/demo-recording.ts
+++ b/apps/web/lib/demo-recording.ts
@@ -57,6 +57,15 @@ export function isDevChromeDisabledClient(): boolean {
   );
 }
 
+/**
+ * Developer chrome is a local-development aid, never a staging or production
+ * surface. Treating any non-production deployment as safe would expose
+ * internal session controls to ordinary preview users.
+ */
+export function isLocalDevelopmentDevChrome(devEnv: string): boolean {
+  return devEnv === 'development';
+}
+
 interface RootLayoutChromeStateInput {
   readonly devEnv: string;
   readonly isDemoRecording?: boolean;
@@ -80,7 +89,7 @@ export function getRootLayoutChromeState({
     isDemoRecording ||
     isDevChromeDisabled ||
     isE2EClientRuntime ||
-    devEnv === 'production'
+    !isLocalDevelopmentDevChrome(devEnv)
   );
 
   return {

--- a/apps/web/tests/unit/demo-recording.test.ts
+++ b/apps/web/tests/unit/demo-recording.test.ts
@@ -122,6 +122,25 @@ describe('demo recording helpers', () => {
     });
   });
 
+  it('never mounts developer chrome in preview or production builds', async () => {
+    const { getRootLayoutChromeState } = await loadModule();
+
+    expect(
+      getRootLayoutChromeState({
+        devEnv: 'preview',
+        isDemoRecording: false,
+        isE2EClientRuntime: false,
+      }).shouldRenderDevChrome
+    ).toBe(false);
+    expect(
+      getRootLayoutChromeState({
+        devEnv: 'production',
+        isDemoRecording: false,
+        isE2EClientRuntime: false,
+      }).shouldRenderDevChrome
+    ).toBe(false);
+  });
+
   it('suppresses dev chrome when NEXT_PUBLIC_E2E_MODE is set', async () => {
     process.env.NEXT_PUBLIC_E2E_MODE = '1';
     const { getRootLayoutChromeState } = await loadModule();

--- a/apps/web/tests/unit/dev/DevToolbarGate.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbarGate.test.tsx
@@ -72,7 +72,7 @@ describe('DevToolbarGate production + path gating', () => {
     ).toBe(false);
   });
 
-  it('renders for non-production (dev/preview) on normal app routes', () => {
+  it('renders only for local development on normal app routes', () => {
     expect(
       shouldRenderDevToolbar({
         env: 'development',
@@ -86,7 +86,14 @@ describe('DevToolbarGate production + path gating', () => {
         pathname: '/app/dashboard',
         nodeEnv: 'production',
       })
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      shouldRenderDevToolbar({
+        env: 'preview',
+        pathname: '/app/dashboard',
+        nodeEnv: 'development',
+      })
+    ).toBe(false);
   });
 
   it('respects disabled / demo / electron / dev-chrome-disabled flags', () => {


### PR DESCRIPTION
## Summary
- Restrict the authenticated dev toolbar to local development only.
- Fail closed for Vercel preview/staging and production at both the root-layout mount and client gate.
- Preserve local developer access and existing customer, demo, and Electron suppressions.

Closes #15169

## Deterministic evidence
- Focused Vitest: 2 files, 21 tests passed.
- Biome: 4 files passed.
- git diff --check passed.

## Rendered evidence
The staging regression is recorded in #15169. This branch does not start another Next/browser process while host swap is constrained; local desktop/mobile capture is an advisory follow-up before native queue. The guard is covered deterministically at the server mount and client gate.

## Scope
No shell layout, sidebar, empty state, audio, or dependency changes.