### PR TITLE
fix(onboarding): place sign in in header [JOV-3384]

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { Camera, Disc3, Eye, Link2, LoaderCircle, Music } from 'lucide-react';
-import Link from 'next/link';
 import type { ComponentType, ReactNode, SVGProps } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { getChatPromptPillClass } from '@/components/jovie/components/chat-prompt-styles';
 import type { ChatSuggestion } from '@/components/jovie/types';
-import { APP_ROUTES } from '@/constants/routes';
 import {
   ONBOARDING_ENTRY_SUPPORT,
   ONBOARDING_ENTRY_TITLE,
@@ -165,17 +163,6 @@ export function OnboardingChatEmptyIntro({
                 />
               ))}
             </div>
-
-            <p className='text-center text-xs leading-5 text-secondary-token'>
-              Already have an account?{' '}
-              <Link
-                href={APP_ROUTES.SIGNIN}
-                className='inline-flex min-h-11 items-center font-medium text-primary-token underline-offset-2 transition-colors duration-fast hover:underline focus-visible:underline focus-visible:outline-none'
-                data-testid='onboarding-sign-in-skip'
-              >
-                Sign in
-              </Link>
-            </p>
           </div>
         ) : (
           <div

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -3,6 +3,7 @@
 import { Skeleton } from '@jovie/ui';
 import { useCallback, useEffect, useState } from 'react';
 import { AppShellFrame } from '@/components/organisms/AppShellFrame';
+import { MarketingSignInLink } from '@/components/organisms/MarketingSignInLink';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
 import { track } from '@/lib/analytics';
 import { publicEnv } from '@/lib/env-public';
@@ -169,6 +170,12 @@ export function OnboardingShell({
             className='relative flex min-h-0 flex-1'
             data-onboarding-session={sessionLabel}
           >
+            <div
+              className='absolute right-3 top-3 z-30 sm:right-4 sm:top-4'
+              data-testid='onboarding-sign-in-header'
+            >
+              <MarketingSignInLink variant='ghost' />
+            </div>
             <OnboardingChat
               intentId={intentId}
               onConversationActivity={handleConversationActivity}

--- a/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
@@ -115,10 +115,10 @@ describe('OnboardingChat empty intro', () => {
 
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
     expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
-    expect(screen.getByTestId('onboarding-sign-in-skip')).toHaveAttribute(
-      'href',
-      '/signin'
-    );
+    expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
+    expect(
+      screen.getByTestId('onboarding-starter-suggestions').parentElement
+    ).toHaveClass('min-h-[7.5rem]');
   });
 
   it('shows a compact processing state for a validated starter handoff', () => {

--- a/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
@@ -116,6 +116,7 @@ describe('OnboardingChat empty intro', () => {
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
     expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
+    // The absolute header affordance must not consume this in-flow rail space.
     expect(
       screen.getByTestId('onboarding-starter-suggestions').parentElement
     ).toHaveClass('min-h-[7.5rem]');

--- a/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/lib/onboarding/empty-state';
 
 describe('OnboardingChatEmptyIntro', () => {
-  it('renders concise entry copy, composer, starters, and sign-in', () => {
+  it('renders concise entry copy, composer, and stable starters', () => {
     const onSelectSuggestion = vi.fn();
 
     render(
@@ -24,10 +24,10 @@ describe('OnboardingChatEmptyIntro', () => {
     expect(screen.getByText(ONBOARDING_ENTRY_SUPPORT)).toBeTruthy();
     expect(screen.getByTestId('test-composer')).toBeTruthy();
     expect(screen.getByTestId('onboarding-starter-suggestions')).toBeTruthy();
-    expect(screen.getByTestId('onboarding-sign-in-skip')).toHaveAttribute(
-      'href',
-      '/signin'
-    );
+    expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
+    expect(
+      screen.getByTestId('onboarding-starter-suggestions').parentElement
+    ).toHaveClass('min-h-[7.5rem]');
 
     for (const suggestion of ONBOARDING_STARTER_SUGGESTIONS) {
       expect(

--- a/apps/web/tests/unit/onboarding/OnboardingShell.sign-in-placement.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingShell.sign-in-placement.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { OnboardingChatEmptyIntro } from '@/components/features/onboarding/OnboardingChatEmptyIntro';
+import { OnboardingShell } from '@/components/features/onboarding/OnboardingShell';
+import { APP_ROUTES } from '@/constants/routes';
+
+vi.mock('@/components/organisms/AppShellFrame', () => ({
+  AppShellFrame: ({ main }: { readonly main: ReactNode }) => <>{main}</>,
+}));
+
+vi.mock('@/components/organisms/Sidebar', () => ({
+  SidebarProvider: ({ children }: { readonly children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock('@/components/features/onboarding/OnboardingChat', () => ({
+  OnboardingChat: () => <div data-testid='onboarding-chat' />,
+}));
+
+vi.mock('@/components/features/onboarding/OnboardingTurnstile', () => ({
+  getBrowserTurnstileHostname: () => 'localhost',
+  isOnboardingTurnstilePanelVisible: () => false,
+  OnboardingTurnstile: () => null,
+  resolveTurnstileSiteKey: () => null,
+}));
+
+vi.mock('@/components/features/onboarding/useOnboardingClaim', () => ({
+  useOnboardingClaim: () => 'idle',
+}));
+
+describe('onboarding sign-in placement', () => {
+  it('anchors the quiet sign-in link in an absolute top-right header slot', () => {
+    render(<OnboardingShell sessionLabel='pending' />);
+
+    const header = screen.getByTestId('onboarding-sign-in-header');
+    expect(header).toHaveClass('absolute', 'right-3', 'top-3');
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.SIGNIN
+    );
+  });
+
+  it('removes the centered duplicate without changing the starter rail reservation', () => {
+    render(
+      <OnboardingChatEmptyIntro
+        composer={<div>Composer</div>}
+        mode='blank'
+        onSelectSuggestion={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Already have an account?')).toBeNull();
+    expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
+    expect(
+      screen.getByTestId('onboarding-starter-suggestions').parentElement
+    ).toHaveClass('min-h-[7.5rem]');
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3384 -->

## Summary
- Move the quiet sign-in affordance into the responsive top-right onboarding header slot.
- Remove the centered duplicate beneath starter prompts.
- Preserve starter-rail height and keep the header affordance out of document flow.

## Verification
- `/Users/timwhite/Jovie/node_modules/.bin/biome check apps/web/components/features/onboarding/OnboardingShell.tsx apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx apps/web/tests/unit/onboarding/OnboardingShell.sign-in-placement.test.tsx`
- `git diff --check`
- Focused Vitest could not start in this isolated worktree because pnpm did not materialize its executable links after a lockfile-pinned offline install (`vitest` not found).

## UI
- Top-right sign-in uses the existing shared `MarketingSignInLink` ghost treatment, with no layout impact.