### PR TITLE
fix(ci): route visual capture to deterministic surfaces

### DIFF
--- a/.github/scripts/pr-visual-review-capture.mjs
+++ b/.github/scripts/pr-visual-review-capture.mjs
@@ -48,25 +48,59 @@ try {
         }
       });
       const url = new URL(route, baseUrl).toString();
-      if (route.startsWith('/app/')) {
-        await page.goto(
-          new URL(
-            '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat',
-            baseUrl
-          ).toString(),
-          { waitUntil: 'commit', timeout: 45_000 }
-        );
-      }
       const safeRoute =
         route.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'home';
       const path = join(outDir, `${safeRoute}-${viewportName}.png`);
       try {
+        if (route.startsWith('/app/')) {
+          const authEntryUrl = new URL(
+            `/api/dev/test-auth/enter?persona=creator-ready&redirect=${encodeURIComponent(route)}`,
+            baseUrl
+          );
+          const authResponse = await context.request.get(
+            authEntryUrl.toString(),
+            {
+              maxRedirects: 0,
+              timeout: 45_000,
+            }
+          );
+          if (authResponse.status() !== 303) {
+            throw new Error(
+              `Test-auth returned HTTP ${authResponse.status()}; expected HTTP 303.`
+            );
+          }
+          const location = authResponse.headers().location;
+          if (!location)
+            throw new Error(
+              'Test-auth 303 did not include a redirect location.'
+            );
+          const destination = new URL(location, baseUrl);
+          const expected = new URL(url);
+          if (destination.origin !== expected.origin)
+            throw new Error('Test-auth redirected outside capture origin.');
+          if (destination.pathname !== expected.pathname) {
+            throw new Error(
+              `Test-auth redirect target ${destination.pathname} did not match requested route ${expected.pathname}.`
+            );
+          }
+        }
         const response = await page.goto(url, {
           waitUntil: 'networkidle',
           timeout: 45_000,
         });
         if (!response || !response.ok())
           throw new Error(`HTTP ${response?.status() ?? 'unknown'}`);
+        if (route.startsWith('/app/')) {
+          const expected = new URL(url);
+          const final = new URL(page.url());
+          if (
+            final.origin !== expected.origin ||
+            final.pathname !== expected.pathname
+          )
+            throw new Error(
+              `Test-auth handoff ended at ${page.url()}, expected ${expected.toString()}.`
+            );
+        }
         const pageText = (await page.locator('body').innerText()).trim();
         if (!pageText || /\b404\b|content not found/i.test(pageText))
           throw new Error('Captured route did not render a meaningful surface');

--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -12,6 +12,9 @@ const CODEX_MODEL =
   /(?:gpt[-_ ]?5(?:[._ -]?\d+)?(?:[-_ ]?codex)?|codex[-_ ]?[\w.-]+)/i;
 
 export const REQUIRED_CAPTURE_VIEWPORTS = ['desktop', 'mobile'];
+const PUBLIC_HOME_CAPTURE_ROUTE = '/';
+const PUBLIC_PROFILE_CAPTURE_ROUTE = '/demo/showcase/public-profile';
+const AUTHENTICATED_CHAT_CAPTURE_ROUTE = '/app/chat';
 
 /** @typedef {{ apiKey?: string, baseUrl?: string, model?: string }} ReviewBackend */
 
@@ -37,31 +40,20 @@ export function routeChangedFiles(files) {
     };
   const routes = new Set();
   for (const file of changed) {
-    if (/admin|console|ops/i.test(file)) routes.add('/demo/admin');
+    // Route only to fixtures that are present in the production build. Generic
+    // UI changes belong on the public home surface; `/demo` and `/demo/admin`
+    // require data/authentication that the capture runner intentionally does
+    // not invent.
+    if (/admin|console|ops/i.test(file)) routes.add(PUBLIC_HOME_CAPTURE_ROUTE);
     else if (/dynamic|profile|username|artist/i.test(file))
-      routes.add('/demo/profile');
-    else if (/chat|shell/i.test(file)) routes.add('/app/chat');
-    else routes.add('/');
+      routes.add(PUBLIC_PROFILE_CAPTURE_ROUTE);
+    else if (/chat|shell/i.test(file))
+      routes.add(AUTHENTICATED_CHAT_CAPTURE_ROUTE);
+    else routes.add(PUBLIC_HOME_CAPTURE_ROUTE);
   }
-  // Every UI change gets one deterministic authenticated shell capture. Public
-  // or demo surfaces alone are not evidence that app-shell changes render.
-  routes.add('/app/chat');
-  // Demo routes remain supplemental coverage; the authenticated shell capture
-  // above is required evidence.
-  routes.add('/demo');
   return {
     shouldReview: true,
-    routes: [...routes].sort((a, b) =>
-      a === '/'
-        ? -1
-        : b === '/'
-          ? 1
-          : a === '/demo'
-            ? -1
-            : b === '/demo'
-              ? 1
-              : a.localeCompare(b)
-    ),
+    routes: [...routes].sort((a, b) => a.localeCompare(b)),
     reason: 'ui-change',
     review_status: 'advisory',
   };

--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -95,14 +95,18 @@ jobs:
           CLERK_SECRET_KEY: sk_test_mock
           NEXT_DISABLE_TOOLBAR: '1'
           NEXT_PUBLIC_CLERK_PROXY_DISABLED: '1'
+          NEXT_PUBLIC_CLERK_MOCK: '1'
+          NEXT_PUBLIC_E2E_MODE: '1'
+          VERCEL_ENV: development
           E2E_USE_TEST_AUTH_BYPASS: '1'
+          E2E_TEST_AUTH_PERSONA: creator-ready
           E2E_CLERK_USER_ID: user_test
 
       - name: Start production server
         if: steps.route.outputs.should_review == 'true'
         run: |
           set -euo pipefail
-          (cd apps/web && PORT=3100 DATABASE_URL=postgresql://localhost/noop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock CLERK_SECRET_KEY=sk_test_mock NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 E2E_USE_TEST_AUTH_BYPASS=1 pnpm run start) > "$RUNNER_TEMP/pr-visual-server.log" 2>&1 &
+          (cd apps/web && PORT=3100 DATABASE_URL=postgresql://localhost/noop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock CLERK_SECRET_KEY=sk_test_mock NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_E2E_MODE=1 VERCEL_ENV=development E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_CLERK_USER_ID=user_test HOSTNAME=localhost NEXT_PUBLIC_APP_URL=http://127.0.0.1:3100 BETTER_AUTH_URL=http://127.0.0.1:3100 NEXT_PUBLIC_BETTER_AUTH_URL=http://127.0.0.1:3100 pnpm run start) > "$RUNNER_TEMP/pr-visual-server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/pr-visual-server.pid"
           for _ in $(seq 1 30); do curl -fsS http://127.0.0.1:3100 >/dev/null 2>&1 && exit 0; sleep 2; done
           cat "$RUNNER_TEMP/pr-visual-server.log"

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -12,7 +12,7 @@ import {
 } from '../../../.github/scripts/pr-visual-review.mjs';
 
 describe('bounded PR visual review contract', () => {
-  it('routes UI changes to the changed surface and always captures desktop/mobile', () => {
+  it('routes UI changes only to deterministic public surfaces', () => {
     expect(
       routeChangedFiles([
         'apps/web/app/(home)/page.tsx',
@@ -21,21 +21,24 @@ describe('bounded PR visual review contract', () => {
       ])
     ).toEqual({
       shouldReview: true,
-      routes: ['/', '/demo', '/app/chat'],
+      routes: ['/'],
       reason: 'ui-change',
       review_status: 'advisory',
     });
   });
 
-  it('routes known profile and admin surfaces without broadening to the whole app', () => {
+  it('routes known profiles to the real fixture and never invents demo routes', () => {
     expect(
       routeChangedFiles(['apps/web/app/(dynamic)/[username]/page.tsx'])
     ).toEqual({
       shouldReview: true,
-      routes: ['/demo', '/app/chat', '/demo/profile'],
+      routes: ['/demo/showcase/public-profile'],
       reason: 'ui-change',
       review_status: 'advisory',
     });
+    expect(routeChangedFiles(['apps/web/app/(admin)/page.tsx']).routes).toEqual(
+      ['/']
+    );
     expect(routeChangedFiles(['scripts/format.mjs'])).toEqual({
       shouldReview: false,
       routes: [],
@@ -63,10 +66,36 @@ describe('bounded PR visual review contract', () => {
       routeChangedFiles(['apps/web/components/organisms/AppShellFrame.tsx'])
     ).toEqual({
       shouldReview: true,
-      routes: ['/demo', '/app/chat'],
+      routes: ['/app/chat'],
       reason: 'ui-change',
       review_status: 'advisory',
     });
+  });
+
+  it('validates authenticated capture handoff before loading an app route', () => {
+    const capture = readFileSync(
+      '.github/scripts/pr-visual-review-capture.mjs',
+      'utf8'
+    );
+    expect(capture).toContain('context.request.get(');
+    expect(capture).toContain('authEntryUrl.toString()');
+    expect(capture).toContain('maxRedirects: 0');
+    expect(capture).toContain('Test-auth returned HTTP');
+    expect(capture).toContain(
+      'Test-auth 303 did not include a redirect location.'
+    );
+    expect(capture).toContain('Test-auth handoff ended at');
+  });
+
+  it('uses the canonical test-auth environment in the capture workflow', () => {
+    const workflow = readFileSync(
+      '.github/workflows/pr-visual-review.yml',
+      'utf8'
+    );
+    expect(workflow).toContain('VERCEL_ENV: development');
+    expect(workflow).toContain("NEXT_PUBLIC_E2E_MODE: '1'");
+    expect(workflow).toContain('E2E_TEST_AUTH_PERSONA: creator-ready');
+    expect(workflow).toContain('HOSTNAME=localhost');
   });
 
   it('keeps prompt input bounded and removes credential-shaped values', () => {


### PR DESCRIPTION
Recovers the #15077 / JOV-4537 capture-harness contract exposed by #15185.

- routes only changed surfaces with deterministic fixtures: public home, real public-profile showcase, or chat shell
- removes universal `/demo` and `/app/chat` captures that produced false failures for unrelated UI work
- configures canonical test-auth environment and records/validates the auth 303, Location, and final app destination before an authenticated capture
- preserves fail-closed capture manifests; no product UI changes

Validation:
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/pr-visual-review.test.mjs` (13 passed)
- `pnpm exec biome check .github/scripts/pr-visual-review.mjs .github/scripts/pr-visual-review-capture.mjs scripts/lib/__tests__/pr-visual-review.test.mjs`
- `git diff --check`

No browser/server proof was run: this is a CI-harness-only repair. The PR remains gated until normal CI is clean.