### PR TITLE
fix(shell): preserve sidebar thread title space

### DIFF
--- a/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
+++ b/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
@@ -204,7 +204,6 @@ export function ChatsPageClient() {
                   thread={thread}
                   active={false}
                   unread={!!thread.unread}
-                  hasThreadActions
                   onThreadContextMenu={onThreadContextMenu}
                 />
               ))}

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -30,6 +30,8 @@ interface SidebarNavChromeOptions {
   readonly collapsed?: boolean;
   readonly nested?: boolean;
   readonly tight?: boolean;
+  /** Use a fixed 20px action slot instead of the variable badge track. */
+  readonly compactActionSlot?: boolean;
   readonly tone?: 'default' | 'primary';
   readonly className?: string;
 }
@@ -66,6 +68,7 @@ export function getSidebarNavRowClassName({
   collapsed,
   nested,
   tight,
+  compactActionSlot,
   tone = 'default',
   className,
 }: SidebarNavChromeOptions) {
@@ -78,9 +81,12 @@ export function getSidebarNavRowClassName({
     collapsed
       ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center'
       : cn(
-          // Badge track: min 34px keeps empty rows aligned; auto grows so Pro /
-          // multi-digit count badges never overflow into the truncated label.
-          'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
+          // Most rows reserve a variable badge track. Thread rows with a
+          // single icon action opt into the exact target width instead, so
+          // their label gets the remaining grid space deterministically.
+          compactActionSlot
+            ? 'grid-cols-[22px_minmax(0,1fr)_20px]'
+            : 'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
           nonCollapsedSize,
           'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'
         ),

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -24,7 +24,7 @@ const threads: SidebarThread[] = [
 ];
 
 describe('SidebarThreadsSection', () => {
-  it('anchors a long thread title fade to the row track instead of shrink-wrapping it', () => {
+  it('keeps a long thread title on the full middle track when chat actions are present', () => {
     const title =
       'Reply with exactly one short sentence confirming the artist release plan';
 
@@ -40,6 +40,7 @@ describe('SidebarThreadsSection', () => {
           },
         ]}
         activeThreadId={null}
+        onThreadContextMenu={vi.fn()}
         tight
         collapsed={false}
       />
@@ -50,6 +51,13 @@ describe('SidebarThreadsSection', () => {
     expect(label).toHaveClass('justify-self-stretch', 'overflow-hidden');
     expect(label).not.toHaveClass('justify-self-start', 'truncate');
     expect(label.className).toContain('mask-image:linear-gradient');
+    expect(screen.getByRole('link', { name: title })).toHaveClass(
+      'grid-cols-[22px_minmax(0,1fr)_20px]'
+    );
+    expect(screen.getByRole('link', { name: title })).not.toHaveClass('pr-8');
+    expect(
+      screen.getByRole('button', { name: `Chat Actions for ${title}` })
+    ).toHaveClass('right-2.5');
   });
 
   it('renders dense thread links with canonical shell row state', () => {

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -187,7 +187,6 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
   thread,
   active,
   unread,
-  hasThreadActions,
   tight,
   onSelect,
   onThreadContextMenu,
@@ -195,7 +194,6 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
   readonly thread: SidebarThread;
   readonly active: boolean;
   readonly unread: boolean;
-  readonly hasThreadActions: boolean;
   readonly tight?: boolean;
   readonly onSelect?: (id: string) => void;
   readonly onThreadContextMenu?: (
@@ -207,7 +205,7 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
     getSidebarNavRowClassName({
       active,
       tight,
-      className: hasThreadActions ? 'pr-8' : undefined,
+      compactActionSlot: Boolean(onThreadContextMenu),
     }),
     'text-left',
     active
@@ -280,7 +278,10 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
             onClick={e => onThreadContextMenu(e, thread)}
             aria-label={`Chat Actions for ${thread.title}`}
             className={cn(
-              'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
+              // Match the canonical 20px trailing grid track. The action is
+              // still visually quiet until intent, but its slot is always
+              // reserved so it never shortens the title track.
+              'absolute right-2.5 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
               'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
             )}
           >
@@ -413,14 +414,12 @@ export function SidebarThreadsSection({
         {visible.map(t => {
           const active = activeThreadId === t.id;
           const unread = !!t.unread && !active;
-          const hasThreadActions = Boolean(onThreadContextMenu);
           return (
             <SidebarThreadRow
               key={t.id}
               thread={t}
               active={active}
               unread={unread}
-              hasThreadActions={hasThreadActions}
               tight={tight}
               onSelect={onSelect}
               onThreadContextMenu={onThreadContextMenu}


### PR DESCRIPTION
## Summary
- Reserve a deterministic 20px action slot only for sidebar chat rows with an actions menu.
- Remove the duplicate `pr-8` reservation that caused long chat titles to fade too early.
- Keep standard navigation badge geometry unchanged; update the standalone Threads page consumer to the same row contract.

Closes #5979.

## Verification
- `pnpm --filter @jovie/web exec vitest run components/shell/SidebarThreadsSection.test.tsx tests/unit/threads/ThreadsPageClient.test.tsx --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose` (12/12)
- Mandatory commit and push gates: secrets, repo hygiene, proxy guard, staged a11y, lint, typecheck, affected regression tests, Tailwind guard, CI harness.

## Visual follow-up
Seeded authenticated desktop/mobile long-label, focus, and overflow screenshots plus Kimi `/design-review` are pending the host memory guard. This remains draft and gated until that evidence is attached.