### PR TITLE
fix(profile): defer celebration storage access

### DIFF
--- a/apps/web/components/features/dashboard/molecules/ProfileLiveCelebration.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfileLiveCelebration.tsx
@@ -27,6 +27,9 @@ export function ProfileLiveCelebration({
   onComplete,
   autoAdvanceMs = 4000,
 }: ProfileLiveCelebrationProps) {
+  const [celebrationState, setCelebrationState] = useState<
+    'checking' | 'fresh' | 'celebrated'
+  >('checking');
   const [isVisible, setIsVisible] = useState(false);
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -37,26 +40,36 @@ export function ProfileLiveCelebration({
   const onCompleteRef = useRef(onComplete);
   const profileUrl = `jov.ie/${username}`;
 
-  // Check localStorage to prevent re-firing celebration
+  // Storage is a client-only concern. Resolve it after hydration so a browser
+  // storage restriction can never affect render purity or hydration.
   const celebrationKey = profileId ? `celebrated_${profileId}` : null;
-  const alreadyCelebrated = celebrationKey
-    ? globalThis.window !== undefined &&
-      globalThis.localStorage.getItem(celebrationKey) !== null
-    : false;
-
-  // Mark as celebrated on first render
   useEffect(() => {
-    if (celebrationKey && !alreadyCelebrated) {
-      globalThis.localStorage.setItem(celebrationKey, String(Date.now()));
+    if (!celebrationKey) {
+      setCelebrationState('fresh');
+      return;
     }
-  }, [celebrationKey, alreadyCelebrated]);
 
-  // If already celebrated, auto-complete immediately
+    try {
+      if (globalThis.localStorage.getItem(celebrationKey) !== null) {
+        setCelebrationState('celebrated');
+        return;
+      }
+
+      globalThis.localStorage.setItem(celebrationKey, String(Date.now()));
+    } catch {
+      // Private browsing and embedded webviews can deny storage. The
+      // celebration remains usable; it simply cannot be persisted there.
+    }
+
+    setCelebrationState('fresh');
+  }, [celebrationKey]);
+
+  // If already celebrated, auto-complete once storage has resolved.
   useEffect(() => {
-    if (alreadyCelebrated) {
+    if (celebrationState === 'celebrated') {
       onCompleteRef.current();
     }
-  }, [alreadyCelebrated]);
+  }, [celebrationState]);
 
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -87,6 +100,10 @@ export function ProfileLiveCelebration({
   }, []);
 
   useEffect(() => {
+    if (celebrationState !== 'fresh') {
+      return;
+    }
+
     hasCompletedRef.current = false;
 
     const dialog = dialogRef.current;
@@ -174,7 +191,7 @@ export function ProfileLiveCelebration({
       }
       previousFocusRef.current?.focus();
     };
-  }, [autoAdvanceMs, completeCelebration, username]);
+  }, [autoAdvanceMs, celebrationState, completeCelebration, username]);
 
   return (
     <dialog

--- a/apps/web/tests/unit/dashboard/ProfileLiveCelebration.test.tsx
+++ b/apps/web/tests/unit/dashboard/ProfileLiveCelebration.test.tsx
@@ -1,0 +1,95 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockTrack = vi.fn();
+
+vi.mock('@/lib/analytics', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+vi.mock('@/components/atoms/Confetti', () => ({
+  ConfettiOverlay: () => <div data-testid='confetti-overlay' />,
+}));
+
+vi.mock(
+  '@/components/features/dashboard/molecules/CelebrationCardPreview',
+  () => ({
+    CelebrationCardPreview: () => (
+      <div data-testid='celebration-card-preview' />
+    ),
+  })
+);
+
+vi.mock(
+  '@/components/features/dashboard/molecules/CopyToClipboardButton',
+  () => ({
+    CopyToClipboardButton: () => <button type='button'>Copy</button>,
+  })
+);
+
+import { ProfileLiveCelebration } from '@/components/features/dashboard/molecules/ProfileLiveCelebration';
+
+describe('ProfileLiveCelebration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    HTMLDialogElement.prototype.showModal = vi.fn();
+    HTMLDialogElement.prototype.close = vi.fn();
+  });
+
+  it('checks browser storage after hydration before opening a fresh celebration', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+
+    render(
+      <ProfileLiveCelebration
+        username='tim'
+        profileId='profile-1'
+        onComplete={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(setItem).toHaveBeenCalledWith(
+        'celebrated_profile-1',
+        expect.any(String)
+      );
+      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('completes without opening a dialog when storage shows the profile was celebrated', async () => {
+    localStorage.setItem('celebrated_profile-1', '1');
+    const onComplete = vi.fn();
+
+    render(
+      <ProfileLiveCelebration
+        username='tim'
+        profileId='profile-1'
+        onComplete={onComplete}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledOnce();
+    });
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it('continues when browser storage is unavailable', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage denied', 'SecurityError');
+    });
+
+    render(
+      <ProfileLiveCelebration
+        username='tim'
+        profileId='profile-1'
+        onComplete={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- defer persisted celebration lookup until after hydration
- keep restricted-storage browsers usable
- prevent a persisted celebration from opening before its state resolves

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/molecules/ProfileLiveCelebration.tsx apps/web/tests/unit/dashboard/ProfileLiveCelebration.test.tsx`
- focused Vitest is covered by source CI; the fresh source-only worktree had no materialized test dependencies

No Linear issue — ad-hoc hydration robustness follow-up.