### PR TITLE
fix(shell): make sidebar thread fade visible

### DIFF
--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -24,7 +24,7 @@ const threads: SidebarThread[] = [
 ];
 
 describe('SidebarThreadsSection', () => {
-  it('uses the full middle track at rest and layers chat actions over its faded edge', () => {
+  it('uses the full middle track at rest and layers chat actions over a visible cross-engine faded edge', () => {
     const title =
       'Reply with exactly one short sentence confirming the artist release plan';
 
@@ -48,9 +48,18 @@ describe('SidebarThreadsSection', () => {
 
     const label = screen.getByText(title);
 
-    expect(label).toHaveClass('justify-self-stretch', 'overflow-hidden');
+    expect(label).toHaveClass(
+      'w-full',
+      'justify-self-stretch',
+      'overflow-hidden'
+    );
     expect(label).not.toHaveClass('justify-self-start', 'truncate');
-    expect(label.className).toContain('mask-image:linear-gradient');
+    expect(label.className).toContain(
+      'mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)'
+    );
+    expect(label.className).toContain(
+      '-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)'
+    );
     const row = screen.getByRole('link', { name: title });
     const action = screen.getByRole('button', {
       name: `Chat Actions for ${title}`,

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -230,7 +230,10 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
       />
       <span
         className={cn(
-          'min-w-0 justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left [mask-image:linear-gradient(to_right,black_calc(100%_-_1rem),transparent)]',
+          // The label owns the complete middle grid track. A fixed terminal
+          // fade (with the WebKit property for every supported shell) makes
+          // truncation read as intentional rather than a hard crop.
+          'min-w-0 w-full justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left [-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)] [mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
           'text-xs',
           unread && 'font-medium'
         )}


### PR DESCRIPTION
## Summary
- make sidebar chat titles explicitly fill their middle grid track
- use a 1.5rem terminal mask with both standard and WebKit properties so long titles fade instead of hard-clipping
- lock the cross-engine fade contract with the focused component test

## Validation
- `git diff --check`
- local focused Vitest unavailable in isolated worktree (`vitest` binary not installed); remote deterministic CI is required

No Linear issue — ad hoc follow-up from authenticated staging evidence.