### PR TITLE
refactor(marketing): consolidate terminal CTA presentation

### DIFF
--- a/apps/web/components/site/MarketingFinalCTA.tsx
+++ b/apps/web/components/site/MarketingFinalCTA.tsx
@@ -1,6 +1,5 @@
-import Link from 'next/link';
 import { HOMEPAGE_FRONT_DOOR_CTA } from '@/data/homepageLaunchCopy';
-import { cn } from '@/lib/utils';
+import { MarketingTerminalCta } from './MarketingTerminalCta';
 
 export interface MarketingFinalCTAProps {
   /** Override headline copy. Defaults to the standard private launch request line. */
@@ -33,42 +32,16 @@ export function MarketingFinalCTA({
   testId = 'marketing-final-cta',
 }: Readonly<MarketingFinalCTAProps>) {
   return (
-    <section
-      data-testid={testId}
-      className={cn(
-        'relative isolate overflow-hidden bg-black px-[clamp(1.25rem,2.2vw,2rem)] py-[clamp(5rem,9vw,8rem)] text-(--color-text-tooltip) dark:bg-black',
-        className
-      )}
-    >
-      <div className='relative z-[2] mx-auto flex w-full max-w-[var(--homepage-section-max,80rem)] flex-col items-center text-center'>
-        <h2 className='font-display max-w-[20ch] text-balance text-[clamp(2rem,3.4vw,3rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)'>
-          {title}
-        </h2>
-        {body ? (
-          <p className='mt-3 max-w-[44rem] text-balance text-lg leading-[1.45] text-white/[0.5]'>
-            {body}
-          </p>
-        ) : null}
-        <div className='mt-7 flex flex-wrap items-center justify-center gap-3'>
-          <Link
-            href={ctaHref}
-            prefetch={false}
-            className='inline-flex h-10 items-center rounded-full bg-(--color-text-tooltip) px-6 text-sm font-semibold tracking-wide text-black transition-opacity duration-subtle ease-subtle hover:opacity-92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black dark:text-black'
-          >
-            {ctaLabel}
-          </Link>
-          {secondaryLabel && secondaryHref ? (
-            <Link
-              href={secondaryHref}
-              prefetch={false}
-              className='inline-flex h-10 items-center gap-1 rounded-full px-6 text-sm font-semibold tracking-wide text-white/92 transition-colors duration-subtle ease-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
-            >
-              {secondaryLabel}
-              <span aria-hidden='true'>→</span>
-            </Link>
-          ) : null}
-        </div>
-      </div>
-    </section>
+    <MarketingTerminalCta
+      title={title}
+      body={body}
+      ctaLabel={ctaLabel}
+      ctaHref={ctaHref}
+      secondaryLabel={secondaryLabel}
+      secondaryHref={secondaryHref}
+      prefetch={false}
+      className={className}
+      testId={testId}
+    />
   );
 }

--- a/apps/web/components/site/MarketingFooterCta.tsx
+++ b/apps/web/components/site/MarketingFooterCta.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { useId } from 'react';
-import { MarketingContainer } from '@/components/marketing';
 import { APP_ROUTES } from '@/constants/routes';
 import { HOMEPAGE_V2_COPY } from '@/data/homepageV2Copy';
-import { cn } from '@/lib/utils';
+import { MarketingTerminalCta } from './MarketingTerminalCta';
 
 const FOOTER_CTA_ARCS = [
   { radiusX: 70, radiusY: 245 },
@@ -42,83 +40,82 @@ export function MarketingFooterCta({
   const secondaryGradientId = `marketing-footer-cta-secondary-${instanceId}`;
 
   return (
-    <section
-      data-testid='marketing-footer-cta'
-      className={cn(
-        'homepage-story-final-cta relative isolate overflow-hidden bg-black dark:bg-black',
-        className
-      )}
-    >
-      <div
-        aria-hidden='true'
-        className='homepage-final-cta-glow pointer-events-none absolute inset-0 z-[1]'
-      />
-      <svg
-        className='homepage-final-cta-rays pointer-events-none absolute inset-x-0 bottom-0 z-[2] w-full'
-        viewBox='0 0 1200 540'
-        preserveAspectRatio='xMidYMax slice'
-        aria-hidden='true'
-      >
-        <defs>
-          <linearGradient id={primaryGradientId} x1='0' x2='0' y1='0' y2='1'>
-            <stop offset='0%' stopColor='#0070f3' stopOpacity='0' />
-            <stop offset='55%' stopColor='#0070f3' stopOpacity='0.35' />
-            <stop offset='92%' stopColor='#ffffff' stopOpacity='0.95' />
-            <stop offset='100%' stopColor='#ffffff' stopOpacity='0.6' />
-          </linearGradient>
-          <linearGradient id={secondaryGradientId} x1='0' x2='0' y1='0' y2='1'>
-            <stop offset='0%' stopColor='#0070f3' stopOpacity='0' />
-            <stop offset='70%' stopColor='#0070f3' stopOpacity='0.55' />
-            <stop offset='100%' stopColor='#dbeaff' stopOpacity='0.85' />
-          </linearGradient>
-        </defs>
-        <ellipse
-          cx='600'
-          cy='600'
-          rx='22'
-          ry='260'
-          stroke={`url(#${secondaryGradientId})`}
-          strokeWidth='2.2'
-          fill='none'
-        />
-        {FOOTER_CTA_ARCS.map((arc, index) => (
-          <ellipse
-            key={`${arc.radiusX}-${arc.radiusY}`}
-            cx='600'
-            cy='600'
-            rx={arc.radiusX}
-            ry={arc.radiusY}
-            stroke={
-              index % 2 === 0
-                ? `url(#${primaryGradientId})`
-                : `url(#${secondaryGradientId})`
-            }
-            strokeWidth={index < 4 ? 1.5 : 1.2}
-            fill='none'
-            opacity={1 - index * 0.05}
+    <MarketingTerminalCta
+      variant='cinematic'
+      testId='marketing-footer-cta'
+      title={title}
+      body={body}
+      ctaLabel={ctaLabel}
+      ctaHref={ctaHref}
+      ctaAnalyticsEvent={ctaAnalyticsEvent}
+      ctaAnalyticsSource={ctaAnalyticsSource}
+      className={className}
+      decoration={
+        <>
+          <div
+            aria-hidden='true'
+            className='homepage-final-cta-glow pointer-events-none absolute inset-0 z-[1]'
           />
-        ))}
-      </svg>
-      <MarketingContainer width='page' className='relative z-10'>
-        <div className='homepage-final-cta-copy mx-auto'>
-          <h2 className='text-balance text-[clamp(2rem,3.4vw,3rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)'>
-            {title}
-          </h2>
-          {body ? (
-            <p className='mx-auto mt-3 max-w-[36rem] text-balance text-lg leading-[1.45] text-white/[0.58]'>
-              {body}
-            </p>
-          ) : null}
-          <Link
-            href={ctaHref}
-            className='homepage-final-cta-action public-action-primary focus-ring-themed'
-            data-analytics-event={ctaAnalyticsEvent}
-            data-analytics-source={ctaAnalyticsSource}
+          <svg
+            className='homepage-final-cta-rays pointer-events-none absolute inset-x-0 bottom-0 z-[2] w-full'
+            viewBox='0 0 1200 540'
+            preserveAspectRatio='xMidYMax slice'
+            aria-hidden='true'
           >
-            {ctaLabel}
-          </Link>
-        </div>
-      </MarketingContainer>
-    </section>
+            <defs>
+              <linearGradient
+                id={primaryGradientId}
+                x1='0'
+                x2='0'
+                y1='0'
+                y2='1'
+              >
+                <stop offset='0%' stopColor='#0070f3' stopOpacity='0' />
+                <stop offset='55%' stopColor='#0070f3' stopOpacity='0.35' />
+                <stop offset='92%' stopColor='#ffffff' stopOpacity='0.95' />
+                <stop offset='100%' stopColor='#ffffff' stopOpacity='0.6' />
+              </linearGradient>
+              <linearGradient
+                id={secondaryGradientId}
+                x1='0'
+                x2='0'
+                y1='0'
+                y2='1'
+              >
+                <stop offset='0%' stopColor='#0070f3' stopOpacity='0' />
+                <stop offset='70%' stopColor='#0070f3' stopOpacity='0.55' />
+                <stop offset='100%' stopColor='#dbeaff' stopOpacity='0.85' />
+              </linearGradient>
+            </defs>
+            <ellipse
+              cx='600'
+              cy='600'
+              rx='22'
+              ry='260'
+              stroke={`url(#${secondaryGradientId})`}
+              strokeWidth='2.2'
+              fill='none'
+            />
+            {FOOTER_CTA_ARCS.map((arc, index) => (
+              <ellipse
+                key={`${arc.radiusX}-${arc.radiusY}`}
+                cx='600'
+                cy='600'
+                rx={arc.radiusX}
+                ry={arc.radiusY}
+                stroke={
+                  index % 2 === 0
+                    ? `url(#${primaryGradientId})`
+                    : `url(#${secondaryGradientId})`
+                }
+                strokeWidth={index < 4 ? 1.5 : 1.2}
+                fill='none'
+                opacity={1 - index * 0.05}
+              />
+            ))}
+          </svg>
+        </>
+      }
+    />
   );
 }

--- a/apps/web/components/site/MarketingTerminalCta.tsx
+++ b/apps/web/components/site/MarketingTerminalCta.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { MarketingContainer } from '@/components/marketing';
+import { cn } from '@/lib/utils';
+
+export interface MarketingTerminalCtaProps {
+  readonly title: string;
+  readonly body?: string;
+  readonly ctaLabel: string;
+  readonly ctaHref: string;
+  readonly secondaryLabel?: string;
+  readonly secondaryHref?: string;
+  readonly ctaAnalyticsEvent?: string;
+  readonly ctaAnalyticsSource?: string;
+  readonly prefetch?: boolean;
+  readonly className?: string;
+  readonly decoration?: ReactNode;
+  readonly testId: string;
+  readonly variant?: 'cinematic' | 'standard';
+}
+
+const styles = {
+  cinematic: {
+    section:
+      'homepage-story-final-cta relative isolate overflow-hidden bg-black dark:bg-black',
+    content: 'homepage-final-cta-copy mx-auto',
+    title:
+      'text-balance text-[clamp(2rem,3.4vw,3rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)',
+    body: 'mx-auto max-w-[36rem] text-balance text-lg leading-[1.45] text-white/[0.58]',
+    actions: 'mt-2 flex flex-wrap items-center justify-center gap-3',
+    primary:
+      'homepage-final-cta-action public-action-primary focus-ring-themed',
+  },
+  standard: {
+    section:
+      'relative isolate overflow-hidden bg-black px-[clamp(1.25rem,2.2vw,2rem)] py-[clamp(5rem,9vw,8rem)] text-(--color-text-tooltip) dark:bg-black',
+    content:
+      'relative z-[2] mx-auto flex w-full max-w-[var(--homepage-section-max,80rem)] flex-col items-center text-center',
+    title:
+      'font-display max-w-[20ch] text-balance text-[clamp(2rem,3.4vw,3rem)] font-bold leading-[1.05] tracking-[-0.025em] text-(--color-text-tooltip)',
+    body: 'mt-3 max-w-[44rem] text-balance text-lg leading-[1.45] text-white/[0.5]',
+    actions: 'mt-7 flex flex-wrap items-center justify-center gap-3',
+    primary:
+      'inline-flex h-10 items-center rounded-full bg-(--color-text-tooltip) px-6 text-sm font-semibold tracking-wide text-black transition-opacity duration-subtle ease-subtle hover:opacity-92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black dark:text-black',
+  },
+} as const;
+
+const secondaryClassName =
+  'inline-flex h-10 items-center gap-1 rounded-full px-6 text-sm font-semibold tracking-wide text-white/92 transition-colors duration-subtle ease-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black';
+
+/** Shared terminal marketing CTA composition. Caller wrappers own copy and decoration only. */
+export function MarketingTerminalCta({
+  title,
+  body,
+  ctaLabel,
+  ctaHref,
+  secondaryLabel,
+  secondaryHref,
+  ctaAnalyticsEvent,
+  ctaAnalyticsSource,
+  prefetch,
+  className,
+  decoration,
+  testId,
+  variant = 'standard',
+}: Readonly<MarketingTerminalCtaProps>) {
+  const variantStyles = styles[variant];
+
+  const content = (
+    <div className={variantStyles.content}>
+      <h2 className={variantStyles.title}>{title}</h2>
+      {body ? <p className={variantStyles.body}>{body}</p> : null}
+      <div className={variantStyles.actions}>
+        <Link
+          href={ctaHref}
+          prefetch={prefetch}
+          className={variantStyles.primary}
+          data-analytics-event={ctaAnalyticsEvent}
+          data-analytics-source={ctaAnalyticsSource}
+        >
+          {ctaLabel}
+        </Link>
+        {secondaryLabel && secondaryHref ? (
+          <Link
+            href={secondaryHref}
+            prefetch={prefetch}
+            className={secondaryClassName}
+          >
+            {secondaryLabel}
+            <span aria-hidden='true'>→</span>
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  return (
+    <section
+      data-testid={testId}
+      className={cn(variantStyles.section, className)}
+    >
+      {decoration}
+      {variant === 'cinematic' ? (
+        <MarketingContainer width='page' className='relative z-10'>
+          {content}
+        </MarketingContainer>
+      ) : (
+        content
+      )}
+    </section>
+  );
+}

--- a/apps/web/tests/unit/marketing/MarketingTerminalCta.test.tsx
+++ b/apps/web/tests/unit/marketing/MarketingTerminalCta.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MarketingFinalCTA } from '@/components/site/MarketingFinalCTA';
+import { MarketingFooterCta } from '@/components/site/MarketingFooterCta';
+
+describe('Marketing terminal CTA wrappers', () => {
+  it('keeps the final CTA copy and both conversion links while using the shared primitive', () => {
+    render(
+      <MarketingFinalCTA
+        title='Release your next record.'
+        body='Keep the release plan moving.'
+        ctaLabel='Request Access'
+        ctaHref='/signup'
+        secondaryLabel='See Pricing'
+        secondaryHref='/pricing'
+      />
+    );
+
+    expect(screen.getByTestId('marketing-final-cta')).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toHaveTextContent(
+      'Release your next record.'
+    );
+    expect(
+      screen.getByRole('link', { name: 'Request Access' })
+    ).toHaveAttribute('href', '/signup');
+    expect(screen.getByRole('link', { name: 'See Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
+  });
+
+  it('keeps footer analytics and emits only one primary action by default', () => {
+    render(
+      <MarketingFooterCta
+        title='Ready to install Jovie?'
+        ctaLabel='Download for Mac'
+        ctaHref='/download'
+        ctaAnalyticsEvent='download_mac_dmg'
+        ctaAnalyticsSource='download_page_footer'
+      />
+    );
+
+    const action = screen.getByRole('link', { name: 'Download for Mac' });
+    expect(action).toHaveAttribute('href', '/download');
+    expect(action).toHaveAttribute('data-analytics-event', 'download_mac_dmg');
+    expect(action).toHaveAttribute(
+      'data-analytics-source',
+      'download_page_footer'
+    );
+    expect(
+      screen.getByTestId('marketing-footer-cta').querySelectorAll('a')
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add one shared terminal CTA presentation primitive
- retain `MarketingFooterCta` cinematic decoration and analytics
- retain `MarketingFinalCTA` copy, route links, and optional secondary action

## Verification
- `pnpm biome check --write` (4 changed files)
- `pnpm --filter web exec vitest run tests/unit/marketing/MarketingTerminalCta.test.tsx` (2/2)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- normal pre-push: proxy, Tailwind, affected verification, and CI harness all passed

## Review
Grok 4.5 advisory review was attempted but stalled in local plugin bootstrap and was terminated; it is non-blocking under the current shipping policy.

<!-- linear-issue-id:JOV-4507 -->