### PR TITLE
feat: add governed brand deal skill

### DIFF
--- a/.agents/skills/brand-deals
+++ b/.agents/skills/brand-deals
@@ -1,0 +1,1 @@
+../../.claude/skills/brand-deals

--- a/.claude/skills/brand-deals/SKILL.md
+++ b/.claude/skills/brand-deals/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: brand-deals
+description: Run one high-integrity creator brand partnership from evidence through deposit, fulfillment, and reporting. Use for sponsor evidence, personal deal-history mining, Backstage opportunities, buyer qualification, opportunity scoring, Inbox approve or reject decisions, SOWs, rights negotiation, campaign preparation, tracking, invoicing, and repeat-demand analysis.
+---
+
+# Brand Deals
+
+Operate one creator-side campaign at a time. Optimize:
+
+`(expected upfront cash × close probability × repeat potential) ÷ creator minutes`
+
+Read [evidence-policy.md](references/evidence-policy.md) before researching a creator or buyer. Read [commercial-guardrails.md](references/commercial-guardrails.md) before recommending terms, drafting a SOW, or approving external communication.
+For Tim White, also read
+[connector-routing.md](references/connector-routing.md) and
+[tim-brand-deal-canon.md](references/tim-brand-deal-canon.md) before sourcing
+opportunities or building sponsor materials.
+
+## 1. Verify source identity before reading evidence
+
+1. List the sources needed for the task.
+2. Poll each connector's authenticated profile before searching it.
+3. Compare the authenticated identity with the required account.
+4. If the Codex Gmail connector is occupied by another account, check Composio
+   before asking the user to replace it. Verify Composio Gmail with the Gmail
+   `users/me/profile` endpoint and compare the returned address
+   case-insensitively.
+5. If every available connector is absent or authenticated as the wrong
+   account, stop that source lane and ask the user to connect the correct
+   account. Continue only with independent verified sources.
+6. Label every fact with its source, account, authentication broker, observed
+   date, and confidence.
+
+Never merge these lanes:
+
+- `t@timwhite.co`: Tim's personal brand-deal email.
+- `tim@jov.ie`: Jovie company email, not a substitute for personal deal history.
+- A7X3: Tim's former influencer-activation company. Its clients and relationships are not automatically Tim's personal brand deals.
+- Backstage.com: Tim's personal acting, UGC, and influencer opportunity channel.
+- Backstage.Army: unrelated to Backstage.com.
+- Creator-economy relationships: adjacency only until a personal deal, warm introduction, or current buying authority is proven.
+
+Do not infer ownership from a channel name, search result, repost, video title, or matching display name. A native account export, authenticated dashboard, contract, invoice, or first-party email must prove ownership.
+
+For personal email research, query metadata first and hydrate only shortlisted
+threads. Do not copy raw email bodies into Jovie. Store the minimum provenance
+needed to revisit the source: authenticated account, broker, thread or message
+ID, sender, subject, observation time, and the exact commercial facts used.
+Never send, label, archive, or delete mail during evidence mining.
+
+## 2. Establish the campaign gate
+
+Before surfacing a buyer, verify:
+
+- No sponsor campaign is currently active.
+- The opportunity has verified creator identity and provenance.
+- The buyer relationship is a personal deal, personal inbound, authenticated marketplace match, or verified warm introduction.
+- The budget can support a $7,500-$12,500 campaign and at least a 50% deposit.
+- The proposed rights avoid perpetual usage, unlimited revisions, and broad exclusivity.
+- The sponsor owns the primary CTA. Jovie tracking measures the campaign without diluting it.
+- LYB is not the CTA until its paid flow has passed purchase and restore verification.
+
+Run:
+
+```bash
+node .claude/skills/brand-deals/scripts/validate-opportunity.mjs <opportunity.json>
+```
+
+Do not surface an opportunity in Inbox unless validation returns `valid: true`.
+
+For Jovie runtime insertion, use
+`emitBrandDealOpportunity` from
+`apps/web/lib/connectors/brand-deal-opportunity-emitter.ts`. Never insert a
+brand-deal `suggested_actions` row directly. The emitter verifies the connected
+account identity, refuses a second pending buyer decision, and stores the
+canonical decision-only kind. If it reports a missing or mismatched connector,
+prompt the user to connect the required account and do not downgrade the
+evidence standard.
+
+## 3. Research and rank candidates
+
+Use current research only after its runtime preflight passes. `/last30days` results are discovery evidence, never proof of the creator's ownership or past deal. Prefer:
+
+1. Verified personal past buyers and agency contacts.
+2. Authenticated inbound email and Backstage opportunities.
+3. Verified warm introductions to current budget owners.
+4. Marketplace matches with clear budget and deliverables.
+5. Cold qualified buyers only when the warm set is exhausted.
+
+Do not mass email. Prepare no more than five personalized recommendations per day.
+
+For each candidate, record:
+
+- Buyer and current role.
+- Provenance and source account.
+- Authentication broker and verified profile identity.
+- Verified personal relationship type.
+- Budget and expected deposit.
+- Creator and audience fit.
+- Rights risk.
+- Close probability.
+- Repeat potential.
+- Estimated creator minutes.
+- Ranking score.
+- Missing connector or evidence.
+
+## 4. Use two explicit approval gates
+
+Create one `brand_deal.opportunity` Inbox item at a time.
+
+### Gate A: buyer approval
+
+Show Tim the buyer, provenance, economics, fit, rights summary, ranking score, and recommendation.
+
+- Reject: record the reason and advance to the next qualified candidate.
+- Approve: prepare the concept, recommendation, scripts, fixed SOW, tracking plan, invoice, and draft communication. Do not send or commit commercially yet.
+
+### Gate B: commercial commitment
+
+Show the exact price, deliverables, deposit, timeline, usage, revisions, exclusivity, cancellation terms, and external message.
+
+- Reject: revise within the fixed scope or move on.
+- Approve: send only the approved message and fixed SOW, then request the 50% deposit.
+
+Never treat buyer approval as permission to change price, rights, deliverables, or recipients.
+
+## 5. Activate only after cash
+
+Mark the campaign active only when the deposit is captured. Keep every other sponsor opportunity pending or declined while one campaign is active.
+
+Prepare all work before Tim records:
+
+- One recommended concept.
+- One script and shot list.
+- One recording session.
+- One approval round.
+- One included revision.
+- Sponsor-first CTA and transparent tracking.
+- Publication checklist.
+- Report and invoice schedule.
+
+Tim records once, approves once, and publishes. Agents handle preparation, edits, tracking, reporting, and invoicing.
+
+## 6. Close the loop
+
+Capture:
+
+- Cash collected and collection date.
+- Tim minutes.
+- Revision count.
+- Published assets and rights window.
+- Sponsor CTA performance.
+- Jovie tracking coverage.
+- Report delivery.
+- Repeat request, renewal, referral, or rejection reason.
+
+Use observed campaign outcomes to update the next ranking. Never present Jovie, LYB, native monetization, or repeat demand as guaranteed revenue.
+
+## Output contract
+
+Always report:
+
+- Current campaign slot: open or occupied.
+- Evidence status and connector identity.
+- One recommended next decision.
+- Exact user approval required.
+- What Jovie will prepare automatically after approval.
+- Any blocked source lane.
+
+Never claim a deal, metric, relationship, send, submission, deposit, or campaign result without direct evidence.

--- a/.claude/skills/brand-deals/agents/openai.yaml
+++ b/.claude/skills/brand-deals/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Brand Deals"
+  short_description: "Run one verified creator partnership end to end."
+  default_prompt: "Use $brand-deals to verify and advance one provenance-backed creator brand opportunity through Jovie Inbox."

--- a/.claude/skills/brand-deals/references/commercial-guardrails.md
+++ b/.claude/skills/brand-deals/references/commercial-guardrails.md
@@ -1,0 +1,48 @@
+# Commercial guardrails
+
+## Default campaign
+
+- Price: $7,500-$12,500.
+- Deposit: 50% before activation.
+- Deliverables: fixed in the SOW.
+- Recording: one session.
+- Creator approval: one round.
+- Included revisions: one.
+- Usage: fixed media, territory, and term. Default to 90 days or less.
+- Exclusivity: none by default. If required, make it narrow, category-specific, paid, and time-bounded.
+- CTA: sponsor-first.
+- Tracking: transparent and subordinate to the sponsor CTA.
+
+## Never grant by default
+
+- Perpetual or irrevocable usage.
+- Unlimited revisions.
+- Broad industry exclusivity.
+- Whitelisting or paid-media usage without a separate term and fee.
+- Raw footage or editable project files without a separate fee.
+- Guaranteed views, clicks, conversions, sales, Jovie revenue, LYB revenue, or native monetization.
+
+## Approval boundaries
+
+Buyer approval authorizes internal preparation only.
+
+Commercial approval must cover the exact:
+
+- Recipient.
+- Price and currency.
+- Deposit.
+- Deliverables.
+- Schedule.
+- Revision limit.
+- Usage term, media, and territory.
+- Exclusivity.
+- Cancellation terms.
+- External message.
+
+Any change to those fields requires a new approval.
+
+## One-campaign invariant
+
+Do not activate a second sponsor campaign while one is active. An active campaign begins when the deposit is collected and ends when contractual deliverables and the initial report are complete.
+
+Pending buyer recommendations are allowed. Keep only one at the top of the decision queue.

--- a/.claude/skills/brand-deals/references/connector-routing.md
+++ b/.claude/skills/brand-deals/references/connector-routing.md
@@ -1,0 +1,66 @@
+# Connector routing
+
+## Poll before prompting
+
+For every required source:
+
+1. Inspect the available connectors.
+2. Query the connector's authenticated profile.
+3. Compare the returned identity with the required identity
+   case-insensitively.
+4. Use a matching connector only for read-only evidence discovery.
+5. If no connector matches, prompt the user with the exact missing account and
+   provider.
+
+Do not assume that an installed, active, or previously used connector is
+authenticated as the right person.
+
+## Tim's personal Gmail
+
+The required personal mailbox is `t@timwhite.co`. The Jovie company mailbox
+`tim@jov.ie` is not a substitute.
+
+Preferred routing:
+
+1. Use a Codex Gmail connector only if its profile is `t@timwhite.co`.
+2. Otherwise, inspect Composio:
+
+   ```bash
+   composio connections list
+   composio proxy \
+     https://gmail.googleapis.com/gmail/v1/users/me/profile \
+     --toolkit gmail
+   ```
+
+3. Require `emailAddress` to equal `t@timwhite.co` case-insensitively.
+4. Search with `GMAIL_FETCH_EMAILS` using metadata-only, small-result queries.
+5. Hydrate only shortlisted evidence with
+   `GMAIL_FETCH_MESSAGE_BY_THREAD_ID`.
+
+If the `composio` command is an older incompatible client, locate the current
+binary reported by the official installer before concluding that the connector
+is unavailable. Never print or persist a Composio API key.
+
+Composio's CLI is an agent research and bootstrap surface, not Jovie's
+production runtime contract. A verified agent may use it to source evidence,
+but Inbox writes still go through Jovie's tested
+`emitBrandDealOpportunity` server boundary.
+
+## Minimum-safe Gmail behavior
+
+- Read only.
+- Query metadata before bodies.
+- Keep source IDs rather than raw bodies.
+- Never send, draft, label, archive, or delete without a separate explicit
+  user-approved action.
+- Do not treat a newsletter, affiliate blast, gifting offer, or generic
+  campaign invite as a qualified buyer.
+- Do not infer budget. An opportunity cannot pass the $7,500-$12,500 gate
+  without a current brief, email, or approved recommendation supporting it.
+
+## Social connectors
+
+Poll each native social connector independently. An authenticated YouTube
+connection does not prove Instagram or TikTok ownership, and a matching public
+handle does not prove any authenticated account. If a social connector is
+expired, report that exact lane as blocked and ask the user to reconnect it.

--- a/.claude/skills/brand-deals/references/evidence-policy.md
+++ b/.claude/skills/brand-deals/references/evidence-policy.md
@@ -1,0 +1,53 @@
+# Evidence policy
+
+## Source authority
+
+| Claim | Acceptable proof | Discovery only |
+| --- | --- | --- |
+| Creator owns an account or asset | Authenticated native dashboard, native export, first-party account settings | Search result, matching display name, repost, channel title |
+| Audience or content metric | Native analytics with account identity and observed date | Public follower count, third-party estimate |
+| Personal past brand deal | Personal email thread, signed contract, invoice, payment receipt, authenticated Backstage booking | A7X3 client, creator-economy relationship, public campaign |
+| Buyer is warm and current | Direct personal correspondence plus current role or verified introduction | Old contact, adjacent founder, former employer |
+| Budget and terms | Current brief, email, offer, SOW, contract | Typical market rate |
+| Deposit collected | Payment processor, bank, or invoice receipt | Verbal acceptance, signed SOW |
+
+Public metrics may support discovery. They do not prove unique reach, ownership, audience quality, or conversion.
+
+Do not infer ownership from a search result, matching display name, repost, channel title, or adjacent relationship.
+
+## Required provenance record
+
+Record these fields for every evidence item:
+
+- `sourceType`
+- `sourceAccount`
+- `authenticationBroker`
+- `sourceReference`
+- `observedAt`
+- `identityMatched`
+- `ownershipVerified`
+- `personalDealVerified`
+- `confidence`
+
+If any required field is missing, label the item unverified and exclude it from buyer-facing materials.
+
+## Tim-specific separations
+
+- Treat `t@timwhite.co` as the required personal Gmail identity for personal deal history.
+- Never substitute `tim@jov.ie`.
+- If Codex Gmail is occupied, poll Composio Gmail and verify the
+  `users/me/profile` address before prompting the user to replace a connector.
+- Treat A7X3 as company-side influencer activation unless a separate personal Tim engagement is proven.
+- Treat Backstage.com as relevant personal UGC, acting, and influencer history.
+- Reject Backstage.Army as an unrelated source.
+- Do not upgrade creator-economy adjacency into a verified buyer relationship.
+
+## Correction rule
+
+When Tim or another source disproves a claim:
+
+1. Withdraw every buyer-facing artifact containing it.
+2. Remove the claim from generators and templates.
+3. Search for sibling claims produced by the same inference.
+4. Add a deterministic regression case.
+5. Rebuild only after first-party proof exists.

--- a/.claude/skills/brand-deals/references/tim-brand-deal-canon.md
+++ b/.claude/skills/brand-deals/references/tim-brand-deal-canon.md
@@ -1,0 +1,97 @@
+# Tim White brand-deal evidence canon
+
+This is a dated seed index, not a permanent claim database. Re-open the cited
+first-party source and reverify identity, terms, and current buyer role before
+using any item in sponsor materials or outreach.
+
+## Verified personal creator campaign precedent
+
+### Artie via Kids in Big Bodies
+
+- Source: authenticated personal Gmail `t@timwhite.co`
+- Authentication broker: Composio Gmail
+- Source reference: Gmail thread `181696d593400f5c`
+- Observed: 2026-07-29
+- Campaign occurred: June 2022
+- Personal engagement: yes
+- Signed contract: yes
+- Negotiated campaign fee: $10,000
+- Scope evidenced in the thread: two event appearances, one Instagram Reel,
+  one Instagram Story with 3-5 frames, and 90-day organic use on owned social
+  channels
+- Commercial lesson: Tim initially quoted $12,000 for the expanded scope; the
+  buyer countered at $10,000; Tim accepted and signed after the contract scope
+  was corrected from two Reels and two Stories to the negotiated one Reel and
+  one Story.
+- Reuse constraint: verify the agency contacts' current roles before treating
+  them as warm buyers.
+
+This is the primary verified precedent for the current
+$7,500-$12,500 productized campaign target.
+
+### Haptik via Affable
+
+- Source: authenticated personal Gmail `t@timwhite.co`
+- Authentication broker: Composio Gmail
+- Source references: Gmail threads `1867a72131220407`,
+  `186ba190d085091e`, `186d87f21f43f816`, `186d9cfd7b058b6b`, and
+  `186e01f088b9d3de`
+- Observed: 2026-07-29
+- Campaign occurred: March 2023
+- Personal paid collaboration: yes
+- Contract signed: yes
+- Fulfillment evidence: Tim's team reported the video in production and asked
+  for the countersigned contract before delivery.
+- Scope correction: a requested three-minute Reel was corrected to Instagram's
+  then-supported 90-second maximum.
+- Fee: not yet verified from the reviewed messages; do not infer it.
+
+## Verified native audience identity
+
+### YouTube
+
+- Source: authenticated Composio YouTube connection with `mine=true`
+- Observed: 2026-07-29
+- Channel ID: `UC90tJdD38139ytPUdEZVl1A`
+- Channel title: Tim White
+- Handle: `@timwhite`
+- Subscribers: 24,100
+- Aggregate channel views: 1,869,114
+- Videos: 148
+- Boundary: these account-level aggregates prove the authenticated channel and
+  its current totals. They do not prove that a particular song, upload, view,
+  or performance result belongs to Tim without inspecting that native asset.
+
+Instagram was expired in Composio when observed. Do not publish an Instagram
+count or native performance claim until that connector is reauthenticated.
+
+## Backstage
+
+- Backstage.com is a relevant personal acting, UGC, and influencer source.
+- Authenticated personal Gmail contains direct Backstage.com mail and a
+  `Tim White-Audition-Backstage` thread.
+- This proves the lane is relevant, not that every Backstage lead became a
+  paid deal. Require a booking, contract, invoice, or payment receipt before
+  claiming a completed paid engagement.
+- Backstage.Army is unrelated and must never be substituted.
+
+## Current inbound is not yet qualified
+
+Authenticated personal Gmail contained current or recent inbound from
+Fohr/Colgate-Palmolive, BagSmart, Dreo/Vanzo Media, AliExpress, Dante Labs/10PM
+Curfew, and other creator programs when observed on 2026-07-29. These are
+discovery leads only until the current buyer, budget, scope, rights, and timing
+are verified. Product-only, affiliate-only, generic newsletter, and
+below-target offers do not pass the campaign gate.
+
+## Required separations
+
+- A7X3 was Tim's company for activating influencers. Do not use A7X3 clients
+  or company-side relationships as proof of Tim's personal creator deals.
+- Creator-economy relationships are not personal buyer history without direct
+  evidence.
+- No YouTube song, video, channel, audience metric, or performance claim is
+  approved merely because a search result or title resembles Tim. Require the
+  authenticated native account and first-party ownership evidence. The
+  aggregate authenticated channel figures above do not authorize a
+  song-specific claim.

--- a/.claude/skills/brand-deals/scripts/validate-opportunity.mjs
+++ b/.claude/skills/brand-deals/scripts/validate-opportunity.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const PERSONAL_RELATIONSHIP_TYPES = new Set([
+  'past_personal_deal',
+  'personal_inbound',
+  'authenticated_marketplace_match',
+  'verified_warm_introduction',
+]);
+
+const FORBIDDEN_RELATIONSHIP_TYPES = new Set([
+  'company_activation',
+  'creator_economy_adjacency',
+  'unverified',
+]);
+
+const VERIFIED_SOURCE_TYPES = new Set([
+  'personal_email',
+  'backstage',
+  'marketplace',
+  'warm_introduction',
+]);
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isVerifiedBackstageReference(value) {
+  if (!isNonEmptyString(value)) return false;
+  try {
+    const hostname = new URL(value).hostname.toLowerCase();
+    return hostname === 'backstage.com' || hostname.endsWith('.backstage.com');
+  } catch {
+    return false;
+  }
+}
+
+function isVerifiedPersonalEmailReference(value) {
+  return (
+    isNonEmptyString(value) &&
+    /^gmail:(?:thread|message):[0-9a-f]+$/i.test(value.trim())
+  );
+}
+
+export function validateOpportunity(input) {
+  const errors = [];
+
+  if (!input || typeof input !== 'object') {
+    return {
+      valid: false,
+      errors: ['opportunity_payload_invalid'],
+      rankingScore: null,
+    };
+  }
+
+  if (!isNonEmptyString(input.title)) errors.push('title_missing');
+  if (!isNonEmptyString(input.buyerName)) errors.push('buyer_name_missing');
+  if (!isNonEmptyString(input.buyerCompany))
+    errors.push('buyer_company_missing');
+  if (!isNonEmptyString(input.sourceLabel))
+    errors.push('source_label_missing');
+  if (!isNonEmptyString(input.rightsSummary))
+    errors.push('rights_summary_missing');
+  if (
+    !isNonEmptyString(input.currency) ||
+    input.currency.trim().toUpperCase() !== 'USD'
+  ) {
+    errors.push('currency_not_usd');
+  }
+
+  if (input.identityMatched !== true) errors.push('identity_not_matched');
+  if (input.ownershipVerified !== true) errors.push('ownership_not_verified');
+  if (input.personalDealVerified !== true)
+    errors.push('personal_relationship_not_verified');
+
+  if (!PERSONAL_RELATIONSHIP_TYPES.has(input.relationshipType)) {
+    errors.push(
+      FORBIDDEN_RELATIONSHIP_TYPES.has(input.relationshipType)
+        ? `forbidden_relationship_type:${input.relationshipType}`
+        : 'invalid_relationship_type'
+    );
+  }
+
+  if (!VERIFIED_SOURCE_TYPES.has(input.sourceType)) {
+    errors.push('source_type_invalid');
+  }
+  if (!input.sourceAccount || !input.requiredSourceAccount) {
+    errors.push('source_account_missing');
+  } else if (
+    input.sourceAccount.trim().toLowerCase() !==
+    input.requiredSourceAccount.trim().toLowerCase()
+  ) {
+    errors.push('source_account_mismatch');
+  }
+
+  if (!isNonEmptyString(input.sourceReference)) {
+    errors.push('source_reference_missing');
+  } else if (/backstage\.army/i.test(input.sourceReference)) {
+    errors.push('unrelated_backstage_source');
+  }
+
+  if (
+    input.sourceType === 'backstage' &&
+    !isVerifiedBackstageReference(input.sourceReference)
+  ) {
+    errors.push('backstage_source_not_verified');
+  }
+  if (
+    input.sourceType === 'personal_email' &&
+    !isVerifiedPersonalEmailReference(input.sourceReference)
+  ) {
+    errors.push('personal_email_source_not_verified');
+  }
+
+  const observedAtMs = Date.parse(input.observedAt);
+  if (
+    !isNonEmptyString(input.observedAt) ||
+    !Number.isFinite(observedAtMs) ||
+    observedAtMs > Date.now() + 5 * 60 * 1000
+  ) {
+    errors.push('observed_at_invalid');
+  }
+  if (
+    input.evidenceStatus !== 'verified' ||
+    !isFiniteNumber(input.confidence) ||
+    input.confidence < 0.9 ||
+    input.confidence > 1
+  ) {
+    errors.push('evidence_not_verified');
+  }
+
+  const budgetMin = input.budgetMinCents;
+  const budgetMax = input.budgetMaxCents;
+  if (
+    !isFiniteNumber(budgetMin) ||
+    !isFiniteNumber(budgetMax) ||
+    budgetMin < 750_000 ||
+    budgetMax > 1_250_000 ||
+    budgetMin > budgetMax
+  ) {
+    errors.push('budget_outside_target');
+  }
+
+  if (
+    !isFiniteNumber(input.depositPercent) ||
+    input.depositPercent < 50 ||
+    input.depositPercent > 100
+  ) {
+    errors.push('deposit_below_50_percent');
+  }
+  if (
+    !Number.isInteger(input.activeSponsorCampaignCount) ||
+    input.activeSponsorCampaignCount !== 0
+  ) {
+    errors.push('active_sponsor_slot_occupied');
+  }
+  if (
+    !Number.isInteger(input.includedRevisions) ||
+    input.includedRevisions < 0 ||
+    input.includedRevisions > 1
+  ) {
+    errors.push('too_many_included_revisions');
+  }
+  if (
+    !Number.isInteger(input.usageTermDays) ||
+    input.usageTermDays < 1 ||
+    input.usageTermDays > 90
+  ) {
+    errors.push('forbidden_usage_term');
+  }
+  if (input.exclusivity !== 'none' && input.exclusivity !== 'narrow_paid') {
+    errors.push('forbidden_exclusivity');
+  }
+  if (input.routeToLyb === true && input.lybPaidFlowVerified !== true) {
+    errors.push('lyb_paid_flow_unverified');
+  }
+  if (
+    typeof input.routeToLyb !== 'boolean' ||
+    typeof input.lybPaidFlowVerified !== 'boolean'
+  ) {
+    errors.push('lyb_verification_state_missing');
+  }
+  if (typeof input.externalSendApproved !== 'boolean') {
+    errors.push('external_send_state_missing');
+  } else if (input.externalSendApproved !== false) {
+    errors.push('external_send_not_allowed_at_buyer_gate');
+  } else if (input.commercialApprovalId !== null) {
+    errors.push('commercial_approval_must_be_null_at_buyer_gate');
+  }
+
+  const expectedCash = input.expectedUpfrontCashCents;
+  const closeProbability = input.closeProbability;
+  const repeatPotential = input.repeatPotential;
+  const creatorMinutes = input.creatorMinutes;
+  const score =
+    isFiniteNumber(expectedCash) &&
+    expectedCash >= (budgetMin * input.depositPercent) / 100 &&
+    expectedCash <= budgetMax &&
+    isFiniteNumber(closeProbability) &&
+    closeProbability >= 0 &&
+    closeProbability <= 1 &&
+    isFiniteNumber(repeatPotential) &&
+    repeatPotential >= 0 &&
+    isFiniteNumber(creatorMinutes) &&
+    creatorMinutes > 0
+      ? ((expectedCash / 100) * closeProbability * repeatPotential) /
+        creatorMinutes
+      : null;
+
+  if (score == null) errors.push('ranking_inputs_invalid');
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    rankingScore: score,
+  };
+}
+
+function main() {
+  const path = process.argv[2];
+  if (!path) {
+    process.stderr.write(
+      'Usage: node validate-opportunity.mjs <opportunity.json>\n'
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const input = JSON.parse(readFileSync(path, 'utf8'));
+  const result = validateOpportunity(input);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.valid) process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Brand-deal execution is governed by a tested Jovie skill (JOV-4578):** connector identity with a Composio Gmail fallback, primary-source personal deal receipts, A7X3/Backstage separation, one-campaign capacity, bounded rights, sponsor-first tracking, LYB monetization proof, and the two approval gates are enforced by deterministic fixtures.
 - **New Chat is the first shared navigation action (JOV-4510):** desktop and mobile now lead with one elevated New Chat row while preserving Inbox and the rest of the canonical customer order.
 - [internal] **Privileged workflow trust-boundary reporting:** post-merge and nightly security scans now inventory `pull_request_target` and `workflow_run` workflows, warn when a privileged pull-request workflow checks out contributor code, and remain advisory while GitHub policy is evaluated.
 - [internal] **macOS desktop packaging accepts the secured XML parser:** Electron Builder's property-list dependency now supplies the MIME type required by the repository's security-patched xmldom floor, so signed and notarized desktop releases can reach artifact creation again.

--- a/scripts/lib/__tests__/brand-deals-skill-contract.test.mjs
+++ b/scripts/lib/__tests__/brand-deals-skill-contract.test.mjs
@@ -1,0 +1,243 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { validateOpportunity } from '../../../.claude/skills/brand-deals/scripts/validate-opportunity.mjs';
+
+const skill = readFileSync(
+  new URL('../../../.claude/skills/brand-deals/SKILL.md', import.meta.url),
+  'utf8'
+);
+const evidencePolicy = readFileSync(
+  new URL(
+    '../../../.claude/skills/brand-deals/references/evidence-policy.md',
+    import.meta.url
+  ),
+  'utf8'
+);
+const commercialGuardrails = readFileSync(
+  new URL(
+    '../../../.claude/skills/brand-deals/references/commercial-guardrails.md',
+    import.meta.url
+  ),
+  'utf8'
+);
+const connectorRouting = readFileSync(
+  new URL(
+    '../../../.claude/skills/brand-deals/references/connector-routing.md',
+    import.meta.url
+  ),
+  'utf8'
+);
+const timBrandDealCanon = readFileSync(
+  new URL(
+    '../../../.claude/skills/brand-deals/references/tim-brand-deal-canon.md',
+    import.meta.url
+  ),
+  'utf8'
+);
+
+const validOpportunity = {
+  title: 'Artie creator-performance campaign',
+  buyerName: 'Hayley Delaine',
+  buyerCompany: 'Kids in Big Bodies',
+  identityMatched: true,
+  ownershipVerified: true,
+  personalDealVerified: true,
+  relationshipType: 'past_personal_deal',
+  sourceType: 'personal_email',
+  sourceLabel: 'Authenticated personal Gmail',
+  sourceAccount: 't@timwhite.co',
+  requiredSourceAccount: 't@timwhite.co',
+  sourceReference: 'gmail:thread:181696d593400f5c',
+  observedAt: '2026-07-29T10:00:00.000Z',
+  evidenceStatus: 'verified',
+  confidence: 1,
+  currency: 'USD',
+  rightsSummary: '90-day organic usage, no broad exclusivity',
+  budgetMinCents: 750_000,
+  budgetMaxCents: 1_000_000,
+  depositPercent: 50,
+  activeSponsorCampaignCount: 0,
+  includedRevisions: 1,
+  usageTerm: '90_days',
+  usageTermDays: 90,
+  exclusivity: 'none',
+  routeToLyb: false,
+  lybPaidFlowVerified: false,
+  externalSendApproved: false,
+  commercialApprovalId: null,
+  expectedUpfrontCashCents: 500_000,
+  closeProbability: 0.6,
+  repeatPotential: 1.5,
+  creatorMinutes: 60,
+};
+
+describe('brand-deals skill contract', () => {
+  it('requires connector identity and keeps personal evidence lanes separate', () => {
+    expect(skill).toContain('Poll each connector');
+    expect(skill).toContain('t@timwhite.co');
+    expect(skill).toContain('tim@jov.ie');
+    expect(skill).toContain('A7X3');
+    expect(skill).toContain('Backstage.com');
+    expect(skill).toContain('Backstage.Army');
+    expect(skill).toContain('Creator-economy relationships');
+    expect(skill).toContain('check Composio');
+    expect(skill).toContain('emitBrandDealOpportunity');
+    expect(skill).toContain('Never insert a');
+  });
+
+  it('polls a Composio fallback and verifies the personal Gmail profile', () => {
+    expect(connectorRouting).toContain('composio connections list');
+    expect(connectorRouting).toContain(
+      'https://gmail.googleapis.com/gmail/v1/users/me/profile'
+    );
+    expect(connectorRouting).toContain('t@timwhite.co');
+    expect(connectorRouting).toContain('case-insensitively');
+    expect(connectorRouting).toContain(
+      'Never print or persist a Composio API key'
+    );
+    expect(connectorRouting).toContain(
+      "not Jovie's\nproduction runtime contract"
+    );
+    expect(connectorRouting).toContain('emitBrandDealOpportunity');
+  });
+
+  it('anchors Tim-specific strategy in verified personal deal receipts', () => {
+    expect(timBrandDealCanon).toContain('Artie via Kids in Big Bodies');
+    expect(timBrandDealCanon).toContain('Gmail thread `181696d593400f5c`');
+    expect(timBrandDealCanon).toContain('Negotiated campaign fee: $10,000');
+    expect(timBrandDealCanon).toContain('Signed contract: yes');
+    expect(timBrandDealCanon).toContain('Haptik via Affable');
+    expect(timBrandDealCanon).toContain('Fee: not yet verified');
+    expect(timBrandDealCanon).toContain('Backstage.Army is unrelated');
+    expect(timBrandDealCanon).toContain('No YouTube song');
+    expect(timBrandDealCanon).toContain('UC90tJdD38139ytPUdEZVl1A');
+    expect(timBrandDealCanon).toContain('Subscribers: 24,100');
+    expect(timBrandDealCanon).toContain('Aggregate channel views: 1,869,114');
+    expect(timBrandDealCanon).toContain('Instagram was expired in Composio');
+  });
+
+  it('requires two approvals and preserves the commercial guardrails', () => {
+    expect(skill).toContain('Gate A: buyer approval');
+    expect(skill).toContain('Gate B: commercial commitment');
+    expect(commercialGuardrails).toContain('50% before activation');
+    expect(commercialGuardrails).toContain('one session');
+    expect(commercialGuardrails).toContain('one round');
+    expect(commercialGuardrails).toContain('Perpetual or irrevocable usage');
+    expect(commercialGuardrails).toContain('Unlimited revisions');
+    expect(commercialGuardrails).toContain('Broad industry exclusivity');
+  });
+
+  it('withdraws disproved claims and creates a regression case', () => {
+    expect(evidencePolicy).toContain('Withdraw every buyer-facing artifact');
+    expect(evidencePolicy).toContain('Add a deterministic regression case');
+    expect(evidencePolicy).toContain('Do not infer ownership');
+  });
+});
+
+describe('brand-deal opportunity validator', () => {
+  it('accepts a verified, fixed-scope opportunity', () => {
+    expect(validateOpportunity(validOpportunity)).toEqual({
+      valid: true,
+      errors: [],
+      rankingScore: 75,
+    });
+  });
+
+  it.each([
+    [
+      'a creator-economy relationship',
+      { relationshipType: 'creator_economy_adjacency' },
+      'forbidden_relationship_type:creator_economy_adjacency',
+    ],
+    [
+      'an A7X3 company activation',
+      { relationshipType: 'company_activation' },
+      'forbidden_relationship_type:company_activation',
+    ],
+    [
+      'the wrong Gmail account',
+      { sourceAccount: 'tim@jov.ie' },
+      'source_account_mismatch',
+    ],
+    [
+      'Backstage.Army',
+      {
+        sourceType: 'backstage',
+        sourceReference: 'https://backstage.army/opportunity/1',
+      },
+      'unrelated_backstage_source',
+    ],
+    [
+      'unverified asset ownership',
+      { ownershipVerified: false },
+      'ownership_not_verified',
+    ],
+    ['perpetual usage', { usageTermDays: 36_500 }, 'forbidden_usage_term'],
+    [
+      'unlimited revisions',
+      { includedRevisions: 99 },
+      'too_many_included_revisions',
+    ],
+    ['broad exclusivity', { exclusivity: 'broad' }, 'forbidden_exclusivity'],
+    [
+      'all-category exclusivity',
+      { exclusivity: 'all_categories' },
+      'forbidden_exclusivity',
+    ],
+    [
+      'a second active campaign',
+      { activeSponsorCampaignCount: 1 },
+      'active_sponsor_slot_occupied',
+    ],
+    [
+      'LYB before paid-flow proof',
+      { routeToLyb: true },
+      'lyb_paid_flow_unverified',
+    ],
+    [
+      'an external send without commercial approval',
+      { externalSendApproved: true },
+      'external_send_not_allowed_at_buyer_gate',
+    ],
+    [
+      'a fake commercial approval receipt at the buyer gate',
+      { externalSendApproved: true, commercialApprovalId: 'approval-123' },
+      'external_send_not_allowed_at_buyer_gate',
+    ],
+    [
+      'a non-Gmail personal source reference',
+      { sourceReference: 'https://example.com/thread/123' },
+      'personal_email_source_not_verified',
+    ],
+    [
+      'a low-confidence evidence claim',
+      { confidence: 0.5 },
+      'evidence_not_verified',
+    ],
+    [
+      'a future observation',
+      { observedAt: '2999-01-01T00:00:00.000Z' },
+      'observed_at_invalid',
+    ],
+    ['a non-USD opportunity', { currency: 'EUR' }, 'currency_not_usd'],
+    [
+      'a missing deposit',
+      { depositPercent: undefined },
+      'deposit_below_50_percent',
+    ],
+    [
+      'missing revision terms',
+      { includedRevisions: undefined },
+      'too_many_included_revisions',
+    ],
+    [
+      'missing evidence observation time',
+      { observedAt: undefined },
+      'observed_at_invalid',
+    ],
+  ])('rejects %s', (_label, patch, expectedError) => {
+    const result = validateOpportunity({ ...validOpportunity, ...patch });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(expectedError);
+  });
+});

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -2,6 +2,7 @@
   "version": 1,
   "codexSkills": [
     "ai-sdk",
+    "brand-deals",
     "find-skills",
     "gstack",
     "nightly-test-agent",
@@ -13,6 +14,7 @@
     "autoplan",
     "benchmark",
     "benchmark-models",
+    "brand-deals",
     "browse",
     "canary",
     "careful",


### PR DESCRIPTION
## Summary

- add a governed `brand-deals` skill for personal creator partnerships, separate from A7X3 company-side activations and creator-economy adjacency
- verify connector identity before evidence use, with Composio Gmail as the fallback for `t@timwhite.co`
- preserve Backstage.com as a relevant UGC and acting source while rejecting lookalikes
- enforce one active campaign, bounded rights, one revision, sponsor-first tracking, 50% deposit, and separate buyer and commercial approvals
- encode corrected Artie, Haptik, Backstage, and native YouTube evidence with no song-level inference

## Verification

- `26` deterministic skill and evidence evals passed
- skill governance passed
- diff check passed
- source diff is `924` lines across `11` files, below the repository size cap

## Documentation

- `.claude/skills/brand-deals/SKILL.md` documents the execution workflow
- `references/` documents evidence policy, connector routing, commercial guardrails, and Tim-specific verified canon
- `.agents/skills/brand-deals` and `skills-lock.json` make the skill discoverable to Jovie agents
- `CHANGELOG.md` records the governed skill

## Boundary

The skill uses Composio as a verified agent research lane, not as a production background runtime. It prepares at most five personalized recommendations per day and cannot send outreach, accept commercial terms, or activate a campaign without Tim approval and a recorded deposit.

Companion runtime PR: #15180
Linear: JOV-4578