### PR TITLE
fix(ci): capture authenticated auth shell changes

### DIFF
--- a/.github/scripts/pr-visual-review.mjs
+++ b/.github/scripts/pr-visual-review.mjs
@@ -15,6 +15,12 @@ export const REQUIRED_CAPTURE_VIEWPORTS = ['desktop', 'mobile'];
 const PUBLIC_HOME_CAPTURE_ROUTE = '/';
 const PUBLIC_PROFILE_CAPTURE_ROUTE = '/demo/showcase/public-profile';
 const AUTHENTICATED_CHAT_CAPTURE_ROUTE = '/app/chat';
+// Changes to the session boundary can leave a public route perfectly healthy
+// while making every authenticated surface unusable. Keep this deliberately
+// narrow: these are the files that establish the app-shell session and route
+// guard, not every page under the auth route group.
+const AUTHENTICATED_SHELL_CAPTURE_FILE =
+  /^(?:apps\/web\/(?:proxy|middleware)\.[cm]?[jt]s|apps\/web\/lib\/auth\/(?:gate|session|auth-session-cookies)\.[cm]?[jt]sx?|apps\/web\/app\/app(?:\/\(shell\))?\/layout\.[cm]?[jt]sx?)$/i;
 
 /** @typedef {{ apiKey?: string, baseUrl?: string, model?: string }} ReviewBackend */
 
@@ -29,7 +35,10 @@ export function sanitizeForPrompt(value) {
 
 export function routeChangedFiles(files) {
   const changed = files.filter(
-    file => UI_FILE.test(file) || /(^|\/)DESIGN\.md$/.test(file)
+    file =>
+      UI_FILE.test(file) ||
+      AUTHENTICATED_SHELL_CAPTURE_FILE.test(file) ||
+      /(^|\/)DESIGN\.md$/.test(file)
   );
   if (changed.length === 0)
     return {
@@ -44,7 +53,10 @@ export function routeChangedFiles(files) {
     // UI changes belong on the public home surface; `/demo` and `/demo/admin`
     // require data/authentication that the capture runner intentionally does
     // not invent.
-    if (/admin|console|ops/i.test(file)) routes.add(PUBLIC_HOME_CAPTURE_ROUTE);
+    if (AUTHENTICATED_SHELL_CAPTURE_FILE.test(file))
+      routes.add(AUTHENTICATED_CHAT_CAPTURE_ROUTE);
+    else if (/admin|console|ops/i.test(file))
+      routes.add(PUBLIC_HOME_CAPTURE_ROUTE);
     else if (/dynamic|profile|username|artist/i.test(file))
       routes.add(PUBLIC_PROFILE_CAPTURE_ROUTE);
     else if (/chat|shell/i.test(file))

--- a/scripts/lib/__tests__/pr-visual-review.test.mjs
+++ b/scripts/lib/__tests__/pr-visual-review.test.mjs
@@ -72,6 +72,24 @@ describe('bounded PR visual review contract', () => {
     });
   });
 
+  it('routes the authenticated session boundary through chat instead of masking it with a public capture', () => {
+    expect(
+      routeChangedFiles([
+        'apps/web/lib/auth/gate.ts',
+        'apps/web/lib/auth/session.ts',
+        'apps/web/lib/auth/auth-session-cookies.ts',
+        'apps/web/proxy.ts',
+        'apps/web/app/app/layout.tsx',
+        'apps/web/app/app/(shell)/layout.tsx',
+      ])
+    ).toEqual({
+      shouldReview: true,
+      routes: ['/app/chat'],
+      reason: 'ui-change',
+      review_status: 'advisory',
+    });
+  });
+
   it('validates authenticated capture handoff before loading an app route', () => {
     const capture = readFileSync(
       '.github/scripts/pr-visual-review-capture.mjs',


### PR DESCRIPTION
## Summary
- Route the narrow authenticated shell boundary to seeded `/app/chat` capture.
- Include proxy, auth gate/session cookies, and app-shell layouts without broadening ordinary auth pages.
- Add deterministic route-classifier regression coverage.

## Verification
- `pnpm exec vitest run --config scripts/vitest.config.mts lib/__tests__/pr-visual-review.test.mjs` (14 passed)
- `pnpm exec biome check --write .github/scripts/pr-visual-review.mjs scripts/lib/__tests__/pr-visual-review.test.mjs`
- `git diff --check`

Follow-up to #15202; this PR only changes capture routing.