### PR TITLE
fix(ci): reconcile temporary queue deferrals

### DIFF
--- a/.github/workflows/merge-queue-autoenroll.yml
+++ b/.github/workflows/merge-queue-autoenroll.yml
@@ -76,6 +76,10 @@ jobs:
           MERGE_QUEUE_BACKEND: ${{ vars.MERGE_QUEUE_BACKEND }}
           DRAIN_MUTATION_AUTHORIZATION: merge-queue-autoenroll
           MERGE_QUEUE_NATIVE_AUTHORIZATION: merge-queue-autoenroll
+          # Queue-pressure deferrals are temporary. Only the existing push on
+          # main controller run may reconcile an exact green auto-merge head;
+          # PR/CI events continue to honor queue-deferred as an explicit hold.
+          DRAIN_RECONCILE_QUEUE_DEFERRED: ${{ github.event_name == 'push' && '1' || '0' }}
         run: |
           if [[ "$MERGE_QUEUE_BACKEND" != "native" ]]; then
             echo "::error::Merge Queue Auto-Enroll requires MERGE_QUEUE_BACKEND=native" >&2

--- a/scripts/drain-pr-queue.sh
+++ b/scripts/drain-pr-queue.sh
@@ -59,6 +59,13 @@ case "$MERGE_QUEUE_BACKEND" in
 esac
 DRAIN_MAX_SECONDS="${DRAIN_MAX_SECONDS:-900}"
 DRAIN_STARTED_AT="$SECONDS"
+# `queue-deferred` is deliberately a hard hold during a saturated queue. On a
+# later main push, though, leaving an otherwise current auto-merge request
+# permanently deferred turns a temporary admission decision into a stranded
+# PR. The existing event-driven controller may opt into this narrowly scoped
+# reconciliation before taking its normal snapshot. It never runs on a PR
+# event or a schedule, and it still requires the canonical source gates.
+DRAIN_RECONCILE_QUEUE_DEFERRED="${DRAIN_RECONCILE_QUEUE_DEFERRED:-0}"
 
 # Keep one scheduled tick bounded. A single in-flight GitHub call may finish
 # after the deadline, but no subsequent per-PR operation is started.
@@ -82,6 +89,133 @@ unlabel() {  # unlabel <num> <label>
   [[ "$DRY_RUN" == "1" ]] && { echo "    [dry-run] would -$2 on #$1"; return 0; }
   gh_retry pr edit "$1" -R "$REPO" --remove-label "$2" >/dev/null 2>&1 \
     && echo "    -$2 on #$1" || echo "    !! failed to remove $2 on #$1"
+}
+
+deferred_state_is_releasable() {  # state json <expected head> <expected base>
+  jq -e --arg expected_head "$2" --arg expected_base "$3" '
+    .state == "OPEN"
+    and (.isDraft | not)
+    and .mergeable == "MERGEABLE"
+    and (.headRefOid // "") == $expected_head
+    and (.baseRefOid // "") == $expected_base
+    and .autoMergeRequest != null
+    and ([.labels[].name] | index("queue-deferred")) != null
+    and ([.labels[].name] | any(
+      . == "needs-human" or . == "hold" or . == "gated"
+      or . == "fast" or . == "needs-conflict-resolution"
+    ) | not)
+  ' <<<"$1" >/dev/null
+}
+
+restore_deferred_hold() {  # restore_deferred_hold <num>
+  local n="$1"
+  [[ "$DRY_RUN" == "1" ]] && return 0
+  if gh_retry pr edit "$n" -R "$REPO" --add-label queue-deferred >/dev/null 2>&1; then
+    echo "    +queue-deferred on #$n (compensated changed release state)"
+    return 0
+  fi
+  echo "    !! could not compensate queue-deferred release for #$n" >&2
+  return 1
+}
+
+# Release only a previously pressure-deferred PR after main advances. This is
+# intentionally called only by Merge Queue Auto-Enroll's existing `push: main`
+# path. A candidate must be live/current, retain its auto-merge request, have
+# no stronger hold, and pass the same canonical source-gate classifier used by
+# normal enrollment. Any race restores the deferral hold rather than enrolling
+# an unproven revision.
+reconcile_deferred_auto_merge_after_main_push() {
+  [[ "$DRAIN_RECONCILE_QUEUE_DEFERRED" == "1" ]] || return 0
+
+  local main_oid candidates pr n expected_head before failures before_release after
+  echo "=== RECONCILE (current auto-merge deferred PRs after main push) ==="
+
+  if ! main_oid="$(gh_retry api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null)" \
+    || [[ ! "$main_oid" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "  !! could not resolve exact main SHA; preserving queue-deferred holds" >&2
+    return 0
+  fi
+  main_oid="$(printf '%s' "$main_oid" | tr '[:upper:]' '[:lower:]')"
+
+  if ! candidates="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
+    --json number,isDraft,mergeable,labels,headRefOid,baseRefOid --jq '
+      [ .[] | select(.isDraft == false) | select(.mergeable == "MERGEABLE")
+        | select([.labels[].name] | index("queue-deferred"))
+        | { n: .number, head: (.headRefOid // ""), base: (.baseRefOid // "") } ]')"; then
+    echo "  !! could not read deferred PR candidates; preserving holds" >&2
+    return 0
+  fi
+
+  while IFS= read -r pr; do
+    stop_if_budget_exhausted && break
+    n="$(jq -r '.n' <<<"$pr")"
+    expected_head="$(jq -r '.head // ""' <<<"$pr" | tr '[:upper:]' '[:lower:]')"
+    expected_base="$(jq -r '.base // ""' <<<"$pr" | tr '[:upper:]' '[:lower:]')"
+    echo "  #$n"
+
+    if [[ ! "$expected_head" =~ ^[0-9a-f]{40}$ || "$expected_base" != "$main_oid" ]]; then
+      echo "    ~ not based on current main; preserving deferral"
+      continue
+    fi
+
+    if ! before="$(gh_retry pr view "$n" -R "$REPO" \
+      --json state,isDraft,mergeable,headRefOid,baseRefOid,labels,autoMergeRequest 2>/dev/null)"; then
+      echo "    ~ could not read live state; preserving deferral"
+      continue
+    fi
+    if ! deferred_state_is_releasable "$before" "$expected_head" "$main_oid"; then
+      echo "    ~ live state is not a current, clean auto-merge defer; preserving"
+      continue
+    fi
+
+    failures="$(check_failures_for_pr "$n")"
+    if [[ "$(jq 'length' <<<"$failures")" -ne 0 ]]; then
+      echo "    ~ canonical source gates are not green: $(jq -r 'join(", ")' <<<"$failures")"
+      continue
+    fi
+
+    # Re-read after checks so neither a new head nor a stronger hold can inherit
+    # an old source-gate result.
+    if ! before_release="$(gh_retry pr view "$n" -R "$REPO" \
+      --json state,isDraft,mergeable,headRefOid,baseRefOid,labels,autoMergeRequest 2>/dev/null)"; then
+      echo "    ~ could not re-read live state; preserving deferral"
+      continue
+    fi
+    if ! deferred_state_is_releasable "$before_release" "$expected_head" "$main_oid"; then
+      echo "    ~ head, base, hold, or auto-merge changed; preserving deferral"
+      continue
+    fi
+
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "    [dry-run] would -queue-deferred on #$n"
+      continue
+    fi
+    if ! gh_retry pr edit "$n" -R "$REPO" --remove-label queue-deferred >/dev/null 2>&1; then
+      echo "    !! failed to remove queue-deferred on #$n" >&2
+      continue
+    fi
+
+    if ! after="$(gh_retry pr view "$n" -R "$REPO" \
+      --json state,isDraft,mergeable,headRefOid,baseRefOid,labels,autoMergeRequest 2>/dev/null)" \
+      || ! jq -e --arg expected_head "$expected_head" --arg expected_base "$main_oid" '
+        .state == "OPEN"
+        and (.isDraft | not)
+        and .mergeable == "MERGEABLE"
+        and (.headRefOid // "") == $expected_head
+        and (.baseRefOid // "") == $expected_base
+        and .autoMergeRequest != null
+        and ([.labels[].name] | index("queue-deferred")) == null
+        and ([.labels[].name] | any(
+          . == "needs-human" or . == "hold" or . == "gated"
+          or . == "fast" or . == "needs-conflict-resolution"
+        ) | not)
+      ' <<<"$after" >/dev/null; then
+      echo "    !! release state changed; restoring queue-deferred hold" >&2
+      restore_deferred_hold "$n" || return 1
+      continue
+    fi
+    echo "    -queue-deferred on #$n (current main + exact green head)"
+  done < <(jq -c '.[]' <<<"$candidates")
 }
 
 # The queue snapshot can be stale by the time enrollment begins. Re-read the
@@ -289,6 +423,8 @@ check_failures_for_pr() {  # check_failures_for_pr <num>
   rm -f "$raw_file" "$out_file" "$err_file"
   jq -cn --arg reason "required check status unavailable" '[$reason]'
 }
+
+reconcile_deferred_auto_merge_after_main_push
 
 SNAP="$(gh_retry pr list -R "$REPO" --state open --limit 200 \
   --json number,title,body,isDraft,mergeable,mergeStateStatus,labels,headRefName --jq '

--- a/scripts/tests/test_gh_retry.py
+++ b/scripts/tests/test_gh_retry.py
@@ -333,6 +333,87 @@ JSON
         assert "#456" in result.stdout
         assert "#789" in result.stdout
 
+    def test_main_push_releases_only_current_green_auto_merge_deferrals(
+        self, tmp_path: Path
+    ) -> None:
+        """A temporary pressure hold cannot strand a current auto-merge head."""
+        head = "a" * 40
+        main = "b" * 40
+        stale_base = "c" * 40
+        list_calls = tmp_path / "list-calls"
+        list_calls.write_text("0", encoding="utf-8")
+        fake_gh = tmp_path / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1 $2" == "api repos/JovieInc/Jovie/git/ref/heads/main" ]]; then
+                  echo "{main}"
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr list" ]]; then
+                  count=$(<"{list_calls}")
+                  count=$((count + 1))
+                  echo "$count" >"{list_calls}"
+                  if [[ "$count" == 1 ]]; then
+                    cat <<'JSON'
+                [{{"n":700,"head":"{head}","base":"{main}"}},{{"n":701,"head":"{head}","base":"{stale_base}"}},{{"n":702,"head":"{head}","base":"{main}"}}]
+JSON
+                  else
+                    cat <<'JSON'
+                [{{"n":700,"t":"Current deferred","draft":false,"m":"MERGEABLE","head":"codex/current-deferred","L":["queue-deferred"],"fail":[]}},{{"n":701,"t":"Stale deferred","draft":false,"m":"MERGEABLE","head":"codex/stale-deferred","L":["queue-deferred"],"fail":[]}},{{"n":702,"t":"Manual deferred","draft":false,"m":"MERGEABLE","head":"codex/manual-deferred","L":["queue-deferred"],"fail":[]}}]
+JSON
+                  fi
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr view" ]]; then
+                  if [[ "$3" == "700" ]]; then
+                    cat <<'JSON'
+                {{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","headRefOid":"{head}","baseRefOid":"{main}","labels":[{{"name":"queue-deferred"}}],"autoMergeRequest":{{"enabledAt":"2026-07-30T00:00:00Z"}}}}
+JSON
+                  elif [[ "$3" == "701" ]]; then
+                    cat <<'JSON'
+                {{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","headRefOid":"{head}","baseRefOid":"{stale_base}","labels":[{{"name":"queue-deferred"}}],"autoMergeRequest":{{"enabledAt":"2026-07-30T00:00:00Z"}}}}
+JSON
+                  else
+                    cat <<'JSON'
+                {{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","headRefOid":"{head}","baseRefOid":"{main}","labels":[{{"name":"queue-deferred"}}],"autoMergeRequest":null}}
+JSON
+                  fi
+                  exit 0
+                fi
+                if [[ "$1 $2" == "pr checks" ]]; then
+                  [[ "$3" == "700" ]]
+                  echo '[{{"name":"PR Ready","bucket":"pass","state":"SUCCESS"}},{{"name":"Migration Guard","bucket":"pass","state":"SUCCESS"}},{{"name":"Fork PR Gate","bucket":"pass","state":"SUCCESS"}},{{"name":"PR Size Guard","bucket":"pass","state":"SUCCESS"}}]'
+                  exit 0
+                fi
+                echo "unexpected gh args: $*" >&2
+                exit 2
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(
+            fake_gh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+
+        result = _run_bash(
+            _drain_command(
+                tmp_path,
+                extra_env="DRY_RUN=1 DRAIN_RECONCILE_QUEUE_DEFERRED=1",
+            )
+        )
+
+        assert result.returncode == 0, f"stdout={result.stdout}\\nstderr={result.stderr}"
+        assert "[dry-run] would -queue-deferred on #700" in result.stdout
+        assert "#701" in result.stdout
+        assert "not based on current main; preserving deferral" in result.stdout
+        assert "[dry-run] would -queue-deferred on #701" not in result.stdout
+        assert "#702" in result.stdout
+        assert "live state is not a current, clean auto-merge defer; preserving" in result.stdout
+        assert "[dry-run] would -queue-deferred on #702" not in result.stdout
+
 
 class TestGraphiteEventAuthorizationGuard:
     def test_workflow_covers_synthetic_and_source_events_with_minimum_permissions(self) -> None:


### PR DESCRIPTION
## Summary

- reconciles only temporary `queue-deferred` holds on the existing `push: main` merge-queue controller path
- requires an OPEN, non-draft, mergeable PR whose exact head is stable, base is current `main`, native auto-merge remains enabled, no other hard hold exists, and canonical source gates are green
- re-reads after checks and restores `queue-deferred` if the release state races

This is not a scheduler or gate change. Advisory visual signals remain nonblocking; deterministic source gates remain required.

## Verification

- `python3 -m pytest scripts/tests/test_gh_retry.py -q` (50 passed)
- `bash -n scripts/drain-pr-queue.sh`
- `git diff --check`