### PR TITLE
fix(ci): keep advisory visual capture nonblocking [JOV-4608]

### DIFF
--- a/.github/workflows/pr-visual-review.yml
+++ b/.github/workflows/pr-visual-review.yml
@@ -31,9 +31,11 @@ env:
 
 jobs:
   capture:
-    # Failures remain visible in Actions, but the native queue treats this exact
-    # evidence check as advisory. Deterministic CI is the merge gate.
+    # Failures remain visible in Actions and its uploaded evidence, but the
+    # check itself cannot become a native merge-queue gate. Deterministic CI
+    # remains fail-closed and is the merge gate.
     name: Capture changed UI (desktop + mobile) (advisory)
+    continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -138,6 +140,8 @@ jobs:
 
   review:
     name: Review screenshots and post advisory review
+    # The review is useful steering information, never a production gate.
+    continue-on-error: true
     needs: capture
     if: ${{ always() && needs.capture.result == 'success' }}
     runs-on: ubuntu-latest

--- a/apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts
+++ b/apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts
@@ -10,6 +10,16 @@ const workflowPath = resolve(
   '.github/workflows/pr-visual-review.yml'
 );
 
+function jobBlock(workflow: string, jobId: string, nextJobId?: string) {
+  const start = workflow.indexOf(`  ${jobId}:`);
+  expect(start, `missing ${jobId} job`).toBeGreaterThanOrEqual(0);
+  const end = nextJobId
+    ? workflow.indexOf(`\n  ${nextJobId}:`, start)
+    : workflow.length;
+  expect(end, `missing ${jobId} job boundary`).toBeGreaterThan(start);
+  return workflow.slice(start, end);
+}
+
 describe('PR visual review workflow', () => {
   it("uses Playwright's default absolute browser cache after installing Chromium", () => {
     const workflow = readFileSync(workflowPath, 'utf8');
@@ -29,5 +39,19 @@ describe('PR visual review workflow', () => {
     expect(workflow).toContain('| jq -r --arg marker "$MARKER"');
     expect(workflow).toContain('contains($marker)');
     expect(workflow).not.toContain('--jq --arg marker');
+  });
+
+  it('keeps capture and screenshot review visibly advisory without terminal queue failures', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const capture = jobBlock(workflow, 'capture', 'review');
+    const review = jobBlock(workflow, 'review');
+
+    expect(capture).toContain(
+      'name: Capture changed UI (desktop + mobile) (advisory)'
+    );
+    expect(capture).toContain('continue-on-error: true');
+    expect(capture).toContain('name: Upload visual evidence');
+    expect(capture).toContain('if: always()');
+    expect(review).toContain('continue-on-error: true');
   });
 });


### PR DESCRIPTION
Closes JOV-4608

## Why
PR #15230 demonstrated that the visual-capture job can end terminal red and eject a source-green UI PR from GitHub native merge queue, despite controller allowlisting.

## Change
- Mark the capture and screenshot-review jobs `continue-on-error: true`.
- Preserve Actions failure detail and uploaded visual evidence.
- Add a workflow contract test to prevent a terminal advisory check from returning.

## Safety
No deterministic required check changes. CI, migration, secrets, and source gates remain fail-closed.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/pr-visual-review-workflow.test.ts` (3/3)
- `pnpm biome check .github/workflows/pr-visual-review.yml apps/web/tests/unit/ci/pr-visual-review-workflow.test.ts`
- `git diff --check`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable; workflow policy change)