### PR TITLE
fix(shell): defer persisted nav badges until hydration

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -142,7 +142,6 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(null);
   const [hasHydratedPersistedState, setHasHydratedPersistedState] =
     useState(false);
-  const artistName = selectedProfile?.displayName?.trim();
   const profileId = selectedProfile?.id ?? '';
   const isDemo = isDemoRoutePath(pathname);
   const telemetryContext = useMemo<NavigationTelemetryContext>(

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -133,11 +133,16 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const isElectron = useIsElectronRuntime();
-  const [threadReadAtById, setThreadReadAtById] =
-    useState<Record<string, string>>(readThreadReadState);
-  const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(
-    readTasksSeenAt
-  );
+  // Persisted navigation state is a client-only enhancement. Reading it during
+  // the first render would make a returning browser render different badges
+  // from the server markup and can force React to abandon hydration.
+  const [threadReadAtById, setThreadReadAtById] = useState<
+    Record<string, string>
+  >({});
+  const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(null);
+  const [hasHydratedPersistedState, setHasHydratedPersistedState] =
+    useState(false);
+  const artistName = selectedProfile?.displayName?.trim();
   const profileId = selectedProfile?.id ?? '';
   const isDemo = isDemoRoutePath(pathname);
   const telemetryContext = useMemo<NavigationTelemetryContext>(
@@ -182,7 +187,19 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   });
 
   useEffect(() => {
-    if (!conversations || conversations.length === 0) return;
+    setThreadReadAtById(readThreadReadState());
+    setTasksSeenAt(readTasksSeenAt());
+    setHasHydratedPersistedState(true);
+  }, []);
+
+  useEffect(() => {
+    if (
+      !hasHydratedPersistedState ||
+      !conversations ||
+      conversations.length === 0
+    ) {
+      return;
+    }
 
     setThreadReadAtById(previous => {
       if (Object.keys(previous).length > 0) return previous;
@@ -196,7 +213,7 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
       writeThreadReadState(baseline);
       return baseline;
     });
-  }, [conversations]);
+  }, [conversations, hasHydratedPersistedState]);
 
   useEffect(() => {
     if (normalizeTrailingSlash(pathname) !== APP_ROUTES.TASKS) return;

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -219,7 +219,7 @@ describe('DashboardNav interactions', () => {
 
   it('keeps demo-disabled rows as links while intercepting unavailable content', async () => {
     const user = userEvent.setup();
-    mockUsePathname.mockReturnValueOnce('/demo/showcase/settings');
+    mockUsePathname.mockReturnValue('/demo/showcase/settings');
     renderDashboardNav({ renderFn: render });
 
     const tasksLink = screen.getByRole('link', { name: 'Tasks' });

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -142,7 +142,7 @@ describe('DashboardNav', () => {
   });
 
   it('keeps a settled-empty Inbox visible while its root destination is active', () => {
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD);
+    mockUsePathname.mockReturnValue(APP_ROUTES.DASHBOARD);
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
       overrides: {
@@ -218,7 +218,7 @@ describe('DashboardNav', () => {
       APP_ROUTES.DASHBOARD_RELEASES,
       APP_ROUTES.RELEASES,
     ]) {
-      mockUsePathname.mockReturnValueOnce(route);
+      mockUsePathname.mockReturnValue(route);
       const view = renderDashboardNav({ renderFn: fastRender });
       expect(view.getByRole('link', { name: 'Library' })).toHaveAttribute(
         'aria-current',
@@ -233,7 +233,7 @@ describe('DashboardNav', () => {
   });
 
   it('uses New Chat consistently for the elevated nav action and page title', async () => {
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.CHAT);
+    mockUsePathname.mockReturnValue(APP_ROUTES.CHAT);
     const { generateMetadata } = await import('@/app/app/(shell)/chat/page');
     const metadata = await generateMetadata();
     const title = String(metadata.title);
@@ -259,7 +259,7 @@ describe('DashboardNav', () => {
   });
 
   it('does not mark New Chat active on a chat thread', () => {
-    mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.CHAT}/thread-123`);
+    mockUsePathname.mockReturnValue(`${APP_ROUTES.CHAT}/thread-123`);
     const { getByRole } = renderDashboardNav({ renderFn: fastRender });
 
     expect(
@@ -268,7 +268,7 @@ describe('DashboardNav', () => {
   });
 
   it('keeps inactive New Chat on the shared primary shell tone', () => {
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.CALENDAR);
+    mockUsePathname.mockReturnValue(APP_ROUTES.CALENDAR);
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
     });
@@ -344,7 +344,7 @@ describe('DashboardNav', () => {
   });
 
   it('renders settings groups only while inside Settings', () => {
-    mockUsePathname.mockReturnValueOnce(APP_ROUTES.SETTINGS_ACCOUNT);
+    mockUsePathname.mockReturnValue(APP_ROUTES.SETTINGS_ACCOUNT);
     const { getAllByText, getByRole, queryByText } = renderDashboardNav({
       renderFn: fastRender,
     });
@@ -358,7 +358,7 @@ describe('DashboardNav', () => {
   });
 
   it('disables task stats query on nested demo routes', () => {
-    mockUsePathname.mockReturnValueOnce('/demo/showcase/settings');
+    mockUsePathname.mockReturnValue('/demo/showcase/settings');
     renderDashboardNav({
       renderFn: fastRender,
       overrides: {
@@ -378,7 +378,7 @@ describe('DashboardNav', () => {
   });
 
   it('renders stable task count geometry and accessible metadata', () => {
-    mockUseTaskStatsQuery.mockReturnValueOnce({
+    mockUseTaskStatsQuery.mockReturnValue({
       data: {
         backlog: 1,
         todo: 2,
@@ -403,7 +403,7 @@ describe('DashboardNav', () => {
 
   it('uses the new task count after Tasks has been opened', () => {
     localStorage.setItem('jovie:tasks-seen-at', '2026-05-24T00:00:00.000Z');
-    mockUseTaskStatsQuery.mockReturnValueOnce({
+    mockUseTaskStatsQuery.mockReturnValue({
       data: {
         backlog: 1,
         todo: 2,
@@ -449,7 +449,7 @@ describe('DashboardNav', () => {
   });
 
   it('renders the Pro badge only after task entitlements resolve as locked', () => {
-    mockUsePlanGate.mockReturnValueOnce({
+    mockUsePlanGate.mockReturnValue({
       canAccessTasksWorkspace: false,
       isLoading: false,
     });
@@ -457,7 +457,7 @@ describe('DashboardNav', () => {
     expect(locked.getByText('Pro')).toHaveAttribute('data-nav-badge', 'pro');
     locked.unmount();
 
-    mockUsePlanGate.mockReturnValueOnce({
+    mockUsePlanGate.mockReturnValue({
       canAccessTasksWorkspace: false,
       isLoading: true,
     });

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { DashboardHeader } from '@/components/features/dashboard/organisms/DashboardHeader';
@@ -33,6 +35,9 @@ const FORBIDDEN_PRIMARY_LABELS = [
   'Releases',
 ] as const;
 
+const DASHBOARD_NAV_SOURCE =
+  'apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx';
+
 function primaryLinks(container: HTMLElement) {
   const section = container.querySelector('[data-nav-section]');
   expect(section).toBeInTheDocument();
@@ -42,6 +47,29 @@ function primaryLinks(container: HTMLElement) {
 describe('DashboardNav', () => {
   afterEach(() => {
     resetDashboardNavTestMocks();
+  });
+
+  it('defers persisted navigation badges until after hydration', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), DASHBOARD_NAV_SOURCE),
+      'utf8'
+    );
+
+    expect(source).toContain(
+      'const [threadReadAtById, setThreadReadAtById] = useState<'
+    );
+    expect(source).toContain('>({});');
+    expect(source).toContain(
+      'const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(null);'
+    );
+    expect(source).toContain('setThreadReadAtById(readThreadReadState());');
+    expect(source).toContain('setTasksSeenAt(readTasksSeenAt());');
+    expect(source).not.toContain(
+      'useState<Record<string, string>>(readThreadReadState)'
+    );
+    expect(source).not.toContain(
+      'useState<string | null>(\n    readTasksSeenAt'
+    );
   });
 
   it('renders the canonical navigation in exact order and no forbidden primary rows', () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -36,7 +36,7 @@ const FORBIDDEN_PRIMARY_LABELS = [
 ] as const;
 
 const DASHBOARD_NAV_SOURCE =
-  'apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx';
+  'components/features/dashboard/dashboard-nav/DashboardNav.tsx';
 
 function primaryLinks(container: HTMLElement) {
   const section = container.querySelector('[data-nav-section]');


### PR DESCRIPTION
## Summary
- Keep the server render and browser hydration render identical by defaulting persisted sidebar unread and task-seen state.
- Restore localStorage-backed navigation state only after hydration.
- Wait to initialize conversation read baselines until persisted state has been restored.

## Verification
- `pnpm biome check apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx`
- `git diff --check`
- Added the hydration regression guard in `DashboardNav.test.tsx`.

Note: this isolated worktree has no materialized package dependencies, so focused Vitest will be exercised by source CI rather than locally.