### PR TITLE
fix(user-button): use semantic overflow icons (JOV-3494)

### DIFF
--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -3,8 +3,9 @@
 import type { CommonDropdownItem, CommonDropdownSubmenu } from '@jovie/ui';
 import { Button, buttonVariants, CommonDropdown } from '@jovie/ui';
 import {
+  Cookie,
   CreditCard,
-  FileText,
+  FileCheck2,
   HelpCircle,
   Keyboard,
   LogOut,
@@ -244,7 +245,7 @@ function buildDropdownItems({
       type: 'action',
       id: 'terms-of-service',
       label: 'Terms Of Service',
-      icon: FileText,
+      icon: FileCheck2,
       onClick: () =>
         window.open(APP_ROUTES.LEGAL_TERMS, '_blank', 'noopener,noreferrer'),
     },
@@ -252,7 +253,7 @@ function buildDropdownItems({
       type: 'action',
       id: 'cookie-policy',
       label: 'Cookie Policy',
-      icon: FileText,
+      icon: Cookie,
       onClick: () =>
         window.open(APP_ROUTES.LEGAL_COOKIES, '_blank', 'noopener,noreferrer'),
     }

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   afterAll,
@@ -803,5 +803,41 @@ describe('UserButton billing actions', () => {
       'data-align',
       'start'
     );
+  });
+
+  it('uses distinct semantic icons for the Learn More menu items', async () => {
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: { isPro: false, plan: null, hasStripeCustomer: false },
+      isLoading: false,
+      error: null,
+    } as any);
+    const user = userEvent.setup();
+
+    render(<UserButton showUserInfo />);
+
+    await user.click(screen.getByRole('button', { name: /Adele Adkins/i }));
+    await user.hover(screen.getByRole('menuitem', { name: 'Learn More' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitem', { name: 'Privacy Policy' })
+      ).toBeVisible();
+    });
+
+    expect(
+      screen
+        .getByRole('menuitem', { name: 'Privacy Policy' })
+        .querySelector('svg')?.className.baseVal
+    ).toContain('lucide-shield');
+    expect(
+      screen
+        .getByRole('menuitem', { name: 'Terms Of Service' })
+        .querySelector('svg')?.className.baseVal
+    ).toContain('lucide-file-check-corner');
+    expect(
+      screen
+        .getByRole('menuitem', { name: 'Cookie Policy' })
+        .querySelector('svg')?.className.baseVal
+    ).toContain('lucide-cookie');
   });
 });


### PR DESCRIPTION
## Summary
- replace duplicated legal-menu icons with semantic terms and cookie icons
- cover Learn More menu icon semantics

## Verification
- `pnpm --filter web exec vitest run tests/components/user-button.test.tsx` (21 passed)
- `pnpm biome check --write apps/web/tests/components/user-button.test.tsx`
- normal pre-commit ladder, including lint-staged typecheck, passed under Node 22.23.1

JOV-3494