### PR TITLE
fix(contacts): add action to empty state

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -209,6 +209,10 @@ export const ContactsTable = memo(function ContactsTable({
               icon={<UserPlus className='h-6 w-6' aria-hidden='true' />}
               heading='No Contacts'
               description='Add a contact to manage bookings, management, and press.'
+              action={{
+                label: 'Add Contact',
+                onClick: () => onAddContact(),
+              }}
             />
           ) : (
             <UnifiedTable

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
@@ -171,7 +171,7 @@ describe('ContactsTable', () => {
     expect(screen.queryByText('No Contacts Yet')).not.toBeInTheDocument();
   });
 
-  it('keeps the empty state informational and exposes the only add action in the header', async () => {
+  it('offers the canonical add contact action from the empty state', () => {
     const onAddContact = vi.fn();
 
     render(
@@ -191,17 +191,8 @@ describe('ContactsTable', () => {
         'Add a contact to manage bookings, management, and press.'
       )
     ).toBeVisible();
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(setHeaderActions).toHaveBeenCalledWith(expect.anything());
-    });
-
-    const headerActions = setHeaderActions.mock.calls.at(-1)?.[0];
-    render(headerActions);
-
     const addContactButton = screen.getByRole('button', {
-      name: 'Add contact',
+      name: 'Add Contact',
     });
     expect(addContactButton).toHaveTextContent('Add Contact');
 


### PR DESCRIPTION
## Summary
- Adds the canonical **Add Contact** action to the Contacts empty state.
- Reuses the existing `onAddContact` flow; no new UI primitive or state.
- Updates the focused regression to verify the visible CTA invokes that flow.

## Verification
- `pnpm --dir /Users/timwhite/Jovie exec biome check …ContactsTable.tsx …ContactsTable.test.tsx` ✅
- `git diff --check` ✅
- Focused Vitest could not start in this isolated checkout because its dependencies are not materialized (`@vitejs/plugin-react`, `dotenv`, and `vitest` unresolved). Canonical remote CI is running.

No browser, server, or visual-review gate was used for this source-only consistency fix.