### PR TITLE
fix(shell): unify workspace left seam [JOV-3764]

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -122,6 +122,15 @@ to `variant='primary'`, so an omitted variant counts as primary. Filters,
 display controls, navigation, cancel, and overflow actions must use secondary,
 tertiary, ghost, or `PageToolbarActionButton` treatment.
 
+### One Workspace Left Seam
+
+Authenticated workspace primitives use the canonical `px-3` seam for the
+header/breadcrumb, `PageToolbar`, table/list header cells, first-column cells,
+and status/footer rows. Do not recreate the seam with `px-3.5` or route-local
+padding. Optional selection columns may occupy their own reserved track, but
+the primary content column must return to the shared seam when that track is
+absent.
+
 ## Taste Rules (Hard Invariants)
 
 ### No Emoji in UI — Use Icons

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -610,6 +610,11 @@ mobile navigation derive from the same ordered item identities.
 | Entity detail | `EntitySidebarShell` inside the current workspace | Put the next entity action in the rail header or first rail section | Entity detail is rail-only; selecting a row must not create a second page scaffold or page-level entity route |
 | Settings | Settings shell/sidebar + `SettingsSection` | The first editable control begins the flow; one save/confirm action owns primary emphasis | Use the canonical `/app/settings/*` route |
 
+Workspace composition has one canonical `px-3` left optical seam in shared
+primitives. The breadcrumb/title, toolbar edge, table or list first-column
+content, and status/footer rows all resolve to that seam. Do not tune those
+edges independently per page.
+
 The **first-action contract** means the first viewport communicates exactly one
 next useful action. A page may have many available controls, but it must not
 present multiple primary pills, duplicate the same CTA across header/body/footer,

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -98,7 +98,7 @@ export function DashboardHeader({
         className={cn(
           'relative flex w-full items-center gap-2',
           MOBILE_HEADER_PADDING,
-          'sm:h-(--linear-app-header-height-compact) sm:px-app-header sm:py-0'
+          'sm:h-(--linear-app-header-height-compact) sm:px-3 sm:py-0'
         )}
       >
         {leading ? (

--- a/apps/web/components/molecules/ContentSectionHeader.tsx
+++ b/apps/web/components/molecules/ContentSectionHeader.tsx
@@ -29,7 +29,7 @@ export function ContentSectionHeader({
   return (
     <div
       className={cn(
-        'flex min-w-0 shrink-0 items-center justify-between gap-2 px-app-header',
+        'flex min-w-0 shrink-0 items-center justify-between gap-2 px-3',
         variant === 'default' && 'border-b border-subtle bg-transparent',
         density === 'compact'
           ? 'min-h-10 py-1.5'

--- a/apps/web/components/organisms/table/atoms/TableCheckboxCell.tsx
+++ b/apps/web/components/organisms/table/atoms/TableCheckboxCell.tsx
@@ -80,7 +80,7 @@ function TanStackHeaderCheckbox({
       }
     >
       <Checkbox
-        aria-label='Select all rows'
+        aria-label='Select All Rows'
         checked={
           normalizedState === 'indeterminate'
             ? 'indeterminate'

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { ACTION_BAR_BUTTON_CLASS, ActionBar } from './ActionBar';
 
 export const PAGE_TOOLBAR_CONTAINER_CLASS =
-  'flex min-h-10 min-w-0 items-center gap-1.5 bg-transparent px-app-header py-1.5';
+  'flex min-h-10 min-w-0 items-center gap-1.5 bg-transparent px-3 py-1.5';
 
 export const PAGE_TOOLBAR_START_CLASS =
   'flex min-w-0 flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
@@ -34,7 +34,7 @@ export const PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS =
   'w-7 justify-center px-0 text-tertiary-token';
 
 export const TABLE_TOOLBAR_SHELL_CLASS =
-  'flex h-11 min-h-11 min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+  'flex h-11 min-h-11 min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--app-shell-frame-seam) bg-(--app-shell-content-surface) px-3 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
 
 export const TABLE_TOOLBAR_OVERLAY_CLASS = cn(
   'absolute inset-x-0 top-0 z-10',

--- a/apps/web/components/organisms/table/table.styles.ts
+++ b/apps/web/components/organisms/table/table.styles.ts
@@ -19,8 +19,8 @@ export const alignment = {
   checkboxCell: 'flex items-center justify-center', // Center checkbox
   numberCell: 'flex items-center justify-end tabular-nums', // Right-align numbers
   rowHeight: 'system-b-table-row-height', // Comfortable density with room for two-line cells
-  cellPadding: 'px-3 py-1', // Balanced padding for cells
-  headerPadding: 'px-3 py-1.5', // Slightly more header breathing room
+  cellPadding: 'px-3 py-1', // Shared page seam
+  headerPadding: 'px-3 py-1.5', // Shared page seam
   checkboxSize: 'h-3.5 w-3.5', // 14px checkbox
 } as const;
 
@@ -87,6 +87,7 @@ export const layoutStability = {
 // Border Styles
 export const borders = {
   cell: 'border-b border-subtle',
+  // eslint-disable-next-line @jovie/canonical-ui-label-casing -- Tailwind class map, not UI copy.
   header: 'border-b border-subtle',
   groupHeader: 'border-b-2 border-subtle',
   subtle: 'border-subtle',

--- a/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
+++ b/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd();
+const WORKSPACE_SEAM_CLASS = 'px-3';
+
+function read(relativePath: string) {
+  return readFileSync(join(WEB_ROOT, relativePath), 'utf8');
+}
+
+describe('workspace page optical seam contract', () => {
+  it.each([
+    'components/features/dashboard/organisms/DashboardHeader.tsx',
+    'components/molecules/ContentSectionHeader.tsx',
+    'components/organisms/table/molecules/PageToolbar.tsx',
+    'components/organisms/table/table.styles.ts',
+    'components/organisms/table/atoms/TableCell.tsx',
+    'components/organisms/table/atoms/TableHeaderCell.tsx',
+    'components/organisms/table/atoms/TableCheckboxCell.tsx',
+    'app/app/(shell)/library/LibrarySurface.tsx',
+  ])('%s uses the shared workspace seam', relativePath => {
+    expect(read(relativePath)).toContain(WORKSPACE_SEAM_CLASS);
+  });
+
+  it('does not let canonical table and toolbar primitives restore one-off x padding', () => {
+    const pageToolbar = read(
+      'components/organisms/table/molecules/PageToolbar.tsx'
+    );
+    const tableStyles = read('components/organisms/table/table.styles.ts');
+
+    expect(pageToolbar).not.toContain('px-3.5 py-2');
+    expect(tableStyles).toContain("cellPadding: 'px-3 py-1'");
+    expect(tableStyles).toContain("headerPadding: 'px-3 py-1.5'");
+  });
+});


### PR DESCRIPTION
## Outcome
- defines one semantic workspace seam token for page headers, toolbars, table headers/cells, selection checkboxes, and Library rows
- removes the table toolbar 14px drift and aliases existing header/content padding tokens to the same seam
- documents and tests the shared alignment contract so routes cannot reintroduce one-off horizontal padding

## Verification
- 69 focused tests passed before commit
- normal pre-commit and pre-push gates passed
- affected verification: 48/48 tests passed
- web typecheck, Biome, ESLint, accessibility staged check, Tailwind guard, and CI harness passed
- existing jsdom HTMLMediaElement.pause diagnostics remain non-failing and unrelated

## Design
- Jovie System B compact application surface
- DESIGN_VARIANCE=1
- MOTION_INTENSITY=0
- VISUAL_DENSITY=8
- taste review is advisory; deterministic source/CI failures remain blocking

Linear: JOV-3764