### PR TITLE
fix(ci): bootstrap visual capture without database

### DIFF
--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -99,6 +99,7 @@ jobs:
           NEXT_PUBLIC_E2E_MODE: '1'
           VERCEL_ENV: development
           E2E_USE_TEST_AUTH_BYPASS: '1'
+          E2E_VISUAL_CAPTURE_SYNTHETIC_AUTH: '1'
           E2E_TEST_AUTH_PERSONA: creator-ready
           E2E_CLERK_USER_ID: user_test
 
@@ -106,7 +107,7 @@ jobs:
         if: steps.route.outputs.should_review == 'true'
         run: |
           set -euo pipefail
-          (cd apps/web && PORT=3100 DATABASE_URL=postgresql://localhost/noop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock CLERK_SECRET_KEY=sk_test_mock NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_E2E_MODE=1 VERCEL_ENV=development E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_CLERK_USER_ID=user_test HOSTNAME=localhost NEXT_PUBLIC_APP_URL=http://127.0.0.1:3100 BETTER_AUTH_URL=http://127.0.0.1:3100 NEXT_PUBLIC_BETTER_AUTH_URL=http://127.0.0.1:3100 pnpm run start) > "$RUNNER_TEMP/pr-visual-server.log" 2>&1 &
+          (cd apps/web && PORT=3100 DATABASE_URL=postgresql://localhost/noop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock CLERK_SECRET_KEY=sk_test_mock NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_E2E_MODE=1 VERCEL_ENV=development E2E_USE_TEST_AUTH_BYPASS=1 E2E_VISUAL_CAPTURE_SYNTHETIC_AUTH=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_CLERK_USER_ID=user_test HOSTNAME=localhost NEXT_PUBLIC_APP_URL=http://127.0.0.1:3100 BETTER_AUTH_URL=http://127.0.0.1:3100 NEXT_PUBLIC_BETTER_AUTH_URL=http://127.0.0.1:3100 pnpm run start) > "$RUNNER_TEMP/pr-visual-server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/pr-visual-server.pid"
           for _ in $(seq 1 30); do curl -fsS http://127.0.0.1:3100 >/dev/null 2>&1 && exit 0; sleep 2; done
           cat "$RUNNER_TEMP/pr-visual-server.log"

--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -221,7 +221,10 @@ jobs:
           process.stdout.write(visualReviewIdentity({ prNumber: process.env.PR_NUMBER, headSha: process.env.PR_HEAD_SHA, runId: process.env.GITHUB_RUN_ID }));
           NODE
           )
-          EXISTING=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq --arg marker "$MARKER" '((add // []) | any(.[]; .user.login == "github-actions[bot]" and (.body | contains($marker))))')
+          # `gh api` cannot combine --slurp with --jq, and --jq does not accept
+          # jq's --arg flags. Fetch the paginated JSON with gh, then evaluate
+          # the exact marker with the standalone jq binary.
+          EXISTING=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" | jq -r --arg marker "$MARKER" '((add // []) | any(.[]; .user.login == "github-actions[bot]" and (.body | contains($marker))))')
           if [ "$EXISTING" = "true" ]; then echo "Exact visual review already exists; idempotent no-op."; exit 0; fi
           jq -n --arg body "$BODY" '{body:$body,event:"COMMENT"}' > review-payload.json
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --method POST --input review-payload.json >/dev/null

--- a/apps/web/app/api/dev/test-auth/enter/route.ts
+++ b/apps/web/app/api/dev/test-auth/enter/route.ts
@@ -6,6 +6,7 @@ import {
   buildDevTestAuthCookieDescriptors,
   ensureDevTestAuthActor,
   getDevTestAuthAvailability,
+  getSyntheticDevTestAuthActor,
   parseDevTestAuthPersona,
   sanitizeDevTestAuthRedirectPath,
 } from '@/lib/auth/dev-test-auth.server';
@@ -75,7 +76,22 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const actor = await ensureDevTestAuthActor(persona);
+  let actor;
+  try {
+    actor = await ensureDevTestAuthActor(persona);
+  } catch (error) {
+    // PR visual capture intentionally runs without a database or secrets. It
+    // still needs the test-mode cookie handoff to reach the requested route;
+    // target-route failures remain fail-closed in the capture manifest.
+    if (
+      process.env.E2E_VISUAL_CAPTURE_SYNTHETIC_AUTH !== '1' ||
+      sessionParam === 'better-auth'
+    ) {
+      throw error;
+    }
+
+    actor = getSyntheticDevTestAuthActor(persona);
+  }
   revalidatePath(APP_ROUTES.DASHBOARD, 'layout');
   const response = new NextResponse(null, { status: 303 });
 

--- a/apps/web/lib/auth/dev-test-auth.server.ts
+++ b/apps/web/lib/auth/dev-test-auth.server.ts
@@ -5,7 +5,10 @@ import { eq, or } from 'drizzle-orm';
 import { cookies, headers } from 'next/headers';
 import { cache } from 'react';
 import { auth } from '@/lib/auth/better-auth';
-import { DEFAULT_DEV_TEST_AUTH_EMAILS } from '@/lib/auth/dev-test-auth-identity';
+import {
+  DEFAULT_DEV_TEST_AUTH_EMAILS,
+  getDeterministicTestBetterAuthUserId,
+} from '@/lib/auth/dev-test-auth-identity';
 import type {
   ClientAuthBootstrap,
   DevTestAuthActor,
@@ -210,21 +213,30 @@ export function getDevTestAuthAvailability(
   };
 }
 
-function getFallbackActorFromPersona(
-  clerkUserId: string,
+export function getSyntheticDevTestAuthActor(
   persona: DevTestAuthPersona
-): DevTestAuthSession {
+): DevTestAuthActor {
   const config = resolvePersonaSeedConfig(persona);
 
   return {
-    dbUserId: clerkUserId,
     persona,
-    clerkUserId,
+    clerkUserId: getDeterministicTestBetterAuthUserId(config.email),
     email: config.email,
     username: config.username,
     fullName: config.fullName,
     isAdmin: config.isAdmin,
     profilePath: config.profilePath,
+  };
+}
+
+function getFallbackActorFromPersona(
+  clerkUserId: string,
+  persona: DevTestAuthPersona
+): DevTestAuthSession {
+  return {
+    ...getSyntheticDevTestAuthActor(persona),
+    dbUserId: clerkUserId,
+    clerkUserId,
   };
 }
 

--- a/apps/web/tests/unit/api/dev/test-auth-routes.test.ts
+++ b/apps/web/tests/unit/api/dev/test-auth-routes.test.ts
@@ -10,6 +10,7 @@ const {
   mockEnsureDevTestAuthActor,
   mockEnsureExistingDevTestAuthActor,
   mockEnsureLiveDevTestAuthActor,
+  mockGetSyntheticDevTestAuthActor,
   mockGetCachedDevTestAuthSession,
   mockGetDevTestAuthAvailability,
   mockIsTrustedTestBypassRequest,
@@ -26,6 +27,7 @@ const {
   mockEnsureDevTestAuthActor: vi.fn(),
   mockEnsureExistingDevTestAuthActor: vi.fn(),
   mockEnsureLiveDevTestAuthActor: vi.fn(),
+  mockGetSyntheticDevTestAuthActor: vi.fn(),
   mockGetCachedDevTestAuthSession: vi.fn(),
   mockGetDevTestAuthAvailability: vi.fn(),
   mockIsTrustedTestBypassRequest: vi.fn(),
@@ -53,6 +55,7 @@ vi.mock('@/lib/auth/dev-test-auth.server', () => ({
   ensureDevTestAuthActor: mockEnsureDevTestAuthActor,
   ensureExistingDevTestAuthActor: mockEnsureExistingDevTestAuthActor,
   ensureLiveDevTestAuthActor: mockEnsureLiveDevTestAuthActor,
+  getSyntheticDevTestAuthActor: mockGetSyntheticDevTestAuthActor,
   getCachedDevTestAuthSession: mockGetCachedDevTestAuthSession,
   getDevTestAuthAvailability: mockGetDevTestAuthAvailability,
   parseDevTestAuthPersona: mockParseDevTestAuthPersona,
@@ -510,6 +513,51 @@ describe('dev test-auth routes', () => {
     expect(response.headers.get('set-cookie')).not.toContain(
       'better-auth.session_token'
     );
+  });
+
+  it('uses a synthetic test-mode actor only for the database-free visual capture lane', async () => {
+    vi.stubEnv('E2E_VISUAL_CAPTURE_SYNTHETIC_AUTH', '1');
+    mockEnsureDevTestAuthActor.mockRejectedValueOnce(
+      new Error('database unavailable')
+    );
+    mockGetSyntheticDevTestAuthActor.mockReturnValueOnce({
+      persona: 'creator-ready',
+      clerkUserId: 'synthetic_creator_ready',
+      email: 'browse-ready+clerk_test@jov.ie',
+      username: 'browse-ready-user',
+      fullName: 'Browse Ready User',
+      isAdmin: false,
+      profilePath: '/browse-ready-user',
+    });
+
+    const { GET } = await import('@/app/api/dev/test-auth/enter/route');
+    const response = await GET(
+      new NextRequest(
+        'http://localhost:3000/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat'
+      )
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe('/app/chat');
+    expect(mockGetSyntheticDevTestAuthActor).toHaveBeenCalledWith(
+      'creator-ready'
+    );
+  });
+
+  it('does not synthesize an actor outside the explicit visual capture lane', async () => {
+    mockEnsureDevTestAuthActor.mockRejectedValueOnce(
+      new Error('database unavailable')
+    );
+    const { GET } = await import('@/app/api/dev/test-auth/enter/route');
+
+    await expect(
+      GET(
+        new NextRequest(
+          'http://localhost:3000/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat'
+        )
+      )
+    ).rejects.toThrow('database unavailable');
+    expect(mockGetSyntheticDevTestAuthActor).not.toHaveBeenCalled();
   });
 
   it('adds a genuine Better Auth cookie only for explicit performance mode', async () => {

--- a/apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts
+++ b/apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts
@@ -21,4 +21,13 @@ describe('PR visual review workflow', () => {
       /PLAYWRIGHT_BROWSERS_PATH:\s*~\/\.cache\/ms-playwright/
     );
   });
+
+  it('checks exact prior review markers with standalone jq after paginating', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toContain('--paginate --slurp');
+    expect(workflow).toContain('| jq -r --arg marker "$MARKER"');
+    expect(workflow).toContain('contains($marker)');
+    expect(workflow).not.toContain('--jq --arg marker');
+  });
 });

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -242,6 +242,12 @@ describe('bounded PR visual review contract', () => {
     expect(workflow).toContain('PR_HEAD_SHA');
     expect(workflow).toContain('visualReviewIdentity');
     expect(workflow).toContain('--paginate --slurp');
+    expect(workflow).toContain('| jq -r --arg marker "$MARKER"');
+    expect(workflow).toContain('contains($marker)');
+    expect(workflow).not.toContain('--jq --arg marker');
+    expect(workflow).not.toContain(
+      '--slurp "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq'
+    );
     expect(workflow).toContain(
       'Exact visual review already exists; idempotent no-op.'
     );


### PR DESCRIPTION
## Summary
- make the secretless PR visual-capture test-auth redirect independent of the intentionally unavailable database
- limit the synthetic actor to an explicit visual-capture environment flag; real Better Auth session creation remains fail-closed
- retain target-route and runtime capture failures as hard evidence failures

## Root cause
The capture job sets `DATABASE_URL=postgresql://localhost/noop`, while `/api/dev/test-auth/enter` eagerly provisions a DB-backed persona before issuing its 303. That made authenticated captures fail before reaching their routed surface.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/dev/test-auth-routes.test.ts` — 32/32
- `pnpm exec biome check apps/web/lib/auth/dev-test-auth.server.ts apps/web/app/api/dev/test-auth/enter/route.ts apps/web/tests/unit/api/dev/test-auth-routes.test.ts .github/workflows/pr-visual-review.yml`
- `git diff --check`

## Evidence boundary
Source-only CI-capture repair. No browser, server, or Kimi session was started. Keep gated until CI shows that routed captures can authenticate and produce valid artifacts.