### PR TITLE
feat(connectors): add verified brand-deal evidence policy

### DIFF
--- a/.claude/skills/brand-deals/references/connector-routing.md
+++ b/.claude/skills/brand-deals/references/connector-routing.md
@@ -25,26 +25,33 @@ Preferred routing:
 1. Use a Codex Gmail connector only if its profile is `t@timwhite.co`.
 2. Otherwise, inspect Composio:
 
-   ```bash
-   composio connections list
-   composio proxy \
-     https://gmail.googleapis.com/gmail/v1/users/me/profile \
-     --toolkit gmail
-   ```
+   - List the available Gmail connection through the installed Composio tool
+     surface.
+   - Invoke the `GMAIL_GET_PROFILE` action through that same surface.
+   - If only a CLI is available, inspect that installed version's help before
+     choosing a verb. Do not assume current or legacy CLI syntax.
 
 3. Require `emailAddress` to equal `t@timwhite.co` case-insensitively.
 4. Search with `GMAIL_FETCH_EMAILS` using metadata-only, small-result queries.
 5. Hydrate only shortlisted evidence with
    `GMAIL_FETCH_MESSAGE_BY_THREAD_ID`.
 
-If the `composio` command is an older incompatible client, locate the current
-binary reported by the official installer before concluding that the connector
-is unavailable. Never print or persist a Composio API key.
+Never run `composio whoami`. Installed legacy clients can print the Composio API
+key in command output. Never print or persist a Composio API key. If the
+`composio` command is an older incompatible client, locate the current binary
+reported by the official installer before concluding that the connector is
+unavailable.
 
 Composio's CLI is an agent research and bootstrap surface, not Jovie's
 production runtime contract. A verified agent may use it to source evidence,
 but Inbox writes still go through Jovie's tested
 `emitBrandDealOpportunity` server boundary.
+
+The native producer must derive the source identity from the connected Gmail
+account. It must never label `tim@jov.ie` as Tim's personal mailbox or substitute
+it for `t@timwhite.co`. If Jovie has no user-approved personal-mailbox preference,
+show the exact authenticated account as provenance and fail closed on any
+Tim-specific identity claim.
 
 ## Minimum-safe Gmail behavior
 

--- a/apps/web/lib/connectors/__tests__/no-gmail-send.test.ts
+++ b/apps/web/lib/connectors/__tests__/no-gmail-send.test.ts
@@ -17,8 +17,19 @@ const GMAIL_LIB_DIR = path.resolve(__dirname, '../../../lib/connectors/gmail');
 
 // Use the actual resolved path relative to the test file
 const GMAIL_DIR = path.resolve(__dirname, '../gmail');
+const NATIVE_GMAIL_SURFACES = [
+  path.resolve(__dirname, '../extract-and-propose.ts'),
+  path.resolve(__dirname, '../enrichment/pipelines/gmail.ts'),
+  path.resolve(__dirname, '../brand-deal-opportunity-emitter.ts'),
+];
 
-describe('Gmail connector: no send export', () => {
+const FORBIDDEN_GMAIL_MUTATION_NAME =
+  /(?:send|draft|forward|reply|archive|trash|delete|modify|label)/i;
+const FORBIDDEN_GMAIL_MUTATION_ENDPOINT =
+  /\/(?:drafts|send|trash|untrash|modify|batchModify|labels)(?:[/?'"]|$)/i;
+const NON_GET_METHOD = /\bmethod\s*:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/i;
+
+describe('Gmail connector: read-only surface', () => {
   it('gmail connector directory exists or is absent (C-PR-2 not yet merged)', () => {
     // This test always passes — it documents the expected state.
     // If the directory exists, the next test will scan it.
@@ -59,6 +70,57 @@ describe('Gmail connector: no send export', () => {
           `${file} appears to export 'send' or re-export its surface — Jovie must NEVER send email on behalf of artists.`
         );
       }
+    }
+  });
+
+  it('exports no Gmail mutation capability and makes no Gmail write request', () => {
+    const dirToCheck = existsSync(GMAIL_DIR)
+      ? GMAIL_DIR
+      : existsSync(GMAIL_LIB_DIR)
+        ? GMAIL_LIB_DIR
+        : null;
+    if (!dirToCheck) return;
+
+    const tsFiles = readdirSync(dirToCheck, { recursive: true }).filter(
+      (file): file is string =>
+        typeof file === 'string' &&
+        file.endsWith('.ts') &&
+        !file.endsWith('.test.ts')
+    );
+
+    for (const file of tsFiles) {
+      const source = readFileSync(path.join(dirToCheck, file), 'utf-8');
+      const exportedNames = [
+        ...source.matchAll(
+          /export\s+(?:async\s+)?(?:function|const)\s+([A-Za-z_$][\w$]*)/g
+        ),
+      ].map(match => match[1] ?? '');
+      expect(
+        exportedNames.filter(name => FORBIDDEN_GMAIL_MUTATION_NAME.test(name)),
+        `${file} exports a Gmail mutation-shaped capability`
+      ).toEqual([]);
+      expect(
+        FORBIDDEN_GMAIL_MUTATION_ENDPOINT.test(source),
+        `${file} references a Gmail mutation endpoint`
+      ).toBe(false);
+      expect(
+        NON_GET_METHOD.test(source),
+        `${file} contains a non-GET request method`
+      ).toBe(false);
+    }
+  });
+
+  it('keeps every native Gmail producer surface free of write requests', () => {
+    for (const filePath of NATIVE_GMAIL_SURFACES) {
+      const source = readFileSync(filePath, 'utf-8');
+      expect(
+        FORBIDDEN_GMAIL_MUTATION_ENDPOINT.test(source),
+        `${path.basename(filePath)} references a Gmail mutation endpoint`
+      ).toBe(false);
+      expect(
+        NON_GET_METHOD.test(source),
+        `${path.basename(filePath)} contains a non-GET request method`
+      ).toBe(false);
     }
   });
 });

--- a/apps/web/lib/connectors/brand-deal-opportunity.test.ts
+++ b/apps/web/lib/connectors/brand-deal-opportunity.test.ts
@@ -70,6 +70,19 @@ describe('parseBrandDealOpportunity', () => {
       { ...verifiedPayload, sourceAccount: 'tim@jov.ie' },
     ],
     [
+      'wrong personal mailbox self-attestation',
+      BRAND_DEAL_OPPORTUNITY_KIND,
+      {
+        ...verifiedPayload,
+        sourceLabel: 'Authenticated Gmail',
+        sourceType: 'personal_email',
+        sourceAccount: 'tim@jov.ie',
+        requiredSourceAccount: 'tim@jov.ie',
+        sourceReference: 'gmail:message:181696d593400f5c',
+        relationshipType: 'personal_inbound',
+      },
+    ],
+    [
       'rejects a non-Gmail personal source reference',
       BRAND_DEAL_OPPORTUNITY_KIND,
       {
@@ -117,7 +130,7 @@ describe('parseBrandDealOpportunity', () => {
     );
     expect(deal).not.toBeNull();
     expect(formatBrandDealOpportunityMetadata(deal!)).toBe(
-      '$7.5k-$12.5k · Alex Buyer @ Example Brand · Backstage · verified · score 75.0 · 90-day organic usage, no exclusivity'
+      '$7.5k-$12.5k · Alex Buyer @ Example Brand · Backstage (t@timwhite.co) · verified · score 75.0 · 90-day organic usage, no exclusivity'
     );
   });
 });

--- a/apps/web/lib/connectors/brand-deal-opportunity.ts
+++ b/apps/web/lib/connectors/brand-deal-opportunity.ts
@@ -1,4 +1,5 @@
 export const BRAND_DEAL_OPPORTUNITY_KIND = 'brand_deal.opportunity';
+export const TIM_BRAND_DEAL_SOURCE_ACCOUNT = 't@timwhite.co';
 
 export interface BrandDealOpportunityData {
   readonly title: string;
@@ -42,6 +43,40 @@ export interface BrandDealOpportunityData {
   readonly repeatPotential: number;
   readonly creatorMinutes: number;
   readonly rankingScore: number;
+}
+
+export interface BrandDealCommercialCandidate {
+  readonly buyerName: string;
+  readonly buyerCompany: string;
+  readonly budgetMinCents: number;
+  readonly budgetMaxCents: number;
+  readonly depositPercent: number;
+  readonly includedRevisions: 0 | 1;
+  readonly usageTermDays: number;
+  readonly exclusivity: 'none' | 'narrow_paid';
+  readonly closeProbability: number;
+  readonly repeatPotential: number;
+  readonly creatorMinutes: number;
+}
+
+export function collectBrandDealEvidenceObjectIds(
+  rows: readonly { readonly sourceRefs: unknown }[]
+): Set<string> {
+  const ids = new Set<string>();
+  for (const row of rows) {
+    if (!Array.isArray(row.sourceRefs)) continue;
+    for (const sourceRef of row.sourceRefs) {
+      if (
+        sourceRef &&
+        typeof sourceRef === 'object' &&
+        'externalObjectId' in sourceRef &&
+        typeof sourceRef.externalObjectId === 'string'
+      ) {
+        ids.add(sourceRef.externalObjectId);
+      }
+    }
+  }
+  return ids;
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -129,6 +164,9 @@ export function parseBrandDealOpportunity(
     !isNonEmptyString(candidate.requiredSourceAccount) ||
     candidate.sourceAccount.trim().toLowerCase() !==
       candidate.requiredSourceAccount.trim().toLowerCase() ||
+    (candidate.sourceType === 'personal_email' &&
+      candidate.requiredSourceAccount.trim().toLowerCase() !==
+        TIM_BRAND_DEAL_SOURCE_ACCOUNT) ||
     !isNonEmptyString(candidate.sourceReference) ||
     !isValidObservedAt(candidate.observedAt) ||
     !isFiniteNonNegativeNumber(candidate.confidence) ||
@@ -182,6 +220,50 @@ export function parseBrandDealOpportunity(
   };
 }
 
+export function buildVerifiedPersonalEmailOpportunity(input: {
+  readonly candidate: BrandDealCommercialCandidate;
+  readonly sourceAccount: string;
+  readonly sourceReference: string;
+  readonly observedAt: string;
+}): BrandDealOpportunityData | null {
+  if (
+    input.sourceAccount.trim().toLowerCase() !== TIM_BRAND_DEAL_SOURCE_ACCOUNT
+  ) {
+    return null;
+  }
+
+  return parseBrandDealOpportunity(BRAND_DEAL_OPPORTUNITY_KIND, {
+    ...input.candidate,
+    title: `${input.candidate.buyerCompany} creator-performance campaign`,
+    rightsSummary: `${input.candidate.usageTermDays}-day usage, ${
+      input.candidate.exclusivity === 'none'
+        ? 'no exclusivity'
+        : 'narrow paid exclusivity'
+    }`,
+    expectedUpfrontCashCents: Math.round(
+      (input.candidate.budgetMinCents * input.candidate.depositPercent) / 100
+    ),
+    confidence: 1,
+    currency: 'USD',
+    sourceLabel: 'Authenticated Gmail',
+    sourceType: 'personal_email',
+    sourceAccount: input.sourceAccount,
+    requiredSourceAccount: TIM_BRAND_DEAL_SOURCE_ACCOUNT,
+    sourceReference: input.sourceReference,
+    observedAt: input.observedAt,
+    evidenceStatus: 'verified',
+    identityMatched: true,
+    ownershipVerified: true,
+    personalDealVerified: true,
+    relationshipType: 'personal_inbound',
+    activeSponsorCampaignCount: 0,
+    routeToLyb: false,
+    lybPaidFlowVerified: false,
+    externalSendApproved: false,
+    commercialApprovalId: null,
+  });
+}
+
 function formatCompactMoney(cents: number, currency: string): string {
   const amount = cents / 100;
   const formatted =
@@ -204,5 +286,5 @@ export function formatBrandDealOpportunityMetadata(
     deal.budgetMinCents === deal.budgetMaxCents
       ? formatCompactMoney(deal.budgetMinCents, deal.currency)
       : `${formatCompactMoney(deal.budgetMinCents, deal.currency)}-${formatCompactMoney(deal.budgetMaxCents, deal.currency)}`;
-  return `${budget} · ${deal.buyerName} @ ${deal.buyerCompany} · ${deal.sourceLabel} · verified · score ${deal.rankingScore.toFixed(1)} · ${deal.rightsSummary}`;
+  return `${budget} · ${deal.buyerName} @ ${deal.buyerCompany} · ${deal.sourceLabel} (${deal.sourceAccount}) · verified · score ${deal.rankingScore.toFixed(1)} · ${deal.rightsSummary}`;
 }

--- a/apps/web/lib/connectors/gmail/client.ts
+++ b/apps/web/lib/connectors/gmail/client.ts
@@ -50,6 +50,27 @@ export function buildGmailBookingQuery(historyWindowDays: number): string {
 }
 
 /**
+ * Narrow read-only query for booking signals and explicit paid brand briefs.
+ * Commercial qualification still happens locally against normalized metadata.
+ */
+export function buildGmailOpportunityQuery(historyWindowDays: number): string {
+  return `category:primary newer_than:${historyWindowDays}d (${[
+    'booking',
+    '"show confirmation"',
+    '"gig confirmation"',
+    'contract',
+    '"performance agreement"',
+    '"event confirmation"',
+    '"paid creator campaign"',
+    '"creator-performance campaign"',
+    '"brand partnership"',
+    '"paid partnership"',
+    '"ugc campaign"',
+    '"sponsor campaign"',
+  ].join(' OR ')})`;
+}
+
+/**
  * Lists Gmail messages matching the booking query.
  * Returns up to `maxResults` message stubs (id + threadId only).
  */

--- a/apps/web/lib/connectors/gmail/extract-brand-deal-candidate.test.ts
+++ b/apps/web/lib/connectors/gmail/extract-brand-deal-candidate.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractGmailBrandDealCandidate,
+  type GmailBrandDealEvidence,
+  selectHighestRankedGmailBrandDealCandidate,
+} from './extract-brand-deal-candidate';
+
+const completeSnippet =
+  'Company: Example Brand. Campaign budget: $10,000. 50% deposit upfront. Rights: 90-day organic usage, no exclusivity. One revision.';
+const currentMessageDate = new Date().toUTCString();
+const completeEvidence: GmailBrandDealEvidence = {
+  externalObjectId: '10000000-0000-4000-8000-000000000001',
+  payload: {
+    subject: 'Current paid creator campaign brief',
+    from: 'Alex Buyer <alex@agency.example>',
+    date: currentMessageDate,
+    snippet: completeSnippet,
+  },
+};
+const extractWith = (payload: GmailBrandDealEvidence['payload']) =>
+  extractGmailBrandDealCandidate({
+    ...completeEvidence,
+    payload: { ...completeEvidence.payload, ...payload },
+  });
+
+describe('extractGmailBrandDealCandidate', () => {
+  it('extracts only explicit current commercial terms from normalized metadata', () => {
+    expect(extractGmailBrandDealCandidate(completeEvidence)).toEqual({
+      evidenceObjectId: completeEvidence.externalObjectId,
+      rankingScore: 41.666666666666664,
+      candidate: {
+        buyerName: 'Alex Buyer',
+        buyerCompany: 'Example Brand',
+        budgetMinCents: 1_000_000,
+        budgetMaxCents: 1_000_000,
+        depositPercent: 50,
+        includedRevisions: 1,
+        usageTermDays: 90,
+        exclusivity: 'none',
+        closeProbability: 0.5,
+        repeatPotential: 1,
+        creatorMinutes: 60,
+      },
+    });
+  });
+
+  it('rejects a sender without an explicit buyer identity', () => {
+    expect(extractWith({ from: 'marketing@example.com' })).toBeNull();
+  });
+
+  it.each([
+    'Company: Example Brand. ',
+    'Campaign budget: $10,000. ',
+    '50% deposit upfront. ',
+    'Rights: 90-day organic usage, no exclusivity. ',
+    'One revision.',
+  ])('rejects a candidate missing explicit terms: %s', fragment => {
+    expect(
+      extractWith({ snippet: completeSnippet.replace(fragment, '') })
+    ).toBeNull();
+  });
+
+  it.each([
+    'Newsletter: current paid creator campaign brief',
+    'Gifting offer: current paid creator campaign brief',
+    'Affiliate current paid creator campaign brief',
+    'A7X3 current paid creator campaign brief',
+    'Creator economy current paid creator campaign brief',
+    'Influencer activation current paid creator campaign brief',
+  ])('rejects adjacent work instead of treating it as a personal deal: %s', subject => {
+    expect(extractWith({ subject })).toBeNull();
+  });
+
+  it('rejects forbidden commercial terms', () => {
+    expect(
+      extractGmailBrandDealCandidate({
+        ...completeEvidence,
+        payload: {
+          ...completeEvidence.payload,
+          snippet: `${completeSnippet} Perpetual usage.`,
+        },
+      })
+    ).toBeNull();
+  });
+
+  it.each([
+    completeSnippet.replace('no exclusivity', 'no broad exclusivity'),
+    completeSnippet.replace('Campaign budget', 'Previous campaign budget'),
+    `${completeSnippet} Completed campaign recap.`,
+  ])('rejects ambiguous or historical terms: %s', snippet => {
+    expect(extractWith({ snippet })).toBeNull();
+  });
+
+  it('rejects stale messages even when their terms are otherwise complete', () => {
+    expect(
+      extractWith({
+        date: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toUTCString(),
+      })
+    ).toBeNull();
+  });
+
+  it('returns only the highest-ranked complete candidate', () => {
+    const lowerValue = {
+      ...completeEvidence,
+      externalObjectId: '10000000-0000-4000-8000-000000000002',
+      payload: {
+        ...completeEvidence.payload,
+        snippet:
+          'Company: Smaller Brand. Campaign budget: $7,500. 50% deposit upfront. Rights: 30-day organic usage, no exclusivity. No revisions.',
+      },
+    };
+
+    expect(
+      selectHighestRankedGmailBrandDealCandidate([lowerValue, completeEvidence])
+        ?.evidenceObjectId
+    ).toBe(completeEvidence.externalObjectId);
+  });
+
+  it('never resurfaces rejected evidence and advances to the next buyer', () => {
+    const nextBuyer = {
+      ...completeEvidence,
+      externalObjectId: '10000000-0000-4000-8000-000000000002',
+      payload: {
+        ...completeEvidence.payload,
+        from: 'Jamie Buyer <jamie@agency.example>',
+        snippet:
+          'Company: Next Brand. Campaign budget: $7,500. 50% deposit upfront. Rights: 30-day organic usage, no exclusivity. No revisions.',
+      },
+    };
+
+    expect(
+      selectHighestRankedGmailBrandDealCandidate(
+        [completeEvidence, nextBuyer],
+        new Set([completeEvidence.externalObjectId])
+      )?.evidenceObjectId
+    ).toBe(nextBuyer.externalObjectId);
+  });
+});

--- a/apps/web/lib/connectors/gmail/extract-brand-deal-candidate.ts
+++ b/apps/web/lib/connectors/gmail/extract-brand-deal-candidate.ts
@@ -1,0 +1,201 @@
+import type { BrandDealCommercialCandidate } from '@/lib/connectors/brand-deal-opportunity';
+
+export interface GmailBrandDealEvidence {
+  readonly externalObjectId: string;
+  readonly payload: {
+    readonly subject?: string;
+    readonly from?: string;
+    readonly date?: string;
+    readonly snippet?: string;
+  };
+}
+
+export interface RankedGmailBrandDealCandidate {
+  readonly evidenceObjectId: string;
+  readonly candidate: BrandDealCommercialCandidate;
+  readonly rankingScore: number;
+}
+
+const QUALIFIED_DEAL_RE =
+  /\b(?:paid creator campaign|creator-performance campaign|brand partnership|paid partnership|ugc campaign|sponsor(?:ed|ship) campaign)\b/i;
+const CURRENT_BRIEF_RE =
+  /\b(?:current|this|proposed)\b[^\n]{0,48}\b(?:campaign|brief|deal|offer)\b/i;
+const HISTORICAL_BRIEF_RE =
+  /\b(?:previous|past|last|completed)\s+(?:campaign|brief|deal|offer)\b|\b(?:campaign|deal)\s+(?:recap|summary)\b/i;
+const FORBIDDEN_ADJACENCY_RE =
+  /\b(?:newsletter|gift(?:ing|ed)?|product seeding|affiliate|a7x3|creator economy|influencer activation)\b/i;
+const FORBIDDEN_TERMS_RE =
+  /\b(?:perpetual|irrevocable|unlimited revisions?|broad exclusivity|all[- ]category exclusivity)\b/i;
+const COMPANY_RE = /\b(?:company|brand)\s*:\s*([^.;\n]{2,80})/i;
+const BUDGET_RE =
+  /\b(?:budget|fee|offer|rate)\s*(?:is|:|of)?\s*\$([\d,.]+)\s*(k)?(?:\s*(?:-|to)\s*\$?([\d,.]+)\s*(k)?)?/i;
+const DEPOSIT_PERCENT_RE =
+  /(?:\b(\d{2,3})%\s*(?:deposit|upfront)\b|\b(?:deposit|upfront)\s*(?:is|:|of)?\s*(\d{2,3})%)/i;
+const USAGE_TERM_RE = /\b(\d{1,3})[- ]day\s+([a-z ]{0,24})usage\b/i;
+const NO_EXCLUSIVITY_RE = /\bno\s+exclusivity\b/i;
+const REVISION_RE = /\b(no|zero|0|one|1)\s+(?:included\s+)?revisions?\b/i;
+const SENDER_NAME_RE = /^"?([^"<@]+?)"?\s*</;
+const NON_BUYER_SENDER_RE =
+  /\b(?:no[- ]?reply|newsletter|marketing|support|team|bookings?|info)\b/i;
+const MAX_MESSAGE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
+
+function parseMoneyCents(raw: string, suffix: string | undefined): number {
+  const numeric = Number.parseFloat(raw.replaceAll(',', ''));
+  if (!Number.isFinite(numeric)) return Number.NaN;
+  return Math.round(numeric * (suffix?.toLowerCase() === 'k' ? 100_000 : 100));
+}
+
+function parseBuyerName(from: string): string | null {
+  const name = from.match(SENDER_NAME_RE)?.[1]?.trim();
+  if (!name || name.length < 2 || NON_BUYER_SENDER_RE.test(name)) return null;
+  return name;
+}
+
+function parseCompany(text: string): string | null {
+  const company = text.match(COMPANY_RE)?.[1]?.trim();
+  if (!company || company.length < 2) return null;
+  return company;
+}
+
+function parseBudget(
+  text: string
+): { readonly minimum: number; readonly maximum: number } | null {
+  const match = text.match(BUDGET_RE);
+  if (!match?.[1]) return null;
+
+  const minimum = parseMoneyCents(match[1], match[2]);
+  const maximum = match[3]
+    ? parseMoneyCents(match[3], match[4] ?? match[2])
+    : minimum;
+  if (
+    !Number.isFinite(minimum) ||
+    !Number.isFinite(maximum) ||
+    minimum > maximum ||
+    minimum < 750_000 ||
+    maximum > 1_250_000
+  ) {
+    return null;
+  }
+
+  return { minimum, maximum };
+}
+
+function parseDepositPercent(text: string): number | null {
+  if (/\bhalf\s+(?:deposit|upfront)\b/i.test(text)) return 50;
+  const match = text.match(DEPOSIT_PERCENT_RE);
+  const percent = Number.parseInt(match?.[1] ?? match?.[2] ?? '', 10);
+  return Number.isInteger(percent) && percent >= 50 && percent <= 100
+    ? percent
+    : null;
+}
+
+function parseUsageTermDays(text: string): number | null {
+  const days = Number.parseInt(text.match(USAGE_TERM_RE)?.[1] ?? '', 10);
+  return Number.isInteger(days) && days >= 1 && days <= 90 ? days : null;
+}
+
+function parseIncludedRevisions(text: string): 0 | 1 | null {
+  const raw = text.match(REVISION_RE)?.[1]?.toLowerCase();
+  if (raw === 'no' || raw === 'zero' || raw === '0') return 0;
+  if (raw === 'one' || raw === '1') return 1;
+  return null;
+}
+
+function hasFreshMessageDate(rawDate: string | undefined): boolean {
+  const messageDate = Date.parse(rawDate ?? '');
+  if (!Number.isFinite(messageDate)) return false;
+  const now = Date.now();
+  return (
+    messageDate >= now - MAX_MESSAGE_AGE_MS &&
+    messageDate <= now + MAX_FUTURE_SKEW_MS
+  );
+}
+
+function rankingScore(
+  candidate: BrandDealCommercialCandidate,
+  expectedUpfrontCashCents: number
+): number {
+  return (
+    ((expectedUpfrontCashCents / 100) *
+      candidate.closeProbability *
+      candidate.repeatPotential) /
+    candidate.creatorMinutes
+  );
+}
+
+export function extractGmailBrandDealCandidate(
+  evidence: GmailBrandDealEvidence
+): RankedGmailBrandDealCandidate | null {
+  const subject = evidence.payload.subject?.trim() ?? '';
+  const snippet = evidence.payload.snippet?.trim() ?? '';
+  const text = `${subject}\n${snippet}`;
+
+  if (
+    !QUALIFIED_DEAL_RE.test(text) ||
+    !CURRENT_BRIEF_RE.test(text) ||
+    HISTORICAL_BRIEF_RE.test(text) ||
+    FORBIDDEN_ADJACENCY_RE.test(text) ||
+    FORBIDDEN_TERMS_RE.test(text) ||
+    !hasFreshMessageDate(evidence.payload.date)
+  ) {
+    return null;
+  }
+
+  const buyerName = parseBuyerName(evidence.payload.from ?? '');
+  const buyerCompany = parseCompany(text);
+  const budget = parseBudget(text);
+  const depositPercent = parseDepositPercent(text);
+  const usageTermDays = parseUsageTermDays(text);
+  const includedRevisions = parseIncludedRevisions(text);
+  if (
+    !buyerName ||
+    !buyerCompany ||
+    !budget ||
+    depositPercent === null ||
+    usageTermDays === null ||
+    includedRevisions === null ||
+    !NO_EXCLUSIVITY_RE.test(text)
+  ) {
+    return null;
+  }
+
+  const candidate: BrandDealCommercialCandidate = {
+    buyerName,
+    buyerCompany,
+    budgetMinCents: budget.minimum,
+    budgetMaxCents: budget.maximum,
+    depositPercent,
+    includedRevisions,
+    usageTermDays,
+    exclusivity: 'none',
+    closeProbability: 0.5,
+    repeatPotential: 1,
+    creatorMinutes: 60,
+  };
+  const expectedUpfrontCashCents = Math.round(
+    (budget.minimum * depositPercent) / 100
+  );
+
+  return {
+    evidenceObjectId: evidence.externalObjectId,
+    candidate,
+    rankingScore: rankingScore(candidate, expectedUpfrontCashCents),
+  };
+}
+
+export function selectHighestRankedGmailBrandDealCandidate(
+  evidence: readonly GmailBrandDealEvidence[],
+  excludedEvidenceObjectIds: ReadonlySet<string> = new Set()
+): RankedGmailBrandDealCandidate | null {
+  return (
+    evidence
+      .filter(item => !excludedEvidenceObjectIds.has(item.externalObjectId))
+      .map(extractGmailBrandDealCandidate)
+      .filter(
+        (candidate): candidate is RankedGmailBrandDealCandidate =>
+          candidate !== null
+      )
+      .sort((left, right) => right.rankingScore - left.rankingScore)[0] ?? null
+  );
+}

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
@@ -59,7 +59,7 @@ describe('mapSuggestedActionToInboxCard', () => {
       signalType: 'brand_deal',
       typeLabel: 'Brand Deal',
       title: 'Example Brand creator-performance pilot',
-      why: '$7.5k-$12.5k · Alex Buyer @ Example Brand · Backstage · verified · score 75.0 · 90-day organic usage, no exclusivity',
+      why: '$7.5k-$12.5k · Alex Buyer @ Example Brand · Backstage (t@timwhite.co) · verified · score 75.0 · 90-day organic usage, no exclusivity',
       primaryActionLabel: 'Approve buyer',
       status: 'pending',
       category: 'brand_deal',

--- a/scripts/lib/__tests__/brand-deals-skill-contract.test.mjs
+++ b/scripts/lib/__tests__/brand-deals-skill-contract.test.mjs
@@ -86,9 +86,11 @@ describe('brand-deals skill contract', () => {
   });
 
   it('polls a Composio fallback and verifies the personal Gmail profile', () => {
-    expect(connectorRouting).toContain('composio connections list');
+    expect(connectorRouting).toContain('GMAIL_GET_PROFILE');
+    expect(connectorRouting).toContain('Never run `composio whoami`');
+    expect(connectorRouting).toContain("inspect that installed version's help");
     expect(connectorRouting).toContain(
-      'https://gmail.googleapis.com/gmail/v1/users/me/profile'
+      "never label `tim@jov.ie` as Tim's personal mailbox"
     );
     expect(connectorRouting).toContain('t@timwhite.co');
     expect(connectorRouting).toContain('case-insensitively');


### PR DESCRIPTION
## Summary
- add deterministic Gmail evidence qualification with fail-closed current, fresh, budget, deposit, revision, usage-rights, and exclusivity policy
- certify Tim personal-deal evidence only for the exact `t@timwhite.co` mailbox while preserving generic Gmail booking/enrichment behavior for other users
- expand read-only Gmail and Composio skill guards; reject historical deals, A7X3 company-side activity, creator-economy relationships, gifting, affiliate, perpetual rights, unlimited revisions, and broad exclusivity

## Safety boundary
- no Gmail send, draft, label, archive, delete, or mutation capability
- no auto-approval or external commercial commitment
- no production or revenue claim

## Verification
- pre-push TypeScript and Biome gates passed
- full required Vitest matrix passed across all 8 shards
- focused final-source tests: 66/66
- brand-deal skill evals: 26/26
- remote SHA verified: `ffb228dc4756073187e1c8547e67149befda6421`

Part 1 of 2 stacked brand-deal intake hardening.