### PR TITLE
fix(inbox): keep canonical header copy

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -144,7 +144,10 @@ describe('OpportunityInboxPageClient', () => {
     );
 
     expect(screen.getByTestId('opportunity-inbox-feed')).toBeInTheDocument();
-    expect(screen.getByText('Home — the inbox')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Inbox' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Pending opportunities, ready to accept or dismiss.')
+    ).toBeInTheDocument();
   });
 
   it('renders and filters a verified brand-deal decision', () => {

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx
@@ -291,14 +291,9 @@ export function OpportunityInboxPageClient({
         initialLinks={initialLinks}
       />
       <header className='system-b-opportunity-inbox-page-header'>
-        {/* ui-casing-allow: design-locked inbox copy */}
-        <h1 className='system-b-opportunity-inbox-page-title'>
-          {inboxHomeEnabled ? 'Inbox' : 'Home — the inbox'}
-        </h1>
+        <h1 className='system-b-opportunity-inbox-page-title'>Inbox</h1>
         <p className='system-b-opportunity-inbox-page-subtitle'>
-          {inboxHomeEnabled
-            ? 'Pending opportunities, ready to accept or dismiss.'
-            : 'One feed, mixed card types — suggestion, new song, tour date, profile match. One interaction grammar. Empty is never blank; accents are reserved for state.'}
+          Pending opportunities, ready to accept or dismiss.
         </p>
       </header>
 

--- a/apps/web/tests/e2e/opportunity-inbox.spec.ts
+++ b/apps/web/tests/e2e/opportunity-inbox.spec.ts
@@ -21,7 +21,7 @@ test.describe('Opportunity Inbox', () => {
     await expect(page.getByTestId('opportunity-inbox-page')).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.getByText('Home — the inbox')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Inbox' })).toBeVisible();
 
     const feed = page.getByTestId('opportunity-inbox-feed');
     const emptyState = page.getByTestId('opportunity-inbox-empty-state');


### PR DESCRIPTION
## Summary
- make the authenticated home header consistently read `Inbox`, independent of the interaction rollout flag
- retain one concise subtitle and remove legacy implementation-oriented copy
- cover the canonical heading in the unit and Inbox smoke tests

## Layout states
The populated, filtered, tour-review, and empty Inbox states retain the same header structure and reserved space. Only text changes; no action or container geometry changes.

## Verification
- `pnpm exec biome check --write apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.tsx apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx apps/web/tests/e2e/opportunity-inbox.spec.ts`
- `git diff --check`
- focused Vitest was attempted but the isolated worktree lacks `@vitejs/plugin-react` and `dotenv`; remote CI is the authoritative execution gate.

Related to #13739.