### PR TITLE
feat(design): add concentric radius elevation contract

### DIFF
--- a/apps/web/lib/design/system-b-radius.ts
+++ b/apps/web/lib/design/system-b-radius.ts
@@ -24,3 +24,46 @@ export const SYSTEM_B_RADIUS_PX = {
 } as const;
 
 export type SystemBRadiusToken = keyof typeof SYSTEM_B_RADIUS_PX;
+
+/**
+ * Shared inset distances that participate in System B's concentric-surface
+ * rule. These values intentionally mirror `--space-*` in design-system.css.
+ */
+export const SYSTEM_B_SURFACE_INSET_PX = {
+  1: 4,
+} as const;
+
+/**
+ * System B surface geometry.
+ *
+ * When one rounded surface is inset inside another, the outer radius must
+ * equal the inner radius plus the inset. This keeps the two corner arcs
+ * concentric instead of making nested cards and overlay rows look misaligned.
+ *
+ * Use the CSS aliases with the same names in `styles/design-system.css` for
+ * classes. This typed representation exists for geometry helpers and tests.
+ */
+export const SYSTEM_B_CONCENTRIC_SURFACES = {
+  card: {
+    outer: 'xl',
+    inner: 'lg',
+    inset: 1,
+  },
+  overlay: {
+    outer: 'xl',
+    inner: 'lg',
+    inset: 1,
+  },
+  panel: {
+    outer: '3xl',
+    inner: '2xl',
+    inset: 1,
+  },
+} as const satisfies Record<
+  string,
+  {
+    readonly outer: SystemBRadiusToken;
+    readonly inner: SystemBRadiusToken;
+    readonly inset: keyof typeof SYSTEM_B_SURFACE_INSET_PX;
+  }
+>;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -171,6 +171,22 @@
   --system-b-duration-fast: var(--ds-motion-subtle-duration);
   --system-b-ease: var(--ds-motion-subtle-easing);
   --system-b-radius-pill: var(--radius-full);
+  /* Concentric nested surfaces: outer radius = inner radius + inset. */
+  --system-b-radius-card: var(--radius-xl);
+  --system-b-radius-card-inner: calc(
+    var(--system-b-radius-card) -
+    var(--space-1)
+  );
+  --system-b-radius-overlay: var(--radius-xl);
+  --system-b-radius-overlay-inner: calc(
+    var(--system-b-radius-overlay) -
+    var(--space-1)
+  );
+  --system-b-radius-panel: var(--radius-3xl);
+  --system-b-radius-panel-inner: calc(
+    var(--system-b-radius-panel) -
+    var(--space-1)
+  );
   --system-b-onboarding-step-handle: var(--geist-purple-solid);
   --system-b-onboarding-step-spotify: var(--color-brand-spotify);
   --system-b-onboarding-step-upgrade: var(--geist-amber-solid);

--- a/apps/web/tests/unit/design-system/concentric-radius-contract.test.ts
+++ b/apps/web/tests/unit/design-system/concentric-radius-contract.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  SYSTEM_B_CONCENTRIC_SURFACES,
+  SYSTEM_B_RADIUS_PX,
+  SYSTEM_B_SURFACE_INSET_PX,
+} from '@/lib/design/system-b-radius';
+
+const APP_ROOT = join(__dirname, '../../..');
+const REPO_ROOT = join(APP_ROOT, '../..');
+
+describe('System B concentric radius contract', () => {
+  it('keeps every outer radius equal to its inner radius plus its inset', () => {
+    for (const [surface, geometry] of Object.entries(
+      SYSTEM_B_CONCENTRIC_SURFACES
+    )) {
+      expect(
+        SYSTEM_B_RADIUS_PX[geometry.outer],
+        `${surface} outer radius`
+      ).toBe(
+        SYSTEM_B_RADIUS_PX[geometry.inner] +
+          SYSTEM_B_SURFACE_INSET_PX[geometry.inset]
+      );
+    }
+  });
+
+  it('defines the shared CSS aliases from existing radius and spacing tokens', () => {
+    const css = readFileSync(
+      join(APP_ROOT, 'styles/design-system.css'),
+      'utf-8'
+    );
+
+    expect(css).toContain('--system-b-radius-card: var(--radius-xl);');
+    expect(css).toMatch(
+      /--system-b-radius-card-inner:\s*calc\(\s*var\(--system-b-radius-card\)\s*-\s*var\(--space-1\)\s*\)/
+    );
+    expect(css).toContain('--system-b-radius-overlay: var(--radius-xl);');
+    expect(css).toMatch(
+      /--system-b-radius-overlay-inner:\s*calc\(\s*var\(--system-b-radius-overlay\)\s*-\s*var\(--space-1\)\s*\)/
+    );
+    expect(css).toContain('--system-b-radius-panel: var(--radius-3xl);');
+    expect(css).toMatch(
+      /--system-b-radius-panel-inner:\s*calc\(\s*var\(--system-b-radius-panel\)\s*-\s*var\(--space-1\)\s*\)/
+    );
+  });
+
+  it('routes shared card and overlay containers through semantic aliases', () => {
+    const card = readFileSync(
+      join(REPO_ROOT, 'packages/ui/atoms/card.tsx'),
+      'utf-8'
+    );
+    const dropdown = readFileSync(
+      join(REPO_ROOT, 'packages/ui/lib/dropdown-styles.ts'),
+      'utf-8'
+    );
+    const overlay = readFileSync(
+      join(REPO_ROOT, 'packages/ui/lib/overlay-styles.ts'),
+      'utf-8'
+    );
+    const themeTokens = readFileSync(
+      join(REPO_ROOT, 'packages/ui/theme/tokens.ts'),
+      'utf-8'
+    );
+
+    expect(card).toContain('rounded-(--system-b-radius-card)');
+    expect(card).not.toContain('rounded-[');
+    expect(dropdown).toContain('rounded-(--system-b-radius-overlay)');
+    expect(dropdown).toContain('rounded-(--system-b-radius-overlay-inner)');
+    expect(dropdown).not.toContain('rounded-[');
+    expect(overlay).toContain('rounded-(--system-b-radius-panel)');
+    expect(overlay).not.toContain('rounded-[');
+    expect(themeTokens).toContain('export const concentricRadii');
+    expect(themeTokens).toContain('var(--system-b-radius-card-inner)');
+  });
+});

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -187,6 +187,23 @@ these, not redefine them.
 - **Canonical button sizes** — `sm` = 28px, `md` = 36px, `lg` = 44px; `icon`
   uses the `md` control height with equal width.
 
+### Concentric radius-by-elevation
+
+Nested System B surfaces use a shared geometric rule: **outer radius = inner
+radius + inset**. Use the semantic CSS aliases rather than a one-off `rounded-*`
+value when creating a reusable card, overlay, or panel.
+
+| Surface | Outer token | Inset | Inner token |
+| --- | --- | --- | --- |
+| Card | `--system-b-radius-card` (`--radius-xl`) | `--space-1` | `--system-b-radius-card-inner` (`--radius-lg`) |
+| Overlay | `--system-b-radius-overlay` (`--radius-xl`) | `--space-1` | `--system-b-radius-overlay-inner` (`--radius-lg`) |
+| Panel/dialog | `--system-b-radius-panel` (`--radius-3xl`) | `--space-1` | `--system-b-radius-panel-inner` (`--radius-2xl`) |
+
+The typed contract is `SYSTEM_B_CONCENTRIC_SURFACES` in
+`apps/web/lib/design/system-b-radius.ts`. Shared `Card`, dropdown/popover, and
+dialog primitives consume the outer aliases. An inset child surface should use
+the matching `*-inner` alias; pill/circle geometry is excluded from this rule.
+
 ## Source guards (composer + header radius/padding)
 
 Composer and app-shell header surfaces must not reintroduce off-token corner

--- a/packages/ui/atoms/card.test.tsx
+++ b/packages/ui/atoms/card.test.tsx
@@ -16,7 +16,7 @@ describe('Card', () => {
     render(<Card data-testid='card'>Card content</Card>);
     const card = screen.getByTestId('card');
     expect(card).toBeInTheDocument();
-    expect(card.className).toContain('rounded-[var(--radius-lg)]');
+    expect(card.className).toContain('rounded-(--system-b-radius-card)');
     expect(card.className).toContain('border-subtle');
     expect(card.className).toContain('bg-surface-1');
   });
@@ -52,7 +52,7 @@ describe('Card', () => {
     );
     const article = screen.getByTestId('article');
     expect(article.tagName).toBe('ARTICLE');
-    expect(article.className).toContain('rounded-[var(--radius-lg)]');
+    expect(article.className).toContain('rounded-(--system-b-radius-card)');
   });
 
   it('supports asChild with section element', () => {
@@ -74,7 +74,7 @@ describe('Card', () => {
     );
     const card = screen.getByTestId('card');
     expect(card.className).toContain('custom-class');
-    expect(card.className).toContain('rounded-[var(--radius-lg)]');
+    expect(card.className).toContain('rounded-(--system-b-radius-card)');
   });
 
   it('passes through HTML attributes', () => {
@@ -319,7 +319,7 @@ describe('Card composition', () => {
     expect(footer.tagName).toBe('FOOTER');
 
     // Verify classes are still applied
-    expect(article.className).toContain('rounded-[var(--radius-lg)]');
+    expect(article.className).toContain('rounded-(--system-b-radius-card)');
     expect(header.className).toContain('flex');
     expect(title.className).toContain('text-base');
   });

--- a/packages/ui/atoms/card.tsx
+++ b/packages/ui/atoms/card.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 const cardVariants = cva(
-  'rounded-[var(--radius-lg)] border border-subtle bg-surface-1 text-primary-token shadow-card transition-colors duration-normal ease-interactive',
+  'rounded-(--system-b-radius-card) border border-subtle bg-surface-1 text-primary-token shadow-card transition-colors duration-normal ease-interactive',
   {
     variants: {
       variant: {

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -306,6 +306,7 @@ export {
   animation,
   borders,
   buttons,
+  concentricRadii,
   featureAccents,
   interactive,
   JovieColor,

--- a/packages/ui/lib/dropdown-styles.ts
+++ b/packages/ui/lib/dropdown-styles.ts
@@ -15,7 +15,7 @@
  *   Content padding: p-0.5, Item: px-2.5 py-1 text-xs leading-4
  *
  * Design tokens used:
- * - Border radius: rounded-xl surfaces, rounded-lg rows, rounded-full triggers
+ * - Border radius: concentric overlay surfaces/rows, rounded-full triggers
  * - Background: bg-surface-0 (elevated)
  * - Border: border-default (uses design token for both modes)
  * - Shadow: consistent across all variants
@@ -55,7 +55,13 @@ export const OVERLAY_SURFACE_BASE =
 /**
  * The shared rounded rectangle used by wrapped overlay content.
  */
-export const OVERLAY_CONTENT_RADIUS = 'rounded-xl';
+export const OVERLAY_CONTENT_RADIUS = 'rounded-(--system-b-radius-overlay)';
+
+/**
+ * Rows inset by the overlay's `p-1` use the matching inner radius so their
+ * corner arc shares the overlay's center.
+ */
+export const OVERLAY_ITEM_RADIUS = 'rounded-(--system-b-radius-overlay-inner)';
 
 export const DROPDOWN_CONTENT_BASE = `z-50 min-w-48 overflow-hidden ${OVERLAY_CONTENT_RADIUS} ${OVERLAY_SURFACE_BASE} p-1`;
 
@@ -164,7 +170,7 @@ export const selectContentClasses = [
  * Used by: DropdownMenuItem, ContextMenuItem, SelectItem
  */
 export const MENU_ITEM_BASE =
-  'relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-lg px-2.5 py-1.5 text-app font-normal leading-5 outline-none ' +
+  `relative flex min-h-8 cursor-default select-none items-center gap-2 ${OVERLAY_ITEM_RADIUS} px-2.5 py-1.5 text-app font-normal leading-5 outline-none ` +
   'transition-colors duration-fast ease-interactive ' +
   'text-secondary-token hover:bg-surface-1 hover:text-primary-token ' +
   'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
@@ -192,7 +198,7 @@ export const MENU_ITEM_SELECTED =
  * Checkbox and radio item styles (with left indicator space)
  */
 export const CHECKBOX_RADIO_ITEM_BASE =
-  'relative flex cursor-default select-none items-center rounded-lg py-1 pl-7 pr-2 text-xs font-normal leading-4 outline-none ' +
+  `relative flex cursor-default select-none items-center ${OVERLAY_ITEM_RADIUS} py-1 pl-7 pr-2 text-xs font-normal leading-4 outline-none ` +
   'transition-colors duration-fast ease-interactive ' +
   'text-secondary-token hover:bg-surface-1 hover:text-primary-token ' +
   'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
@@ -203,7 +209,7 @@ export const CHECKBOX_RADIO_ITEM_BASE =
  * Select item base — unified with MENU_ITEM_BASE hover/focus behavior
  */
 export const SELECT_ITEM_BASE =
-  'relative flex w-full cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-app font-normal leading-5 outline-none ' +
+  `relative flex w-full cursor-default select-none items-center ${OVERLAY_ITEM_RADIUS} py-1.5 pl-8 pr-2 text-app font-normal leading-5 outline-none ` +
   'transition-colors duration-fast ease-interactive ' +
   'text-secondary-token ' +
   'focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:ring-1 focus-visible:ring-focus/35 ' +
@@ -218,7 +224,7 @@ export const SELECT_ITEM_BASE =
  * Compact menu item — smaller padding & font for dense UIs (tables, sidebars)
  */
 export const MENU_ITEM_COMPACT =
-  'relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-lg px-2.5 py-1 text-xs font-normal leading-4 outline-none ' +
+  `relative flex min-h-8 cursor-default select-none items-center gap-2 ${OVERLAY_ITEM_RADIUS} px-2.5 py-1 text-xs font-normal leading-4 outline-none ` +
   'transition-colors duration-fast ease-interactive ' +
   'text-secondary-token hover:bg-surface-1 hover:text-primary-token ' +
   'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
@@ -367,7 +373,7 @@ export const searchableSubMenuContentClasses = [
  * Compact base — currently equivalent to DROPDOWN_CONTENT_BASE; retained for future divergence
  */
 export const DROPDOWN_CONTENT_COMPACT_BASE =
-  'z-50 min-w-48 overflow-hidden rounded-xl border border-default bg-surface-0 p-0.5 text-primary-token shadow-popover';
+  'z-50 min-w-48 overflow-hidden rounded-(--system-b-radius-overlay) border border-default bg-surface-0 p-0.5 text-primary-token shadow-popover';
 
 /**
  * Complete compact DropdownMenu content classes

--- a/packages/ui/lib/overlay-styles.ts
+++ b/packages/ui/lib/overlay-styles.ts
@@ -38,7 +38,7 @@ export const centeredContentStyles = {
     'data-[state=open]:animate-in data-[state=closed]:animate-out ' +
     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 ' +
     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-  rounded: 'rounded-(--linear-radius-lg)',
+  rounded: 'rounded-(--system-b-radius-panel)',
   // Motion-reduced fallback
   reducedMotion: 'motion-reduce:animate-none motion-reduce:transition-opacity',
 } as const;

--- a/packages/ui/theme/tokens.ts
+++ b/packages/ui/theme/tokens.ts
@@ -176,6 +176,30 @@ export const radii = {
   full: 'var(--radius-full)', // 9999px — circles
 } as const;
 
+/**
+ * Semantic radius pairs for nested System B surfaces. The outer radius is
+ * always the inner radius plus `inset`, keeping the two corner arcs
+ * concentric. Use the outer alias for a shared surface and the matching inner
+ * alias for a rounded child placed inside its inset.
+ */
+export const concentricRadii = {
+  card: {
+    outer: 'var(--system-b-radius-card)',
+    inner: 'var(--system-b-radius-card-inner)',
+    inset: 'var(--space-1)',
+  },
+  overlay: {
+    outer: 'var(--system-b-radius-overlay)',
+    inner: 'var(--system-b-radius-overlay-inner)',
+    inset: 'var(--space-1)',
+  },
+  panel: {
+    outer: 'var(--system-b-radius-panel)',
+    inner: 'var(--system-b-radius-panel-inner)',
+    inset: 'var(--space-1)',
+  },
+} as const;
+
 // ============================================
 // SPACING (8px grid system)
 // ============================================


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3369 -->

## Summary
- introduce a typed System B concentric radius contract based on existing radius and spacing tokens
- route shared Card, dropdown/popover, and dialog primitives through semantic outer/inner aliases
- document the rule and add a regression test for `outer = inner + inset` and no arbitrary radius in the shared primitives

## Verification
- `biome check --write` on all changed files ✅
- direct geometry assertion via `tsx` ✅
- `check-bug-to-test-rule.ts` ✅ not applicable (design-system foundation, not bug fix)
- `git diff --check` ✅
- Focused Vitest / package typecheck were attempted but local worktree dependency links cannot resolve existing `@vitejs/plugin-react`, React, and Radix packages before test/project compilation. The normal push gate passed; source CI is the canonical validation environment.

## Risk
- Shared geometry only. No route, server, auth, or feature behavior changes.
- Taste review is advisory under the current shipping policy; no Kimi used.

## Follow-up
- LYB iOS token/primitive alignment is tracked separately as [JOV-4594](https://linear.app/jovie/issue/JOV-4594/lyb-ios-adopt-concentric-radius-by-elevation-surface-contract), parented to JOV-3369. It deliberately remains out of this web-only PR.
