### PR TITLE
fix(library): defer persisted view until hydration

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -2488,9 +2488,10 @@ export function LibrarySurface({
   const [preset, setPreset] = useState<LibraryPresetId>(() =>
     parseLibraryViewParam(searchParams.get('view'))
   );
-  const [savedView, setSavedView] = useState<LibrarySavedViewId>(() =>
-    readPersistedLibrarySavedView()
-  );
+  // Keep the server render and the browser's first hydration render identical.
+  // A persisted view belongs to the post-hydration enhancement path; reading it
+  // here would make a returning user's first client render differ from SSR.
+  const [savedView, setSavedView] = useState<LibrarySavedViewId>('all');
   const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
   const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
   const { view, setView } = useLibraryViewMode();
@@ -2510,6 +2511,10 @@ export function LibrarySurface({
   useEffect(() => {
     setPreset(parseLibraryViewParam(searchParams.get('view')));
   }, [searchParams]);
+
+  useEffect(() => {
+    setSavedView(readPersistedLibrarySavedView());
+  }, []);
 
   // Version-stack duplicate ingests so each release renders as one row
   // (JOV-3089); overrides then layer on top of the surviving canonical row.

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -302,6 +302,21 @@ describe('LibrarySurface', () => {
     expect(source).not.toMatch(/grid gap-2\.5/u);
   });
 
+  it('defers persisted saved-view reads until after hydration', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), LIBRARY_SURFACE_SOURCE),
+      'utf8'
+    );
+
+    expect(source).toContain(
+      "const [savedView, setSavedView] = useState<LibrarySavedViewId>('all');"
+    );
+    expect(source).toContain('setSavedView(readPersistedLibrarySavedView());');
+    expect(source).not.toContain(
+      'useState<LibrarySavedViewId>(() =>\n    readPersistedLibrarySavedView()'
+    );
+  });
+
   it('renders an empty read-only library state with a releases escape hatch', () => {
     renderLibrary([]);
 


### PR DESCRIPTION
## Summary
- Render the canonical saved view during SSR and first hydration.
- Restore a persisted Library view only after hydration.
- Add a regression guard against reading localStorage in initial state.

## Verification
- `git diff --check` passed.
- Local Vitest could not load because this checkout is missing declared `@vitejs/plugin-react` and `dotenv`; remote deterministic CI is the authoritative gate.