### PR TITLE
fix(shell): allocate right rail beside main plane [JOV-4522]

### DIFF
--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -88,17 +88,21 @@ export const AppShellFrame = memo(function AppShellFrame({
           data-app-shell-content-column='true'
           className='flex min-h-0 min-w-0 flex-1 flex-col transition-[flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none'
         >
-          <main
-            id='main-content'
-            className={cn(
-              // `isolate` gives <main> its own stacking context so the negative-z
-              // chat ambient layer below paints above main's background but
-              // beneath the in-flow header/content (#13386).
-              'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--color-bg-surface-0)/90',
-              'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
-            )}
+          <div
+            data-app-shell-main-plane='true'
+            className='flex min-h-0 min-w-0 flex-1 overflow-hidden transition-[gap,flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none lg:gap-(--app-shell-gap)'
           >
-            {/* Full-bleed ambient wash on chat routes — spans the whole content
+            <main
+              id='main-content'
+              className={cn(
+                // `isolate` gives <main> its own stacking context so the negative-z
+                // chat ambient layer below paints above main's background but
+                // beneath the in-flow header/content (#13386).
+                'relative isolate flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--color-bg-surface-0)/90',
+                'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
+              )}
+            >
+              {/* Full-bleed ambient wash on chat routes — spans the whole content
               panel so its top edge is above the (transparent) header band.
               Negative z-index is load-bearing: an absolute sibling with z-auto
               would paint ON TOP of the in-flow static header; `-z-10` inside
@@ -107,37 +111,38 @@ export const AppShellFrame = memo(function AppShellFrame({
               previous chat canvas tone on all breakpoints. Pure background:
               pointer-events-none, no layout impact (#13386, preserves the
               full-viewport guarantee from #12135 / JOV-3614). */}
-            {chatAmbientGradient ? (
+              {chatAmbientGradient ? (
+                <div
+                  aria-hidden='true'
+                  data-testid='chat-ambient-gradient'
+                  className='pointer-events-none absolute inset-0 -z-10 bg-(--app-shell-content-surface)'
+                  style={{ backgroundImage: CHAT_AMBIENT_GRADIENT_IMAGE }}
+                />
+              ) : null}
+              {isCodeFlagEnabled('CANVAS_GRAIN') && <CanvasGrain />}
+              {header}
               <div
-                aria-hidden='true'
-                data-testid='chat-ambient-gradient'
-                className='pointer-events-none absolute inset-0 -z-10 bg-(--app-shell-content-surface)'
-                style={{ backgroundImage: CHAT_AMBIENT_GRADIENT_IMAGE }}
-              />
-            ) : null}
-            {isCodeFlagEnabled('CANVAS_GRAIN') && <CanvasGrain />}
-            {header}
-            <div
-              className={cn(
-                'flex flex-1 min-h-0 min-w-0 overflow-hidden transition-[gap] duration-cinematic ease-cinematic motion-reduce:transition-none lg:gap-(--app-shell-gap)'
-              )}
-            >
-              <div
-                data-testid='app-shell-scroll'
                 className={cn(
-                  // Shell-level pane never owns vertical scroll — routes and table
-                  // surfaces scroll inside this clip so the right rail stays fixed.
-                  'flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden overflow-x-auto overscroll-contain transition-[flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none pb-[var(--dev-toolbar-height,0px)]',
-                  contentClassName
+                  'flex flex-1 min-h-0 min-w-0 overflow-hidden transition-[gap] duration-cinematic ease-cinematic motion-reduce:transition-none'
                 )}
               >
-                {main}
+                <div
+                  data-testid='app-shell-scroll'
+                  className={cn(
+                    // Shell-level pane never owns vertical scroll — routes and table
+                    // surfaces scroll inside this clip so the right rail stays fixed.
+                    'flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden overflow-x-auto overscroll-contain transition-[flex-basis,width] duration-cinematic ease-cinematic motion-reduce:transition-none pb-[var(--dev-toolbar-height,0px)]',
+                    contentClassName
+                  )}
+                >
+                  {main}
+                </div>
               </div>
-              {rightPanel ? (
-                <AppShellRightRail>{rightPanel}</AppShellRightRail>
-              ) : null}
-            </div>
-          </main>
+            </main>
+            {rightPanel ? (
+              <AppShellRightRail>{rightPanel}</AppShellRightRail>
+            ) : null}
+          </div>
           {/* The player is shell chrome, not content-card chrome. Keeping it as
               an in-flow sibling reserves its own tray below <main>, matching
               the sidebar's canvas elevation without obscuring routes or rails. */}

--- a/apps/web/components/shell/AppShellRightRail.tsx
+++ b/apps/web/components/shell/AppShellRightRail.tsx
@@ -10,11 +10,12 @@ export interface AppShellRightRailProps {
 /**
  * Shared AppShell right-rail frame slot.
  *
- * Owns the sticky structural container that sits beside the main scroll clip in
- * AppShellFrame. Card elevation, borders, and drawer width animation live in
- * RightDrawer / EntitySidebarShell / DrawerSurfaceCard — this primitive only
- * pins the rail outside route-owned scroll so list and grid surfaces do not
- * drag the context panel along with them.
+ * Owns the sticky structural container that sits beside the entire main plane
+ * in AppShellFrame. On desktop it is a sibling of the main card, so a drawer
+ * width is layout allocation that narrows the header and route surface rather
+ * than an overlay on top of either. Card elevation, borders, and drawer width
+ * animation live in RightDrawer / EntitySidebarShell / DrawerSurfaceCard.
+ * Mobile continues to be owned by RightDrawer's fixed sheet adapter.
  *
  * Usage (normally composed by AppShellFrame):
  *   <AppShellRightRail>
@@ -36,7 +37,7 @@ export function AppShellRightRail({
         // self-stretch (not self-start): the rail sits beside the non-scrolling
         // shell clip and must fill the content-row height so open drawers clip
         // inside the rail instead of floating over the transcript (JOV-3958).
-        'sticky top-0 z-30 lg:z-10 flex h-full min-h-0 shrink-0 flex-col self-stretch overflow-hidden',
+        'sticky top-0 z-30 flex h-full min-h-0 w-0 shrink-0 flex-col self-stretch overflow-hidden lg:z-10 lg:w-fit',
         // Mirror the left sidebar mount language so inner drawer width changes
         // reclaim canvas space with the same cinematic timing.
         'transition-[flex-basis,width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none',

--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -19,6 +19,8 @@ describe('AppShellRightRail', () => {
       'top-0',
       'z-30',
       'lg:z-10',
+      'w-0',
+      'lg:w-fit',
       'h-full',
       'min-h-0',
       'self-stretch',
@@ -42,6 +44,24 @@ describe('AppShellRightRail', () => {
     const rail = screen.getByTestId('app-shell-right-rail');
 
     expect(rail).toHaveClass('lg:rounded-(--linear-app-shell-radius)');
+  });
+
+  it('has no desktop overlay positioning and only allocates the width of its drawer child', () => {
+    render(
+      <AppShellRightRail>
+        <div>Panel</div>
+      </AppShellRightRail>
+    );
+
+    const rail = screen.getByTestId('app-shell-right-rail');
+
+    expect(rail).toHaveClass('lg:w-fit', 'shrink-0');
+    expect(rail).not.toHaveClass(
+      'fixed',
+      'absolute',
+      'lg:fixed',
+      'lg:absolute'
+    );
   });
 
   it('merges custom className without replacing base sticky layout', () => {

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -29,7 +29,7 @@ describe('AppShellFrame', () => {
     // #main-content keeps its full rounded shell radius — no Electron override
     // strips the top corners now that the header lives inside the card.
     expect(mainContent).toHaveClass('lg:rounded-(--app-shell-radius)');
-    expect(mainContent.querySelector('div.flex.flex-1')).toHaveClass(
+    expect(mainContent.closest('[data-app-shell-main-plane]')).toHaveClass(
       'lg:gap-(--app-shell-gap)'
     );
     expect(screen.getByText('Sidebar')).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe('AppShellFrame', () => {
     expect(mainContent).toContainElement(headers[0] as HTMLElement);
   });
 
-  it('keeps the right rail outside the non-scrolling shell clip', () => {
+  it('allocates the right rail beside the complete main plane instead of overlaying route content', () => {
     render(
       <AppShellFrame
         sidebar={<aside>Sidebar</aside>}
@@ -56,11 +56,23 @@ describe('AppShellFrame', () => {
     expect(scrollPane).toHaveClass('overflow-hidden');
     expect(scrollPane).not.toHaveClass('overflow-y-auto');
     expect(scrollPane).toContainElement(screen.getByText('Main Content'));
+    const mainPlane = screen.getByTestId('app-shell-right-rail').parentElement;
+
+    expect(mainPlane).toHaveAttribute('data-app-shell-main-plane', 'true');
+    expect(mainPlane).toContainElement(screen.getByRole('main'));
+    expect(mainPlane).toContainElement(rightRail);
+    expect(screen.getByRole('main')).not.toContainElement(rightRail);
     expect(scrollPane).not.toContainElement(rightRail);
     expect(rightRail).toContainElement(
       screen.getByTestId('fixture-right-rail')
     );
     expect(rightRail).toHaveClass('sticky', 'top-0');
+    expect(mainPlane).toHaveClass(
+      'transition-[gap,flex-basis,width]',
+      'duration-cinematic',
+      'motion-reduce:transition-none',
+      'lg:gap-(--app-shell-gap)'
+    );
   });
 
   it('reserves dev-toolbar height inside the shell scroll pane', () => {
@@ -125,8 +137,10 @@ describe('AppShellFrame', () => {
       />
     );
 
-    expect(screen.getByTestId('app-shell-scroll').parentElement).toHaveClass(
-      'transition-[gap]',
+    const mainPlane = screen.getByTestId('app-shell-right-rail').parentElement;
+
+    expect(mainPlane).toHaveClass(
+      'transition-[gap,flex-basis,width]',
       'duration-cinematic',
       'motion-reduce:transition-none'
     );


### PR DESCRIPTION
## Summary
- moves the shared right rail beside the full desktop main plane, so header and route surface make room together rather than being overlaid
- keeps the existing `RightDrawer` mobile fixed-sheet, focus, inert, scroll-lock, and Escape paths unchanged
- makes the shell rail shrink to its drawer child on desktop and zero-width on mobile

## Verification
- `pnpm --filter web exec vitest run tests/unit/shell/shell-ux-regressions-source.test.ts tests/unit/components/organisms/AppShellFrame.test.tsx components/shell/__tests__/AppShellRightRail.test.tsx` (19/19)
- `pnpm exec biome check` on changed files
- `git diff --check`
- normal pre-push gate (Tailwind/proxy/typecheck, affected verification, lint)

Closes JOV-4522