### PR TITLE
fix(release): repair staging alias SHA provenance

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -517,6 +517,7 @@ jobs:
           exact_json="$(
             VERCEL_CANDIDATE_DEPLOYMENT_URL="$deployment_url" \
             VERCEL_CANDIDATE_DEPLOYMENT_ID="$EXPECTED_DEPLOYMENT_ID" \
+            VERCEL_INCLUDE_COMMIT_SHA=true \
             VERCEL_DEPLOYMENT_MAX_PAGES=5 \
             VERCEL_API_TIMEOUT_MS=120000 \
             VERCEL_DEPLOYMENT_POLL_INTERVAL_MS=3000 \
@@ -526,6 +527,12 @@ jobs:
             echo "::error::Exact staging deployment identity did not converge."
             exit 1
           }
+          candidate_commit_sha="$(jq -r '.commitSha // ""' <<<"$exact_json")"
+          [[ "$candidate_commit_sha" =~ ^[0-9a-f]{40}$ ]] &&
+            [ "$candidate_commit_sha" = "$EXPECTED_COMMIT_SHA" ] || {
+              echo "::error::Exact staging deployment did not expose the expected full commit SHA."
+              exit 1
+            }
 
           for attempt in $(seq 1 15); do
             alias_json="$(./node_modules/.bin/vercel inspect staging.jov.ie \
@@ -534,12 +541,9 @@ jobs:
               >/dev/null 2>&1 <<<"$alias_json"; then
               alias_id="$(jq -r '.id' <<<"$alias_json")"
               alias_state="$(jq -r '.readyState | ascii_upcase' <<<"$alias_json")"
-              alias_commit_sha="$(jq -r '.meta.githubCommitSha // ""' <<<"$alias_json")"
               if [ "$alias_id" = "$EXPECTED_DEPLOYMENT_ID" ] &&
-                [ "$alias_state" = "READY" ] &&
-                [[ "$alias_commit_sha" =~ ^[0-9a-f]{40}$ ]] &&
-                [ "$alias_commit_sha" = "$EXPECTED_COMMIT_SHA" ]; then
-                echo "staging.jov.ie owns exact READY deployment $alias_id at $alias_commit_sha."
+                [ "$alias_state" = "READY" ]; then
+                echo "staging.jov.ie owns exact READY deployment $alias_id at $candidate_commit_sha."
                 break
               fi
             fi

--- a/apps/web/scripts/lighthouse-vercel-bypass.test.ts
+++ b/apps/web/scripts/lighthouse-vercel-bypass.test.ts
@@ -1077,6 +1077,43 @@ describe('origin-bound Vercel protection bypass', () => {
     }
   });
 
+  it('returns the validated exact SHA only when an explicit caller requests it', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          deployments: [
+            {
+              uid: 'dpl_exact',
+              url: DEPLOYMENT_URL,
+              projectId: 'prj_jovie',
+              readyState: 'READY',
+              meta: { githubCommitSha: EXPECTED_SHA },
+            },
+          ],
+          pagination: { next: null },
+        })
+      ),
+    });
+
+    await expect(
+      resolveAuthorizedVercelDeployment({
+        fetchImpl,
+        token: 'sentinel-vercel-token',
+        orgId: 'team_jovie',
+        projectId: 'prj_jovie',
+        commitSha: EXPECTED_SHA,
+        candidateUrl: DEPLOYMENT_URL,
+        candidateId: 'dpl_exact',
+        includeCommitSha: true,
+      })
+    ).resolves.toEqual({
+      id: 'dpl_exact',
+      url: DEPLOYMENT_URL.slice(0, -1),
+      commitSha: EXPECTED_SHA,
+    });
+  });
+
   it('treats an exact deployment ID with a not-yet-indexed URL as transient', async () => {
     const apiResponse = (deployments: unknown[]) => ({
       status: 200,

--- a/apps/web/scripts/vercel-protected-origin.cjs
+++ b/apps/web/scripts/vercel-protected-origin.cjs
@@ -1155,6 +1155,7 @@ async function resolveAuthorizedVercelDeployment({
   commitSha = process.env.EXPECTED_COMMIT_SHA ?? process.env.COMMIT_SHA,
   candidateUrl = process.env.VERCEL_CANDIDATE_DEPLOYMENT_URL,
   candidateId = process.env.VERCEL_CANDIDATE_DEPLOYMENT_ID,
+  includeCommitSha = process.env.VERCEL_INCLUDE_COMMIT_SHA === 'true',
   allowMissingCommitSha = process.env.VERCEL_ALLOW_MISSING_COMMIT_SHA ===
     'true',
   maxPages = process.env.VERCEL_DEPLOYMENT_MAX_PAGES ??
@@ -1377,9 +1378,10 @@ async function resolveAuthorizedVercelDeployment({
           if (state === 'READY') {
             matchingReady.set(id, { id, url: urlOrigin });
             if (exactCandidateId || exactCandidateUrl) {
-              return allowMissingCommitSha
-                ? { id, url: urlOrigin, commitSha: observedSha }
-                : { id, url: urlOrigin };
+              if (allowMissingCommitSha || includeCommitSha) {
+                return { id, url: urlOrigin, commitSha: observedSha };
+              }
+              return { id, url: urlOrigin };
             }
           } else {
             matchingTransient = true;

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -2224,15 +2224,17 @@ describe('canary health gate workflow', () => {
       aliasJob,
       'Prove staging alias owns the exact deployment and full SHA'
     );
+    expect(aliasProofStep).toContain('VERCEL_INCLUDE_COMMIT_SHA=true');
     expect(aliasProofStep).toContain(
-      'alias_commit_sha="$(jq -r \'.meta.githubCommitSha // ""\' <<<"$alias_json")"'
+      'candidate_commit_sha="$(jq -r \'.commitSha // ""\' <<<"$exact_json")"'
     );
     expect(aliasProofStep).toContain(
-      '[[ "$alias_commit_sha" =~ ^[0-9a-f]{40}$ ]]'
+      '[[ "$candidate_commit_sha" =~ ^[0-9a-f]{40}$ ]]'
     );
     expect(aliasProofStep).toContain(
-      '[ "$alias_commit_sha" = "$EXPECTED_COMMIT_SHA" ]'
+      '[ "$candidate_commit_sha" = "$EXPECTED_COMMIT_SHA" ]'
     );
+    expect(aliasProofStep).not.toContain('alias_commit_sha=');
     expect(oauthStep).toContain('BASE_URL: https://staging.jov.ie');
     expect(oauthStep).toContain(
       'EXPECTED_VERCEL_ALIAS_ORIGIN: https://staging.jov.ie'


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4589 -->

## Summary
- resolve the exact candidate deployment through the Vercel deployment API and request its validated full SHA
- prove `staging.jov.ie` resolves to that exact READY deployment ID without relying on alias-inspector metadata that Vercel does not expose
- add resolver and workflow contract regressions

## Evidence
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts scripts/lighthouse-vercel-bypass.test.ts` — 156/156 passed
- `pnpm biome check --write .github/workflows/production-release.yml apps/web/scripts/vercel-protected-origin.cjs apps/web/scripts/lighthouse-vercel-bypass.test.ts apps/web/tests/unit/ci/deploy-workflow.test.ts` — passed
- `pnpm exec actionlint .github/workflows/production-release.yml` — passed
- `pnpm --filter @jovie/web run test:bug-to-test` — config/release classification, not applicable

## Failure boundary
Controller [30510647934](https://github.com/JovieInc/Jovie/actions/runs/30510647934) successfully assigned the alias to `dpl_DUNWRiz8pN5d2KqxhMirr13Jwrhs`, then failed only because `vercel inspect staging.jov.ie --format=json` omitted `meta.githubCommitSha`. This keeps both requirements fail-closed by joining the alias result on exact deployment ID with the deployment API’s full SHA.