### PR TITLE
fix(chat): keep entity mentions inline [JOV-3523]

### DIFF
--- a/apps/web/components/jovie/components/AssistantMessageText.test.tsx
+++ b/apps/web/components/jovie/components/AssistantMessageText.test.tsx
@@ -5,9 +5,18 @@ import { fastRender } from '@/tests/utils/fast-render';
 import { AssistantMessageText } from './AssistantMessageText';
 
 vi.mock('./ChatMarkdown', () => ({
-  ChatMarkdown: ({ content }: { content: string }) => (
-    <div data-testid='chat-markdown'>{content}</div>
-  ),
+  ChatMarkdown: ({
+    content,
+    inline = false,
+  }: {
+    readonly content: string;
+    readonly inline?: boolean;
+  }) =>
+    inline ? (
+      <span data-testid='chat-markdown'>{content}</span>
+    ) : (
+      <div data-testid='chat-markdown'>{content}</div>
+    ),
 }));
 
 describe('AssistantMessageText', () => {
@@ -34,12 +43,30 @@ describe('AssistantMessageText', () => {
     const markdownSegments = screen.getAllByTestId('chat-markdown');
     expect(markdownSegments[0]).toHaveTextContent('Listen to');
     expect(markdownSegments[1]).toHaveTextContent('tonight.');
+    expect(markdownSegments).toHaveLength(2);
+    expect(markdownSegments.every(segment => segment.tagName === 'SPAN')).toBe(
+      true
+    );
     expect(screen.queryByText('@release:rel_1[Sober]')).toBeNull();
 
     await user.click(screen.getByTestId('entity-chip-popover-trigger'));
     const content = await screen.findByTestId('entity-chip-popover-content');
     expect(content).toHaveAttribute('data-entity-kind', 'release');
     expect(content.textContent).toContain('Sober');
+  });
+
+  it('keeps structured markdown on the normal block renderer', () => {
+    fastRender(
+      <AssistantMessageText
+        content={'- @release:rel_1[Sober]\n  keeps list semantics'}
+      />
+    );
+
+    expect(
+      screen
+        .getAllByTestId('chat-markdown')
+        .every(segment => segment.tagName === 'DIV')
+    ).toBe(true);
   });
 
   it('renders skill tokens as neutral assistant mentions', () => {

--- a/apps/web/components/jovie/components/AssistantMessageText.tsx
+++ b/apps/web/components/jovie/components/AssistantMessageText.tsx
@@ -16,6 +16,18 @@ function tokenKey(token: ChatToken, index: number): string {
   return `skill:${token.id}:${index}`;
 }
 
+/**
+ * Preserve Streamdown's block rendering for structured markdown. Plain prose
+ * adjacent to an entity token is safe to render inline, which keeps the whole
+ * sentence on one text flow instead of creating detached paragraph blocks.
+ */
+function isInlineMarkdownFragment(content: string): boolean {
+  return (
+    !/[\r\n]/.test(content) &&
+    !/^\s*(?:[-*+] |\d+[.)] |#{1,6}\s|>|```)/.test(content)
+  );
+}
+
 interface AssistantMessageTextProps {
   readonly content: string;
   readonly isStreaming?: boolean;
@@ -46,6 +58,7 @@ export function AssistantMessageText({
               key={key}
               content={token.value}
               isStreaming={isStreaming}
+              inline={isInlineMarkdownFragment(token.value)}
             />
           );
         }

--- a/apps/web/components/jovie/components/ChatMarkdown.tsx
+++ b/apps/web/components/jovie/components/ChatMarkdown.tsx
@@ -9,6 +9,8 @@ interface ChatMarkdownProps {
   readonly content: string;
   readonly className?: string;
   readonly isStreaming?: boolean;
+  /** Render a prose fragment without Streamdown's paragraph block wrapper. */
+  readonly inline?: boolean;
 }
 
 /**
@@ -18,9 +20,12 @@ export const ChatMarkdown = memo(function ChatMarkdown({
   content,
   className,
   isStreaming = false,
+  inline = false,
 }: ChatMarkdownProps) {
   return (
-    <Streamdown {...getChatMarkdownStreamdownConfig(isStreaming, className)}>
+    <Streamdown
+      {...getChatMarkdownStreamdownConfig(isStreaming, className, inline)}
+    >
       {content}
     </Streamdown>
   );

--- a/apps/web/lib/markdown/streamdown-config.ts
+++ b/apps/web/lib/markdown/streamdown-config.ts
@@ -1,10 +1,22 @@
-import type { StreamdownProps } from 'streamdown';
+import { createElement } from 'react';
+import type { Components, StreamdownProps } from 'streamdown';
 
 import { cn } from '@/lib/utils';
 
 const SAFE_PROTOCOL_PATTERN = /^(https?:|mailto:|tel:|\/|#)/i;
 
 const CHAT_MARKDOWN_STYLES = 'system-b-chat-markdown text-primary-token';
+
+/**
+ * Entity mentions split an otherwise ordinary sentence into multiple markdown
+ * segments. Rendering each segment as a default paragraph makes the mention
+ * look detached and can strand the following word on its own line. This is
+ * deliberately limited to the inline-message path; full markdown keeps the
+ * default block anatomy.
+ */
+const INLINE_MARKDOWN_COMPONENTS: Components = {
+  p: ({ children }) => createElement('span', null, children),
+};
 
 const urlTransform: NonNullable<StreamdownProps['urlTransform']> = url => {
   if (!url || !SAFE_PROTOCOL_PATTERN.test(url)) {
@@ -74,19 +86,23 @@ export const CHAT_MARKDOWN_STATIC_CONFIG: StreamdownProps = {
 
 export function getChatMarkdownStreamdownConfig(
   isStreaming: boolean,
-  className?: string
+  className?: string,
+  inline = false
 ): StreamdownProps {
   const baseConfig = isStreaming
     ? CHAT_MARKDOWN_STREAMING_CONFIG
     : CHAT_MARKDOWN_STATIC_CONFIG;
 
-  if (!className) {
+  if (!className && !inline) {
     return baseConfig;
   }
 
   return {
     ...baseConfig,
-    className: cn(CHAT_MARKDOWN_STYLES, className),
+    className: className
+      ? cn(CHAT_MARKDOWN_STYLES, className)
+      : CHAT_MARKDOWN_STYLES,
+    ...(inline ? { components: INLINE_MARKDOWN_COMPONENTS } : {}),
   };
 }
 

--- a/apps/web/tests/unit/chat/streamdown-config.test.ts
+++ b/apps/web/tests/unit/chat/streamdown-config.test.ts
@@ -26,6 +26,15 @@ describe('getChatMarkdownStreamdownConfig', () => {
     );
   });
 
+  it('uses an inline paragraph renderer only for entity-adjacent prose', () => {
+    const config = getChatMarkdownStreamdownConfig(false, undefined, true);
+
+    expect(config.components?.p).toBeDefined();
+    expect(config.components?.p).not.toBe(
+      CHAT_MARKDOWN_STATIC_CONFIG.components?.p
+    );
+  });
+
   it('allows GFM table elements (regression: gh-11948 silent table stripping)', () => {
     const config = getChatMarkdownStreamdownConfig(false);
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3523 -->

## Summary
- render plain assistant prose around entity mentions with Streamdown’s inline paragraph renderer
- preserve normal block rendering for multiline and structured Markdown
- add focused regressions for sentence flow and the inline config

## Verification
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/AssistantMessageText.test.tsx components/jovie/components/EntityChip.test.tsx components/jovie/components/EntityChipPopover.test.tsx tests/unit/chat/TokenizedText.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts tests/unit/chat/streamdown-config.test.ts` — 50/50 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — completed through the repo singleflight path
- `biome check` on the five touched files — passed

No browser or external design-review gate: this is an isolated, deterministic chat rendering repair.