### PR TITLE
fix(contacts): use shared right rail [JOV-4629]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -15,6 +15,7 @@ import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/Dashboar
 import { DashboardHeaderActionGroup } from '@/features/dashboard/atoms/DashboardHeaderActionGroup';
 import { DrawerToggleButton } from '@/features/dashboard/atoms/DrawerToggleButton';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
+import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { SIDEBAR_WIDTH, TABLE_MIN_WIDTHS } from '@/lib/constants/layout';
 import type { ContactRole } from '@/types/contacts';
 import { ContactDetailSidebar } from './ContactDetailSidebar';
@@ -170,6 +171,38 @@ export const ContactsTable = memo(function ContactsTable({
     onDelete(selectedContact);
   }, [selectedContact, onDelete]);
 
+  const sidebarPanel = useMemo(
+    () => (
+      <ContactDetailSidebar
+        contact={selectedContact}
+        isOpen={isSidebarOpen}
+        onClose={handleClose}
+        onUpdate={handleUpdate}
+        onSave={handleSave}
+        onDelete={handleDelete}
+        contextMenuItems={
+          selectedContact
+            ? convertToCommonDropdownItems(getContextMenuItems(selectedContact))
+            : undefined
+        }
+      />
+    ),
+    [
+      getContextMenuItems,
+      handleClose,
+      handleDelete,
+      handleSave,
+      handleUpdate,
+      isSidebarOpen,
+      selectedContact,
+    ]
+  );
+
+  // The shell owns desktop rail allocation, so Contacts registers its detail
+  // surface there instead of mounting a route-local sibling beside the table.
+  // RightDrawer preserves the existing mobile sheet behavior.
+  useRegisterRightPanel(sidebarPanel);
+
   // Arrow keys update sidebar when it's already open
   const handleFocusedRowChange = useCallback(
     (index: number) => {
@@ -230,21 +263,6 @@ export const ContactsTable = memo(function ContactsTable({
           )}
         </div>
       </div>
-
-      {/* Right sidebar */}
-      <ContactDetailSidebar
-        contact={selectedContact}
-        isOpen={isSidebarOpen}
-        onClose={handleClose}
-        onUpdate={handleUpdate}
-        onSave={handleSave}
-        onDelete={handleDelete}
-        contextMenuItems={
-          selectedContact
-            ? convertToCommonDropdownItems(getContextMenuItems(selectedContact))
-            : undefined
-        }
-      />
     </div>
   );
 });

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -1,6 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import {
+  RightPanelProvider,
+  useRightPanel,
+} from '@/contexts/RightPanelContext';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
 import { ContactsTable } from '@/features/dashboard/organisms/contacts-table/ContactsTable';
 
@@ -111,18 +115,39 @@ const contacts: EditableContact[] = [
   },
 ];
 
+function RightPanelOutlet() {
+  return <output data-testid='contacts-right-panel'>{useRightPanel()}</output>;
+}
+
+function renderContactsTable(props: ComponentProps<typeof ContactsTable>) {
+  return render(
+    <RightPanelProvider>
+      <ContactsTable {...props} />
+      <RightPanelOutlet />
+    </RightPanelProvider>
+  );
+}
+
 describe('ContactsTable', () => {
-  it('persists drawer selection through the shared table selection contract', () => {
-    render(
-      <ContactsTable
-        contacts={contacts}
-        artistName='Tim White'
-        onUpdate={() => undefined}
-        onSave={async () => undefined}
-        onDelete={() => undefined}
-        onAddContact={() => undefined}
-      />
-    );
+  it('registers details in the shared right rail instead of mounting them beside the table', async () => {
+    renderContactsTable({
+      contacts,
+      artistName: 'Tim White',
+      onUpdate: () => undefined,
+      onSave: async () => undefined,
+      onDelete: () => undefined,
+      onAddContact: () => undefined,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
+        'data-open',
+        'false'
+      );
+    });
+
+    const sidebar = screen.getByTestId('contact-detail-sidebar');
+    expect(screen.getByTestId('contacts-table')).not.toContainElement(sidebar);
 
     expect(screen.getByText('1 contact')).toBeInTheDocument();
     expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
@@ -134,14 +159,16 @@ describe('ContactsTable', () => {
       screen.getByRole('button', { name: 'Select first contact' })
     );
 
-    expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
-      'data-open',
-      'true'
-    );
-    expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
-      'data-contact-id',
-      'contact-1'
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
+        'data-open',
+        'true'
+      );
+      expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
+        'data-contact-id',
+        'contact-1'
+      );
+    });
     expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
       'data-first-row-selected',
       'true'
@@ -151,17 +178,15 @@ describe('ContactsTable', () => {
   });
 
   it('forwards loading state to the table instead of showing a false empty state', () => {
-    render(
-      <ContactsTable
-        contacts={[]}
-        artistName='Tim White'
-        isLoading
-        onUpdate={() => undefined}
-        onSave={async () => undefined}
-        onDelete={() => undefined}
-        onAddContact={() => undefined}
-      />
-    );
+    renderContactsTable({
+      contacts: [],
+      artistName: 'Tim White',
+      isLoading: true,
+      onUpdate: () => undefined,
+      onSave: async () => undefined,
+      onDelete: () => undefined,
+      onAddContact: () => undefined,
+    });
 
     expect(screen.getByTestId('contacts-table')).toBeInTheDocument();
     expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
@@ -174,16 +199,14 @@ describe('ContactsTable', () => {
   it('offers the canonical add contact action from the empty state', () => {
     const onAddContact = vi.fn();
 
-    render(
-      <ContactsTable
-        contacts={[]}
-        artistName='Tim White'
-        onUpdate={() => undefined}
-        onSave={async () => undefined}
-        onDelete={() => undefined}
-        onAddContact={onAddContact}
-      />
-    );
+    renderContactsTable({
+      contacts: [],
+      artistName: 'Tim White',
+      onUpdate: () => undefined,
+      onSave: async () => undefined,
+      onDelete: () => undefined,
+      onAddContact,
+    });
 
     expect(screen.getByRole('heading', { name: 'No Contacts' })).toBeVisible();
     expect(


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4629 -->

## Summary
- register ContactDetailSidebar with the shared shell right panel
- remove the route-local table sibling so desktop allocation pushes the full main plane
- preserve selection, actions, and RightDrawer mobile-sheet behavior

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx apps/web/tests/unit/dashboard/ContactsTable.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/dashboard/ContactsTable.test.tsx tests/unit/dashboard/ContactDetailSidebar.test.tsx tests/unit/dashboard/ContactsManager.test.tsx` (7/7)
- `pnpm --filter web exec vitest run tests/unit/app/contacts-page-client.test.tsx tests/unit/app/contacts-page.test.tsx tests/unit/dashboard/SettingsContactsSection.test.tsx` (8/8)
- normal pre-push gate

No visual taste review blocks this isolated shell-consumption fix.