### PR TITLE
fix(shell): preserve sidebar thread title track

### DIFF
--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -30,8 +30,8 @@ interface SidebarNavChromeOptions {
   readonly collapsed?: boolean;
   readonly nested?: boolean;
   readonly tight?: boolean;
-  /** Use a fixed 20px action slot instead of the variable badge track. */
-  readonly compactActionSlot?: boolean;
+  /** An absolute trailing action layers over the label's faded edge. */
+  readonly trailingOverlay?: boolean;
   readonly tone?: 'default' | 'primary';
   readonly className?: string;
 }
@@ -68,7 +68,7 @@ export function getSidebarNavRowClassName({
   collapsed,
   nested,
   tight,
-  compactActionSlot,
+  trailingOverlay,
   tone = 'default',
   className,
 }: SidebarNavChromeOptions) {
@@ -81,11 +81,8 @@ export function getSidebarNavRowClassName({
     collapsed
       ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center'
       : cn(
-          // Most rows reserve a variable badge track. Thread rows with a
-          // single icon action opt into the exact target width instead, so
-          // their label gets the remaining grid space deterministically.
-          compactActionSlot
-            ? 'grid-cols-[22px_minmax(0,1fr)_20px]'
+          trailingOverlay
+            ? 'grid-cols-[22px_minmax(0,1fr)]'
             : 'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
           nonCollapsedSize,
           'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -24,7 +24,7 @@ const threads: SidebarThread[] = [
 ];
 
 describe('SidebarThreadsSection', () => {
-  it('keeps a long thread title on the full middle track when chat actions are present', () => {
+  it('uses the full middle track at rest and layers chat actions over its faded edge', () => {
     const title =
       'Reply with exactly one short sentence confirming the artist release plan';
 
@@ -51,13 +51,19 @@ describe('SidebarThreadsSection', () => {
     expect(label).toHaveClass('justify-self-stretch', 'overflow-hidden');
     expect(label).not.toHaveClass('justify-self-start', 'truncate');
     expect(label.className).toContain('mask-image:linear-gradient');
-    expect(screen.getByRole('link', { name: title })).toHaveClass(
-      'grid-cols-[22px_minmax(0,1fr)_20px]'
+    const row = screen.getByRole('link', { name: title });
+    const action = screen.getByRole('button', {
+      name: `Chat Actions for ${title}`,
+    });
+
+    expect(row).toHaveClass('grid-cols-[22px_minmax(0,1fr)]');
+    expect(row).not.toHaveClass(
+      'grid-cols-[22px_minmax(0,1fr)_20px]',
+      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
+      'pr-8'
     );
-    expect(screen.getByRole('link', { name: title })).not.toHaveClass('pr-8');
-    expect(
-      screen.getByRole('button', { name: `Chat Actions for ${title}` })
-    ).toHaveClass('right-2.5');
+    expect(action).toHaveClass('right-2.5', 'group-hover/thread:bg-surface-0');
+    expect(action).toHaveClass('absolute', 'opacity-0');
   });
 
   it('renders dense thread links with canonical shell row state', () => {

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -205,7 +205,7 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
     getSidebarNavRowClassName({
       active,
       tight,
-      compactActionSlot: Boolean(onThreadContextMenu),
+      trailingOverlay: Boolean(onThreadContextMenu),
     }),
     'text-left',
     active
@@ -278,11 +278,12 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
             onClick={e => onThreadContextMenu(e, thread)}
             aria-label={`Chat Actions for ${thread.title}`}
             className={cn(
-              // Match the canonical 20px trailing grid track. The action is
-              // still visually quiet until intent, but its slot is always
-              // reserved so it never shortens the title track.
-              'absolute right-2.5 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
-              'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
+              // The action deliberately sits above the label instead of
+              // owning a permanent grid track. The title can use the full
+              // middle column at rest; on intent, its existing right-edge
+              // fade runs beneath this opaque action surface.
+              'absolute right-2.5 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:bg-surface-0 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
+              'opacity-0 group-hover/thread:opacity-100 group-hover/thread:bg-surface-0 focus-visible:opacity-100'
             )}
           >
             <MoreHorizontal


### PR DESCRIPTION
## Summary
- let thread labels use the complete middle track while the three-dot action is hidden
- layer the action above the label’s existing cinematic fade only on hover or keyboard focus
- cover the no-reserved-track geometry and overlay behavior with focused regressions

## Verification
- `pnpm --filter web exec vitest run components/shell/SidebarThreadsSection.test.tsx components/shell/SidebarNavItem.test.tsx` (9/9)
- `pnpm exec biome check apps/web/components/shell/SidebarNavItem.tsx apps/web/components/shell/SidebarThreadsSection.tsx apps/web/components/shell/SidebarThreadsSection.test.tsx`
- `git diff --check`

## Evidence boundary
Source-only change. Authenticated staging screenshots and design review remain required before queue admission.

No Linear issue — ad-hoc bounded regression follow-up.