### PR TITLE
refactor(calendar): use canonical action buttons

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -715,30 +715,37 @@ export function CalendarPageClient() {
                   >
                     {selectedPendingIds.size > 0 && (
                       <>
-                        <button
+                        <Button
                           type='button'
+                          variant='secondary'
+                          size='sm'
                           onClick={handleBulkConfirm}
                           disabled={isActionPending}
                           className='system-b-calendar-action-confirm h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
                         >
-                          Confirm selected ({selectedPendingIds.size})
-                        </button>
-                        <button
+                          Confirm Selected ({selectedPendingIds.size})
+                        </Button>
+                        <Button
                           type='button'
+                          variant='tertiary'
+                          size='sm'
+                          destructive
                           onClick={handleBulkReject}
                           disabled={isActionPending}
                           className='system-b-calendar-action-reject h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
                         >
-                          Reject selected ({selectedPendingIds.size})
-                        </button>
-                        <button
+                          Reject Selected ({selectedPendingIds.size})
+                        </Button>
+                        <Button
                           type='button'
+                          variant='ghost'
+                          size='sm'
                           onClick={() => setSelectedPendingIds(new Set())}
                           disabled={isActionPending}
                           className='system-b-calendar-action-ghost h-7 rounded-md px-2 transition-colors duration-subtle ease-subtle'
                         >
                           Clear
-                        </button>
+                        </Button>
                       </>
                     )}
                   </div>
@@ -748,8 +755,10 @@ export function CalendarPageClient() {
               {/* Rejected events — collapsed by default */}
               {rejectedSelectedEvents.length > 0 && (
                 <div className='mt-4'>
-                  <button
+                  <Button
                     type='button'
+                    variant='ghost'
+                    size='sm'
                     onClick={() => setShowRejected(s => !s)}
                     aria-expanded={showRejected}
                     aria-controls='rejected-events-list'
@@ -758,7 +767,7 @@ export function CalendarPageClient() {
                     {showRejected
                       ? 'Hide rejected'
                       : `Show rejected · ${rejectedSelectedEvents.length}`}
-                  </button>
+                  </Button>
                   {showRejected && (
                     <ul
                       id='rejected-events-list'
@@ -811,8 +820,10 @@ type FilterPillProps = Readonly<{
 
 function FilterPill(props: FilterPillProps) {
   return (
-    <button
+    <Button
       type='button'
+      variant='ghost'
+      size='sm'
       onClick={props.onClick}
       aria-pressed={props.active}
       className={cn(
@@ -825,7 +836,7 @@ function FilterPill(props: FilterPillProps) {
       )}
     >
       {props.label}
-    </button>
+    </Button>
   );
 }
 
@@ -896,43 +907,53 @@ function EventRow(props: EventRowProps) {
         )}
         {props.variant === 'pending' && (
           <>
-            <button
+            <Button
               type='button'
+              variant='secondary'
+              size='sm'
               onClick={props.onConfirm}
               disabled={props.disabled}
               className='system-b-calendar-action-confirm h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
             >
               Confirm
-            </button>
-            <button
+            </Button>
+            <Button
               type='button'
+              variant='tertiary'
+              size='sm'
+              destructive
               onClick={props.onReject}
               disabled={props.disabled}
               className='system-b-calendar-action-reject h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
             >
               Reject
-            </button>
+            </Button>
           </>
         )}
         {props.variant === 'confirmed' && props.onReject && (
-          <button
+          <Button
             type='button'
+            variant='ghost'
+            size='sm'
+            destructive
             onClick={props.onReject}
             disabled={props.disabled}
             className='system-b-calendar-action-danger-ghost h-7 rounded-md px-2 transition-colors duration-subtle ease-subtle'
           >
             Reject
-          </button>
+          </Button>
         )}
         {props.variant === 'rejected' && props.onUndoReject && (
-          <button
+          <Button
             type='button'
+            variant='secondary'
+            size='sm'
             onClick={props.onUndoReject}
             disabled={props.disabled}
             className='system-b-calendar-action-secondary h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
           >
-            Undo reject
-          </button>
+            Undo Reject
+          </Button>
         )}
       </div>
     </li>

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -161,6 +161,38 @@ describe('CalendarPageClient', () => {
     expect(screen.getByText('Movement Festival')).toBeInTheDocument();
   });
 
+  it('uses canonical Button variants for filters and event-review actions', () => {
+    mocks.useEventsQuery.mockReturnValue({
+      data: [pendingEvent, confirmedEvent, rejectedEvent],
+      isLoading: false,
+    });
+    renderCalendar();
+
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute(
+      'data-variant',
+      'ghost'
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /18 Movement Festival Warehouse Set Old Listing/,
+      })
+    );
+
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute(
+      'data-variant',
+      'secondary'
+    );
+    expect(
+      screen
+        .getAllByRole('button', { name: 'Reject' })
+        .some(button => button.getAttribute('data-variant') === 'tertiary')
+    ).toBe(true);
+    expect(
+      screen.getByRole('button', { name: 'Show rejected · 1' })
+    ).toHaveAttribute('data-variant', 'ghost');
+  });
+
   it('does not fetch scoped release or event data without a selected profile', () => {
     mocks.useDashboardData.mockReturnValue({
       selectedProfile: null,
@@ -216,12 +248,12 @@ describe('CalendarPageClient', () => {
     );
 
     expect(bulkSlot).toHaveAttribute('data-active', 'true');
-    expect(screen.getByText('Confirm selected (1)')).toHaveClass(
-      'system-b-calendar-action-confirm'
-    );
-    expect(screen.getByText('Reject selected (1)')).toHaveClass(
-      'system-b-calendar-action-reject'
-    );
+    expect(
+      screen.getByRole('button', { name: 'Confirm Selected (1)' })
+    ).toHaveClass('system-b-calendar-action-confirm');
+    expect(
+      screen.getByRole('button', { name: 'Reject Selected (1)' })
+    ).toHaveClass('system-b-calendar-action-reject');
 
     const rejectedToggle = screen.getByRole('button', {
       name: 'Show rejected · 1',
@@ -230,7 +262,7 @@ describe('CalendarPageClient', () => {
     fireEvent.click(rejectedToggle);
 
     expect(screen.getAllByText('Old Listing')).toHaveLength(2);
-    expect(screen.getByRole('button', { name: 'Undo reject' })).toHaveClass(
+    expect(screen.getByRole('button', { name: 'Undo Reject' })).toHaveClass(
       'system-b-calendar-action-secondary'
     );
   });


### PR DESCRIPTION
<!-- linear-issue-id:e822302f-c7e0-4335-89ce-f572ad86b92c -->

## Summary

- Replaces Calendar filter, bulk-review, rejected-list, and event-review raw buttons with the shared `Button` primitive.
- Keeps each existing System B action class and compact geometry while gaining canonical focus-visible, disabled, and semantic variant behavior.
- Normalizes three action labels to the required Title Case.

## Verification

- `pnpm --filter web exec vitest run tests/unit/calendar/CalendarPageClient.test.tsx` (6/6)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm exec biome check apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx apps/web/tests/unit/calendar/CalendarPageClient.test.tsx`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable: canonicalization, no bug classification)
- Normal pre-push gate, including affected verification, passed.

## Scope

Only `CalendarPageClient` plus its focused unit test. Day-cell buttons, calendar behavior, and layout are intentionally unchanged.
