### PR TITLE
fix(ui): reserve search rings for keyboard focus

### DIFF
--- a/apps/web/components/molecules/AppSearchField.test.tsx
+++ b/apps/web/components/molecules/AppSearchField.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppSearchField } from './AppSearchField';
+
+describe('AppSearchField', () => {
+  it('keeps the container ring keyboard-only while preserving input focus feedback', () => {
+    const { container } = render(
+      <AppSearchField ariaLabel='Search library' onChange={vi.fn()} value='' />
+    );
+
+    expect(
+      screen.getByRole('searchbox', { name: 'Search library' })
+    ).toBeVisible();
+    expect(container.firstElementChild).toHaveClass(
+      'focus-within:border-(--linear-border-focus)',
+      'focus-within:bg-surface-0',
+      'has-[:focus-visible]:ring-2',
+      'has-[:focus-visible]:ring-ring/14'
+    );
+    expect(container.firstElementChild?.className).not.toContain(
+      'focus-within:ring-'
+    );
+  });
+});

--- a/apps/web/components/molecules/AppSearchField.tsx
+++ b/apps/web/components/molecules/AppSearchField.tsx
@@ -36,7 +36,7 @@ export function AppSearchField({
   return (
     <div
       className={cn(
-        'flex h-app-control-sm items-center gap-1.5 rounded-full border border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14',
+        'flex h-app-control-sm items-center gap-1.5 rounded-full border border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) px-2.5 text-primary-token transition-[border-color,box-shadow,background-color] duration-subtle hover:bg-surface-1 focus-within:border-(--linear-border-focus) focus-within:bg-surface-0 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/14',
         className
       )}
     >

--- a/apps/web/components/shell/HeaderSearchSurface.test.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.test.tsx
@@ -103,7 +103,7 @@ describe('HeaderSearchSurface', () => {
     );
   });
 
-  it('focuses the search field inside a tokenized focus-within ring', async () => {
+  it('keeps search feedback on focus but reserves the ring for keyboard focus', async () => {
     const { container } = render(
       <HeaderSearchSurface isOpen onOpen={vi.fn()} onClose={vi.fn()} />
     );
@@ -113,8 +113,12 @@ describe('HeaderSearchSurface', () => {
 
     expect(container.firstElementChild).toHaveClass(
       'focus-within:border-focus',
-      'focus-within:ring-2',
-      'focus-within:ring-ring/14'
+      'focus-within:bg-surface-0',
+      'has-[:focus-visible]:ring-2',
+      'has-[:focus-visible]:ring-ring/14'
+    );
+    expect(container.firstElementChild?.className).not.toContain(
+      'focus-within:ring-'
     );
   });
 

--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -512,7 +512,7 @@ export function HeaderSearchSurface({
       className={cn(
         headerSearchSurfaceChrome,
         headerSearchSurfaceWidth,
-        'relative flex h-7 min-h-7 min-w-0 items-center justify-start px-2 py-0 text-left shadow-popover transition-[border-color,box-shadow,background-color] duration-subtle focus-within:border-focus focus-within:bg-surface-0 focus-within:ring-2 focus-within:ring-ring/14',
+        'relative flex h-7 min-h-7 min-w-0 items-center justify-start px-2 py-0 text-left shadow-popover transition-[border-color,box-shadow,background-color] duration-subtle focus-within:border-focus focus-within:bg-surface-0 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/14',
         className
       )}
     >


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4596 -->

## Summary

- reserve the AppSearchField container ring for keyboard-visible focus
- apply the same contract to HeaderSearchSurface while retaining active input feedback
- add a regression test for the shared app search field and update header coverage

## Verification

- `pnpm exec biome check --write apps/web/components/molecules/AppSearchField.tsx apps/web/components/molecules/AppSearchField.test.tsx apps/web/components/shell/HeaderSearchSurface.tsx apps/web/components/shell/HeaderSearchSurface.test.tsx`
- `pnpm --filter web exec vitest run components/molecules/AppSearchField.test.tsx components/shell/HeaderSearchSurface.test.tsx` (11 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable, non-bug classification)

## Risk

Low. This changes only focus styling. Keyboard focus remains visibly ringed; pointer focus retains the existing border and surface feedback.
