### PR TITLE
test(ci): guard TestFlight validator references

### DIFF
--- a/scripts/verify-workflow-references.test.mjs
+++ b/scripts/verify-workflow-references.test.mjs
@@ -41,6 +41,28 @@ jobs:
   ]);
 });
 
+test('reports a missing TestFlight validator before release', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-refs-'));
+  temporaryRoots.push(root);
+  fs.mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'apps', 'ios', 'scripts'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.github', 'workflows', 'ios-testflight.yml'),
+    `
+name: iOS TestFlight
+jobs:
+  upload:
+    runs-on: macos-latest
+    steps:
+      - run: bash apps/ios/scripts/validate-testflight-env.sh
+`
+  );
+
+  assert.deepEqual(validateWorkflowReferences(root), [
+    '.github/workflows/ios-testflight.yml:7: command path does not resolve: apps/ios/scripts/validate-testflight-env.sh',
+  ]);
+});
+
 test('passes when workflow references resolve', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'workflow-refs-'));
   temporaryRoots.push(root);


### PR DESCRIPTION
## Summary
- preserve the current Better Auth TestFlight validator path on `main`
- add a focused regression contract proving a missing `apps/ios/scripts/validate-testflight-env.sh` reference fails before release

## Verification
- `node --test scripts/verify-workflow-references.test.mjs`
- `pnpm verify:workflow-references`
- `node --test apps/ios/scripts/validate-testflight-env.test.mjs`
- `bash -n apps/ios/scripts/validate-testflight-env.sh`

The missing validator itself is already present on current `main` from the Better Auth migration; this PR adds the release-gate regression coverage requested for that historical blocker. Do not merge automatically.