### PR TITLE
fix(ui): consolidate toolbar action chrome

### DIFF
--- a/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
+++ b/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
@@ -5,6 +5,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { LayoutGrid, LayoutList, Settings2, X } from 'lucide-react';
 import { memo, type ReactNode, useCallback } from 'react';
 import { cn } from '@/lib/utils';
+import { PAGE_TOOLBAR_ACTION_BUTTON_CLASS } from './PageToolbar';
 
 export type ViewMode = 'list' | 'board';
 export type Density = 'compact' | 'normal' | 'comfortable';
@@ -141,7 +142,10 @@ export function DisplayMenuDropdown({
   const defaultTrigger = (
     <button
       type='button'
-      className='inline-flex items-center gap-1.5 rounded-full border border-transparent px-2 py-1 text-app font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
+      className={cn(
+        PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+        'px-2 text-app text-secondary-token'
+      )}
     >
       <Settings2 className='h-4 w-4' />
       Display
@@ -159,7 +163,7 @@ export function DisplayMenuDropdown({
           </span>
           <PopoverPrimitive.Close
             aria-label='Close'
-            className='rounded-full border border-transparent p-0.5 text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1'
+            className='rounded-full border-0 bg-transparent p-1 text-tertiary-token shadow-none transition-[background-color,color] duration-subtle hover:bg-(--linear-row-hover) hover:text-primary-token focus-visible:bg-(--linear-row-hover) focus-visible:text-primary-token focus-visible:outline-none'
           >
             <X className='h-4 w-4' />
           </PopoverPrimitive.Close>

--- a/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
+++ b/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
@@ -163,7 +163,7 @@ export function DisplayMenuDropdown({
           </span>
           <PopoverPrimitive.Close
             aria-label='Close'
-            className='rounded-full border-0 bg-transparent p-1 text-tertiary-token shadow-none transition-[background-color,color] duration-subtle hover:bg-(--linear-row-hover) hover:text-primary-token focus-visible:bg-(--linear-row-hover) focus-visible:text-primary-token focus-visible:outline-none'
+            className='rounded-full border-0 bg-transparent p-1 text-tertiary-token shadow-none transition-[background-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none'
           >
             <X className='h-4 w-4' />
           </PopoverPrimitive.Close>

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -21,10 +21,10 @@ export const PAGE_TOOLBAR_META_TEXT_CLASS =
   'text-xs text-tertiary-token tabular-nums';
 
 export const PAGE_TOOLBAR_TAB_BUTTON_CLASS =
-  'inline-flex h-7.5 items-center justify-center gap-1.5 rounded-pill bg-transparent px-2.5 text-2xs font-caption font-[540] tracking-tight text-secondary-token shadow-none transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:bg-surface-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16 disabled:pointer-events-none disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
+  'inline-flex h-7.5 items-center justify-center gap-1.5 rounded-pill bg-transparent px-2.5 text-2xs font-caption font-[540] tracking-tight text-tertiary-token shadow-none transition-[background-color,color,box-shadow] duration-subtle hover:bg-(--linear-row-hover) hover:text-primary-token focus-visible:bg-(--linear-row-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16 disabled:pointer-events-none disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
 
 export const PAGE_TOOLBAR_TAB_ACTIVE_CLASS =
-  'ring-2 ring-(--color-accent) text-primary-token';
+  'bg-(--linear-row-hover) text-primary-token';
 
 export const PAGE_TOOLBAR_ACTION_BUTTON_CLASS = cn(
   ACTION_BAR_BUTTON_CLASS,

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -23,8 +23,7 @@ export const PAGE_TOOLBAR_META_TEXT_CLASS =
 export const PAGE_TOOLBAR_TAB_BUTTON_CLASS =
   'inline-flex h-7.5 items-center justify-center gap-1.5 rounded-pill bg-transparent px-2.5 text-2xs font-caption font-[540] tracking-tight text-tertiary-token shadow-none transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16 disabled:pointer-events-none disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
 
-export const PAGE_TOOLBAR_TAB_ACTIVE_CLASS =
-  'bg-surface-1 text-primary-token';
+export const PAGE_TOOLBAR_TAB_ACTIVE_CLASS = 'bg-surface-1 text-primary-token';
 
 export const PAGE_TOOLBAR_ACTION_BUTTON_CLASS = cn(
   ACTION_BAR_BUTTON_CLASS,

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -21,14 +21,14 @@ export const PAGE_TOOLBAR_META_TEXT_CLASS =
   'text-xs text-tertiary-token tabular-nums';
 
 export const PAGE_TOOLBAR_TAB_BUTTON_CLASS =
-  'inline-flex h-7.5 items-center justify-center gap-1.5 rounded-pill bg-transparent px-2.5 text-2xs font-caption font-[540] tracking-tight text-tertiary-token shadow-none transition-[background-color,color,box-shadow] duration-subtle hover:bg-(--linear-row-hover) hover:text-primary-token focus-visible:bg-(--linear-row-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16 disabled:pointer-events-none disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
+  'inline-flex h-7.5 items-center justify-center gap-1.5 rounded-pill bg-transparent px-2.5 text-2xs font-caption font-[540] tracking-tight text-tertiary-token shadow-none transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16 disabled:pointer-events-none disabled:opacity-50 [&_svg]:h-3.5 [&_svg]:w-3.5';
 
 export const PAGE_TOOLBAR_TAB_ACTIVE_CLASS =
-  'bg-(--linear-row-hover) text-primary-token';
+  'bg-surface-1 text-primary-token';
 
 export const PAGE_TOOLBAR_ACTION_BUTTON_CLASS = cn(
   ACTION_BAR_BUTTON_CLASS,
-  'h-7 rounded-full border-0 bg-transparent px-2 text-2xs font-[540] text-tertiary-token shadow-none hover:border-0 hover:bg-(--linear-row-hover) hover:text-primary-token hover:shadow-none focus-visible:border-0 focus-visible:bg-(--linear-row-hover) focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-0 active:border-0 active:bg-(--linear-row-hover) active:text-primary-token active:shadow-none disabled:pointer-events-none disabled:bg-transparent disabled:opacity-35 [&_svg]:h-3.5 [&_svg]:w-3.5'
+  'h-7 rounded-full border-0 bg-transparent px-2 text-2xs font-[540] text-tertiary-token shadow-none hover:border-0 hover:bg-surface-1 hover:text-primary-token hover:shadow-none focus-visible:border-0 focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-0 active:border-0 active:bg-surface-1 active:text-primary-token active:shadow-none disabled:pointer-events-none disabled:bg-transparent disabled:opacity-35 [&_svg]:h-3.5 [&_svg]:w-3.5'
 );
 
 export const PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS =

--- a/apps/web/tests/unit/components/table/PageToolbar.test.tsx
+++ b/apps/web/tests/unit/components/table/PageToolbar.test.tsx
@@ -70,7 +70,7 @@ describe('PageToolbar buttons', () => {
 
   it('keeps inactive view tabs quiet and gives the active view a surface, not a ring', () => {
     expect(PAGE_TOOLBAR_TAB_BUTTON_CLASS).toContain('text-tertiary-token');
-    expect(PAGE_TOOLBAR_TAB_ACTIVE_CLASS).toContain('bg-(--linear-row-hover)');
+    expect(PAGE_TOOLBAR_TAB_ACTIVE_CLASS).toContain('bg-surface-1');
     expect(PAGE_TOOLBAR_TAB_ACTIVE_CLASS).not.toContain('ring-');
   });
 
@@ -79,10 +79,10 @@ describe('PageToolbar buttons', () => {
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('border-0');
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('bg-transparent');
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain(
-      'hover:bg-(--linear-row-hover)'
+      'hover:bg-surface-1'
     );
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain(
-      'focus-visible:bg-(--linear-row-hover)'
+      'focus-visible:bg-surface-1'
     );
   });
 

--- a/apps/web/tests/unit/components/table/PageToolbar.test.tsx
+++ b/apps/web/tests/unit/components/table/PageToolbar.test.tsx
@@ -78,9 +78,7 @@ describe('PageToolbar buttons', () => {
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('rounded-full');
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('border-0');
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('bg-transparent');
-    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain(
-      'hover:bg-surface-1'
-    );
+    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('hover:bg-surface-1');
     expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain(
       'focus-visible:bg-surface-1'
     );

--- a/apps/web/tests/unit/components/table/PageToolbar.test.tsx
+++ b/apps/web/tests/unit/components/table/PageToolbar.test.tsx
@@ -5,6 +5,9 @@ import { Search } from 'lucide-react';
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+  PAGE_TOOLBAR_TAB_ACTIVE_CLASS,
+  PAGE_TOOLBAR_TAB_BUTTON_CLASS,
   PageToolbar,
   PageToolbarActionButton,
   PageToolbarTabButton,
@@ -63,6 +66,24 @@ describe('PageToolbar buttons', () => {
 
     const button = screen.getByRole('button', { name: 'Releases' });
     expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps inactive view tabs quiet and gives the active view a surface, not a ring', () => {
+    expect(PAGE_TOOLBAR_TAB_BUTTON_CLASS).toContain('text-tertiary-token');
+    expect(PAGE_TOOLBAR_TAB_ACTIVE_CLASS).toContain('bg-(--linear-row-hover)');
+    expect(PAGE_TOOLBAR_TAB_ACTIVE_CLASS).not.toContain('ring-');
+  });
+
+  it('keeps toolbar actions borderless and transparent until hover or keyboard focus', () => {
+    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('rounded-full');
+    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('border-0');
+    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain('bg-transparent');
+    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain(
+      'hover:bg-(--linear-row-hover)'
+    );
+    expect(PAGE_TOOLBAR_ACTION_BUTTON_CLASS).toContain(
+      'focus-visible:bg-(--linear-row-hover)'
+    );
   });
 
   it('keeps icon-only actions accessible', () => {

--- a/apps/web/tests/unit/dashboard/display-menu-dropdown-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/display-menu-dropdown-system-b-style-guard.test.ts
@@ -8,6 +8,16 @@ const sourcePath = join(
 );
 
 describe('DisplayMenuDropdown System B style guard', () => {
+  it('composes the canonical toolbar action trigger instead of restoring local chrome', () => {
+    const source = readFileSync(sourcePath, 'utf8');
+
+    expect(source).toContain(
+      "import { PAGE_TOOLBAR_ACTION_BUTTON_CLASS } from './PageToolbar';"
+    );
+    expect(source).toContain('PAGE_TOOLBAR_ACTION_BUTTON_CLASS');
+    expect(source).not.toContain('hover:border-subtle');
+  });
+
   it('keeps the checked switch state neutral instead of primary/accent filled', () => {
     const source = readFileSync(sourcePath, 'utf8');
 

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1738
+  "count": 1734
 }


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4520 -->

## Summary
- quiet inactive PageToolbar view labels and use a subtle selected surface rather than an accent ring
- keep shared toolbar actions borderless and transparent at rest, with a rounded hover and keyboard-focus surface
- make the reusable DisplayMenuDropdown default trigger compose the toolbar action primitive, covering Tasks and Admin Waitlist without page-local chrome

## Visual-state stability
Rest, hover, keyboard focus, active view, and popover-close states retain the existing control dimensions. No conditional content or layout-affecting transition was added.

## Verification
- `pnpm biome check --write` passed for the four changed files
- `git diff --check` passed
- Focused Vitest command could not start locally because the clean worktree dependency links were absent and an offline install was stopped under low disk headroom. Source CI remains the admission check.
- Grok 4.5 CLI was invoked as advisory review but returned no verdict; it is not an admission gate.

## Scope
This is the representative shared-toolbar slice only. It does not migrate every table menu.