### PR TITLE
test(auth): guard OAuth identity route contract

### DIFF
--- a/apps/web/tests/unit/auth/oauth-provider-route-contract.test.ts
+++ b/apps/web/tests/unit/auth/oauth-provider-route-contract.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(process.cwd(), '../..');
+const identityRoute = path.join(
+  repoRoot,
+  'apps/web/app/(auth)/identity/page.tsx'
+);
+const betterAuthConfig = path.join(
+  repoRoot,
+  'apps/web/lib/auth/better-auth.ts'
+);
+
+/**
+ * The OAuth provider redirects its login, consent, and signup prompts to a
+ * product-owned page. Keep the provider configuration and the Next route
+ * coupled so a deployment cannot silently turn the native flow into a 404.
+ */
+describe('OAuth provider auth-page route contract', () => {
+  it('implements every configured OAuth prompt path', async () => {
+    const [routeSource, authSource] = await Promise.all([
+      readFile(identityRoute, 'utf8'),
+      readFile(betterAuthConfig, 'utf8'),
+    ]);
+
+    expect(routeSource).toContain('export default function IdentityPage');
+    expect(routeSource).toContain("export const dynamic = 'force-dynamic'");
+
+    const configuredPages = [
+      authSource.match(/loginPage:\s*'([^']+)'/)?.[1],
+      authSource.match(/consentPage:\s*'([^']+)'/)?.[1],
+      authSource.match(/signup:\s*\{\s*page:\s*'([^']+)'/)?.[1],
+    ];
+
+    expect(configuredPages).toEqual(['/identity', '/identity', '/identity']);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a hermetic contract test coupling Better Auth OAuth `loginPage`, `consentPage`, and `signup.page` to the product-owned `/identity` route.
- Prevents a future provider configuration/deployment change from silently redirecting native OAuth to an unimplemented page.
- The provider route and Better Auth wiring already exist on `main` via `d3c9fecbef6` / #14403; this PR adds the missing regression guard rather than changing auth semantics.

Closes #15174

## Root-cause/evidence boundary

The live sanitized probe still returns the native authorize redirect path `/identity`, while `GET https://jov.ie/api/auth/identity` currently returns HTTP 404. GitHub's Production deployment records are stale relative to current `main` (latest recorded production SHA is from March), so this draft must not be described as an iPhone-login fix or as a production deployment.

No credentials, cookies, PKCE values, state, or full authorization URLs are included here.

## Regression coverage

- `apps/web/tests/unit/auth/oauth-provider-route-contract.test.ts`
  - asserts the implemented route exports the page and is dynamic;
  - asserts all three Better Auth OAuth prompt paths are `/identity`.
- Existing `apps/web/lib/auth/oauth-provider-error-return.test.ts` exercises the hermetic native authorize → provider callback → PKCE token exchange and validates the `logyourbody://oauth` redirect contract.
- Existing `apps/web/app/(auth)/identity/IdentityPageClient.test.tsx` covers the Apple sign-in surface and Better Auth invocation.

## Exact local evidence

- `pnpm --filter web exec vitest run app/(auth)/identity/IdentityPageClient.test.tsx tests/unit/auth/oauth-provider-route-contract.test.ts lib/auth/oauth-provider-error-return.test.ts`
  - **3 test files passed, 13 tests passed**.
- `pnpm --filter @jovie/web exec tsc -p tsconfig.typecheck.json --noEmit --pretty false`
  - **exit 0**.
- `pnpm biome check --write apps/web`
  - **Checked 7320 files in 26s. No fixes applied.**
- `git diff --check`
  - **exit 0**.

The repository wrapper typecheck (`pnpm --filter @jovie/web run typecheck -- --pretty false`) was also attempted but timed out after 300s; direct `tsc` completed successfully.

## Production verification command (after deployment)

Run without printing query values or authorization URLs:

```bash
set -euo pipefail
headers=$(mktemp)
status=$(curl -sS -o /dev/null -D "$headers" -w '%{http_code}' --get \
  'https://jov.ie/api/auth/oauth2/authorize' \
  --data-urlencode 'response_type=code' \
  --data-urlencode 'client_id=logyourbody-ios' \
  --data-urlencode 'redirect_uri=logyourbody://oauth' \
  --data-urlencode 'scope=openid' \
  --data-urlencode 'state=redacted-state' \
  --data-urlencode 'code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
  --data-urlencode 'code_challenge_method=S256')
location_path=$(python3 - "$headers" <<'PY'
import sys
from urllib.parse import urlsplit
for line in open(sys.argv[1]):
    if line.lower().startswith('location:'):
        print(urlsplit(line.split(':', 1)[1].strip()).path)
        break
PY
)
identity_status=$(curl -sS -o /dev/null -w '%{http_code}' 'https://jov.ie/api/auth/identity')
rm -f "$headers"
test "$status" = 302
test "$location_path" = /identity
test "$identity_status" = 200
printf 'authorize_status=%s location_path=%s identity_status=%s\n' "$status" "$location_path" "$identity_status"
```

Then independently run a real iPhone flow and capture a redacted receipt proving authorize → identity → `logyourbody://oauth` with a code and original state. Until that receipt exists on the deployed SHA, iPhone login remains **unverified**.

## Security

No changes to redirect validation, CSRF/state handling, PKCE, consent, client registration, or privacy/error sanitization. The test only reads checked-in source and performs no network or auth setup.

## Rollback

Revert commit `514a15da0a6`; no migration or runtime rollback is required. This removes only the regression test.

## No-merge statement

Draft only. Do not merge, enable auto-merge, enroll in the merge queue, or claim the iPhone login is fixed. Production verification and deployment are separate follow-up actions.
