### PR TITLE
fix(library): remove deprecated outline button variants

### DIFF
--- a/apps/web/components/features/library-asset-share/LibraryAssetSharePanel.tsx
+++ b/apps/web/components/features/library-asset-share/LibraryAssetSharePanel.tsx
@@ -164,7 +164,7 @@ export function LibraryAssetSharePanel({
       {visibility === 'private' ? (
         <Button
           type='button'
-          variant='outline'
+          variant='secondary'
           size='sm'
           onClick={() => {
             handleRevoke().catch(() => {});

--- a/apps/web/components/features/library-asset-share/LibraryAssetShareUrlCell.tsx
+++ b/apps/web/components/features/library-asset-share/LibraryAssetShareUrlCell.tsx
@@ -49,7 +49,7 @@ export function LibraryAssetShareUrlCell({
       </span>
       <Button
         type='button'
-        variant='outline'
+        variant='secondary'
         size='icon'
         onClick={event => {
           handleCopy(event).catch(() => {});

--- a/apps/web/components/features/library-share/LibraryShareDropCreator.tsx
+++ b/apps/web/components/features/library-share/LibraryShareDropCreator.tsx
@@ -162,7 +162,7 @@ export function LibraryShareDropCreator({
           </span>
           <Button
             type='button'
-            variant='outline'
+            variant='secondary'
             size='sm'
             onClick={() => {
               copyShareUrl(createdUrl).catch(() => {});

--- a/apps/web/tests/unit/library-share/library-share-actions-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/library-share/library-share-actions-system-b-style-guard.test.ts
@@ -15,6 +15,12 @@ describe('library share action System B styling', () => {
   const gateSource = readSource(
     'components/features/library-share/LibrarySharePassphraseGate.tsx'
   );
+  const assetShareUrlCellSource = readSource(
+    'components/features/library-asset-share/LibraryAssetShareUrlCell.tsx'
+  );
+  const assetSharePanelSource = readSource(
+    'components/features/library-asset-share/LibraryAssetSharePanel.tsx'
+  );
 
   it('keeps central share actions on neutral primary button tokens', () => {
     for (const source of [creatorSource, gateSource]) {
@@ -27,6 +33,17 @@ describe('library share action System B styling', () => {
       expect(source).toContain('bg-btn-primary');
       expect(source).toContain('text-btn-primary-foreground');
       expect(source).toContain('hover:bg-btn-primary-hover');
+    }
+  });
+
+  it('uses canonical secondary buttons for the live Library copy and revoke actions', () => {
+    for (const source of [
+      creatorSource,
+      assetShareUrlCellSource,
+      assetSharePanelSource,
+    ]) {
+      expect(source).not.toContain("variant='outline'");
+      expect(source).toContain("variant='secondary'");
     }
   });
 });


### PR DESCRIPTION
## Summary
- migrate the live Library share URL copy, revoke-link, and created-share copy controls from the deprecated `outline` alias to canonical `secondary`
- retain existing neutral outlined/surface visual treatment because `outline` normalizes to `secondary`
- add a source guard so these rendered Library actions cannot regress to the deprecated alias

## Verification
- `pnpm --dir apps/web exec vitest run --config=vitest.config.mts tests/unit/library-share/library-share-actions-system-b-style-guard.test.ts` ✅ (2 tests)
- `pnpm --dir apps/web exec biome check …` ✅
- attempted `LibraryShareDropCreator.test.tsx`; blocked before the test suite by pre-existing cross-worktree module resolution (`react/jsx-dev-runtime` from `packages/ui/atoms/overflow-menu-trigger.tsx`)

Source-only cleanup; no local server, browser, or port 3224 used.