### PR TITLE
refactor(library): use shared shell right rail [JOV-4597]

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -48,7 +48,6 @@ import {
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
-  type CSSProperties,
   createContext,
   type MouseEvent,
   memo,
@@ -83,6 +82,7 @@ import {
   ToolbarMenuChoiceItem,
 } from '@/components/molecules/menus/ToolbarMenuPrimitives';
 import { PageShell } from '@/components/organisms/PageShell';
+import { RightDrawer } from '@/components/organisms/RightDrawer';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import {
   PAGE_TOOLBAR_END_GROUP_CLASS,
@@ -107,6 +107,7 @@ import type { FilterPill } from '@/components/shell/pill-search.types';
 import { APP_ROUTES } from '@/constants/routes';
 import { useRegisterHeaderSearch } from '@/contexts/HeaderActionsContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
+import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
 import { PROVIDER_CONFIG } from '@/lib/discography/config';
 import type { ProviderKey } from '@/lib/discography/types';
@@ -2082,7 +2083,6 @@ function AssetDrawer({
   onClose,
   activePreviewId,
   playingPreviewId,
-  isDesktopLayout,
   onTogglePreview,
   onAudioUploaded,
   getContextMenuItems,
@@ -2097,7 +2097,6 @@ function AssetDrawer({
   readonly onClose: () => void;
   readonly activePreviewId: string | null;
   readonly playingPreviewId: string | null;
-  readonly isDesktopLayout: boolean;
   readonly onTogglePreview: LibraryPreviewToggle;
   readonly onAudioUploaded: (assetId: string, previewUrl: string) => void;
   readonly getContextMenuItems: LibraryContextMenuBuilder;
@@ -2130,9 +2129,13 @@ function AssetDrawer({
     currentId !== null &&
     currentId === playingPreviewId &&
     currentId === activePreviewId;
-  const closedDrawerClassName = cn(
-    'pointer-events-none opacity-0',
-    isDesktopLayout ? null : 'translate-y-2 hidden'
+  const handleDrawerKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      onClose();
+    },
+    [onClose]
   );
   const drawerHeaderActions = current ? (
     <DrawerHeaderActions
@@ -2147,16 +2150,12 @@ function AssetDrawer({
   ) : null;
 
   return (
-    <aside
-      aria-hidden={!open}
-      inert={open ? undefined : true}
-      className={cn(
-        'system-b-library-drawer h-full min-h-0 overflow-hidden border-l border-subtle transition-[opacity,transform] duration-cinematic ease-cinematic',
-        isDesktopLayout
-          ? 'static z-auto rounded-none border-y-0 border-r-0 shadow-none'
-          : 'system-b-library-drawer--mobile fixed inset-x-3 bottom-20 top-16 z-40 border',
-        open ? 'translate-y-0 opacity-100' : closedDrawerClassName
-      )}
+    <RightDrawer
+      isOpen={open}
+      width={360}
+      ariaLabel='Library asset details'
+      onKeyDown={handleDrawerKeyDown}
+      className='system-b-library-drawer border-l border-(--app-shell-frame-seam)'
       data-testid='library-asset-drawer'
     >
       {current ? (
@@ -2437,7 +2436,7 @@ function AssetDrawer({
           </div>
         </TableContextMenu>
       ) : null}
-    </aside>
+    </RightDrawer>
   );
 }
 
@@ -2642,22 +2641,6 @@ export function LibrarySurface({
     }
   }, [selectedId, visibleAssets]);
 
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.defaultPrevented) return;
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
-        return;
-      }
-      if (event.key === 'Escape' && drawerOpen) {
-        event.preventDefault();
-        setDrawerOpen(false);
-      }
-    }
-
-    globalThis.addEventListener('keydown', onKeyDown);
-    return () => globalThis.removeEventListener('keydown', onKeyDown);
-  }, [drawerOpen]);
-
   const handlePresetChange = useCallback(
     (next: LibraryPresetId) => {
       setPreset(next);
@@ -2840,10 +2823,43 @@ export function LibrarySurface({
     [router]
   );
 
-  const drawerColumnWidth = drawerOpen ? '360px' : '0px';
-  const libraryGridTemplateColumns = isDesktopLayout
-    ? `minmax(0,1fr) ${drawerColumnWidth}`
-    : 'minmax(0, 1fr)';
+  const assetDrawerPanel = useMemo(
+    () => (
+      <AssetDrawer
+        asset={selectedAsset}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        activePreviewId={activePreviewId}
+        playingPreviewId={playingPreviewId}
+        onTogglePreview={handleTogglePreview}
+        onAudioUploaded={handleAudioUploaded}
+        getContextMenuItems={getContextMenuItems}
+        profileId={profileId}
+        artistHandle={artistHandle}
+        pressKitCandidates={effectiveAssets.filter(
+          item => getLibraryItemKind(item) === 'release'
+        )}
+        onApprovalStatusChange={handleApprovalStatusChange}
+        onShareChange={handleShareChange}
+      />
+    ),
+    [
+      activePreviewId,
+      artistHandle,
+      drawerOpen,
+      effectiveAssets,
+      getContextMenuItems,
+      handleApprovalStatusChange,
+      handleAudioUploaded,
+      handleShareChange,
+      handleTogglePreview,
+      playingPreviewId,
+      profileId,
+      selectedAsset,
+    ]
+  );
+
+  useRegisterRightPanel(assetDrawerPanel);
 
   if (effectiveAssets.length === 0) {
     return <EmptyCatalog />;
@@ -2880,16 +2896,9 @@ export function LibrarySurface({
       <NavigationDestinationReady destination='library' />
       <div
         data-testid='library-content-frame'
-        className='grid h-full min-h-0 flex-1 overflow-hidden'
-        style={
-          {
-            gridTemplateColumns: libraryGridTemplateColumns,
-            transition:
-              'grid-template-columns var(--duration-cinematic) var(--ease-cinematic)',
-          } as CSSProperties
-        }
+        className='flex h-full min-h-0 flex-1 overflow-hidden'
       >
-        <div className='flex min-h-0 min-w-0 flex-col overflow-hidden'>
+        <div className='flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden'>
           <div className='min-h-0 flex-1 overflow-y-auto pb-20 lg:pb-0'>
             {visibleAssets.length === 0 ? (
               <NoResults onReset={resetView} />
@@ -2933,24 +2942,6 @@ export function LibrarySurface({
             activePreviewTitle={activePreviewTitle}
           />
         </div>
-        <AssetDrawer
-          asset={selectedAsset}
-          open={drawerOpen}
-          onClose={() => setDrawerOpen(false)}
-          activePreviewId={activePreviewId}
-          playingPreviewId={playingPreviewId}
-          isDesktopLayout={isDesktopLayout}
-          onTogglePreview={handleTogglePreview}
-          onAudioUploaded={handleAudioUploaded}
-          getContextMenuItems={getContextMenuItems}
-          profileId={profileId}
-          artistHandle={artistHandle}
-          pressKitCandidates={effectiveAssets.filter(
-            item => getLibraryItemKind(item) === 'release'
-          )}
-          onApprovalStatusChange={handleApprovalStatusChange}
-          onShareChange={handleShareChange}
-        />
       </div>
     </PageShell>
   );

--- a/apps/web/tests/unit/library/LibrarySurface.right-rail-contract.test.ts
+++ b/apps/web/tests/unit/library/LibrarySurface.right-rail-contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE_PATH = resolve(
+  process.cwd(),
+  'app/app/(shell)/library/LibrarySurface.tsx'
+);
+
+describe('LibrarySurface shared right rail contract', () => {
+  it('registers the asset detail drawer with the authenticated shell', () => {
+    const source = readFileSync(SOURCE_PATH, 'utf8');
+
+    expect(source).toContain(
+      "import { RightDrawer } from '@/components/organisms/RightDrawer';"
+    );
+    expect(source).toContain(
+      "import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';"
+    );
+    expect(source).toContain('useRegisterRightPanel(assetDrawerPanel);');
+    expect(source).toContain('<RightDrawer');
+    expect(source).toContain("ariaLabel='Library asset details'");
+    expect(source).toContain(
+      "className='flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden'"
+    );
+  });
+
+  it('does not retain the route-local drawer layout implementation', () => {
+    const source = readFileSync(SOURCE_PATH, 'utf8');
+
+    expect(source).not.toContain('libraryGridTemplateColumns');
+    expect(source).not.toContain('gridTemplateColumns');
+    expect(source).not.toContain('system-b-library-drawer--mobile');
+    expect(source).not.toContain('fixed inset-x-3 bottom-20 top-16');
+  });
+});

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -18,6 +18,10 @@ import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchS
 import { APP_ROUTES } from '@/constants/routes';
 import { HeaderActionsProvider } from '@/contexts/HeaderActionsContext';
 import {
+  RightPanelProvider,
+  useRightPanel,
+} from '@/contexts/RightPanelContext';
+import {
   ShellSidebarOverrideProvider,
   useShellSidebarOverride,
 } from '@/contexts/ShellSidebarOverrideContext';
@@ -156,13 +160,20 @@ function buildAsset(
   };
 }
 
+function RightPanelOutlet() {
+  return useRightPanel();
+}
+
 function renderLibraryWithHeader(assets: readonly LibraryReleaseAsset[]) {
   return render(
     <TooltipProvider>
-      <HeaderActionsProvider>
-        <HeaderSearchSurfaceFromContext />
-        <LibrarySurface assets={assets} />
-      </HeaderActionsProvider>
+      <RightPanelProvider>
+        <HeaderActionsProvider>
+          <HeaderSearchSurfaceFromContext />
+          <LibrarySurface assets={assets} />
+          <RightPanelOutlet />
+        </HeaderActionsProvider>
+      </RightPanelProvider>
     </TooltipProvider>
   );
 }
@@ -170,7 +181,10 @@ function renderLibraryWithHeader(assets: readonly LibraryReleaseAsset[]) {
 function renderLibrary(assets: readonly LibraryReleaseAsset[]) {
   return render(
     <TooltipProvider>
-      <LibrarySurface assets={assets} />
+      <RightPanelProvider>
+        <LibrarySurface assets={assets} />
+        <RightPanelOutlet />
+      </RightPanelProvider>
     </TooltipProvider>
   );
 }
@@ -194,10 +208,13 @@ function SidebarOverrideProbe() {
 function renderLibraryWithSidebarProbe(assets: readonly LibraryReleaseAsset[]) {
   return render(
     <TooltipProvider>
-      <ShellSidebarOverrideProvider>
-        <LibrarySurface assets={assets} />
-        <SidebarOverrideProbe />
-      </ShellSidebarOverrideProvider>
+      <RightPanelProvider>
+        <ShellSidebarOverrideProvider>
+          <LibrarySurface assets={assets} />
+          <SidebarOverrideProbe />
+          <RightPanelOutlet />
+        </ShellSidebarOverrideProvider>
+      </RightPanelProvider>
     </TooltipProvider>
   );
 }
@@ -262,6 +279,8 @@ describe('LibrarySurface', () => {
     expect(source).toContain('function LibraryFilterPanel');
     expect(source).toContain("data-testid='library-filter-active-indicator'");
     expect(source).toContain("surfaceMode='table'");
+    expect(source).toContain('useRegisterRightPanel(assetDrawerPanel)');
+    expect(source).not.toContain('libraryGridTemplateColumns');
     expect(source).not.toContain('Search library by title');
     expect(source).not.toContain('useRegisterShellSidebarOverride');
     expect(source).not.toContain('max-h-[45svh]');
@@ -686,7 +705,7 @@ describe('LibrarySurface', () => {
     expect(drawer.getByText('68/100')).toBeDefined();
     expect(drawer.getByText('Progressive House')).toBeDefined();
 
-    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
 
     expect(screen.getByTestId('library-asset-drawer')).toHaveAttribute(
       'aria-hidden',


### PR DESCRIPTION
## Summary

- migrate Library asset details from its route-local grid/overlay implementation into the authenticated shell's shared `useRegisterRightPanel` path
- render the existing asset detail content inside the canonical `RightDrawer` at the existing 360px desktop width
- inherit shared mobile modal, focus, inert, scroll-lock, Escape, reduced-motion, and cinematic width behavior without changing asset content or selection semantics
- remove the Library-owned grid column animation and preserve a full-width, flexing content canvas

## Verification

- `biome check` passed for all three changed files
- source contract assertions passed 8/8
- `git diff --check` passed
- normal commit and push hooks passed
- full focused Library Vitest was attempted but the shared host already had long-running Vitest shards; the owned attempts were terminated cleanly rather than adding queue pressure. Source CI remains authoritative.

## Risk

Bounded to the authenticated Library route and its test harness. No data, API, asset detail content, auth, or release behavior changed.

Linear: JOV-4597
