### PR TITLE
fix(chat): restore composer after Live Profile dialog

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebarSections.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebarSections.tsx
@@ -132,6 +132,9 @@ export function ProfileBentoView({
             <CommonDropdown
               items={menuItems}
               align='end'
+              // The UTM action opens a Dialog. Keeping this transient menu
+              // non-modal avoids competing Radix body pointer-event layers.
+              modal={false}
               aria-label='Profile Actions'
               trigger={
                 <Button

--- a/apps/web/tests/e2e/chat-rail-composer-interaction.spec.ts
+++ b/apps/web/tests/e2e/chat-rail-composer-interaction.spec.ts
@@ -210,4 +210,30 @@ test.describe('right-rail × composer interaction', () => {
     await textarea.fill('rapid toggles completed');
     await expect(textarea).toHaveValue('rapid toggles completed');
   });
+
+  test('F: profile-menu dialog transition releases the composer', async ({
+    page,
+  }) => {
+    await page.locator(RAIL_TOGGLE).click();
+    await expect(page.locator(RIGHT_RAIL)).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: 'Profile Actions' }).click();
+    await page.getByRole('menuitem', { name: 'UTM Builder' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toBeHidden({ timeout: 10_000 });
+
+    const pointerEvents = await page.evaluate(
+      () => getComputedStyle(document.body).pointerEvents
+    );
+    expect(pointerEvents).not.toBe('none');
+
+    const textarea = page.locator(COMPOSER_TEXTAREA);
+    await textarea.click();
+    await textarea.fill('composer remains available after UTM dialog');
+    await expect(textarea).toHaveValue(
+      'composer remains available after UTM dialog'
+    );
+  });
 });

--- a/packages/ui/atoms/common-dropdown-types.ts
+++ b/packages/ui/atoms/common-dropdown-types.ts
@@ -244,6 +244,15 @@ export interface CommonDropdownProps {
   readonly onOpenChange?: (open: boolean) => void;
 
   /**
+   * Whether the menu should block interaction outside its content.
+   *
+   * Keep the default for standalone menus. Set this to false when an action
+   * opens another modal layer so Radix can release the menu before the dialog
+   * takes over body interaction.
+   */
+  readonly modal?: boolean;
+
+  /**
    * Disable portal rendering (render in DOM position)
    */
   readonly disablePortal?: boolean;

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -105,6 +105,12 @@ describe('CommonDropdown', () => {
       await user.click(screen.getByRole('button', { name: 'More actions' }));
       expect(onOpenChange).toHaveBeenCalledWith(true);
     });
+
+    it('keeps the document body interactive when modal is disabled', () => {
+      render(<CommonDropdown items={basicItems} open={true} modal={false} />);
+
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
   });
 
   describe('Action Items', () => {

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -46,6 +46,7 @@ export function CommonDropdown(props: CommonDropdownProps) {
     sideOffset = 4,
     open,
     onOpenChange,
+    modal = true,
     disablePortal = false,
     portalProps,
     contentClassName,
@@ -151,7 +152,11 @@ export function CommonDropdown(props: CommonDropdownProps) {
   }
 
   return (
-    <DropdownMenuPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+    <DropdownMenuPrimitive.Root
+      open={open}
+      onOpenChange={handleOpenChange}
+      modal={modal}
+    >
       <DropdownMenuPrimitive.Trigger
         asChild
         disabled={disabled}


### PR DESCRIPTION
## Summary
- make `CommonDropdown` forward Radix modal behavior with its current default preserved
- keep Profile Actions non-modal while its UTM action opens the modal dialog
- cover the complete menu-to-dialog-to-composer interaction in the existing chat rail E2E

## Verification
- `pnpm biome check --write` (5 changed files)
- `pnpm --filter @jovie/ui test -- atoms/common-dropdown.test.tsx` (69/69)
- standard pre-push: Biome, Next proxy guard, Tailwind guard, and web typecheck

Fixes JOV-3965