### PR TITLE
fix(release): tolerate staging alias metadata shape

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -502,7 +502,7 @@ jobs:
           ./node_modules/.bin/vercel alias set "$deployment_url" staging.jov.ie \
             --scope "$VERCEL_ORG_ID"
 
-      - name: Prove staging alias owns the exact deployment and full SHA
+      - name: Prove staging alias owns the SHA-attested exact deployment
         if: ${{ steps.head.outputs.is_current == 'true' }}
         env:
           DEPLOYMENT_URL_B64: ${{ needs.deploy-staging.outputs.deploy_url_b64 }}
@@ -534,12 +534,12 @@ jobs:
               >/dev/null 2>&1 <<<"$alias_json"; then
               alias_id="$(jq -r '.id' <<<"$alias_json")"
               alias_state="$(jq -r '.readyState | ascii_upcase' <<<"$alias_json")"
-              alias_commit_sha="$(jq -r '.meta.githubCommitSha // ""' <<<"$alias_json")"
               if [ "$alias_id" = "$EXPECTED_DEPLOYMENT_ID" ] &&
-                [ "$alias_state" = "READY" ] &&
-                [[ "$alias_commit_sha" =~ ^[0-9a-f]{40}$ ]] &&
-                [ "$alias_commit_sha" = "$EXPECTED_COMMIT_SHA" ]; then
-                echo "staging.jov.ie owns exact READY deployment $alias_id at $alias_commit_sha."
+                [ "$alias_state" = "READY" ]; then
+                # resolve-deployment has already bound this ID to the full
+                # EXPECTED_COMMIT_SHA via Vercel's deployment API. The alias
+                # inspect shape does not consistently expose deployment meta.
+                echo "staging.jov.ie owns SHA-attested exact READY deployment $alias_id at $EXPECTED_COMMIT_SHA."
                 break
               fi
             fi

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -2222,17 +2222,21 @@ describe('canary health gate workflow', () => {
     );
     const aliasProofStep = getStepBlock(
       aliasJob,
-      'Prove staging alias owns the exact deployment and full SHA'
+      'Prove staging alias owns the SHA-attested exact deployment'
+    );
+    expect(aliasProofStep).toContain('resolve-deployment');
+    expect(aliasProofStep).toContain(
+      'VERCEL_CANDIDATE_DEPLOYMENT_ID="$EXPECTED_DEPLOYMENT_ID"'
     );
     expect(aliasProofStep).toContain(
-      'alias_commit_sha="$(jq -r \'.meta.githubCommitSha // ""\' <<<"$alias_json")"'
+      'EXPECTED_COMMIT_SHA: ${{ inputs.expected_sha }}'
     );
     expect(aliasProofStep).toContain(
-      '[[ "$alias_commit_sha" =~ ^[0-9a-f]{40}$ ]]'
+      '[ "$alias_id" = "$EXPECTED_DEPLOYMENT_ID" ]'
     );
-    expect(aliasProofStep).toContain(
-      '[ "$alias_commit_sha" = "$EXPECTED_COMMIT_SHA" ]'
-    );
+    expect(aliasProofStep).toContain('[ "$alias_state" = "READY" ]');
+    expect(aliasProofStep).not.toContain('alias_commit_sha=');
+    expect(aliasProofStep).not.toContain('.meta.githubCommitSha');
     expect(oauthStep).toContain('BASE_URL: https://staging.jov.ie');
     expect(oauthStep).toContain(
       'EXPECTED_VERCEL_ALIAS_ORIGIN: https://staging.jov.ie'


### PR DESCRIPTION
## Incident
Production Controller run [30510647934](https://github.com/JovieInc/Jovie/actions/runs/30510647934) aliased `staging.jov.ie` successfully, but failed after 15 retries because `vercel inspect staging.jov.ie --format=json` did not expose `.meta.githubCommitSha`.

## Fix
- preserve the fail-closed `resolve-deployment` API proof of candidate ID, project, READY state, and the full expected SHA
- prove the alias resolves to that already SHA-attested exact READY deployment by ID
- avoid treating the provider CLI alias-inspection metadata shape as deployment provenance

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts` — 97 passed
- `pnpm exec biome check .github/workflows/production-release.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `pnpm exec actionlint .github/workflows/production-release.yml`
- `git diff --check`

Follow-up to merged JOV-4579 / #15167. Draft and gated pending source CI.