### PR TITLE
fix(auth): defer signed-in form hiding until hydration

### DIFF
--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { AuthProviderButtonSlot } from '@/features/auth/AuthProviderButtons';
 import { useAuthSafe } from '@/hooks/useClerkSafe';
@@ -117,6 +117,11 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
   } = props;
   const searchParams = useSearchParams();
   const { isLoaded: isAuthLoaded, isSignedIn } = useAuthSafe();
+  // `useAuthSafe` can resolve a cached Better Auth session synchronously in
+  // the browser while SSR has no session. Keep the first client render equal
+  // to the server tree, then let the route-level entry guard own the signed-in
+  // redirect after hydration.
+  const [hasHydrated, setHasHydrated] = useState(false);
   const [pendingProvider, setPendingProvider] =
     useState<PrimaryAuthOAuthProvider | null>(null);
   const [oauthError, setOauthError] = useState<string | null>(null);
@@ -139,6 +144,10 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
     () => getEnabledAuthOAuthProviders(),
     []
   );
+
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   const _redirectSignedInVisitor = useCallback(() => {
     const destination = getClientAuthenticatedAuthEntryRedirect(searchParams);
@@ -187,7 +196,7 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
     [mode, pendingProvider]
   );
 
-  if (isAuthLoaded && isSignedIn) {
+  if (hasHydrated && isAuthLoaded && isSignedIn) {
     return null;
   }
 

--- a/apps/web/components/features/auth/EmailCodeAuthForm.tsx
+++ b/apps/web/components/features/auth/EmailCodeAuthForm.tsx
@@ -120,6 +120,10 @@ export function EmailCodeAuthForm({
 }: EmailCodeAuthFormProps) {
   const searchParams = useSearchParams();
   const { isLoaded: isAuthLoaded, isSignedIn } = useAuthSafe();
+  // Match SSR on the first client pass. Better Auth can expose a cached
+  // session before hydration, but returning null here would replace the form
+  // that the server rendered and trigger a hydration mismatch.
+  const [hasHydrated, setHasHydrated] = useState(false);
   const [step, setStep] = useState<EmailCodeStep>('email');
   const [emailAddress, setEmailAddress] = useState(initialEmailAddress ?? '');
   const [code, setCode] = useState('');
@@ -134,6 +138,10 @@ export function EmailCodeAuthForm({
     const destination = getClientAuthenticatedAuthEntryRedirect(searchParams);
     globalThis.location?.assign(destination);
   }, [searchParams]);
+
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   // Notify the parent when the OTP code-entry/lockout step is active so One
   // Tap can be suppressed (plan design row 20). `'email'` = inactive; `'code'`
@@ -298,7 +306,7 @@ export function EmailCodeAuthForm({
     }
   }, []);
 
-  if (isAuthLoaded && isSignedIn) {
+  if (hasHydrated && isAuthLoaded && isSignedIn) {
     return null;
   }
 

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -178,7 +178,7 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
 
     const serverMarkup = renderToStaticMarkup(<AuthShell mode='sign-in' />);
     expect(serverMarkup).toContain('data-auth-shell-ready="true"');
-    expect(serverMarkup).toContain('Email me a code');
+    expect(serverMarkup).toContain('Email me a Code');
 
     const { container } = render(<AuthShell mode='sign-in' />);
     await waitFor(() => expect(container).toBeEmptyDOMElement());

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
@@ -172,9 +173,14 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
     });
   });
 
-  it('renders nothing when the visitor is already signed in', () => {
+  it('keeps the signed-in first render deterministic, then hides after hydration', async () => {
     authState.isSignedIn = true;
+
+    const serverMarkup = renderToStaticMarkup(<AuthShell mode='sign-in' />);
+    expect(serverMarkup).toContain('data-auth-shell-ready="true"');
+    expect(serverMarkup).toContain('Email me a code');
+
     const { container } = render(<AuthShell mode='sign-in' />);
-    expect(container).toBeEmptyDOMElement();
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 });

--- a/apps/web/tests/unit/components/features/auth/EmailCodeAuthForm.test.tsx
+++ b/apps/web/tests/unit/components/features/auth/EmailCodeAuthForm.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -11,13 +12,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * transition.
  */
 
-const { mockSendVerificationOtp, mockSignInEmailOtp } = vi.hoisted(() => ({
-  mockSendVerificationOtp: vi.fn(),
-  mockSignInEmailOtp: vi.fn(),
-}));
+const { authState, mockSendVerificationOtp, mockSignInEmailOtp } = vi.hoisted(
+  () => ({
+    authState: { isLoaded: true, isSignedIn: false },
+    mockSendVerificationOtp: vi.fn(),
+    mockSignInEmailOtp: vi.fn(),
+  })
+);
 
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/hooks/useClerkSafe', () => ({
+  useAuthSafe: () => ({
+    isLoaded: authState.isLoaded,
+    isSignedIn: authState.isSignedIn,
+  }),
 }));
 
 vi.mock('@/lib/auth/client', () => ({
@@ -63,6 +74,22 @@ describe('EmailCodeAuthForm', () => {
     // clearAllMocks does not drain that queue — it would otherwise leak into
     // the next test's first send/verify call. reset guarantees a clean slate.
     vi.resetAllMocks();
+    authState.isLoaded = true;
+    authState.isSignedIn = false;
+  });
+
+  it('keeps signed-in initial markup deterministic, then hides after hydration', async () => {
+    authState.isSignedIn = true;
+
+    const serverMarkup = renderToStaticMarkup(
+      <EmailCodeAuthForm mode='sign-in' redirectUrl='/app/dashboard' />
+    );
+    expect(serverMarkup).toContain('Email Address');
+
+    const { container } = render(
+      <EmailCodeAuthForm mode='sign-in' redirectUrl='/app/dashboard' />
+    );
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   describe('send-code error mapping (readErrorCode / getSendErrorMessage)', () => {


### PR DESCRIPTION
## Summary
- keep AuthShell and EmailCodeAuthForm SSR/client initial markup deterministic when Better Auth has a cached session
- hide the signed-in form only after hydration; route-level entry guard retains redirect ownership
- add regression coverage for both outer and nested guards

## Verification
- `pnpm biome check --write` on all four changed files ✅
- `git diff --check` ✅
- focused Vitest could not start locally: current isolated dependency materialization lacks `@vitejs/plugin-react` and `dotenv`; source CI is the authoritative gate