### PR TITLE
fix(pricing): normalize hero heading casing [JOV-3473]

### DIFF
--- a/apps/web/app/(marketing)/launch/pricing/page.tsx
+++ b/apps/web/app/(marketing)/launch/pricing/page.tsx
@@ -71,7 +71,7 @@ export default function PricingPage() {
       <MarketingHero variant='centered'>
         {/* ui-casing-allow: marketing display headline */}
         <h1 id='pricing-heading' className='marketing-h2-linear max-w-170'>
-          Simple pricing.{' '}
+          Simple Pricing.{' '}
           <span className='text-secondary-token'>No surprises.</span>
         </h1>
       </MarketingHero>


### PR DESCRIPTION
## Summary
- normalize the launch-pricing H1 to canonical Title Case
- leave sentence-case metadata and supporting copy unchanged

## Verification
- `pnpm exec biome check --write apps/web/app/(marketing)/launch/pricing/page.tsx`
- `pnpm exec eslint apps/web/app/(marketing)/launch/pricing/page.tsx --max-warnings=0`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable: UI polish, not bug classification)
- `git diff --check`

<!-- linear-issue-identifier:JOV-3473 -->