### PR TITLE
fix(profiles): action the no-profile empty state

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -73,6 +73,20 @@ const data: ProfilesWorkspaceData = {
 };
 
 describe('ProfilesWorkspace', () => {
+  it('uses the canonical empty state with a direct artist-profile action', () => {
+    render(<ProfilesWorkspace data={null} />);
+
+    expect(
+      screen.getByTestId('profiles-workspace-empty-state')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'No Artist Profile Selected' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Set Up Artist Profile' })
+    ).toHaveAttribute('href', '/app/settings/artist-profile');
+  });
+
   it('filters the unified table without exposing locked rank values', () => {
     render(<ProfilesWorkspace data={data} />);
 

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -10,6 +10,7 @@ import {
   Globe2,
   LockKeyhole,
   RefreshCw,
+  UserRound,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -21,6 +22,7 @@ import {
   EntitySidebarShell,
 } from '@/components/molecules/drawer';
 import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
+import { EmptyState } from '@/components/molecules/EmptyState';
 import { PageShell } from '@/components/organisms/PageShell';
 import {
   PageToolbar,
@@ -354,9 +356,16 @@ export function ProfilesWorkspace({
   if (!data) {
     return (
       <PageShell data-testid='profiles-workspace'>
-        <TableEmptyState
-          title='No artist profile selected'
-          description='Select or claim an artist profile to monitor its presence.'
+        <EmptyState
+          icon={<UserRound className='h-5 w-5' aria-hidden />}
+          heading='No Artist Profile Selected'
+          description='Set up an artist profile to monitor its presence.'
+          action={{
+            label: 'Set Up Artist Profile',
+            href: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
+          }}
+          testId='profiles-workspace-empty-state'
+          className='min-h-75'
         />
       </PageShell>
     );


### PR DESCRIPTION
## Summary
- Replace the profiles workspace’s bespoke no-profile card with the canonical `EmptyState`.
- Preserve one focused next step: **Set Up Artist Profile** links to `/app/settings/artist-profile`.
- Add a component regression for the Title Case empty-state copy and direct action.

## Verification
- `git diff --check`
- Local Biome/Vitest could not start because this isolated worktree has no materialized binaries (`biome` and `vitest` missing); normal push completed without bypass.
- Remote deterministic CI is the admission gate.

## Scope
- No browser/server/Kimi run: this is an ordinary source-first UI cleanup with no behavior outside the empty state.