### PR TITLE
fix(backlog): use authoritative Linear leases for JOV-4580

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
-import { access, readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ORCHESTRATOR_DIR = resolve(__dirname, '..');
+const execFileAsync = promisify(execFile);
 
 const classifier = await import('../classifier.mjs');
 const scorer = await import('../scorer.mjs');
@@ -91,6 +94,20 @@ describe('classifier', () => {
     const c = new classifier.IssueClassification(makeIssue());
     c.category = 'duplicate';
     assert.equal(scorer.scoreIssue(c).score, 0);
+  });
+
+  it('counts only Linear In Progress issues as active shipping leases', () => {
+    assert.deepEqual(
+      scorer.currentShippingLoad([
+        makeIssue({ state: 'Todo' }),
+        makeIssue({ state: 'In Progress' }),
+      ]),
+      { healthy: true, count: 1 }
+    );
+    assert.deepEqual(scorer.currentShippingLoad([]), {
+      healthy: true,
+      count: 0,
+    });
   });
 });
 
@@ -365,6 +382,71 @@ describe('entrypoint contract', () => {
     assert.match(await readFile(executable, 'utf8'), /Deterministic-first/);
     assert.equal(JSON.parse(await readFile(config, 'utf8')).version, 1);
   });
+
+  it('preserves an injected key and falls back to the configured file', async () => {
+    const tempDir = await mkdtemp('/tmp/backlog-wrapper-');
+    const fakeBin = resolve(tempDir, 'bin');
+    await mkdir(fakeBin, { recursive: true });
+    const fakeNode = resolve(fakeBin, 'node');
+    await writeFile(
+      fakeNode,
+      '#!/usr/bin/env bash\nprintf \'%s\\n\' "${LINEAR_API_KEY:-}" > "$WRAPPER_KEY_OUTPUT"\nprintf \'%s\\n\' "$*" > "$WRAPPER_ARGS_OUTPUT"\n'
+    );
+    await execFileAsync('chmod', ['+x', fakeNode]);
+
+    const run = env =>
+      execFileAsync(resolve(ORCHESTRATOR_DIR, 'run-backlog.sh'), ['dry-run'], {
+        env: {
+          ...process.env,
+          ...env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        },
+      });
+
+    const keyOutput = resolve(tempDir, 'key');
+    const argsOutput = resolve(tempDir, 'args');
+    await run({
+      HOME: resolve(tempDir, 'missing-home'),
+      LINEAR_API_KEY: 'injected-key',
+      WRAPPER_KEY_OUTPUT: keyOutput,
+      WRAPPER_ARGS_OUTPUT: argsOutput,
+    });
+    assert.equal(await readFile(keyOutput, 'utf8'), 'injected-key\n');
+    assert.equal(
+      await readFile(argsOutput, 'utf8'),
+      'backlog-orchestrator.mjs dry-run\n'
+    );
+
+    const fileHome = resolve(tempDir, 'file-home');
+    await mkdir(resolve(fileHome, '.config/symphony'), { recursive: true });
+    await writeFile(
+      resolve(fileHome, '.config/symphony/linear.env'),
+      'file-key\n'
+    );
+    await run({
+      HOME: fileHome,
+      LINEAR_API_KEY: '',
+      WRAPPER_KEY_OUTPUT: keyOutput,
+      WRAPPER_ARGS_OUTPUT: argsOutput,
+    });
+    assert.equal(await readFile(keyOutput, 'utf8'), 'file-key\n');
+  });
+
+  it('fails clearly when neither credential source exists', async () => {
+    await assert.rejects(
+      execFileAsync(resolve(ORCHESTRATOR_DIR, 'run-backlog.sh'), ['dry-run'], {
+        env: {
+          ...process.env,
+          HOME: '/tmp/no-backlog-credentials',
+          LINEAR_API_KEY: '',
+        },
+      }),
+      error =>
+        /LINEAR_API_KEY is not set and credential file is unavailable/.test(
+          `${error.stderr}`
+        )
+    );
+  });
 });
 
 describe('deterministic Symphony admission boundary', () => {
@@ -437,6 +519,23 @@ describe('deterministic Symphony admission boundary', () => {
     );
     assert.equal(result.admit.length, 0);
     assert.match(result.reason, /synthetic|no eligible/i);
+  });
+
+  it('admits with zero active leases and blocks with one active lease', async () => {
+    const issue = admissionIssue({ identifier: 'JOV-4580' });
+    const noLeases = await admitter.selectNextToAdmit(
+      [classification(issue)],
+      [],
+      { currentlyShipping: 0, productionRed: false }
+    );
+    const oneLease = await admitter.selectNextToAdmit(
+      [classification(issue)],
+      [],
+      { currentlyShipping: 1, productionRed: false }
+    );
+    assert.equal(noLeases.admit.length, 1);
+    assert.equal(oneLease.admit.length, 0);
+    assert.equal(oneLease.reason, 'at capacity (1/1)');
   });
 
   it('selects exactly one concrete eligible JOV issue deterministically', async () => {

--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -441,10 +441,14 @@ describe('entrypoint contract', () => {
           LINEAR_API_KEY: '',
         },
       }),
-      error =>
-        /LINEAR_API_KEY is not set and credential file is unavailable/.test(
-          `${error.stderr}`
-        )
+      error => {
+        const err = /** @type {{ stderr?: unknown; message?: unknown }} */ (
+          error
+        );
+        return /LINEAR_API_KEY is not set and credential file is unavailable/.test(
+          `${err.stderr ?? err.message ?? error}`
+        );
+      }
     );
   });
 });

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -228,8 +228,8 @@ async function runAdmitNext(cache, isDryRun) {
 
   const workstreams = workstreamer.bundleWorkstreams(classifications);
 
-  // Check current shipping state
-  const state = await scorer.currentShippingLoad();
+  // Count live leases from the authoritative Linear active-issue snapshot.
+  const state = scorer.currentShippingLoad(allIssues);
 
   const result = await admitter.selectNextToAdmit(
     classifications,

--- a/scripts/backlog-orchestrator/run-backlog.sh
+++ b/scripts/backlog-orchestrator/run-backlog.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export LINEAR_API_KEY="$(cat ~/.config/symphony/linear.env | tr -d "\n\r" | sed 's/^LINEAR_API_KEY=//')"
+if [[ -z "${LINEAR_API_KEY:-}" ]]; then
+  linear_env_file="${HOME}/.config/symphony/linear.env"
+  if [[ ! -r "$linear_env_file" ]]; then
+    printf 'LINEAR_API_KEY is not set and credential file is unavailable: %s\n' "$linear_env_file" >&2
+    exit 1
+  fi
+  LINEAR_API_KEY="$(tr -d '\r\n' < "$linear_env_file")"
+  LINEAR_API_KEY="${LINEAR_API_KEY#LINEAR_API_KEY=}"
+  export LINEAR_API_KEY
+fi
+
+if [[ -z "${LINEAR_API_KEY:-}" ]]; then
+  printf 'LINEAR_API_KEY is empty; set it or provide %s\n' "${HOME}/.config/symphony/linear.env" >&2
+  exit 1
+fi
+
 cd "$(dirname "$0")"
 exec node backlog-orchestrator.mjs "$@"

--- a/scripts/backlog-orchestrator/scorer.mjs
+++ b/scripts/backlog-orchestrator/scorer.mjs
@@ -97,17 +97,15 @@ export async function isProductionRed() {
 }
 
 /**
- * Check current shipping throughput — how many items are in flight.
+ * Count active shipping leases from the authoritative Linear state snapshot.
+ *
+ * A production version endpoint proves reachability, not whether Symphony has
+ * an active shipment. The orchestrator already fetches the active Linear issue
+ * set, so use its In Progress issues as the lease source instead.
  */
-export async function currentShippingLoad() {
-  try {
-    // Use the production version endpoint + controller state
-    const resp = await fetch('https://jov.ie/api/version', {
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!resp.ok) return { healthy: false, count: 0 };
-    return { healthy: true, count: 1 };
-  } catch {
-    return { healthy: false, count: 0 };
-  }
+export function currentShippingLoad(activeIssues = []) {
+  const count = activeIssues.filter(
+    issue => (issue.state?.name || issue.state) === 'In Progress'
+  ).length;
+  return { healthy: true, count };
 }


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4580 -->

## Summary
- Fixes JOV-4580 by deriving admission capacity from the authoritative Linear active-issue snapshot (`In Progress`), not `https://jov.ie/api/version` reachability.
- Makes `run-backlog.sh` credential precedence explicit: preserve injected `LINEAR_API_KEY`, otherwise read `~/.config/symphony/linear.env`, and fail clearly when neither exists.
- Adds focused coverage for zero/one admission, active lease counting, wrapper precedence/fallback/failure, and preserves existing idempotent admission coverage.

## Checks
- `node --test scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` — **PASS** (24 tests, 24 passed, 0 failed).
- `pnpm exec biome check scripts/backlog-orchestrator/scorer.mjs scripts/backlog-orchestrator/backlog-orchestrator.mjs scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` — **PASS** (3 files checked, no fixes applied).
- `bash -n scripts/backlog-orchestrator/run-backlog.sh` — **PASS**.
- `git diff --check` — **PASS**.
- `pnpm run typecheck:scripts` — **BLOCKED by pre-existing stale baseline** (77 baselined error groups no longer reproduce; no changed-file error was reported; Node 22.22.3 also warns the repo requests 22.23.1).

## Risk
- Medium/high control-plane risk: admission now fails closed against the live Linear `In Progress` state rather than treating production reachability as a lease. Existing stale-lease recovery runs before the active snapshot in normal admission flow.
- Wrapper changes only affect credential selection and error reporting; no credentials are logged or written.

## Rollback
- Revert commit `01cb0d8e4193e7747b14ded393b8328eebf26e99`.
- No production or Linear state was mutated by this implementation or verification.

## No-merge statement
- Draft only. Do not merge; do not enable auto-merge. CI feedback is requested before any promotion.
