### PR TITLE
feat(connectors): wire verified Gmail brand-deal intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Native Gmail brand-deal qualification is fail-closed (JOV-4578):** Jovie now surfaces only the highest-ranked current brief with explicit buyer, company, budget, deposit, rights, and revision terms; provenance comes from the connected Gmail record, Calendar is optional, and pending or approved sponsor work blocks another campaign.
 - **Verified brand deals can enter Jovie's Inbox for one explicit decision (JOV-4578):** provenance-checked opportunities now appear as Brand Deals with budget, source, and ranking evidence; rejecting moves on, while approving authorizes preparation only and never sends outreach or creates a campaign without a separate commercial approval and deposit.
 - [internal] **Brand-deal execution is governed by a tested Jovie skill (JOV-4578):** connector identity with a Composio Gmail fallback, primary-source personal deal receipts, A7X3/Backstage separation, one-campaign capacity, bounded rights, sponsor-first tracking, LYB monetization proof, and the two approval gates are enforced by deterministic fixtures.
 - **New Chat is the first shared navigation action (JOV-4510):** desktop and mobile now lead with one elevated New Chat row while preserving Inbox and the rest of the canonical customer order.

--- a/apps/web/lib/connectors/brand-deal-opportunity-emitter.test.ts
+++ b/apps/web/lib/connectors/brand-deal-opportunity-emitter.test.ts
@@ -12,50 +12,44 @@ import { emitBrandDealOpportunity } from './brand-deal-opportunity-emitter';
 
 const USER_ID = '10000000-0000-4000-8000-000000000001';
 const CONNECTOR_ACCOUNT_ID = '20000000-0000-4000-8000-000000000001';
-const verifiedPayload = {
-  title: 'Example Brand creator-performance pilot',
-  buyerName: 'Alex Buyer',
-  buyerCompany: 'Example Brand',
-  budgetMinCents: 750_000,
-  budgetMaxCents: 1_250_000,
-  currency: 'USD',
-  sourceLabel: 'Backstage',
-  sourceType: 'backstage',
-  sourceAccount: 't@timwhite.co',
-  requiredSourceAccount: 't@timwhite.co',
-  sourceReference: 'https://www.backstage.com/casting/example',
-  observedAt: '2026-07-29T10:00:00.000Z',
-  evidenceStatus: 'verified',
-  confidence: 1,
-  identityMatched: true,
-  ownershipVerified: true,
-  personalDealVerified: true,
-  relationshipType: 'authenticated_marketplace_match',
-  rightsSummary: '90-day organic usage, no exclusivity',
-  depositPercent: 50,
-  activeSponsorCampaignCount: 0,
-  includedRevisions: 1,
-  usageTermDays: 90,
-  exclusivity: 'none',
-  routeToLyb: false,
-  lybPaidFlowVerified: false,
-  externalSendApproved: false,
-  commercialApprovalId: null,
-  expectedUpfrontCashCents: 500_000,
-  closeProbability: 0.6,
-  repeatPotential: 1.5,
-  creatorMinutes: 60,
+const EVIDENCE_OBJECT_ID = '30000000-0000-4000-8000-000000000001';
+const fetchedAt = new Date();
+const evidencePayload = {
+  subject: 'Current paid creator campaign',
+  from: 'Alex Buyer <alex@example.com>',
+  date: fetchedAt.toISOString(),
+  snippet:
+    'This campaign brief is ready. Company: Example Brand. Budget: $10k. Deposit: 50%. 90-day organic usage. No exclusivity. One revision.',
 };
-
+const evidenceObject = {
+  id: EVIDENCE_OBJECT_ID,
+  connectorAccountId: CONNECTOR_ACCOUNT_ID,
+  provider: 'gmail',
+  kind: 'gmail_message',
+  providerId: '181696d593400f5c',
+  payload: evidencePayload,
+  fetchedAt,
+};
+const connectorAccount = {
+  id: CONNECTOR_ACCOUNT_ID,
+  provider: 'gmail',
+  providerAccountId: 't@timwhite.co',
+};
 function mockSelectResults(...results: readonly unknown[][]) {
   let call = 0;
   vi.mocked(db.select).mockImplementation(() => {
     const rows = results[call++] ?? [];
-    return {
+    const chain = {
       from: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue(rows),
-    } as unknown as ReturnType<typeof db.select>;
+      then: (
+        onFulfilled?: (value: readonly unknown[]) => unknown,
+        onRejected?: (reason: unknown) => unknown
+      ) => Promise.resolve(rows).then(onFulfilled, onRejected),
+    };
+    return chain as unknown as ReturnType<typeof db.select>;
   });
 }
 
@@ -76,62 +70,64 @@ describe('emitBrandDealOpportunity', () => {
     vi.clearAllMocks();
   });
 
-  it('rejects malformed evidence before reading connector state', async () => {
+  it('rejects evidence that is not a persisted external object', async () => {
+    mockSelectResults([]);
+
     await expect(
       emitBrandDealOpportunity({
         userId: USER_ID,
-        connectorAccountId: CONNECTOR_ACCOUNT_ID,
-        payload: { ...verifiedPayload, ownershipVerified: false },
-        rationale: 'Malformed evidence.',
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
       })
     ).resolves.toEqual({
       created: false,
       actionId: null,
-      reason: 'invalid-opportunity',
+      reason: 'evidence-object-not-found',
     });
-    expect(db.select).not.toHaveBeenCalled();
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('rejects a payload that does not match the authenticated connector account', async () => {
-    mockSelectResults([
-      {
-        id: CONNECTOR_ACCOUNT_ID,
-        provider: 'gmail',
-        providerAccountId: 'tim@jov.ie',
-      },
-    ]);
+  it('rejects external objects outside the native Gmail message lane', async () => {
+    mockSelectResults([{ ...evidenceObject, provider: 'google_calendar' }]);
 
     await expect(
       emitBrandDealOpportunity({
         userId: USER_ID,
-        connectorAccountId: CONNECTOR_ACCOUNT_ID,
-        payload: verifiedPayload,
-        rationale: 'Wrong connector.',
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
       })
     ).resolves.toEqual({
       created: false,
       actionId: null,
-      reason: 'connector-account-mismatch',
+      reason: 'evidence-object-unsupported',
     });
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('rejects a non-Gmail connector even when its account id matches', async () => {
-    mockSelectResults([
-      {
-        id: CONNECTOR_ACCOUNT_ID,
-        provider: 'google_calendar',
-        providerAccountId: 't@timwhite.co',
-      },
-    ]);
+  it('requires the evidence object to belong to a connected account owned by the user', async () => {
+    mockSelectResults([evidenceObject], []);
 
     await expect(
       emitBrandDealOpportunity({
         userId: USER_ID,
-        connectorAccountId: CONNECTOR_ACCOUNT_ID,
-        payload: verifiedPayload,
-        rationale: 'Wrong connector provider.',
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
+      })
+    ).resolves.toEqual({
+      created: false,
+      actionId: null,
+      reason: 'connector-account-not-connected',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-Gmail connected account', async () => {
+    mockSelectResults(
+      [evidenceObject],
+      [{ ...connectorAccount, provider: 'google_calendar' }]
+    );
+
+    await expect(
+      emitBrandDealOpportunity({
+        userId: USER_ID,
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
       })
     ).resolves.toEqual({
       created: false,
@@ -141,24 +137,70 @@ describe('emitBrandDealOpportunity', () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('keeps one pending brand-deal decision in the Inbox', async () => {
+  it('rejects a connected Gmail that is not Tim’s approved personal mailbox', async () => {
     mockSelectResults(
-      [
-        {
-          id: CONNECTOR_ACCOUNT_ID,
-          provider: 'gmail',
-          providerAccountId: 't@timwhite.co',
-        },
-      ],
-      [{ id: 'existing-action' }]
+      [evidenceObject],
+      [{ ...connectorAccount, providerAccountId: 'tim@jov.ie' }]
     );
 
     await expect(
       emitBrandDealOpportunity({
         userId: USER_ID,
-        connectorAccountId: CONNECTOR_ACCOUNT_ID,
-        payload: verifiedPayload,
-        rationale: 'Verified personal Backstage match.',
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
+      })
+    ).resolves.toEqual({
+      created: false,
+      actionId: null,
+      reason: 'invalid-opportunity',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects incomplete commercial terms after deriving provenance', async () => {
+    mockSelectResults(
+      [
+        {
+          ...evidenceObject,
+          payload: {
+            ...evidencePayload,
+            snippet: evidencePayload.snippet.replace(
+              'Deposit: 50%',
+              'Deposit: 25%'
+            ),
+          },
+        },
+      ],
+      [connectorAccount]
+    );
+
+    await expect(
+      emitBrandDealOpportunity({
+        userId: USER_ID,
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
+      })
+    ).resolves.toEqual({
+      created: false,
+      actionId: null,
+      reason: 'invalid-opportunity',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'pending',
+    'approved',
+  ])('refuses a new opportunity while a %s brand-deal slot exists', async _status => {
+    mockSelectResults(
+      [evidenceObject],
+      [connectorAccount],
+      [],
+      [{ id: 'existing-action', status: _status }]
+    );
+
+    await expect(
+      emitBrandDealOpportunity({
+        userId: USER_ID,
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
       })
     ).resolves.toEqual({
       created: false,
@@ -168,24 +210,40 @@ describe('emitBrandDealOpportunity', () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('inserts a verified, ranked, decision-only Inbox opportunity', async () => {
+  it('refuses a new opportunity when an older approved campaign exists behind a newer rejected decision', async () => {
     mockSelectResults(
-      [
-        {
-          id: CONNECTOR_ACCOUNT_ID,
-          provider: 'gmail',
-          providerAccountId: 't@timwhite.co',
-        },
-      ],
-      []
+      [evidenceObject],
+      [connectorAccount],
+      [],
+      [{ id: 'older-approved-action', status: 'approved' }]
+    );
+
+    await expect(
+      emitBrandDealOpportunity({
+        userId: USER_ID,
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
+      })
+    ).resolves.toEqual({
+      created: false,
+      actionId: 'older-approved-action',
+      reason: 'decision-slot-occupied',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('derives provenance and commercial terms from persisted evidence', async () => {
+    mockSelectResults(
+      [evidenceObject],
+      [connectorAccount],
+      [],
+      [],
+      [{ id: 'rejected-action', status: 'rejected' }]
     );
     const insert = mockInsertResult([{ id: 'inserted-action' }]);
 
     const result = await emitBrandDealOpportunity({
       userId: USER_ID,
-      connectorAccountId: CONNECTOR_ACCOUNT_ID,
-      payload: verifiedPayload,
-      rationale: 'Verified personal Backstage match.',
+      evidenceObjectId: EVIDENCE_OBJECT_ID,
     });
 
     expect(result.created).toBe(true);
@@ -197,8 +255,121 @@ describe('emitBrandDealOpportunity', () => {
         signalType: 'brand_deal',
         status: 'pending',
         sideEffects: [],
-        payload: expect.objectContaining({ rankingScore: 75 }),
+        sourceRefs: [
+          expect.objectContaining({
+            connectorAccountId: CONNECTOR_ACCOUNT_ID,
+            externalObjectId: EVIDENCE_OBJECT_ID,
+            sourceType: 'personal_email',
+            sourceReference: 'gmail:message:181696d593400f5c',
+          }),
+        ],
+        payload: expect.objectContaining({
+          sourceType: 'personal_email',
+          sourceAccount: 't@timwhite.co',
+          requiredSourceAccount: 't@timwhite.co',
+          sourceReference: 'gmail:message:181696d593400f5c',
+          observedAt: fetchedAt.toISOString(),
+          title: 'Example Brand creator-performance campaign',
+          rightsSummary: '90-day usage, no exclusivity',
+          expectedUpfrontCashCents: 500_000,
+          confidence: 1,
+          evidenceStatus: 'verified',
+          ownershipVerified: true,
+          personalDealVerified: true,
+          activeSponsorCampaignCount: 0,
+          externalSendApproved: false,
+          commercialApprovalId: null,
+          rankingScore: 41.666666666666664,
+        }),
       })
     );
+  });
+
+  it('refuses to re-emit evidence that already has a decided action', async () => {
+    mockSelectResults(
+      [evidenceObject],
+      [connectorAccount],
+      [
+        {
+          sourceRefs: [{ externalObjectId: EVIDENCE_OBJECT_ID }],
+        },
+      ]
+    );
+
+    await expect(
+      emitBrandDealOpportunity({
+        userId: USER_ID,
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
+      })
+    ).resolves.toEqual({
+      created: false,
+      actionId: null,
+      reason: 'evidence-already-decided',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('uses one deterministic slot generation for concurrent inserts and advances only after a terminal decision', async () => {
+    mockSelectResults(
+      [evidenceObject],
+      [connectorAccount],
+      [],
+      [],
+      [{ id: 'prior-rejected-action' }]
+    );
+    const firstInsert = mockInsertResult([{ id: 'inserted-action' }]);
+    await emitBrandDealOpportunity({
+      userId: USER_ID,
+      evidenceObjectId: EVIDENCE_OBJECT_ID,
+    });
+    const firstActionId = (
+      vi.mocked(firstInsert.values).mock.calls[0]?.[0] as { id: string }
+    ).id;
+
+    mockSelectResults(
+      [evidenceObject],
+      [connectorAccount],
+      [],
+      [],
+      [{ id: 'prior-rejected-action' }]
+    );
+    const losingInsert = mockInsertResult([]);
+    await expect(
+      emitBrandDealOpportunity({
+        userId: USER_ID,
+        evidenceObjectId: EVIDENCE_OBJECT_ID,
+      })
+    ).resolves.toEqual({
+      created: false,
+      actionId: firstActionId,
+      reason: 'duplicate',
+    });
+    expect(
+      (
+        vi.mocked(losingInsert.values).mock.calls[0]?.[0] as {
+          id: string;
+        }
+      ).id
+    ).toBe(firstActionId);
+
+    mockSelectResults(
+      [evidenceObject],
+      [connectorAccount],
+      [],
+      [],
+      [{ id: 'newer-rejected-action' }]
+    );
+    const nextGenerationInsert = mockInsertResult([{ id: 'next-action' }]);
+    await emitBrandDealOpportunity({
+      userId: USER_ID,
+      evidenceObjectId: EVIDENCE_OBJECT_ID,
+    });
+    expect(
+      (
+        vi.mocked(nextGenerationInsert.values).mock.calls[0]?.[0] as {
+          id: string;
+        }
+      ).id
+    ).not.toBe(firstActionId);
   });
 });

--- a/apps/web/lib/connectors/brand-deal-opportunity-emitter.ts
+++ b/apps/web/lib/connectors/brand-deal-opportunity-emitter.ts
@@ -1,15 +1,18 @@
 import 'server-only';
 
 import { createHash } from 'node:crypto';
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import {
   BRAND_DEAL_OPPORTUNITY_KIND,
-  parseBrandDealOpportunity,
+  buildVerifiedPersonalEmailOpportunity,
+  collectBrandDealEvidenceObjectIds,
 } from '@/lib/connectors/brand-deal-opportunity';
+import { extractGmailBrandDealCandidate } from '@/lib/connectors/gmail/extract-brand-deal-candidate';
 import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
 import { db } from '@/lib/db';
 import {
   connectorAccounts,
+  externalObjects,
   suggestedActions,
 } from '@/lib/db/schema/connectors';
 
@@ -20,9 +23,11 @@ export type EmitBrandDealOpportunityResult =
       readonly actionId: string | null;
       readonly reason:
         | 'invalid-opportunity'
+        | 'evidence-object-not-found'
+        | 'evidence-object-unsupported'
         | 'connector-account-not-connected'
-        | 'connector-account-mismatch'
         | 'connector-provider-unsupported'
+        | 'evidence-already-decided'
         | 'decision-slot-occupied'
         | 'duplicate';
     };
@@ -41,21 +46,68 @@ function deterministicActionId(input: string): string {
   ].join('-');
 }
 
+function normalizedStringField(
+  payload: unknown,
+  field: 'subject' | 'from' | 'date' | 'snippet'
+): string | undefined {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return undefined;
+  }
+  const value = (payload as Record<string, unknown>)[field];
+  return typeof value === 'string' ? value : undefined;
+}
+
 export async function emitBrandDealOpportunity(input: {
   readonly userId: string;
-  readonly connectorAccountId: string;
-  readonly payload: unknown;
-  readonly rationale: string;
+  readonly evidenceObjectId: string;
 }): Promise<EmitBrandDealOpportunityResult> {
-  const parsed = parseBrandDealOpportunity(
-    BRAND_DEAL_OPPORTUNITY_KIND,
-    input.payload
-  );
-  if (!parsed) {
+  const [evidenceObject] = await db
+    .select({
+      id: externalObjects.id,
+      connectorAccountId: externalObjects.connectorAccountId,
+      provider: externalObjects.provider,
+      kind: externalObjects.kind,
+      providerId: externalObjects.providerId,
+      payload: externalObjects.payload,
+      fetchedAt: externalObjects.fetchedAt,
+    })
+    .from(externalObjects)
+    .where(eq(externalObjects.id, input.evidenceObjectId))
+    .limit(1);
+
+  if (!evidenceObject) {
+    return {
+      created: false,
+      actionId: null,
+      reason: 'evidence-object-not-found',
+    };
+  }
+
+  const persistedCandidate = extractGmailBrandDealCandidate({
+    externalObjectId: evidenceObject.id,
+    payload: {
+      subject: normalizedStringField(evidenceObject.payload, 'subject'),
+      from: normalizedStringField(evidenceObject.payload, 'from'),
+      date: normalizedStringField(evidenceObject.payload, 'date'),
+      snippet: normalizedStringField(evidenceObject.payload, 'snippet'),
+    },
+  });
+  if (!persistedCandidate) {
     return {
       created: false,
       actionId: null,
       reason: 'invalid-opportunity',
+    };
+  }
+
+  if (
+    evidenceObject.provider !== CONNECTOR_PROVIDERS.gmail ||
+    evidenceObject.kind !== 'gmail_message'
+  ) {
+    return {
+      created: false,
+      actionId: null,
+      reason: 'evidence-object-unsupported',
     };
   }
 
@@ -68,7 +120,7 @@ export async function emitBrandDealOpportunity(input: {
     .from(connectorAccounts)
     .where(
       and(
-        eq(connectorAccounts.id, input.connectorAccountId),
+        eq(connectorAccounts.id, evidenceObject.connectorAccountId),
         eq(connectorAccounts.userId, input.userId),
         eq(connectorAccounts.status, 'connected')
       )
@@ -91,42 +143,81 @@ export async function emitBrandDealOpportunity(input: {
     };
   }
 
-  const authenticatedAccount = connectorAccount.providerAccountId
-    .trim()
-    .toLowerCase();
-  if (
-    authenticatedAccount !== parsed.sourceAccount.trim().toLowerCase() ||
-    authenticatedAccount !== parsed.requiredSourceAccount.trim().toLowerCase()
-  ) {
+  const parsed = buildVerifiedPersonalEmailOpportunity({
+    candidate: persistedCandidate.candidate,
+    sourceAccount: connectorAccount.providerAccountId,
+    sourceReference: `gmail:message:${evidenceObject.providerId}`,
+    observedAt: evidenceObject.fetchedAt.toISOString(),
+  });
+  if (!parsed) {
     return {
       created: false,
       actionId: null,
-      reason: 'connector-account-mismatch',
+      reason: 'invalid-opportunity',
     };
   }
 
-  const [pendingDecision] = await db
+  const priorEvidence = await db
+    .select({ sourceRefs: suggestedActions.sourceRefs })
+    .from(suggestedActions)
+    .where(
+      and(
+        eq(suggestedActions.userId, input.userId),
+        eq(suggestedActions.kind, BRAND_DEAL_OPPORTUNITY_KIND)
+      )
+    );
+  if (collectBrandDealEvidenceObjectIds(priorEvidence).has(evidenceObject.id)) {
+    return {
+      created: false,
+      actionId: null,
+      reason: 'evidence-already-decided',
+    };
+  }
+
+  const [activeDecision] = await db
+    .select({
+      id: suggestedActions.id,
+      status: suggestedActions.status,
+    })
+    .from(suggestedActions)
+    .where(
+      and(
+        eq(suggestedActions.userId, input.userId),
+        eq(suggestedActions.kind, BRAND_DEAL_OPPORTUNITY_KIND),
+        inArray(suggestedActions.status, ['pending', 'approved'])
+      )
+    )
+    .orderBy(desc(suggestedActions.createdAt))
+    .limit(1);
+
+  if (activeDecision) {
+    return {
+      created: false,
+      actionId: activeDecision.id,
+      reason: 'decision-slot-occupied',
+    };
+  }
+
+  const [latestDecision] = await db
     .select({ id: suggestedActions.id })
     .from(suggestedActions)
     .where(
       and(
         eq(suggestedActions.userId, input.userId),
         eq(suggestedActions.kind, BRAND_DEAL_OPPORTUNITY_KIND),
-        eq(suggestedActions.status, 'pending')
+        inArray(suggestedActions.status, [
+          'executed',
+          'rejected',
+          'failed',
+          'expired',
+        ])
       )
     )
+    .orderBy(desc(suggestedActions.createdAt))
     .limit(1);
 
-  if (pendingDecision) {
-    return {
-      created: false,
-      actionId: pendingDecision.id,
-      reason: 'decision-slot-occupied',
-    };
-  }
-
   const actionId = deterministicActionId(
-    `${input.userId}:${connectorAccount.id}:${parsed.sourceReference}`
+    `${input.userId}:brand-deal-slot:${latestDecision?.id ?? 'initial'}`
   );
   const idempotencyKey = `brand-deal:${actionId}`;
   const inserted = await db
@@ -142,13 +233,15 @@ export async function emitBrandDealOpportunity(input: {
       sourceRefs: [
         {
           connectorAccountId: connectorAccount.id,
+          externalObjectId: evidenceObject.id,
           sourceType: parsed.sourceType,
           sourceReference: parsed.sourceReference,
           observedAt: parsed.observedAt,
           confidence: parsed.confidence,
         },
       ],
-      rationale: input.rationale.trim() || 'Verified brand-deal opportunity.',
+      rationale:
+        'Complete current commercial terms found in authenticated Gmail.',
       idempotencyKey,
       sideEffects: [],
     })

--- a/apps/web/lib/connectors/enrichment/pipelines/gmail.ts
+++ b/apps/web/lib/connectors/enrichment/pipelines/gmail.ts
@@ -1,6 +1,12 @@
 import 'server-only';
 
 import { and, desc, eq } from 'drizzle-orm';
+import {
+  BRAND_DEAL_OPPORTUNITY_KIND,
+  collectBrandDealEvidenceObjectIds,
+} from '@/lib/connectors/brand-deal-opportunity';
+import { emitBrandDealOpportunity } from '@/lib/connectors/brand-deal-opportunity-emitter';
+import { selectHighestRankedGmailBrandDealCandidate } from '@/lib/connectors/gmail/extract-brand-deal-candidate';
 import { extractEventSignal } from '@/lib/connectors/gmail/extract-event-signal';
 import {
   hasOverlappingEvent,
@@ -10,7 +16,7 @@ import {
 import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
 import { loadDecryptedToken } from '@/lib/connectors/token-vault';
 import { db } from '@/lib/db';
-import { externalObjects } from '@/lib/db/schema/connectors';
+import { externalObjects, suggestedActions } from '@/lib/db/schema/connectors';
 import { logger } from '@/lib/utils/logger';
 import {
   persistEntityMentionFacts,
@@ -91,6 +97,7 @@ export const gmailEnrichmentPipeline: ConnectorEnrichmentPipeline = {
     let contextFactsCreated = 0;
     let memoryObservationsCreated = 0;
     let memoryEntitiesCreated = 0;
+    let suggestionsCreated = 0;
 
     for (const object of objects) {
       const payload = object.payload as GmailObjectPayload;
@@ -125,6 +132,33 @@ export const gmailEnrichmentPipeline: ConnectorEnrichmentPipeline = {
       });
       memoryObservationsCreated += memoryResult.observationsCreated;
       memoryEntitiesCreated += memoryResult.entitiesCreated;
+    }
+
+    const priorBrandDealActions = await db
+      .select({ sourceRefs: suggestedActions.sourceRefs })
+      .from(suggestedActions)
+      .where(
+        and(
+          eq(suggestedActions.userId, context.scope.userId),
+          eq(suggestedActions.kind, BRAND_DEAL_OPPORTUNITY_KIND)
+        )
+      );
+    const previouslyConsideredEvidenceIds = collectBrandDealEvidenceObjectIds(
+      priorBrandDealActions
+    );
+    const brandDealCandidate = selectHighestRankedGmailBrandDealCandidate(
+      objects.map(object => ({
+        externalObjectId: object.id,
+        payload: object.payload as GmailObjectPayload,
+      })),
+      previouslyConsideredEvidenceIds
+    );
+    if (brandDealCandidate) {
+      const emitted = await emitBrandDealOpportunity({
+        userId: context.scope.userId,
+        evidenceObjectId: brandDealCandidate.evidenceObjectId,
+      });
+      if (emitted.created) suggestionsCreated += 1;
     }
 
     const extractorInput = objects.map(object => {
@@ -169,7 +203,6 @@ export const gmailEnrichmentPipeline: ConnectorEnrichmentPipeline = {
       }
     }
 
-    let suggestionsCreated = 0;
     if (eventFacts.length > 0 && context.calendarAccountId) {
       const calendarTokens = await loadDecryptedToken(
         context.calendarAccountId
@@ -188,7 +221,7 @@ export const gmailEnrichmentPipeline: ConnectorEnrichmentPipeline = {
           }
         }
 
-        suggestionsCreated = await emitCalendarCreateSuggestions({
+        suggestionsCreated += await emitCalendarCreateSuggestions({
           userId: context.scope.userId,
           calendarAccountId: context.calendarAccountId,
           events: eventFacts,

--- a/apps/web/lib/connectors/enrichment/runner.ts
+++ b/apps/web/lib/connectors/enrichment/runner.ts
@@ -17,10 +17,11 @@ const EMPTY_RESULT: ConnectorEnrichmentRunResult = {
  * Turns synced external_objects into context_facts + memory graph observations.
  */
 export async function runConnectorEnrichment(
-  userId: string
+  userId: string,
+  options: { readonly gmailAccountId?: string } = {}
 ): Promise<ConnectorEnrichmentRunResult> {
   try {
-    const context = await resolveConnectorEnrichmentContext(userId);
+    const context = await resolveConnectorEnrichmentContext(userId, options);
     if (!context) {
       logger.info('[connector-enrichment] Skipping — no connected scope', {
         userId,

--- a/apps/web/lib/connectors/enrichment/scope.ts
+++ b/apps/web/lib/connectors/enrichment/scope.ts
@@ -26,7 +26,8 @@ async function resolveCreatorProfileId(
 }
 
 export async function resolveConnectorEnrichmentContext(
-  userId: string
+  userId: string,
+  options: { readonly gmailAccountId?: string } = {}
 ): Promise<ConnectorEnrichmentAccountContext | null> {
   const accounts = await db
     .select({
@@ -42,9 +43,13 @@ export async function resolveConnectorEnrichmentContext(
       )
     );
 
-  const gmail = accounts.find(
-    row => row.provider === CONNECTOR_PROVIDERS.gmail
-  );
+  const gmail = options.gmailAccountId
+    ? accounts.find(
+        row =>
+          row.id === options.gmailAccountId &&
+          row.provider === CONNECTOR_PROVIDERS.gmail
+      )
+    : accounts.find(row => row.provider === CONNECTOR_PROVIDERS.gmail);
   const calendar = accounts.find(
     row => row.provider === CONNECTOR_PROVIDERS.google_calendar
   );

--- a/apps/web/lib/connectors/extract-and-propose.ts
+++ b/apps/web/lib/connectors/extract-and-propose.ts
@@ -1,8 +1,9 @@
 import 'server-only';
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
+import { TIM_BRAND_DEAL_SOURCE_ACCOUNT } from '@/lib/connectors/brand-deal-opportunity';
 import { runConnectorEnrichment } from '@/lib/connectors/enrichment';
 import {
-  buildGmailBookingQuery,
+  buildGmailOpportunityQuery,
   type GmailMessage,
   getGmailMessage,
   getHeader,
@@ -22,66 +23,64 @@ const DEFAULT_GMAIL_WINDOW_DAYS = 30;
  * Core extraction pipeline for the AI Connector magic moment.
  *
  * Steps:
- * 1. Load decrypted tokens for the user's Gmail + Calendar connector accounts.
- * 2. Fetch Gmail booking candidates via narrow query and persist external_objects.
+ * 1. Load decrypted tokens for the user's Gmail connector account.
+ * 2. Fetch Gmail booking and paid-brand candidates via a narrow query.
  * 3. Run connector enrichment pipelines (context_facts + memory graph + suggestions).
  *
  * @returns Number of new suggested actions created.
  */
 export async function extractAndPropose(userId: string): Promise<number> {
-  const synced = await syncGmailExternalObjects(userId);
-  if (!synced) return 0;
+  const gmailAccountId = await syncGmailExternalObjects(userId);
+  if (!gmailAccountId) return 0;
 
-  const enrichment = await runConnectorEnrichment(userId);
+  const enrichment = await runConnectorEnrichment(userId, {
+    gmailAccountId,
+  });
   return enrichment.totalSuggestionsCreated;
 }
 
-async function syncGmailExternalObjects(userId: string): Promise<boolean> {
-  const [gmailAccount, calendarAccount] = await Promise.all([
-    db
-      .select({ id: connectorAccounts.id })
-      .from(connectorAccounts)
-      .where(
-        and(
-          eq(connectorAccounts.userId, userId),
-          eq(connectorAccounts.provider, CONNECTOR_PROVIDERS.gmail),
-          eq(connectorAccounts.status, 'connected')
-        )
+async function syncGmailExternalObjects(
+  userId: string
+): Promise<string | null> {
+  const gmailAccounts = await db
+    .select({
+      id: connectorAccounts.id,
+      providerAccountId: connectorAccounts.providerAccountId,
+    })
+    .from(connectorAccounts)
+    .where(
+      and(
+        eq(connectorAccounts.userId, userId),
+        eq(connectorAccounts.provider, CONNECTOR_PROVIDERS.gmail),
+        eq(connectorAccounts.status, 'connected')
       )
-      .limit(1)
-      .then(rows => rows[0] ?? null),
-    db
-      .select({ id: connectorAccounts.id })
-      .from(connectorAccounts)
-      .where(
-        and(
-          eq(connectorAccounts.userId, userId),
-          eq(connectorAccounts.provider, CONNECTOR_PROVIDERS.google_calendar),
-          eq(connectorAccounts.status, 'connected')
-        )
-      )
-      .limit(1)
-      .then(rows => rows[0] ?? null),
-  ]);
+    )
+    .orderBy(desc(connectorAccounts.updatedAt));
+  const gmailAccount =
+    gmailAccounts.find(
+      account =>
+        account.providerAccountId.trim().toLowerCase() ===
+        TIM_BRAND_DEAL_SOURCE_ACCOUNT
+    ) ?? gmailAccounts[0];
 
-  if (!gmailAccount || !calendarAccount) {
-    logger.info('[extract-and-propose] Skipping — connectors not connected', {
+  if (!gmailAccount) {
+    logger.info('[extract-and-propose] Skipping — Gmail not connected', {
       userId,
     });
-    return false;
+    return null;
   }
 
   const gmailTokens = await loadDecryptedToken(gmailAccount.id);
   if (!gmailTokens) {
     logger.error('[extract-and-propose] Token load failed', { userId });
-    return false;
+    return null;
   }
 
   const historyWindowDays =
     parseInt(env.GMAIL_HISTORY_WINDOW_DAYS ?? '', 10) ||
     DEFAULT_GMAIL_WINDOW_DAYS;
 
-  const query = buildGmailBookingQuery(historyWindowDays);
+  const query = buildGmailOpportunityQuery(historyWindowDays);
   const listResult = await listGmailMessages(
     gmailTokens.accessToken,
     query,
@@ -90,10 +89,10 @@ async function syncGmailExternalObjects(userId: string): Promise<boolean> {
   const messageStubs = listResult.messages ?? [];
 
   if (messageStubs.length === 0) {
-    logger.info('[extract-and-propose] No Gmail booking candidates found', {
+    logger.info('[extract-and-propose] No Gmail opportunity candidates found', {
       userId,
     });
-    return true;
+    return gmailAccount.id;
   }
 
   const messageDetails = await Promise.allSettled(
@@ -139,7 +138,7 @@ async function syncGmailExternalObjects(userId: string): Promise<boolean> {
     messageCount: messages.length,
   });
 
-  return true;
+  return gmailAccount.id;
 }
 
 export async function extractAndProposeWithErrorCapture(

--- a/apps/web/lib/connectors/gmail/brand-deal-producer-contract.test.ts
+++ b/apps/web/lib/connectors/gmail/brand-deal-producer-contract.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readConnectorSource = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+describe('native Gmail brand-deal producer contract', () => {
+  it('syncs Gmail without requiring Calendar and persists metadata only', () => {
+    const source = readConnectorSource('../extract-and-propose.ts');
+    expect(source).toContain('buildGmailOpportunityQuery');
+    expect(source).toContain('TIM_BRAND_DEAL_SOURCE_ACCOUNT');
+    expect(source).toContain('gmailAccounts[0]');
+    expect(source).toContain('gmailAccountId');
+    expect(source).not.toContain('CONNECTOR_PROVIDERS.google_calendar');
+    expect(source).toContain('snippet: m.snippet.slice(0, 200)');
+    expect(source).not.toMatch(/\bbody:\s*m\./);
+  });
+
+  it('selects one highest-ranked candidate and emits it through the trusted boundary', () => {
+    const source = readConnectorSource('../enrichment/pipelines/gmail.ts');
+    const emitter = readConnectorSource('../brand-deal-opportunity-emitter.ts');
+    expect(source).toContain('selectHighestRankedGmailBrandDealCandidate');
+    expect(source).toContain('emitBrandDealOpportunity');
+    expect(source).toContain(
+      'evidenceObjectId: brandDealCandidate.evidenceObjectId'
+    );
+    expect(source).not.toContain('candidate: brandDealCandidate.candidate');
+    expect(emitter).toContain('payload: externalObjects.payload');
+    expect(emitter).not.toMatch(/readonly candidate:/);
+    expect(emitter).toContain(':brand-deal-slot:');
+  });
+
+  it('keeps Gmail retrieval read-only and metadata-scoped', () => {
+    const source = readConnectorSource('./client.ts');
+    expect(source).toContain("format: 'metadata'");
+    expect(source).not.toContain("format: 'full'");
+    expect(source).toContain('"paid creator campaign"');
+  });
+});


### PR DESCRIPTION
## Summary
- reload persisted normalized Gmail evidence by `userId` and `evidenceObjectId` before emitting a candidate
- carry the exact connected Gmail account through enrichment and preserve generic Gmail event enrichment for non-Tim users
- enforce one active sponsor slot across pending and approved actions, consume decided evidence, and create pending-only suggestions with `sideEffects: []`

## Safety boundary
- no Gmail send, draft, label, archive, delete, or mutation capability
- no auto-approval or automatic commercial commitment
- this merged foundation does **not** enable production polling: the only caller remains the development-only `/api/dev/connectors/extract-now` route

## Verification at merge
- merged head: `c3d9f8c71297ef2781436f87be3b87894032d9da`
- merge commit: `7a8f61a5696b34dbd056153bfddc951eeca0d9a5`
- pre-push TypeScript and Biome gates passed
- full required Vitest matrix passed across all 8 shards
- focused final-source tests: 66/66
- brand-deal skill evals: 26/26
- diff: 8 files, 505 insertions, 163 deletions

## Post-merge review findings
A later `/ship` pre-landing review found required production blockers. They are tracked in [JOV-4599](https://linear.app/jovie/issue/JOV-4599/complete-production-safe-gmail-brand-deal-polling-and-lifecycle):

- sender-controlled `From`, subject, and snippet text must not be labeled verified buyer/commercial evidence
- Gmail snippet/body-derived text conflicts with the `external_objects.payload` privacy invariant
- approved brand deals need explicit completion/cancellation transitions so the one-sponsor slot does not remain occupied forever
- partial Gmail fetch/persistence failures must be observable and fail closed
- deterministic pagination/ranking is needed before claiming the highest-ranked current opportunity
- a bounded production scheduler/caller and exact runtime proof are still required

Post-merge behavior-test commit `a7a1360fb5972fbac057b083bb79945019544a6b` passed the full guarded push and is remote-verified on `codex/brand-deal-producer-runtime`, but it is **not** part of this merged PR or `main`.

Do not claim autonomous Gmail brand-deal polling or production readiness from this PR alone.
