### PR TITLE
feat(ui): add canonical stackable badge group [JOV-4523]

### DIFF
--- a/packages/ui/atoms/index.ts
+++ b/packages/ui/atoms/index.ts
@@ -2,7 +2,6 @@ export type { BadgeProps } from './badge';
 export { Badge, badgeVariants } from './badge';
 export type { ButtonProps } from './button';
 export { Button, buttonVariants } from './button';
-
 export {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -22,13 +21,18 @@ export {
 } from './dropdown-menu';
 export type { KbdProps } from './kbd';
 export { Kbd } from './kbd';
-
 export {
   Popover,
   PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from './popover';
+export type {
+  StackableBadgeGroupProps,
+  StackableBadgeItem,
+  StackableBadgeTone,
+} from './stackable-badge-group';
+export { StackableBadgeGroup } from './stackable-badge-group';
 export type { TooltipContentProps } from './tooltip';
 export {
   Tooltip,

--- a/packages/ui/atoms/stackable-badge-group.test.tsx
+++ b/packages/ui/atoms/stackable-badge-group.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import {
+  StackableBadgeGroup,
+  type StackableBadgeItem,
+} from './stackable-badge-group';
+
+const ITEMS: readonly StackableBadgeItem[] = [
+  {
+    id: 'spotify',
+    label: 'Spotify for Artists with a deliberately long label',
+    icon: <span>Sp</span>,
+    tone: 'success',
+  },
+  { id: 'apple', label: 'Apple Music', icon: <span>Am</span>, tone: 'info' },
+  { id: 'apple-duplicate', label: 'Apple Music', icon: <span>Am</span> },
+  { id: 'youtube', label: 'YouTube', icon: <span>Yt</span>, disabled: true },
+];
+
+describe('StackableBadgeGroup', () => {
+  it('returns null for an empty list', () => {
+    const { container } = render(<StackableBadgeGroup items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('keeps a compact fixed table slot and clamps the primary label', () => {
+    render(<StackableBadgeGroup items={ITEMS} />);
+
+    const group = screen.getByRole('group');
+    expect(group).toHaveClass('h-5');
+    expect(group).toHaveClass('w-32');
+    expect(group).toHaveClass('overflow-hidden');
+    expect(screen.getByText(ITEMS[0].label)).toHaveClass('truncate');
+  });
+
+  it('keeps the consumer-selected standard slot stable as item counts change', () => {
+    const { rerender } = render(
+      <StackableBadgeGroup items={ITEMS.slice(0, 1)} width='standard' />
+    );
+
+    expect(screen.getByRole('group')).toHaveClass('w-40');
+    rerender(<StackableBadgeGroup items={ITEMS} width='standard' />);
+    expect(screen.getByRole('group')).toHaveClass('w-40');
+  });
+
+  it('preserves input order and supports duplicate icons and labels', async () => {
+    const user = userEvent.setup();
+    render(<StackableBadgeGroup items={ITEMS} maxVisible={2} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Show 2 more badges' })
+    );
+
+    const rows = screen.getAllByRole('listitem');
+    ITEMS.forEach((item, index) => {
+      expect(within(rows[index]).getByText(item.label)).toBeInTheDocument();
+    });
+    expect(screen.getAllByText('Am')).toHaveLength(3);
+  });
+
+  it('caps visible entries and discloses the exact overflow count', () => {
+    render(<StackableBadgeGroup items={ITEMS} maxVisible={2} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Show 2 more badges' })
+    ).toHaveTextContent('+2 more');
+  });
+
+  it('does not render a disclosure when every item is visible', () => {
+    render(<StackableBadgeGroup items={ITEMS} maxVisible={4} />);
+    expect(
+      screen.queryByRole('button', { name: /show .* more badges/i })
+    ).toBeNull();
+  });
+
+  it('uses logical overlap and retains RTL direction on the group', () => {
+    render(<StackableBadgeGroup dir='rtl' items={ITEMS} maxVisible={2} />);
+
+    const group = screen.getByRole('group');
+    expect(group).toHaveAttribute('dir', 'rtl');
+    expect(screen.getByTitle('Apple Music')).toHaveClass('-ms-1.5');
+  });
+
+  it('renders selected and disabled states with shared token classes', () => {
+    render(
+      <StackableBadgeGroup
+        items={[
+          { id: 'selected', label: 'Selected', selected: true },
+          { id: 'disabled', label: 'Disabled', disabled: true },
+        ]}
+        maxVisible={2}
+      />
+    );
+
+    expect(screen.getByTitle('Selected')).toHaveClass('ring-1');
+    expect(screen.getByTitle('Disabled')).toHaveClass('opacity-50');
+  });
+
+  it('opens a keyboard-accessible full list through the overflow control', async () => {
+    const user = userEvent.setup();
+    render(<StackableBadgeGroup items={ITEMS} maxVisible={1} />);
+
+    const trigger = screen.getByRole('button', { name: 'Show 3 more badges' });
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await user.keyboard('{Enter}');
+
+    expect(
+      screen.getByRole('list', { name: 'All badges' })
+    ).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('list', { name: 'All badges' })).toBeNull();
+  });
+});

--- a/packages/ui/atoms/stackable-badge-group.tsx
+++ b/packages/ui/atoms/stackable-badge-group.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../lib/utils';
+import { badgeVariants } from './badge';
+import { Button } from './button';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+export type StackableBadgeTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'accent'
+  | 'warning'
+  | 'error';
+
+/** One stable entry in a compact stack. Input order is display order. */
+export interface StackableBadgeItem {
+  /** Stable identity. Labels and icons may repeat. */
+  readonly id: string;
+  /** Exposed in the primary badge and the full-list disclosure. */
+  readonly label: string;
+  /** Optional brand or semantic mark. Lower stack entries render icon-only. */
+  readonly icon?: React.ReactNode;
+  readonly tone?: StackableBadgeTone;
+  readonly selected?: boolean;
+  readonly disabled?: boolean;
+}
+
+export interface StackableBadgeGroupProps
+  extends Omit<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, 'children'> {
+  readonly items: readonly StackableBadgeItem[];
+  /** Includes the labelled primary item. A minimum of one remains visible. */
+  readonly maxVisible?: number;
+  /** Compact table geometry is the default; standard uses the same fixed slot. */
+  readonly density?: 'dense' | 'standard';
+  /**
+   * Fixed inline slot selected by the consumer. Compact is table-first; every
+   * item count uses the same slot so adjacent columns never move.
+   */
+  readonly width?: 'compact' | 'standard';
+  /** Override the list announcement when the item labels alone are insufficient. */
+  readonly ariaLabel?: string;
+}
+
+const visibleCap = (maxVisible: number) => Math.max(1, maxVisible);
+
+const itemClasses = (item: StackableBadgeItem) =>
+  cn(
+    badgeVariants({ size: 'sm', tone: item.tone ?? 'neutral' }),
+    'h-5 shrink-0 justify-center border-2 border-surface-0 transition-colors duration-fast ease-interactive',
+    item.selected && 'ring-1 ring-accent/40',
+    item.disabled && 'opacity-50',
+    'group-hover/badge-stack:bg-surface-2 group-focus-within/badge-stack:bg-surface-2'
+  );
+
+/**
+ * Compact, fixed-width badge stack for dense table cells and metadata rows.
+ *
+ * The first item carries its label. Remaining visible entries show only their
+ * icons and overlap at the logical inline-start edge. Overflow is always an
+ * accessible Radix disclosure containing the complete, input-ordered list.
+ * The consumer selects a fixed compact or standard slot; changes in item count
+ * never move adjacent table columns.
+ */
+export function StackableBadgeGroup({
+  items,
+  maxVisible = 3,
+  density = 'dense',
+  width = 'compact',
+  ariaLabel,
+  className,
+  ...props
+}: StackableBadgeGroupProps) {
+  if (items.length === 0) return null;
+
+  const visible = items.slice(0, visibleCap(maxVisible));
+  const overflowCount = Math.max(0, items.length - visible.length);
+  const primary = visible[0];
+  const groupLabel = ariaLabel ?? items.map(item => item.label).join(', ');
+
+  return (
+    <fieldset
+      aria-label={groupLabel}
+      className={cn(
+        'group/badge-stack m-0 inline-flex h-5 max-w-full items-center overflow-hidden border-0 p-0',
+        width === 'compact' ? 'w-32' : 'w-40',
+        density === 'standard' && 'h-6',
+        className
+      )}
+      data-slot='stackable-badge-group'
+      {...props}
+    >
+      <span
+        className={cn(
+          itemClasses(primary),
+          'min-w-0 max-w-32 flex-1 gap-1 px-1.5',
+          density === 'standard' && 'h-6'
+        )}
+        title={primary.label}
+      >
+        {primary.icon && (
+          <span aria-hidden='true' className='grid shrink-0 place-items-center'>
+            {primary.icon}
+          </span>
+        )}
+        <span className='min-w-0 truncate'>{primary.label}</span>
+      </span>
+
+      <span aria-hidden='true' className='flex shrink-0 items-center'>
+        {visible.slice(1).map(item => (
+          <span
+            key={item.id}
+            className={cn(
+              itemClasses(item),
+              '-ms-1.5 w-5 p-0',
+              density === 'standard' && 'h-6 w-6'
+            )}
+            title={item.label}
+          >
+            <span className='grid shrink-0 place-items-center'>
+              {item.icon ?? (
+                <span className='h-1.5 w-1.5 rounded-full bg-current' />
+              )}
+            </span>
+          </span>
+        ))}
+      </span>
+
+      {overflowCount > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              aria-label={`Show ${overflowCount} more badges`}
+              className={cn(
+                'ms-1 h-5 shrink-0 px-1.5 text-3xs font-medium tabular-nums',
+                density === 'standard' && 'h-6'
+              )}
+              size='sm'
+              variant='ghost'
+            >
+              +{overflowCount} more
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align='end' className='w-56 p-1' side='bottom'>
+            <ul aria-label='All badges' className='grid gap-0.5'>
+              {items.map(item => (
+                <li
+                  key={item.id}
+                  className={cn(
+                    'flex min-h-8 items-center gap-2 rounded-lg px-2 text-xs text-secondary-token',
+                    item.selected && 'bg-surface-1 text-primary-token',
+                    item.disabled && 'opacity-50'
+                  )}
+                >
+                  <span
+                    aria-hidden='true'
+                    className={cn(itemClasses(item), 'h-4 w-4 p-0 text-3xs')}
+                  >
+                    {item.icon ?? (
+                      <span className='h-1.5 w-1.5 rounded-full bg-current' />
+                    )}
+                  </span>
+                  <span className='min-w-0 truncate'>{item.label}</span>
+                </li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
+      )}
+    </fieldset>
+  );
+}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -250,6 +250,13 @@ export { LoadingSkeleton, Skeleton } from './atoms/skeleton';
 // Spinner
 export type { SpinnerProps, SpinnerSize, SpinnerTone } from './atoms/spinner';
 export { Spinner } from './atoms/spinner';
+// Stackable Badge Group
+export type {
+  StackableBadgeGroupProps,
+  StackableBadgeItem,
+  StackableBadgeTone,
+} from './atoms/stackable-badge-group';
+export { StackableBadgeGroup } from './atoms/stackable-badge-group';
 // Switch
 export { Switch } from './atoms/switch';
 // Textarea


### PR DESCRIPTION
## Summary
- add a typed `StackableBadgeGroup` primitive for compact DSP/status collections
- keep the top item readable, overlap lower icons, and expose deterministic `+N more` overflow
- use shared Button/Popover primitives with compact and standard width contracts

## Verification
- focused UI tests: 50 passed, 1 existing skip
- package typecheck passed
- Biome passed
- diff-check passed

## Issue
[JOV-4523](https://linear.app/jovie/issue/JOV-4523)
