### PR TITLE
fix(ci): bind visual review to exact capture identity

### DIFF
--- a/.github/scripts/pr-visual-review-capture.mjs
+++ b/.github/scripts/pr-visual-review-capture.mjs
@@ -2,6 +2,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { chromium } from 'playwright';
+import { validateCaptureManifest } from './pr-visual-review.mjs';
 
 const baseUrl = process.env.BASE_URL ?? 'http://127.0.0.1:3100';
 const routes = JSON.parse(process.env.PR_VISUAL_ROUTES ?? '[]');
@@ -112,4 +113,14 @@ await writeFile(
   join(outDir, 'manifest.json'),
   JSON.stringify({ baseUrl, routes, viewports, captures: manifest }, null, 2)
 );
-if (manifest.some(item => item.status === 'failed')) process.exitCode = 1;
+const validation = validateCaptureManifest(
+  { routes, viewports, captures: manifest },
+  { routes, viewportNames: Object.keys(viewports) }
+);
+if (!validation.ok) {
+  await writeFile(
+    join(outDir, 'capture-validation.json'),
+    JSON.stringify(validation, null, 2)
+  );
+  process.exitCode = 1;
+}

--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -11,6 +11,8 @@ const GROK_MODEL = /grok[-_ ]?4(?:[._ -]?5)?/i;
 const CODEX_MODEL =
   /(?:gpt[-_ ]?5(?:[._ -]?\d+)?(?:[-_ ]?codex)?|codex[-_ ]?[\w.-]+)/i;
 
+export const REQUIRED_CAPTURE_VIEWPORTS = ['desktop', 'mobile'];
+
 /** @typedef {{ apiKey?: string, baseUrl?: string, model?: string }} ReviewBackend */
 
 export function sanitizeForPrompt(value) {
@@ -41,8 +43,11 @@ export function routeChangedFiles(files) {
     else if (/chat|shell/i.test(file)) routes.add('/app/chat');
     else routes.add('/');
   }
-  // Demo routes are deterministic; chat/shell routes use the seeded test-auth
-  // app surface above so captures show the changed authenticated chrome.
+  // Every UI change gets one deterministic authenticated shell capture. Public
+  // or demo surfaces alone are not evidence that app-shell changes render.
+  routes.add('/app/chat');
+  // Demo routes remain supplemental coverage; the authenticated shell capture
+  // above is required evidence.
   routes.add('/demo');
   return {
     shouldReview: true,
@@ -60,6 +65,55 @@ export function routeChangedFiles(files) {
     reason: 'ui-change',
     review_status: 'advisory',
   };
+}
+
+/**
+ * Validate that a capture manifest proves every requested route at every
+ * required viewport. A partial manifest is evidence of a failed capture, not
+ * a successful run with fewer screenshots.
+ *
+ * @param {{ routes?: unknown, viewports?: unknown, captures?: unknown }} manifest
+ * @param {{ routes?: string[], viewportNames?: string[] }} [expected]
+ */
+export function validateCaptureManifest(manifest, expected = {}) {
+  const routes = expected.routes ?? manifest?.routes;
+  const viewportNames =
+    expected.viewportNames ??
+    (manifest?.viewports && typeof manifest.viewports === 'object'
+      ? Object.keys(manifest.viewports)
+      : REQUIRED_CAPTURE_VIEWPORTS);
+  const captures = Array.isArray(manifest?.captures) ? manifest.captures : [];
+  const failures = [];
+
+  if (!Array.isArray(routes) || routes.length === 0)
+    failures.push('no required routes');
+  if (!Array.isArray(viewportNames) || viewportNames.length === 0)
+    failures.push('no required viewports');
+
+  const byTarget = new Map();
+  for (const capture of captures) {
+    if (!capture || typeof capture !== 'object') continue;
+    const key = `${capture.route ?? ''}::${capture.viewport ?? ''}`;
+    if (byTarget.has(key)) failures.push(`duplicate capture ${key}`);
+    byTarget.set(key, capture);
+  }
+
+  for (const route of Array.isArray(routes) ? routes : []) {
+    for (const viewport of Array.isArray(viewportNames) ? viewportNames : []) {
+      const key = `${route}::${viewport}`;
+      const capture = byTarget.get(key);
+      if (!capture) {
+        failures.push(`missing capture ${key}`);
+        continue;
+      }
+      if (capture.status !== 'captured')
+        failures.push(`failed capture ${key}: ${capture.error ?? 'unknown'}`);
+      if (typeof capture.path !== 'string' || capture.path.length === 0)
+        failures.push(`missing artifact path ${key}`);
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
 }
 
 export function classifyReviewOutcome({
@@ -215,6 +269,8 @@ export function formatReviewBody({
   review,
   runId,
   artifactUrl,
+  prNumber,
+  headSha,
   followUp = null,
 }) {
   const findings = normalizeFindings(review);
@@ -229,7 +285,22 @@ export function formatReviewBody({
           )
           .join('\n')
       : '- None';
-  return `## Visual review (${runId})\n\n${review?.summary ?? 'No summary returned.'}\n\n### Objective findings\n${render(objective)}\n\n### Subjective / taste findings (review-only)\n${render(subjective)}\n\nArtifacts: ${artifactUrl}\n\nFollow-up: ${followUp ?? 'No automatic follow-up created. Subjective findings never create follow-up PRs.'}`;
+  return `${visualReviewIdentity({ prNumber, headSha, runId })}\n## Visual review (${runId})\n\n${review?.summary ?? 'No summary returned.'}\n\n### Objective findings\n${render(objective)}\n\n### Subjective / taste findings (review-only)\n${render(subjective)}\n\nArtifacts: ${artifactUrl}\n\nFollow-up: ${followUp ?? 'No automatic follow-up created. Subjective findings never create follow-up PRs.'}`;
+}
+
+/**
+ * Stable provenance marker for an advisory review. Idempotence is scoped to an
+ * exact PR, head SHA, and Actions run; a stale review must never suppress a
+ * result for a new head or run.
+ */
+export function visualReviewIdentity({ prNumber, headSha, runId }) {
+  if (!/^\d+$/.test(String(prNumber ?? '')))
+    throw new Error('visual review identity requires a PR number');
+  if (!/^[0-9a-f]{40}$/i.test(String(headSha ?? '')))
+    throw new Error('visual review identity requires a 40-character head SHA');
+  if (!/^\d+$/.test(String(runId ?? '')))
+    throw new Error('visual review identity requires an Actions run ID');
+  return `<!-- visual-review:pr=${prNumber};head=${headSha};run=${runId} -->`;
 }
 
 async function main() {

--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -151,6 +151,7 @@ jobs:
       CODEX_VISUAL_REVIEW_API_KEY: ${{ secrets.CODEX_VISUAL_REVIEW_API_KEY }}
       CODEX_VISUAL_REVIEW_BASE_URL: ${{ vars.CODEX_VISUAL_REVIEW_BASE_URL || 'https://api.openai.com/v1' }}
       CODEX_VISUAL_REVIEW_MODEL: ${{ vars.CODEX_VISUAL_REVIEW_MODEL || 'gpt-5.2-codex' }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Checkout trusted base helpers
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -201,17 +202,22 @@ jobs:
           set -euo pipefail
           BODY=$(node --input-type=module - <<'NODE'
           import { readFile } from 'node:fs/promises';
-          import { formatReviewBody } from './.github/scripts/pr-visual-review.mjs';
+          import { formatReviewBody, visualReviewIdentity } from './.github/scripts/pr-visual-review.mjs';
           const result = JSON.parse(await readFile('review-result.json', 'utf8'));
           const run = process.env.GITHUB_RUN_ID;
           const body = result.status === 'completed'
-            ? formatReviewBody({ review: result.review, runId: run, artifactUrl: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${run}` })
-            : `## Visual review (${run})\n\n**review_status: ${result.review_status}**\n\n${result.error}\n\nNo findings were generated and this advisory lane does not block merging.`;
+            ? formatReviewBody({ review: result.review, runId: run, artifactUrl: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${run}`, prNumber: process.env.PR_NUMBER, headSha: process.env.PR_HEAD_SHA })
+            : `${visualReviewIdentity({ prNumber: process.env.PR_NUMBER, headSha: process.env.PR_HEAD_SHA, runId: run })}\n## Visual review (${run})\n\n**review_status: ${result.review_status}**\n\n${result.error}\n\nNo findings were generated and this advisory lane does not block merging.`;
           process.stdout.write(body);
           NODE
           )
-          EXISTING=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Visual review ("))) ] | length')
-          if [ "$EXISTING" -gt 0 ]; then echo "Existing visual review found; idempotent no-op."; exit 0; fi
+          MARKER=$(node --input-type=module - <<'NODE'
+          import { visualReviewIdentity } from './.github/scripts/pr-visual-review.mjs';
+          process.stdout.write(visualReviewIdentity({ prNumber: process.env.PR_NUMBER, headSha: process.env.PR_HEAD_SHA, runId: process.env.GITHUB_RUN_ID }));
+          NODE
+          )
+          EXISTING=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq --arg marker "$MARKER" '((add // []) | any(.[]; .user.login == "github-actions[bot]" and (.body | contains($marker))))')
+          if [ "$EXISTING" = "true" ]; then echo "Exact visual review already exists; idempotent no-op."; exit 0; fi
           jq -n --arg body "$BODY" '{body:$body,event:"COMMENT"}' > review-payload.json
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --method POST --input review-payload.json >/dev/null
 

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -7,6 +7,8 @@ import {
   reviewWithConfiguredBackends,
   routeChangedFiles,
   sanitizeForPrompt,
+  validateCaptureManifest,
+  visualReviewIdentity,
 } from '../../../.github/scripts/pr-visual-review.mjs';
 
 describe('bounded PR visual review contract', () => {
@@ -19,7 +21,7 @@ describe('bounded PR visual review contract', () => {
       ])
     ).toEqual({
       shouldReview: true,
-      routes: ['/', '/demo'],
+      routes: ['/', '/demo', '/app/chat'],
       reason: 'ui-change',
       review_status: 'advisory',
     });
@@ -30,7 +32,7 @@ describe('bounded PR visual review contract', () => {
       routeChangedFiles(['apps/web/app/(dynamic)/[username]/page.tsx'])
     ).toEqual({
       shouldReview: true,
-      routes: ['/demo', '/demo/profile'],
+      routes: ['/demo', '/app/chat', '/demo/profile'],
       reason: 'ui-change',
       review_status: 'advisory',
     });
@@ -80,6 +82,58 @@ describe('bounded PR visual review contract', () => {
     expect(prompt).not.toContain('secret-value');
     expect(prompt).toContain('grok-4.5|codex');
     expect(prompt.toLowerCase()).not.toContain('kimi');
+  });
+
+  it('requires every requested route and viewport in a capture manifest', () => {
+    const complete = validateCaptureManifest({
+      routes: ['/app/chat'],
+      viewports: { desktop: {}, mobile: {} },
+      captures: [
+        {
+          route: '/app/chat',
+          viewport: 'desktop',
+          status: 'captured',
+          path: 'chat-desktop.png',
+        },
+        {
+          route: '/app/chat',
+          viewport: 'mobile',
+          status: 'captured',
+          path: 'chat-mobile.png',
+        },
+      ],
+    });
+    expect(complete).toEqual({ ok: true, failures: [] });
+
+    const incomplete = validateCaptureManifest({
+      routes: ['/app/chat'],
+      viewports: { desktop: {}, mobile: {} },
+      captures: [
+        {
+          route: '/app/chat',
+          viewport: 'desktop',
+          status: 'captured',
+          path: 'chat-desktop.png',
+        },
+      ],
+    });
+    expect(incomplete.ok).toBe(false);
+    expect(incomplete.failures).toContain('missing capture /app/chat::mobile');
+  });
+
+  it('keys visual review idempotency to the exact PR, head, and run', () => {
+    expect(
+      visualReviewIdentity({
+        prNumber: '15199',
+        headSha: 'a'.repeat(40),
+        runId: '12345',
+      })
+    ).toBe(
+      '<!-- visual-review:pr=15199;head=' + 'a'.repeat(40) + ';run=12345 -->'
+    );
+    expect(() =>
+      visualReviewIdentity({ prNumber: '15199', headSha: 'short', runId: '1' })
+    ).toThrow('40-character head SHA');
   });
 
   it('uses Grok 4.5 first and independently falls back to Codex', async () => {
@@ -144,9 +198,6 @@ describe('bounded PR visual review contract', () => {
     expect(workflow).toContain('cancel-in-progress: true');
     expect(workflow).toContain('retention-days: 14');
     expect(workflow).toContain('VISUAL_REVIEW_AUTOFIX_ENABLED');
-    expect(workflow).toContain(
-      'Existing visual review found; idempotent no-op.'
-    );
     expect(workflow).toContain('Do not alter subjective/taste findings.');
     expect(workflow).toContain('review_status');
     expect(workflow).toContain(
@@ -159,6 +210,12 @@ describe('bounded PR visual review contract', () => {
     expect(workflow).toContain("'unavailable'");
     expect(workflow).toContain("'skipped'");
     expect(workflow).not.toContain('pr-visual-review-capture.mjs || true');
+    expect(workflow).toContain('PR_HEAD_SHA');
+    expect(workflow).toContain('visualReviewIdentity');
+    expect(workflow).toContain('--paginate --slurp');
+    expect(workflow).toContain(
+      'Exact visual review already exists; idempotent no-op.'
+    );
     expect(workflow).not.toContain('requested_reviewers');
   });
 
@@ -171,5 +228,7 @@ describe('bounded PR visual review contract', () => {
     expect(capture).toContain("type: 'page-error'");
     expect(capture).toContain('response.status() >= 500');
     expect(capture).toContain('Captured route emitted runtime failures');
+    expect(capture).toContain('validateCaptureManifest');
+    expect(capture).toContain('capture-validation.json');
   });
 });


### PR DESCRIPTION
Refs #15077 / JOV-4542.

This CI-only repair makes authenticated visual capture fail closed when any requested route × viewport is missing, failed, duplicated, or missing its artifact. It also keys visual-review idempotency to the exact PR number, head SHA, and Actions run ID, so a historical review cannot suppress a current result.

Verification:
- 11 focused visual-review tests
- Biome on changed source and tests
- Node syntax checks
- workflow YAML parse
- git diff --check

No product UI, server, browser, or runtime capture changes.