### PR TITLE
fix(shell): prevent mobile media-query hydration mismatches

### DIFF
--- a/apps/web/hooks/useMediaQuery.test.tsx
+++ b/apps/web/hooks/useMediaQuery.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMediaQuery } from './useMediaQuery';
+
+function MediaQueryProbe() {
+  const isMobile = useMediaQuery('(max-width: 1023px)');
+  return (
+    <output data-testid='media-query-probe'>
+      {isMobile ? 'mobile' : 'desktop'}
+    </output>
+  );
+}
+
+function createMediaQueryList(matches: boolean): MediaQueryList {
+  return {
+    matches,
+    media: '(max-width: 1023px)',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useMediaQuery hydration contract', () => {
+  it('keeps the server and first hydration render on the default snapshot', async () => {
+    const recoverableErrors: unknown[] = [];
+    const mediaQueryList = createMediaQueryList(true);
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => mediaQueryList)
+    );
+
+    const tree = createElement(MediaQueryProbe);
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(tree);
+    document.body.append(container);
+
+    expect(container.textContent).toBe('desktop');
+
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(container, tree, {
+        onRecoverableError: error => recoverableErrors.push(error),
+      });
+    });
+
+    expect(recoverableErrors).toEqual([]);
+    expect(container.textContent).toBe('mobile');
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/apps/web/hooks/useMediaQuery.ts
+++ b/apps/web/hooks/useMediaQuery.ts
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+import { useCallback, useSyncExternalStore } from 'react';
 
 interface UseMediaQueryOptions {
   defaultValue?: boolean;
@@ -12,38 +11,35 @@ export function useMediaQuery(
   options: UseMediaQueryOptions = {}
 ): boolean {
   const { defaultValue = false } = options;
-  const [matches, setMatches] = useState<boolean>(() => {
-    if (
-      typeof globalThis !== 'undefined' &&
-      typeof globalThis.matchMedia === 'function'
-    ) {
-      return globalThis.matchMedia(query).matches;
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (typeof globalThis.matchMedia !== 'function') {
+        return () => {};
+      }
+
+      const mediaQueryList = globalThis.matchMedia(query);
+      mediaQueryList.addEventListener('change', onStoreChange);
+
+      return () => {
+        mediaQueryList.removeEventListener('change', onStoreChange);
+      };
+    },
+    [query]
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (typeof globalThis.matchMedia !== 'function') {
+      return defaultValue;
     }
 
-    return defaultValue;
-  });
+    return globalThis.matchMedia(query).matches;
+  }, [defaultValue, query]);
 
-  useIsomorphicLayoutEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      typeof globalThis.matchMedia !== 'function'
-    ) {
-      return undefined;
-    }
+  // React uses this snapshot for SSR and its first hydration render. Reading
+  // matchMedia during that render lets a mobile client choose a different
+  // shell tree than the server, which causes recoverable hydration failures.
+  const getServerSnapshot = useCallback(() => defaultValue, [defaultValue]);
 
-    const mediaQueryList = globalThis.matchMedia(query);
-    setMatches(mediaQueryList.matches);
-
-    const handleChange = (event: MediaQueryListEvent) => {
-      setMatches(event.matches);
-    };
-
-    mediaQueryList.addEventListener('change', handleChange);
-
-    return () => {
-      mediaQueryList.removeEventListener('change', handleChange);
-    };
-  }, [query]);
-
-  return matches;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary

Fixes the shared `useMediaQuery` primitive so SSR and the first client hydration render use the same fallback snapshot. This prevents mobile-only authenticated-shell React hydration recovery errors, including the observed Contacts route at 390px.

## Evidence

- `pnpm --filter web exec vitest run hooks/useMediaQuery.test.tsx` — pass (1/1)
- `pnpm exec biome check --write apps/web/hooks/useMediaQuery.ts apps/web/hooks/useMediaQuery.test.tsx` — pass
- `git diff --check` — pass
- `pnpm --filter @jovie/web run test:bug-to-test` — not classified by current rule; regression test included.

## Runtime proof boundary

No server/browser/Kimi run: host pressure and the serialized sidebar typecheck lane were active. Exact-head mobile 390px authenticated Contacts console/overflow proof is still required before promotion.

## Scope

JOV-15171. Shared responsive hydration contract only; no Contacts data, UI, or navigation refactor.