### PR TITLE
fix(ui): polish sidebar action and account menu [JOV-4607]

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -280,7 +280,10 @@ export function NavMenuItem({
   const shellInnerContent = (
     <>
       <item.icon
-        className={getSidebarNavIconClassName({ active: isActive })}
+        className={getSidebarNavIconClassName({
+          active: isActive,
+          tone: item.tone,
+        })}
         strokeWidth={2.25}
         aria-hidden='true'
       />

--- a/apps/web/components/organisms/user-button/UsageMenuItem.tsx
+++ b/apps/web/components/organisms/user-button/UsageMenuItem.tsx
@@ -66,7 +66,7 @@ export function UsageMenuItem({
   };
 
   return (
-    <div className='border-t border-subtle/60' data-testid='usage-menu-item'>
+    <div data-testid='usage-menu-item'>
       <Button
         type='button'
         variant='ghost'

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { CommonDropdownItem, CommonDropdownSubmenu } from '@jovie/ui';
-import { Button, buttonVariants, CommonDropdown } from '@jovie/ui';
+import { Button, CommonDropdown } from '@jovie/ui';
 import {
   Cookie,
   CreditCard,
@@ -108,15 +108,14 @@ function buildDropdownItems({
     {
       type: 'action-row',
       id: 'profile-help',
-      className:
-        'grid min-h-12 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-1 px-1',
+      className: 'grid w-full grid-cols-1 px-1',
       items: [
         {
           type: 'action',
           id: 'profile-card',
           label: `Open profile for ${displayName}`,
           onClick: handleProfile,
-          className: 'min-w-0 gap-2.5 px-1.5 py-1.5',
+          className: 'min-w-0 min-h-12 gap-2.5 px-1.5 py-1.5',
           content: (
             <>
               <Avatar
@@ -160,11 +159,7 @@ function buildDropdownItems({
           label: 'Help',
           icon: HelpCircle,
           onClick: handleHelp,
-          className: buttonVariants({
-            variant: 'secondary',
-            size: 'sm',
-            className: 'shrink-0 gap-1 px-2',
-          }),
+          className: 'min-h-8',
         },
       ],
     },
@@ -485,7 +480,7 @@ export function UserButton({
             open={isMenuOpen}
             onOpenChange={setIsMenuOpen}
             disabled
-            contentClassName='w-60'
+            contentClassName='w-72 max-w-[calc(100vw-1rem)]'
           />
         </div>
       );
@@ -589,7 +584,7 @@ export function UserButton({
         align={trigger || showUserInfo ? 'start' : 'end'}
         open={isMenuOpen}
         onOpenChange={setIsMenuOpen}
-        contentClassName='w-60 max-w-[calc(100vw-1rem)]'
+        contentClassName='w-72 max-w-[calc(100vw-1rem)]'
       />
       <DashboardFeedbackModal
         isOpen={isFeedbackOpen}

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -36,8 +36,11 @@ interface SidebarNavChromeOptions {
   readonly className?: string;
 }
 
+// Create actions are deliberately not a second selected-nav treatment. Their
+// blue icon and stronger label distinguish creation without competing with the
+// route's neutral active state.
 const SIDEBAR_PRIMARY_CHROME =
-  'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)] text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,white_14%)]';
+  'text-primary-token font-medium hover:bg-sidebar-accent';
 
 // Active state uses a quiet neutral fill with white type and a Jovie teal icon.
 // Avoid a left rail or guide decoration so every shared sidebar consumer keeps
@@ -96,6 +99,7 @@ export function getSidebarNavIconClassName({
   active,
   nested,
   tight,
+  tone,
   className,
 }: SidebarNavChromeOptions) {
   const inactiveIconColor = nested
@@ -107,7 +111,11 @@ export function getSidebarNavIconClassName({
     tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
     // The selected row deliberately owns white label text. Keep its icon on
     // the canonical Jovie teal token so the active signal remains quiet.
-    active ? 'text-accent-teal!' : inactiveIconColor,
+    active
+      ? 'text-accent-teal!'
+      : tone === 'primary'
+        ? 'text-accent-blue'
+        : inactiveIconColor,
     className
   );
 }

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -664,7 +664,7 @@ describe('UserButton billing actions', () => {
     expect(screen.queryByText('Usage Stats')).not.toBeInTheDocument();
   });
 
-  it('keeps identity and Help inline as sibling roving-focus menu actions', async () => {
+  it('gives narrow identity content its own full-width row and preserves menu focus order', async () => {
     const longDisplayName =
       'Adele Adkins and the Very Long International Touring Ensemble';
     mockUseUserSafe.mockReturnValue({
@@ -696,15 +696,10 @@ describe('UserButton billing actions', () => {
     );
     expect(identityRow).not.toBeNull();
     expect(screen.getByRole('menu')).toHaveClass(
-      'w-60',
+      'w-72',
       'max-w-[calc(100vw-1rem)]'
     );
-    expect(identityRow).toHaveClass(
-      'grid',
-      'grid-cols-[minmax(0,1fr)_auto]',
-      'min-h-12',
-      'w-full'
-    );
+    expect(identityRow).toHaveClass('grid', 'grid-cols-1', 'w-full');
     expect(identityRow?.querySelectorAll('[role="menuitem"]')).toHaveLength(2);
     expect(identityRow?.querySelector('button, a')).toBeNull();
 
@@ -723,10 +718,14 @@ describe('UserButton billing actions', () => {
       longDisplayName
     );
 
+    // The dropdown's max width protects the full row contract on 390px
+    // screens, while the title keeps the complete identity discoverable.
+    expect(screen.getByRole('menu')).toHaveClass('max-w-[calc(100vw-1rem)]');
+
     const helpItem = within(identityRow as HTMLElement).getByRole('menuitem', {
       name: 'Help',
     });
-    expect(helpItem).toHaveClass('shrink-0');
+    expect(helpItem).toHaveClass('min-h-8');
     await user.keyboard('{ArrowDown}');
     expect(profileItem).toHaveFocus();
     await user.keyboard('{ArrowDown}');

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -267,7 +267,7 @@ describe('DashboardNav', () => {
     ).toBeNull();
   });
 
-  it('keeps inactive New Chat on the shared primary shell tone', () => {
+  it('keeps inactive New Chat distinct from a selected navigation row', () => {
     mockUsePathname.mockReturnValue(APP_ROUTES.CALENDAR);
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
@@ -275,9 +275,12 @@ describe('DashboardNav', () => {
 
     const chatLink = getByRole('link', { name: 'New Chat' });
     expect(chatLink).toHaveClass('text-primary-token');
-    expect(chatLink).toHaveClass(
-      'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)]'
+    expect(chatLink).toHaveClass('font-medium');
+    expect(chatLink).not.toHaveClass('bg-sidebar-accent-active');
+    expect(chatLink).not.toHaveClass(
+      'shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
     );
+    expect(chatLink.querySelector('svg')).toHaveClass('text-accent-blue');
     expect(chatLink).not.toHaveAttribute('aria-current');
   });
 

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1734
+  "count": 1732
 }

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -1030,12 +1030,14 @@ describe('LibrarySurface', () => {
       })
     );
     expect(navigationMock.refresh).toHaveBeenCalledTimes(1);
-    expect(
-      within(screen.getByTestId('library-asset-drawer')).getAllByRole(
-        'button',
-        { name: /Play Preview for Take Me Over/u }
-      ).length
-    ).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId('library-asset-drawer')).getAllByRole(
+          'button',
+          { name: /Play Preview for Take Me Over/u }
+        ).length
+      ).toBeGreaterThan(0);
+    });
   });
 
   it('opens the read-only asset drawer from list rows', () => {


### PR DESCRIPTION
## Summary
- make New Chat a quiet create action instead of a selected nav row
- give account identity its own full-width menu row and return Help to the shared roving-focus row contract
- normalize menu width and remove the redundant Usage row border

## Design read
Reading this as: a dense app-shell navigation surface for artists, with a calm System B language, leaning toward Linear-like operational clarity.

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm --filter @jovie/web exec vitest run tests/components/user-button.test.tsx tests/unit/dashboard/DashboardNav.test.tsx components/features/dashboard/dashboard-nav/config.test.ts` (46 passed)
- `pnpm biome check --write` on changed files
- `git diff --check`

Closes JOV-4607