### PR TITLE
fix(shell): relocate Search into sidebar [JOV-4574]

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -127,7 +127,7 @@ function formatTaskBadge(
   return count > 99 ? '99+' : count;
 }
 
-export function DashboardNav(_: DashboardNavProps) {
+export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   const { inboxNavigation, selectedProfile } = useDashboardData();
   const { isMobile, openMobile, state: sidebarState } = useSidebar();
   const pathname = usePathname();
@@ -492,7 +492,18 @@ export function DashboardNav(_: DashboardNavProps) {
                       {renderSection(section.items)}
                     </SidebarCollapsibleGroup>
                   ) : (
-                    renderSection(section.items)
+                    <>
+                      {renderSection(section.items.slice(0, 1))}
+                      {index === 0 && searchSurface ? (
+                        <div
+                          data-sidebar-search-slot='true'
+                          className='my-1.5 h-7 shrink-0 group-data-[collapsible=icon]:hidden'
+                        >
+                          {searchSurface}
+                        </div>
+                      ) : null}
+                      {renderSection(section.items.slice(1))}
+                    </>
                   )}
                 </div>
               ))}

--- a/apps/web/components/features/dashboard/dashboard-nav/types.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/types.ts
@@ -14,4 +14,6 @@ export interface NavItem {
 
 export interface DashboardNavProps {
   readonly collapsed?: boolean;
+  /** Shell-owned surface placed after the elevated New Chat action. */
+  readonly children?: ReactNode;
 }

--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -7,8 +7,6 @@ import { useComposerFocus } from '@/components/features/chat/Composer';
 import { SidebarCollapseButton } from '@/components/molecules/sidebar-collapse-button/SidebarCollapseButton';
 import { SidebarProvider, useSidebar } from '@/components/organisms/Sidebar';
 import { UnifiedSidebar } from '@/components/organisms/UnifiedSidebar';
-import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchSurfaceFromContext';
-import { useOptionalHeaderActions } from '@/contexts/HeaderActionsContext';
 import { useRightPanel } from '@/contexts/RightPanelContext';
 import { DashboardHeader } from '@/features/dashboard/organisms/DashboardHeader';
 import { DashboardMobileTabs } from '@/features/dashboard/organisms/DashboardMobileTabs';
@@ -57,7 +55,6 @@ function AuthShellInner({
   const { isComposerFocused } = useComposerFocus();
   const rightPanel = useRightPanel();
   const previewPanelState = usePreviewPanelState();
-  const headerActionsState = useOptionalHeaderActions();
   const sidebarTrigger = isMobile ? null : sidebarState === 'closed' ? (
     <SidebarCollapseButton />
   ) : null;
@@ -91,11 +88,6 @@ function AuthShellInner({
       ) : null,
     [section, showCustomerMobileTabs]
   );
-  const searchSurface = useMemo(() => {
-    return headerActionsState ? (
-      <HeaderSearchSurfaceFromContext className='w-full sm:w-55 lg:w-65' />
-    ) : null;
-  }, [headerActionsState]);
   const audioPlayer = useMemo(() => <PersistentAudioBar />, []);
 
   return (
@@ -108,8 +100,6 @@ function AuthShellInner({
             sidebarTrigger={sidebarTrigger}
             breadcrumbSuffix={headerBadge}
             action={headerAction}
-            searchSurface={searchSurface}
-            isSearchActive={headerActionsState?.isSearchOpen ?? false}
             mobileProfileSlot={
               section === 'ov' || section === 'admin' ? null : (
                 <MobileProfileDrawer onOpen={previewPanelState.toggle} />

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/organisms/Sidebar';
 import { UserButton } from '@/components/organisms/user-button';
 import { getVersionUpdateTitle } from '@/components/shell/getVersionUpdateTitle';
+import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchSurfaceFromContext';
 import { InstallBanner } from '@/components/shell/InstallBanner';
 import { BASE_URL } from '@/constants/domains';
 import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
@@ -507,7 +508,9 @@ export function UnifiedSidebar({
             ) : sidebarOverride ? (
               sidebarOverride.content
             ) : (
-              <DashboardNav />
+              <DashboardNav>
+                <HeaderSearchSurfaceFromContext className='w-full max-w-none sm:w-full lg:w-full' />
+              </DashboardNav>
             )}
           </SidebarGroupContent>
         </SidebarGroup>

--- a/apps/web/tests/unit/app/command-palette-search-guard.test.ts
+++ b/apps/web/tests/unit/app/command-palette-search-guard.test.ts
@@ -19,20 +19,25 @@ describe('command palette search shell guard', () => {
     expect(source).not.toContain('isHeaderSearchActive=');
   });
 
-  it('keeps AuthShell owning the shared header search surface', () => {
-    const source = readSource('components/organisms/AuthShell.tsx');
-
-    expect(source).not.toContain('headerSearchSurface');
-    expect(source).not.toContain('isHeaderSearchActive');
-    expect(source).toContain('HeaderSearchSurfaceFromContext');
-    expect(source).toContain('useOptionalHeaderActions');
-    expect(source).toContain('searchSurface={searchSurface}');
-    expect(source).toContain(
-      'isSearchActive={headerActionsState?.isSearchOpen ?? false}'
+  it('keeps the shared search surface in the canonical sidebar only', () => {
+    const authShell = readSource('components/organisms/AuthShell.tsx');
+    const sidebar = readSource('components/organisms/UnifiedSidebar.tsx');
+    const navigation = readSource(
+      'components/features/dashboard/dashboard-nav/DashboardNav.tsx'
     );
+
+    expect(authShell).not.toContain('HeaderSearchSurfaceFromContext');
+    expect(authShell).not.toContain('useOptionalHeaderActions');
+    expect(authShell).not.toContain('searchSurface=');
+    expect(authShell).not.toContain('isSearchActive=');
+    expect(sidebar).toContain('HeaderSearchSurfaceFromContext');
+    expect(sidebar).toMatch(
+      /<DashboardNav>[\s\S]*?<HeaderSearchSurfaceFromContext[\s\S]*?<\/DashboardNav>/
+    );
+    expect(navigation).toContain("data-sidebar-search-slot='true'");
   });
 
-  it('keeps Search exclusively in the shared header surface', () => {
+  it('keeps Search out of duplicate navigation rows', () => {
     const source = readSource(
       'components/features/dashboard/dashboard-nav/DashboardNav.tsx'
     );

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -46,7 +46,15 @@ vi.mock('@/hooks/useClerkSafe', () => ({
 }));
 
 vi.mock('@/features/dashboard/dashboard-nav', () => ({
-  DashboardNav: () => <div data-testid='dashboard-nav' />,
+  DashboardNav: ({ children }: { readonly children?: ReactNode }) => (
+    <div data-testid='dashboard-nav'>{children}</div>
+  ),
+}));
+
+vi.mock('@/components/shell/HeaderSearchSurfaceFromContext', () => ({
+  HeaderSearchSurfaceFromContext: () => (
+    <button type='button'>Search Sidebar</button>
+  ),
 }));
 
 vi.mock('@/components/organisms/user-button', () => ({
@@ -166,6 +174,9 @@ describe('UnifiedSidebar library route', () => {
     expect(screen.queryByText('Loading Library')).not.toBeInTheDocument();
     expect(screen.getByTestId('dashboard-nav')).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Search Sidebar' })
+    ).toBeInTheDocument();
+    expect(
       screen.queryByRole('link', { name: 'Back to App' })
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('user-button')).toBeInTheDocument();
@@ -219,6 +230,9 @@ describe('UnifiedSidebar library route', () => {
       'href',
       APP_ROUTES.CHAT
     );
+    expect(
+      screen.queryByRole('button', { name: 'Search Sidebar' })
+    ).not.toBeInTheDocument();
   });
 
   it('omits header New Conversation and the web collapse control in Electron dashboard mode', () => {
@@ -317,6 +331,9 @@ describe('UnifiedSidebar library route', () => {
       }))
     );
     expect(screen.queryByTestId('dashboard-nav')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Search Sidebar' })
+    ).not.toBeInTheDocument();
     expect(screen.queryByTestId('user-button')).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Sign Out' })

--- a/apps/web/tests/unit/components/organisms/sidebar-height-chain.test.tsx
+++ b/apps/web/tests/unit/components/organisms/sidebar-height-chain.test.tsx
@@ -35,7 +35,9 @@ describe('sidebar full-height flex chain (JOV-3960)', () => {
     expect(unifiedSource).toContain(
       "SidebarGroupContent className='flex min-h-0 flex-1 flex-col'"
     );
-    expect(unifiedSource).toContain('<DashboardNav />');
+    expect(unifiedSource).toMatch(
+      /<DashboardNav>[\s\S]*?HeaderSearchSurfaceFromContext[\s\S]*?<\/DashboardNav>/
+    );
     expect(unifiedSource).toContain('SidebarFooter');
     expect(unifiedSource).toMatch(/SidebarFooter className='mt-auto/);
   });

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -65,6 +65,25 @@ describe('DashboardNav', () => {
     expect(queryByRole('link', { name: 'Settings' })).toBeNull();
   });
 
+  it('places the shell search slot after New Chat and before remaining navigation', () => {
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      navChildren: <button type='button'>Search</button>,
+    });
+
+    const newChat = getByRole('link', { name: 'New Chat' });
+    const search = getByRole('button', { name: 'Search' });
+    const inbox = getByRole('link', { name: 'Inbox' });
+
+    expect(
+      newChat.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      search.compareDocumentPosition(inbox) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(search.parentElement).toHaveClass('h-7', 'shrink-0');
+  });
+
   it('keeps the canonical six visible without rollout state', () => {
     const { container } = renderDashboardNav({
       renderFn: fastRender,

--- a/apps/web/tests/utils/dashboard-nav-test-support.tsx
+++ b/apps/web/tests/utils/dashboard-nav-test-support.tsx
@@ -199,12 +199,14 @@ export function renderDashboardNav({
   overrides = {},
   sidebarProps = {},
   appFlags = {},
+  navChildren = null,
   children = null,
 }: Readonly<{
   renderFn?: RenderDashboardNavFn;
   overrides?: Partial<DashboardData>;
   sidebarProps?: ComponentProps<typeof SidebarProvider>;
   appFlags?: Partial<AppFlagSnapshot>;
+  navChildren?: ReactNode;
   children?: ReactNode;
 }>) {
   const value: DashboardData = { ...baseDashboardData, ...overrides };
@@ -218,7 +220,7 @@ export function renderDashboardNav({
       <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, ...appFlags }}>
         <DashboardDataProvider value={value}>
           <SidebarProvider {...sidebarProps}>
-            <DashboardNav />
+            <DashboardNav>{navChildren}</DashboardNav>
             {children}
           </SidebarProvider>
         </DashboardDataProvider>


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4574 -->

## Summary
- Recovers the existing JOV-4574 Search relocation onto current main.
- Places the shell-owned Search surface after New Chat in the sidebar.
- Removes the duplicate header placement and preserves collapsed-sidebar behavior.

## Verification
- `pnpm biome check` on all 9 changed files: passed.
- Focused navigation/sidebar tests were run against the original materialized recovery worktree; source CI is the authoritative current-head gate.
- No server, browser, or preview process started.

## Delivery
- Gated draft pending source CI.
- UI runtime review follows the authenticated staging evidence loop.