### PR TITLE
fix(auth): preserve synthetic visual capture session

### DIFF
--- a/apps/web/lib/auth/gate.ts
+++ b/apps/web/lib/auth/gate.ts
@@ -486,6 +486,20 @@ async function resolveAuthIdentity(knownAppUserId?: string): Promise<{
   clerkUserId: string | null;
   email: string | null;
 }> {
+  // The secretless visual-capture runtime carries a Better Auth identity in
+  // test cookies, but has no persisted app `users.id`. In that deliberately
+  // synthetic mode it must win over a caller's cached app-id hint. Normal
+  // sessions retain the known-id fast path below.
+  if (canUseE2ETestAuthFallback()) {
+    const bypassSession = await getCachedDevTestAuthSession();
+    if (bypassSession) {
+      return {
+        clerkUserId: bypassSession.clerkUserId,
+        email: bypassSession.email,
+      };
+    }
+  }
+
   if (knownAppUserId) {
     const [appUser] = await db
       .select({

--- a/apps/web/tests/unit/lib/auth/gate.critical.test.ts
+++ b/apps/web/tests/unit/lib/auth/gate.critical.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Better Auth critical gate coverage.
@@ -162,6 +162,21 @@ function chainLimit(rows: unknown[]) {
   };
 }
 
+function chainLimitRejecting(error: Error) {
+  return {
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockRejectedValue(error),
+        }),
+      }),
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockRejectedValue(error),
+      }),
+    }),
+  };
+}
+
 function activeDbUser(overrides: Record<string, unknown> = {}) {
   return {
     id: 'db_user_1',
@@ -185,6 +200,10 @@ function activeDbUser(overrides: Record<string, unknown> = {}) {
 }
 
 describe('@critical gate.ts (Better Auth)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetCachedDevTestAuthSession.mockResolvedValue(null);
@@ -310,6 +329,40 @@ describe('@critical gate.ts (Better Auth)', () => {
     expect(mockGetSession).not.toHaveBeenCalled();
     expect(result.state).toBe(CanonicalUserState.ACTIVE);
     expect(result.dbUserId).toBe('db_user_1');
+  });
+
+  it('keeps a synthetic creator-ready test session on its Better Auth identity when the shell passes its cached id', async () => {
+    vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+    vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
+    vi.stubEnv('VERCEL_ENV', 'development');
+    mockGetCachedDevTestAuthSession.mockResolvedValue({
+      // Secretless capture has no app users row. `cached.ts` therefore
+      // exposes the BA id here while the auth gate must select its synthetic
+      // ACTIVE fallback below.
+      dbUserId: 'ba_creator_ready',
+      clerkUserId: 'ba_creator_ready',
+      email: 'browse-ready+clerk_test@jov.ie',
+      persona: 'creator-ready',
+    });
+    mockDbSelect.mockReturnValue(
+      chainLimitRejecting(new Error('database unavailable in visual capture'))
+    );
+
+    const result = await resolveUserState({
+      knownClerkUserId: 'ba_creator_ready',
+    });
+
+    expect(result).toMatchObject({
+      state: CanonicalUserState.ACTIVE,
+      clerkUserId: 'ba_creator_ready',
+      dbUserId: '00000000-0000-4000-8000-000000000101',
+    });
+    expect(mockEq).toHaveBeenCalledWith(
+      'users.betterAuthUserId',
+      'ba_creator_ready'
+    );
+    expect(mockEq).not.toHaveBeenCalledWith('users.id', 'ba_creator_ready');
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 
   it('creates a DB user when waitlist gate is disabled and no waitlist entry exists', async () => {


### PR DESCRIPTION
## Summary
- keep the secretless visual-capture persona on its Better Auth identity before the shell applies an app-user-id hint
- preserve the normal persisted-session fast path and fail-closed production auth behavior
- cover creator-ready capture with an unavailable database and the synthetic ACTIVE gate fallback

## Verification
- `git diff --check`
- `biome check apps/web/lib/auth/gate.ts apps/web/tests/unit/lib/auth/gate.critical.test.ts`
- focused Vitest will run in deterministic source CI (this isolated worktree has no local dependencies; no server/browser was started)

Fixes the authenticated app-shell capture boundary exposed by run 30516654853.