### PR TITLE
fix(ui): unify rail toggles and press feedback [JOV-4606]

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -218,7 +218,7 @@ This is the subtraction principle applied specifically to container boundaries. 
 
 - Hover states must not move layout or shift components without a product reason.
 - Do **NOT** use `translate`, `scale`, lift-on-hover, or floating-card motion on buttons, cards, screenshots, auth surfaces, or marketing panels as a default polish move.
-- Press/click feedback uses the shared `--scale-press` token (`0.98`) when tactile feedback is useful. Shared controls must disable the transform under reduced motion and provide a static opt-out where motion would distract.
+- Press/click compression is opt-in and uses the shared `--scale-press` token (`0.98`) only when an action has no immediate visible response. Dropdowns, accordions, tabs, toggles, and rail controls already communicate their state change and must not scale. Shared controls must disable the transform under reduced motion.
 - Menus, panels, drawers, and sidebars may use intentional `translate`/`scale` motion for open/close because the movement communicates spatial state.
 - Prefer background-color, border-color, text-color, opacity, or shadow changes for hover feedback.
 - If motion is necessary because the UI is directly manipulating something spatial, it must be intentional and clearly tied to that interaction.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -541,8 +541,11 @@ These are surface-side aliases of `--ds-motion-*` tokens (DS_FOUNDATION_V1).
 
 - Press feedback uses the shared `--scale-press` token. The canonical value is
   `0.98`: enough tactile response to register without visible shrink or jump.
-- Shared interactive primitives, including Button, apply the token once.
-  Feature code must not add its own `whileTap` scale or hardcoded active scale.
+- Press compression is opt-in. Use it only when an action has no immediate
+  visible response; dropdowns, accordions, tabs, toggles, and rail controls
+  already communicate their state change and must stay geometrically static.
+- Shared interactive primitives apply the token once when opted in. Feature
+  code must not add its own `whileTap` scale or hardcoded active scale.
 - Hover and focus feedback do not scale controls. Use semantic surface, text,
   border, opacity, or shadow changes that preserve geometry.
 - `prefers-reduced-motion: reduce` disables press transforms. Components that

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -738,13 +738,12 @@ body {
   }
   /* Tactile press — transform only; never transition:all (DESIGN.md / JOV-3368) */
   .interactive-press {
-    @apply transition-transform duration-subtle ease-subtle active:scale-[0.96];
+    @apply transition-transform duration-subtle ease-subtle active:scale-[var(--scale-press)] motion-reduce:active:scale-100;
   }
   /* Button component styles */
   .btn {
-    @apply inline-flex items-center justify-center rounded-full text-app font-medium transition-[background-color,transform] duration-normal ease-subtle disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center justify-center rounded-full text-app font-medium transition-[background-color,border-color,color] duration-normal ease-subtle disabled:opacity-50 disabled:pointer-events-none;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-(--linear-bg-page);
-    @apply active:scale-[0.96];
   }
   .btn-primary {
     background-color: var(--color-btn-primary-bg);
@@ -2036,23 +2035,6 @@ body {
   h6 {
     @apply text-base lg:text-lg;
   }
-  /* Interactive controls — tactile press via transform only (no transition:all) */
-  :where(
-    button:not(:disabled):not([data-static="true"]),
-    [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
-    summary
-  ) {
-    transition: transform var(--duration-subtle) var(--ease-subtle);
-  }
-  @media (prefers-reduced-motion: no-preference) {
-    :where(
-        button:not(:disabled):not([data-static="true"]),
-        [role="button"]:not([aria-disabled="true"]):not([data-static="true"]),
-        summary
-      ):active {
-      transform: scale(0.96);
-    }
-  }
 }
 
 /* ============================================
@@ -2174,7 +2156,7 @@ body {
     );
   }
   .btn-press {
-    @apply transition-transform duration-subtle ease-subtle active:scale-[0.96];
+    @apply transition-transform duration-subtle ease-subtle active:scale-[var(--scale-press)] motion-reduce:active:scale-100;
   }
   /* Chat empty state — refined depth & motion */
   .chat-logo-mark {

--- a/apps/web/components/atoms/RailToggleButton.test.tsx
+++ b/apps/web/components/atoms/RailToggleButton.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@jovie/ui', () => ({
+  Button: ({
+    children,
+    pressFeedback: _pressFeedback,
+    static: _static,
+    ...props
+  }: React.ComponentProps<'button'> & {
+    readonly pressFeedback?: boolean;
+    readonly static?: boolean;
+  }) => <button {...props}>{children}</button>,
+  TooltipShortcut: ({ children }: { readonly children: React.ReactNode }) =>
+    children,
+}));
+
+import { RailToggleButton } from './RailToggleButton';
+
+describe('RailToggleButton', () => {
+  it('uses one static chrome contract for a left rail', async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RailToggleButton
+        side='left'
+        open
+        openLabel='Collapse sidebar'
+        closedLabel='Expand sidebar'
+        onToggle={onToggle}
+        dataTestId='left-toggle'
+        iconTestId='left-icon'
+      />
+    );
+
+    const button = screen.getByTestId('left-toggle');
+    expect(button).toHaveAttribute('data-rail-toggle', 'left');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveClass('h-7', 'w-7', 'rounded-full');
+    expect(button.className).not.toContain('active:scale');
+    expect(screen.getByTestId('left-icon')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+
+    await user.click(button);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirrors the same contract for a closed right rail', () => {
+    render(
+      <RailToggleButton
+        side='right'
+        open={false}
+        openLabel='Hide profile'
+        closedLabel='Show profile'
+        onToggle={vi.fn()}
+        dataTestId='right-toggle'
+      />
+    );
+
+    const button = screen.getByTestId('right-toggle');
+    expect(button).toHaveAttribute('data-rail-toggle', 'right');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-label', 'Show profile');
+    expect(button).toHaveClass('h-7', 'w-7', 'rounded-full');
+  });
+});

--- a/apps/web/components/atoms/RailToggleButton.tsx
+++ b/apps/web/components/atoms/RailToggleButton.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Button, TooltipShortcut } from '@jovie/ui';
+import {
+  PanelLeftClose,
+  PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export const RAIL_TOGGLE_BUTTON_CLASS =
+  'h-7 w-7 rounded-full border-transparent bg-transparent px-0 text-tertiary-token shadow-none transition-[background-color,color,box-shadow] duration-subtle hover:border-transparent hover:bg-surface-0 hover:text-primary-token focus-visible:border-transparent focus-visible:bg-surface-0 focus-visible:ring-2 focus-visible:ring-ring/55 active:border-transparent active:bg-surface-0';
+
+interface RailToggleButtonProps {
+  readonly side: 'left' | 'right';
+  readonly open: boolean;
+  readonly openLabel: string;
+  readonly closedLabel: string;
+  readonly onToggle: () => void;
+  readonly disabled?: boolean;
+  readonly shortcut?: string;
+  readonly className?: string;
+  readonly dataTestId?: string;
+  readonly iconTestId?: string;
+}
+
+/**
+ * Canonical shell-rail control. Left and right rails share the same chrome,
+ * hit target, focus behavior, and mirrored Lucide icon family.
+ */
+export function RailToggleButton({
+  side,
+  open,
+  openLabel,
+  closedLabel,
+  onToggle,
+  disabled,
+  shortcut,
+  className,
+  dataTestId,
+  iconTestId,
+}: RailToggleButtonProps) {
+  const label = open ? openLabel : closedLabel;
+  const Icon =
+    side === 'left'
+      ? open
+        ? PanelLeftClose
+        : PanelLeftOpen
+      : open
+        ? PanelRightClose
+        : PanelRightOpen;
+
+  const button = (
+    <Button
+      type='button'
+      variant='ghost'
+      size='icon'
+      aria-label={label}
+      aria-expanded={open}
+      aria-pressed={open}
+      onClick={onToggle}
+      disabled={disabled}
+      data-testid={dataTestId}
+      data-rail-toggle={side}
+      className={cn(RAIL_TOGGLE_BUTTON_CLASS, className)}
+    >
+      <Icon
+        className='size-3.5'
+        strokeWidth={2}
+        aria-hidden='true'
+        data-testid={iconTestId}
+      />
+    </Button>
+  );
+
+  return (
+    <TooltipShortcut label={label} shortcut={shortcut} side='bottom'>
+      {button}
+    </TooltipShortcut>
+  );
+}

--- a/apps/web/components/features/dashboard/atoms/DrawerToggleButton.tsx
+++ b/apps/web/components/features/dashboard/atoms/DrawerToggleButton.tsx
@@ -2,9 +2,9 @@
 
 import { PanelRight } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { RailToggleButton } from '@/components/atoms/RailToggleButton';
 import { PageToolbarActionButton } from '@/components/organisms/table';
 import { useTableMeta } from '@/contexts/TableMetaContext';
-import { DashboardHeaderActionButton } from './DashboardHeaderActionButton';
 
 export function DrawerToggleButton({
   className,
@@ -47,12 +47,13 @@ export function DrawerToggleButton({
   }
 
   return (
-    <DashboardHeaderActionButton
-      ariaLabel={ariaLabel}
-      pressed={isOpen}
+    <RailToggleButton
+      side='right'
+      open={isOpen}
+      openLabel={ariaLabel}
+      closedLabel={ariaLabel}
       disabled={!tableMeta.toggle}
-      onClick={() => tableMeta.toggle?.()}
-      icon={<Icon className='h-4 w-4' />}
+      onToggle={() => tableMeta.toggle?.()}
       className={className}
     />
   );

--- a/apps/web/components/features/dashboard/layout/PreviewToggleButton.tsx
+++ b/apps/web/components/features/dashboard/layout/PreviewToggleButton.tsx
@@ -1,28 +1,19 @@
 'use client';
 
-import { TooltipShortcut } from '@jovie/ui';
-import { PanelRight, PanelRightOpen } from 'lucide-react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
-import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
+import { RailToggleButton } from '@/components/atoms/RailToggleButton';
 import { RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE } from '@/hooks/useRightRailKeyboardShortcut';
 
 export function PreviewToggleButton() {
   const { isOpen, toggle } = usePreviewPanelState();
-  const label = isOpen ? 'Hide preview' : 'Show preview';
-  const Icon = isOpen ? PanelRightOpen : PanelRight;
-
   return (
-    <TooltipShortcut
-      label={label}
+    <RailToggleButton
+      side='right'
+      open={isOpen}
+      openLabel='Hide preview'
+      closedLabel='Show preview'
+      onToggle={toggle}
       shortcut={RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE}
-      side='bottom'
-    >
-      <DashboardHeaderActionButton
-        ariaLabel={label}
-        pressed={isOpen}
-        onClick={toggle}
-        icon={<Icon className='h-3.5 w-3.5' aria-hidden='true' />}
-      />
-    </TooltipShortcut>
+    />
   );
 }

--- a/apps/web/components/features/profile/nav/BottomTabBar.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.tsx
@@ -133,7 +133,7 @@ export function BottomTabBar({
                 type='button'
                 onClick={() => onTabSelect(tab.mode)}
                 className={cn(
-                  'relative flex h-full min-w-0 touch-manipulation items-center justify-center rounded-full text-center transition-[color,transform] duration-subtle ease-subtle active:scale-[0.94] motion-reduce:transform-none',
+                  'relative flex h-full min-w-0 touch-manipulation items-center justify-center rounded-full text-center transition-colors duration-subtle ease-subtle',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                   isActive
                     ? 'text-white dark:text-white'

--- a/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.test.tsx
+++ b/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.test.tsx
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@jovie/ui', () => ({
+  Button: ({
+    children,
+    pressFeedback: _pressFeedback,
+    static: _static,
+    ...props
+  }: React.ComponentProps<'button'> & {
+    readonly pressFeedback?: boolean;
+    readonly static?: boolean;
+  }) => <button {...props}>{children}</button>,
   TooltipShortcut: ({ children }: { readonly children: React.ReactNode }) =>
     children,
 }));
@@ -21,9 +30,16 @@ describe('SidebarCollapseButton', () => {
 
     const button = screen.getByRole('button', { name: /collapse sidebar/i });
 
-    expect(button).toHaveClass('rounded-full', 'border-0', 'bg-transparent');
+    expect(button).toHaveClass(
+      'h-7',
+      'w-7',
+      'rounded-full',
+      'border-transparent',
+      'bg-transparent'
+    );
     expect(button).toHaveClass('hover:bg-surface-0');
-    // No decorative border token classes (border-0 is the only border utility).
+    expect(button).toHaveAttribute('data-rail-toggle', 'left');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(button.className).not.toMatch(/\bborder-(?:default|subtle|\[)/);
     expect(button.className).not.toContain('rounded-md');
     expect(button.className).not.toContain('hover:border-default');

--- a/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx
+++ b/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { TooltipShortcut } from '@jovie/ui';
-import { PanelLeft } from 'lucide-react';
+import { RailToggleButton } from '@/components/atoms/RailToggleButton';
 import { useSidebar } from '@/components/organisms/Sidebar';
 import { SIDEBAR_KEYBOARD_SHORTCUT_BARE } from '@/hooks/useSidebarKeyboardShortcut';
-import { cn } from '@/lib/utils';
 
 interface SidebarCollapseButtonProps {
   readonly className?: string;
@@ -15,24 +13,18 @@ export function SidebarCollapseButton({
 }: SidebarCollapseButtonProps) {
   const { toggleSidebar, state } = useSidebar();
   const isCollapsed = state === 'closed';
-  const label = isCollapsed ? 'Expand sidebar' : 'Collapse sidebar';
-  const shortcut = SIDEBAR_KEYBOARD_SHORTCUT_BARE;
 
   return (
-    <TooltipShortcut label={label} shortcut={shortcut} side='right'>
-      <button
-        type='button'
-        onClick={toggleSidebar}
-        aria-label={label}
-        className={cn(
-          // System B icon chrome: borderless circle, transparent idle, soft hover fill.
-          // Matches ArtistProfileRailToggle — founder directive JOV-3959.
-          'inline-flex h-7 w-7 items-center justify-center rounded-full border-0 bg-transparent text-secondary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55',
-          className
-        )}
-      >
-        <PanelLeft className='h-3.5 w-3.5' strokeWidth={2} aria-hidden='true' />
-      </button>
-    </TooltipShortcut>
+    <RailToggleButton
+      side='left'
+      open={!isCollapsed}
+      openLabel='Collapse sidebar'
+      closedLabel='Expand sidebar'
+      onToggle={toggleSidebar}
+      shortcut={SIDEBAR_KEYBOARD_SHORTCUT_BARE}
+      className={className}
+      dataTestId='sidebar-rail-toggle'
+      iconTestId='sidebar-rail-toggle-icon'
+    />
   );
 }

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -512,7 +512,7 @@ export function EntityCard({
               ) : (
                 <span
                   className={cn(
-                    'inline-flex shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-[background-color,transform] duration-subtle group-hover:bg-btn-primary-hover group-active:scale-[0.96] motion-reduce:transform-none',
+                    'inline-flex shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-[background-color,transform] duration-subtle group-hover:bg-btn-primary-hover group-active:scale-[var(--scale-press)] motion-reduce:transform-none',
                     isProfileLandscape ? 'h-8 w-fit' : 'h-9 w-full'
                   )}
                 >

--- a/apps/web/components/shell/ArtistProfileRailToggle.tsx
+++ b/apps/web/components/shell/ArtistProfileRailToggle.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
-import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
+import { RailToggleButton } from '@/components/atoms/RailToggleButton';
 import { RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE } from '@/hooks/useRightRailKeyboardShortcut';
 
 /**
@@ -20,29 +19,18 @@ export function ArtistProfileRailToggle() {
 
   const primaryName = selectedProfile?.displayName?.trim() || 'Artist profile';
 
-  const label = isOpen
-    ? `Hide ${primaryName} profile`
-    : `Show ${primaryName} profile`;
-
   if (!selectedProfile) return null;
 
-  const RailIcon = isOpen ? PanelRightClose : PanelRightOpen;
-
   return (
-    <DashboardHeaderActionButton
-      ariaLabel={label}
-      pressed={isOpen}
-      onClick={toggle}
+    <RailToggleButton
+      side='right'
+      open={isOpen}
+      openLabel={`Hide ${primaryName} profile`}
+      closedLabel={`Show ${primaryName} profile`}
+      onToggle={toggle}
+      shortcut={RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE}
       dataTestId='artist-profile-rail-toggle'
-      tooltipLabel={label}
-      tooltipShortcut={RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE}
-      icon={
-        <RailIcon
-          data-testid='artist-profile-rail-icon'
-          className='size-3.5'
-          aria-hidden='true'
-        />
-      }
+      iconTestId='artist-profile-rail-icon'
     />
   );
 }

--- a/apps/web/components/shell/__tests__/ArtistProfileRailToggle.test.tsx
+++ b/apps/web/components/shell/__tests__/ArtistProfileRailToggle.test.tsx
@@ -33,9 +33,15 @@ vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
 }));
 
 vi.mock('@jovie/ui', () => ({
-  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
-    <button {...props}>{children}</button>
-  ),
+  Button: ({
+    children,
+    pressFeedback: _pressFeedback,
+    static: _static,
+    ...props
+  }: React.ComponentProps<'button'> & {
+    readonly pressFeedback?: boolean;
+    readonly static?: boolean;
+  }) => <button {...props}>{children}</button>,
   TooltipShortcut: ({ children }: { children: React.ReactNode }) => children,
 }));
 
@@ -53,6 +59,8 @@ describe('ArtistProfileRailToggle', () => {
 
     const button = screen.getByTestId('artist-profile-rail-toggle');
     expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('data-rail-toggle', 'right');
     expect(button).toHaveAttribute('aria-label', 'Show Tim White profile');
     expect(screen.getByTestId('artist-profile-rail-icon')).toHaveAttribute(
       'aria-hidden',

--- a/apps/web/tests/unit/app/globals-ui-feel-style-guard.test.ts
+++ b/apps/web/tests/unit/app/globals-ui-feel-style-guard.test.ts
@@ -33,15 +33,15 @@ describe('globals.css ui-feel quick wins (JOV-3368)', () => {
     );
   });
 
-  it('uses named transition-transform and active scale on interactive controls', () => {
+  it('keeps press compression explicit and token-driven', () => {
     expect(source).toContain('.interactive-press');
     expect(source).toMatch(
-      /\.interactive-press\s*\{[\s\S]*transition-transform[\s\S]*active:scale-\[0\.96\]/
+      /\.interactive-press\s*\{[\s\S]*transition-transform[\s\S]*active:scale-\[var\(--scale-press\)\]/
     );
-    expect(source).toMatch(
-      /button:not\(:disabled\)[\s\S]*transition:\s*transform var\(--duration-subtle\)/
+    expect(source).not.toContain(
+      'button:not(:disabled):not([data-static="true"])'
     );
-    expect(source).toMatch(/transform:\s*scale\(0\.96\)/);
+    expect(source).not.toMatch(/transform:\s*scale\(0\.96\)/);
     expect(source).not.toMatch(
       /\.interactive-press\s*\{[^}]*transition:\s*all/
     );
@@ -49,7 +49,7 @@ describe('globals.css ui-feel quick wins (JOV-3368)', () => {
 
   it('migrates btn-press from opacity to scale press feedback', () => {
     expect(source).toMatch(
-      /\.btn-press\s*\{[\s\S]*transition-transform[\s\S]*active:scale-\[0\.96\]/
+      /\.btn-press\s*\{[\s\S]*transition-transform[\s\S]*active:scale-\[var\(--scale-press\)\]/
     );
     expect(source).not.toMatch(/\.btn-press\s*\{[^}]*active:opacity-80/);
   });

--- a/apps/web/tests/unit/design-system/press-motion-contract.test.ts
+++ b/apps/web/tests/unit/design-system/press-motion-contract.test.ts
@@ -21,6 +21,37 @@ describe('shared press-motion contract', () => {
     expect(button).toContain('active:scale-[var(--scale-press)]');
     expect(button).toContain('motion-reduce:active:scale-100');
     expect(button).not.toContain('active:scale-[0.96]');
+    expect(button).toContain('pressFeedback = false');
+  });
+
+  it('does not scale every interactive element globally', () => {
+    const globals = readWeb('app/globals.css');
+
+    expect(globals).not.toContain('transform: scale(0.96)');
+    expect(globals).not.toContain('active:scale-[0.96]');
+    expect(globals).not.toContain(
+      'button:not(:disabled):not([data-static="true"])'
+    );
+    expect(globals).not.toContain(
+      '[role="button"]:not([aria-disabled="true"]):not([data-static="true"])'
+    );
+    expect(globals).toContain(
+      'active:scale-[var(--scale-press)] motion-reduce:active:scale-100'
+    );
+  });
+
+  it('keeps immediate-state controls static and remaining press feedback at 0.98', () => {
+    const bottomTabs = readWeb(
+      'components/features/profile/nav/BottomTabBar.tsx'
+    );
+    const entityCard = readWeb(
+      'components/organisms/entity-card/EntityCard.tsx'
+    );
+
+    expect(bottomTabs).not.toContain('active:scale');
+    expect(bottomTabs).not.toContain('transition-[color,transform]');
+    expect(entityCard).toContain('group-active:scale-[var(--scale-press)]');
+    expect(entityCard).not.toContain('group-active:scale-[0.96]');
   });
 
   it.each([

--- a/apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts
+++ b/apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts
@@ -62,11 +62,40 @@ describe('shell UX regressions source contracts (JOV-3958/3959/3960)', () => {
       'utf8'
     );
 
-    expect(source).toContain('rounded-full');
-    expect(source).toContain('border-0');
-    expect(source).toContain('hover:bg-surface-0');
+    expect(source).toContain('<RailToggleButton');
+    expect(source).toContain("side='left'");
     expect(source).not.toContain('hover:border-default');
     expect(source).not.toContain('rounded-md border');
+  });
+
+  it('routes both shell sides through the shared rail-toggle primitive (JOV-4606)', () => {
+    const leftToggle = readFileSync(
+      path.join(
+        webRoot,
+        'components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx'
+      ),
+      'utf8'
+    );
+    const rightToggle = readFileSync(
+      path.join(webRoot, 'components/shell/ArtistProfileRailToggle.tsx'),
+      'utf8'
+    );
+    const sharedToggle = readFileSync(
+      path.join(webRoot, 'components/atoms/RailToggleButton.tsx'),
+      'utf8'
+    );
+
+    expect(leftToggle).toContain('<RailToggleButton');
+    expect(leftToggle).toContain("side='left'");
+    expect(rightToggle).toContain('<RailToggleButton');
+    expect(rightToggle).toContain("side='right'");
+    expect(sharedToggle).toContain('PanelLeftClose');
+    expect(sharedToggle).toContain('PanelLeftOpen');
+    expect(sharedToggle).toContain('PanelRightClose');
+    expect(sharedToggle).toContain('PanelRightOpen');
+    expect(sharedToggle).toContain('h-7 w-7 rounded-full');
+    expect(sharedToggle).toContain("size='icon'");
+    expect(sharedToggle).not.toContain('active:scale');
   });
 
   it('keeps left allocation, main-plane geometry, and right allocation on one rail-motion contract (JOV-4522)', () => {

--- a/packages/ui/atoms/button.test.tsx
+++ b/packages/ui/atoms/button.test.tsx
@@ -128,14 +128,20 @@ describe('Button', () => {
     expect(btn.className).not.toContain('text-accent-foreground');
   });
 
-  it('uses tactile press feedback with a static opt-out', () => {
+  it('keeps tactile press feedback opt-in with a static override', () => {
     render(
       <>
-        <Button>Press</Button>
-        <Button static>Static</Button>
+        <Button>Default</Button>
+        <Button pressFeedback>Press</Button>
+        <Button pressFeedback static>
+          Static
+        </Button>
       </>
     );
 
+    expect(
+      screen.getByRole('button', { name: 'Default' }).className
+    ).not.toContain('active:scale-[var(--scale-press)]');
     expect(screen.getByRole('button', { name: 'Press' }).className).toContain(
       'active:scale-[var(--scale-press)]'
     );
@@ -145,6 +151,10 @@ describe('Button', () => {
     expect(
       screen.getByRole('button', { name: 'Static' }).className
     ).not.toContain('active:scale-[var(--scale-press)]');
+    expect(screen.getByRole('button', { name: 'Press' })).toHaveAttribute(
+      'data-press-feedback',
+      'true'
+    );
   });
 
   it('uses the Jovie focus token', () => {

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -166,6 +166,9 @@ export interface ButtonProps
   readonly size?: ButtonSize | DeprecatedButtonSize | null;
   readonly asChild?: boolean;
   readonly loading?: boolean;
+  /** Enables subtle tactile compression for actions without another immediate cue. */
+  readonly pressFeedback?: boolean;
+  /** @deprecated Prefer leaving pressFeedback unset. */
   readonly static?: boolean;
   readonly destructive?: boolean;
 }
@@ -213,6 +216,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       size,
       asChild = false,
       loading = false,
+      pressFeedback = false,
       static: isStatic = false,
       destructive = false,
       disabled,
@@ -223,6 +227,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const Comp = asChild ? Slot : 'button';
     const isDisabled = disabled || loading;
+    const hasPressFeedback = pressFeedback && !isStatic && !isDisabled;
     const dataState = getDataState(loading, isDisabled);
     const normalizedVariant = normalizeButtonVariant({
       variant,
@@ -240,8 +245,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         normalizedVariant.destructive &&
           DESTRUCTIVE_CLASSES[normalizedVariant.variant],
         className,
-        !isStatic &&
-          !isDisabled &&
+        hasPressFeedback &&
           'active:scale-[var(--scale-press)] motion-reduce:active:scale-100',
         isDisabled && 'pointer-events-none'
       ),
@@ -251,6 +255,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       'data-variant': normalizedVariant.variant,
       'data-size': normalizedSize,
       'data-destructive': normalizedVariant.destructive ? 'true' : undefined,
+      'data-press-feedback': hasPressFeedback ? 'true' : undefined,
+      'data-static': isStatic ? 'true' : undefined,
     };
 
     // In asChild mode (Radix Slot), React.Children.only requires a single child.


### PR DESCRIPTION
## Description

- routes left sidebar, profile preview, generic preview, and header drawer toggles through one mirrored Lucide rail-toggle primitive
- removes blanket 0.96 press scaling from every button, role=button, and summary
- makes shared Button compression opt-in and keeps the remaining whole-card cue on the canonical 0.98 token
- removes scale motion from profile tab navigation and updates the design canon

## Testing

- [x] Web focused suites: 60/60
- [x] UI Button suite: 19/19
- [x] Web and UI typecheck
- [x] Biome, Tailwind guard, server boundaries, affected verification, CI harness, diff check
- [x] Regression tests added

bug-to-test: satisfied

## Icon Usage Standards

- [x] Mirrored Lucide PanelLeft/PanelRight icons
- [x] Shared 14px glyph, 28px visible control, 44px effective target
- [x] Accessible label, pressed/expanded state, and decorative icon hiding

## Design Skill Evidence

Reading this as: shared app-shell controls for creators, with a compact and quiet product language, leaning toward Jovie System B / Linear.

Dials: DESIGN_VARIANCE=2, MOTION_INTENSITY=1, VISUAL_DENSITY=8.

- Contrast: pass — semantic text/surface/focus tokens only
- States: pass — idle, hover, pressed, disabled, open, closed, focus-visible
- Layout: pass — fixed 28px visible geometry and existing 44px Button target
- Motion: pass — rail state changes do not scale; opt-in compression is capped at 0.98 and reduced-motion safe
- Icons: pass — one mirrored Lucide family
- Anti-slop: pass — removes duplicate chrome and a blanket animation rule
- Evidence: focused source/component tests plus typecheck and normal hooks; visual taste remains non-blocking per current UI shipping policy

## Related Issues

Closes JOV-4606
Related to JOV-4469
Related to JOV-4522
