### PR TITLE
fix(ui): use canonical logo focus token

### DIFF
--- a/apps/web/components/atoms/JovieLogo.tsx
+++ b/apps/web/components/atoms/JovieLogo.tsx
@@ -72,7 +72,7 @@ export function JovieLogo({
         aria-label={computedAriaLabel}
         target={target}
         rel={target === '_blank' ? 'noopener noreferrer' : undefined}
-        className='rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition-colors'
+        className='rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 transition-colors'
         title={title}
       >
         <div className={wrapperClasses}>{logoContent}</div>

--- a/apps/web/tests/unit/atoms/JovieLogo.test.tsx
+++ b/apps/web/tests/unit/atoms/JovieLogo.test.tsx
@@ -62,6 +62,14 @@ describe('JovieLogo', () => {
     expect(svg).toHaveClass('h-4');
   });
 
+  it('uses the canonical focus token instead of a one-off color', () => {
+    render(<JovieLogo />);
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveClass('focus-visible:ring-focus');
+    expect(link).not.toHaveClass('focus-visible:ring-indigo-500');
+  });
+
   it('has no a11y violations', async () => {
     const { container } = render(<JovieLogo />);
     await expectNoA11yViolations(container);


### PR DESCRIPTION
## Summary
- replace the Jovie logo’s one-off indigo keyboard focus ring with the shared `focus` token
- cover the canonical focus class with a unit regression

## Verification
- `pnpm --filter web exec vitest run tests/unit/atoms/JovieLogo.test.tsx` (9 passed)
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm biome check --write apps/web/components/atoms/JovieLogo.tsx apps/web/tests/unit/atoms/JovieLogo.test.tsx`
- `git diff --check`

<!-- linear-issue-id: ad-hoc -->