### PR TITLE
fix(auth): stabilize sign-in hydration guard

### DIFF
--- a/apps/web/components/features/auth/AuthenticatedAuthEntryGuard.tsx
+++ b/apps/web/components/features/auth/AuthenticatedAuthEntryGuard.tsx
@@ -23,10 +23,15 @@ export function AuthenticatedAuthEntryGuard({
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isLoaded, isSignedIn } = useAuthSafe();
-  const [isRedirecting, setIsRedirecting] = useState(
-    () =>
-      typeof document !== 'undefined' && hasClientAuthSession(document.cookie)
-  );
+  // The initial render must be identical on the server and client. Reading
+  // `document.cookie` from a lazy initializer made an existing session render
+  // `null` during browser hydration while the server had rendered the auth
+  // form, which triggers React hydration error #418 on `/signin`.
+  //
+  // Cookie-based fast redirect remains useful, but it belongs in the effect
+  // after hydration. The server-side auth route already handles the normal
+  // authenticated request path before this client guard mounts.
+  const [isRedirecting, setIsRedirecting] = useState(false);
 
   useEffect(() => {
     const cookieSignedIn =

--- a/apps/web/tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx
+++ b/apps/web/tests/unit/auth/AuthenticatedAuthEntryGuard.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { replaceMock, searchParamsState, authState } = vi.hoisted(() => ({
@@ -113,5 +114,31 @@ describe('AuthenticatedAuthEntryGuard', () => {
       expect(getByText('Sign-in form')).toBeInTheDocument();
       expect(replaceMock).not.toHaveBeenCalled();
     });
+  });
+
+  it('keeps the server auth markup stable when a browser session cookie exists', () => {
+    document.cookie = '__client_uat=1700000000';
+    authState.isLoaded = false;
+
+    const originalDocument = globalThis.document;
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const markup = renderToStaticMarkup(
+        <AuthenticatedAuthEntryGuard>
+          <div>Sign-in form</div>
+        </AuthenticatedAuthEntryGuard>
+      );
+
+      expect(markup).toContain('Sign-in form');
+    } finally {
+      Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Prevents React hydration error #418 on `/signin` when the browser already has an auth activity cookie.

The auth-entry guard previously read `document.cookie` in its initial state initializer. The server always rendered the sign-in form, while a browser with `__client_uat` rendered `null` immediately, creating a server/client markup mismatch before Google One Tap/FedCM could run.

The initial render is now deterministic (`false`) on both server and client. The cookie fast-path remains in the existing post-hydration effect.

## Validation

- `biome check` passed for the two changed files
- `git diff --check` passed
- Added a server-markup regression test
- Focused Vitest could not start locally because this fresh isolated worktree lacks generated dependency links for `@vitejs/plugin-react` and `dotenv`; source CI is the authoritative focused test run.

<!-- linear-issue-id:ad-hoc-signin-hydration-418 -->
