### PR TITLE
fix(inbox): center empty state with shared primitive

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { OpportunityInboxEmptyState } from './OpportunityInboxEmptyState';
+
+describe('OpportunityInboxEmptyState', () => {
+  it('uses the canonical centered empty-state layout with the catalog action', () => {
+    render(
+      <OpportunityInboxEmptyState
+        actionCards={[
+          {
+            id: 'connect-spotify',
+            title: 'Connect Spotify',
+            body: 'Link your catalog so Jovie can spot releases.',
+            actionLabel: 'Connect catalog',
+            href: '/app/settings/artist-profile',
+          },
+        ]}
+      />
+    );
+
+    const emptyState = screen.getByTestId('opportunity-inbox-empty-state');
+    expect(emptyState).toHaveClass('flex-1', 'items-center', 'justify-center');
+    expect(
+      screen.getByRole('link', { name: 'Connect catalog' })
+    ).toHaveAttribute('href', '/app/settings/artist-profile');
+  });
+
+  it('keeps the chat fallback when no catalog action is available', () => {
+    render(<OpportunityInboxEmptyState />);
+
+    expect(screen.getByRole('link', { name: 'Start A Chat' })).toHaveAttribute(
+      'href',
+      '/app/chat'
+    );
+  });
+});

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.tsx
@@ -1,14 +1,9 @@
-'use client';
-
-import { ArrowRight } from 'lucide-react';
-import Link from 'next/link';
+import { EmptyState } from '@/components/molecules/EmptyState';
 import { APP_ROUTES } from '@/constants/routes';
 import type { OpportunityInboxEmptyActionCard } from '@/lib/connectors/opportunity-inbox-types';
-import { cn } from '@/lib/utils';
 
 export interface OpportunityInboxEmptyStateProps {
   readonly actionCards?: readonly OpportunityInboxEmptyActionCard[];
-  readonly className?: string;
 }
 
 /**
@@ -17,37 +12,17 @@ export interface OpportunityInboxEmptyStateProps {
  */
 export function OpportunityInboxEmptyState({
   actionCards,
-  className,
 }: OpportunityInboxEmptyStateProps) {
   const primaryCard = actionCards?.[0];
   const ctaHref = primaryCard?.href ?? APP_ROUTES.CHAT;
   const ctaLabel = primaryCard?.actionLabel ?? 'Start A Chat';
 
   return (
-    <section
-      className={cn('system-b-opportunity-inbox-empty', className)}
-      data-testid='opportunity-inbox-empty-state'
-    >
-      <header className='system-b-opportunity-inbox-empty-header'>
-        {/* ui-casing-allow: design-locked inbox copy */}
-        <h2 className='system-b-opportunity-inbox-empty-title'>
-          Your Inbox Is Clear
-        </h2>
-        <p className='system-b-opportunity-inbox-empty-subtitle'>
-          Jovie is watching for the next opportunity.
-        </p>
-      </header>
-
-      <div className='mt-4'>
-        <Link
-          href={ctaHref}
-          className='system-b-opportunity-inbox-empty-card-action inline-flex items-center gap-1.5'
-          data-testid='opportunity-inbox-empty-cta'
-        >
-          {ctaLabel}
-          <ArrowRight className='system-b-opportunity-inbox-primary-icon' />
-        </Link>
-      </div>
-    </section>
+    <EmptyState
+      heading='Your Inbox Is Clear'
+      description='Jovie is watching for the next opportunity.'
+      action={{ href: ctaHref, label: ctaLabel }}
+      testId='opportunity-inbox-empty-state'
+    />
   );
 }

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -169,9 +169,9 @@ describe('OpportunityInboxPageClient', () => {
       screen.getByTestId('opportunity-inbox-empty-state')
     ).toBeInTheDocument();
     expect(screen.getByText('Your Inbox Is Clear')).toBeInTheDocument();
-    expect(screen.getByTestId('opportunity-inbox-empty-cta')).toHaveTextContent(
-      'Connect catalog'
-    );
+    expect(
+      screen.getByRole('link', { name: 'Connect catalog' })
+    ).toHaveAttribute('href', '/app/settings/artist-profile');
   });
 
   it('filters cards by signal type and restores them on All', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4176 -->

Closes #13896

## Summary
- replace the hand-rolled `/app` Inbox zero-work fragment with the shared centered `EmptyState`
- preserve the supplied Connect catalog action and the Chat fallback
- add focused consumer coverage for both action paths

## Verification
- `pnpm --filter @jovie/web exec vitest run components/features/opportunity-inbox/OpportunityInboxEmptyState.test.tsx components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx --maxWorkers=1 --reporter=verbose` (10 passed)
- `pnpm biome check --write` on changed files
- normal pre-commit and pre-push gates passed

## Rendered evidence
Desktop/mobile authenticated runtime capture remains queued behind the shared host-capacity lane. This is advisory visual follow-up, not a human merge hold; CI and native queue remain authoritative for landing.