### PR TITLE
fix(admin): use shared shell rail for People details [JOV-4630]

### DIFF
--- a/apps/web/app/app/(shell)/admin/people/page.tsx
+++ b/apps/web/app/app/(shell)/admin/people/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import type { SearchParams } from 'nuqs/server';
+import { AdminPeopleRightPanelProvider } from '@/components/features/admin/AdminPeopleRightPanelProvider';
 import { AdminCreatorsPageWrapper } from '@/components/features/admin/admin-creator-profiles/AdminCreatorsPageWrapper';
 import { AdminReleasesPageWrapper } from '@/components/features/admin/admin-releases-table';
 import { AdminUsersTableUnified } from '@/components/features/admin/admin-users-table/AdminUsersTableUnified';
@@ -219,7 +220,7 @@ export default async function AdminPeoplePage({
       testId='admin-people-page'
       viewTestId={`admin-people-view-${view}`}
     >
-      {content}
+      <AdminPeopleRightPanelProvider>{content}</AdminPeopleRightPanelProvider>
     </AdminPage>
   );
 }

--- a/apps/web/components/features/admin/AdminPeopleRightPanelProvider.tsx
+++ b/apps/web/components/features/admin/AdminPeopleRightPanelProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
+
+interface AdminPeopleRightPanelContextValue {
+  readonly setPanel: (panel: ReactNode) => void;
+}
+
+const AdminPeopleRightPanelContext =
+  createContext<AdminPeopleRightPanelContextValue | null>(null);
+
+/**
+ * The Admin People tabs share one shell-level right-panel owner. Individual
+ * tables supply their selected detail surface, while the authenticated shell
+ * remains the only desktop width/allocation owner.
+ */
+export function AdminPeopleRightPanelProvider({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  const [panel, setPanel] = useState<ReactNode>(null);
+  useRegisterRightPanel(panel);
+
+  const value = useMemo(() => ({ setPanel }), [setPanel]);
+
+  return (
+    <AdminPeopleRightPanelContext.Provider value={value}>
+      {children}
+    </AdminPeopleRightPanelContext.Provider>
+  );
+}
+
+/** Register the active Admin People tab's detail surface with the shared rail. */
+export function useAdminPeopleRightPanel(panel: ReactNode) {
+  const context = useContext(AdminPeopleRightPanelContext);
+  if (!context) {
+    throw new TypeError(
+      'useAdminPeopleRightPanel must be used within AdminPeopleRightPanelProvider'
+    );
+  }
+
+  useEffect(() => {
+    context.setPanel(panel);
+    return () => context.setPanel(null);
+  }, [context, panel]);
+}

--- a/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
+++ b/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TableErrorFallback } from '@/components/atoms/TableErrorFallback';
 import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
+import { useAdminPeopleRightPanel } from '@/components/features/admin/AdminPeopleRightPanelProvider';
 import { toast } from '@/components/feedback';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import {
@@ -367,6 +368,22 @@ export function AdminUsersTableUnified(props: Readonly<AdminUsersTableProps>) {
     [actionCallbacks]
   );
 
+  const detailPanel = useMemo(
+    () => (
+      <AdminUserDetailDrawer
+        user={selectedUser}
+        onClose={() => setSelectedUser(null)}
+        contextMenuItems={
+          selectedUser
+            ? convertToCommonDropdownItems(getContextMenuItems(selectedUser))
+            : undefined
+        }
+      />
+    ),
+    [getContextMenuItems, selectedUser]
+  );
+  useAdminPeopleRightPanel(detailPanel);
+
   // Bulk actions
   const bulkActions = useMemo(() => {
     const selectedUsers = users.filter(u => selectedIds.has(u.id));
@@ -543,133 +560,120 @@ export function AdminUsersTableUnified(props: Readonly<AdminUsersTableProps>) {
 
   return (
     <QueryErrorBoundary fallback={TableErrorFallback}>
-      <div className='flex h-full'>
-        <div className='flex-1 min-w-0'>
-          <AdminTableShell
-            testId='admin-users-content'
-            className='rounded-none border-0'
-            toolbar={
-              <>
-                <TableBulkActionsToolbar
-                  selectedCount={selectedCount}
-                  onClearSelection={clearSelection}
-                  actions={bulkActions}
-                />
-                <AdminTableHeader
-                  title='Users'
-                  subtitle='Review lifecycle state, profile completion, and suppression health.'
-                />
-                <AdminTableSubheader
-                  start={
-                    <div className={PAGE_TOOLBAR_META_TEXT_CLASS}>
-                      Showing {from.toLocaleString()}–{to.toLocaleString()} of{' '}
-                      {total.toLocaleString()} users
-                    </div>
-                  }
-                  end={
-                    <div className={PAGE_TOOLBAR_END_GROUP_CLASS}>
-                      <ExportCSVButton<AdminUserRow>
-                        getData={() => users}
-                        columns={usersCSVColumns}
-                        filename={USERS_CSV_FILENAME_PREFIX}
-                        disabled={users.length === 0}
-                        ariaLabel='Export users to CSV file'
-                        chrome='page-toolbar'
-                        iconOnly
-                        tooltipLabel='Export'
-                      />
-                    </div>
-                  }
-                />
-              </>
-            }
-          >
-            {() =>
-              isMobile ? (
-                <div className='space-y-2 p-3'>
-                  {users.length === 0 ? (
-                    <ContentSurfaceCard className='flex flex-col items-center gap-3 bg-surface-0 px-4 py-10 text-center'>
-                      <Users className='h-6 w-6' />
-                      <div>
-                        <div className='text-sm font-semibold tracking-tight text-primary-token'>
-                          No users found
-                        </div>
-                        <div className='text-xs text-secondary-token'>
-                          Users will appear here once they sign up.
-                        </div>
-                      </div>
-                    </ContentSurfaceCard>
-                  ) : (
-                    users.map(user => (
-                      <AdminUserMobileCard
-                        key={user.id}
-                        user={user}
-                        isSelected={selectedIds.has(user.id)}
-                        onToggleSelect={toggleSelect}
-                        contextMenuItems={getContextMenuItems(user)}
-                      />
-                    ))
-                  )}
-
-                  {hasNextPage ? (
-                    <Button
-                      type='button'
-                      variant='secondary'
-                      size='sm'
-                      className='w-full'
-                      loading={isFetchingNextPage}
-                      onClick={() => {
-                        fetchNextPage().catch(() => {});
-                      }}
-                    >
-                      Load More Users
-                    </Button>
-                  ) : null}
+      <AdminTableShell
+        testId='admin-users-content'
+        className='rounded-none border-0'
+        toolbar={
+          <>
+            <TableBulkActionsToolbar
+              selectedCount={selectedCount}
+              onClearSelection={clearSelection}
+              actions={bulkActions}
+            />
+            <AdminTableHeader
+              title='Users'
+              subtitle='Review lifecycle state, profile completion, and suppression health.'
+            />
+            <AdminTableSubheader
+              start={
+                <div className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+                  Showing {from.toLocaleString()}–{to.toLocaleString()} of{' '}
+                  {total.toLocaleString()} users
                 </div>
+              }
+              end={
+                <div className={PAGE_TOOLBAR_END_GROUP_CLASS}>
+                  <ExportCSVButton<AdminUserRow>
+                    getData={() => users}
+                    columns={usersCSVColumns}
+                    filename={USERS_CSV_FILENAME_PREFIX}
+                    disabled={users.length === 0}
+                    ariaLabel='Export users to CSV file'
+                    chrome='page-toolbar'
+                    iconOnly
+                    tooltipLabel='Export'
+                  />
+                </div>
+              }
+            />
+          </>
+        }
+      >
+        {() =>
+          isMobile ? (
+            <div className='space-y-2 p-3'>
+              {users.length === 0 ? (
+                <ContentSurfaceCard className='flex flex-col items-center gap-3 bg-surface-0 px-4 py-10 text-center'>
+                  <Users className='h-6 w-6' />
+                  <div>
+                    <div className='text-sm font-semibold tracking-tight text-primary-token'>
+                      No users found
+                    </div>
+                    <div className='text-xs text-secondary-token'>
+                      Users will appear here once they sign up.
+                    </div>
+                  </div>
+                </ContentSurfaceCard>
               ) : (
-                <AdminDataTable
-                  data={users}
-                  columns={columns}
-                  rowSelection={rowSelection}
-                  isLoading={false}
-                  emptyState={
-                    <ContentSurfaceCard className='mx-4 my-6 flex flex-col items-center gap-3 bg-surface-0 px-4 py-10 text-center'>
-                      <Users className='h-6 w-6' />
-                      <div>
-                        <div className='text-sm font-semibold tracking-tight text-primary-token'>
-                          No users found
-                        </div>
-                        <div className='text-xs text-secondary-token'>
-                          Users will appear here once they sign up.
-                        </div>
-                      </div>
-                    </ContentSurfaceCard>
-                  }
-                  getRowId={row => row.id}
-                  getRowClassName={getRowClassName}
-                  onRowClick={handleRowClick}
-                  onFocusedRowChange={handleFocusedRowChange}
-                  getContextMenuItems={getContextMenuItems}
-                  hasNextPage={hasNextPage}
-                  isFetchingNextPage={isFetchingNextPage}
-                  onLoadMore={() => {
+                users.map(user => (
+                  <AdminUserMobileCard
+                    key={user.id}
+                    user={user}
+                    isSelected={selectedIds.has(user.id)}
+                    onToggleSelect={toggleSelect}
+                    contextMenuItems={getContextMenuItems(user)}
+                  />
+                ))
+              )}
+
+              {hasNextPage ? (
+                <Button
+                  type='button'
+                  variant='secondary'
+                  size='sm'
+                  className='w-full'
+                  loading={isFetchingNextPage}
+                  onClick={() => {
                     fetchNextPage().catch(() => {});
                   }}
-                />
-              )
-            }
-          </AdminTableShell>
-        </div>
-        <AdminUserDetailDrawer
-          user={selectedUser}
-          onClose={() => setSelectedUser(null)}
-          contextMenuItems={
-            selectedUser
-              ? convertToCommonDropdownItems(getContextMenuItems(selectedUser))
-              : undefined
-          }
-        />
-      </div>
+                >
+                  Load More Users
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <AdminDataTable
+              data={users}
+              columns={columns}
+              rowSelection={rowSelection}
+              isLoading={false}
+              emptyState={
+                <ContentSurfaceCard className='mx-4 my-6 flex flex-col items-center gap-3 bg-surface-0 px-4 py-10 text-center'>
+                  <Users className='h-6 w-6' />
+                  <div>
+                    <div className='text-sm font-semibold tracking-tight text-primary-token'>
+                      No users found
+                    </div>
+                    <div className='text-xs text-secondary-token'>
+                      Users will appear here once they sign up.
+                    </div>
+                  </div>
+                </ContentSurfaceCard>
+              }
+              getRowId={row => row.id}
+              getRowClassName={getRowClassName}
+              onRowClick={handleRowClick}
+              onFocusedRowChange={handleFocusedRowChange}
+              getContextMenuItems={getContextMenuItems}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              onLoadMore={() => {
+                fetchNextPage().catch(() => {});
+              }}
+            />
+          )
+        }
+      </AdminTableShell>
 
       {/* Ban confirmation dialog with reason */}
       <AlertDialog

--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -5,6 +5,7 @@ import { ClipboardCopy, MessageSquareText, XCircle } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { TruncatedText } from '@/components/atoms/TruncatedText';
 import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
+import { useAdminPeopleRightPanel } from '@/components/features/admin/AdminPeopleRightPanelProvider';
 import { toast } from '@/components/feedback';
 import {
   DrawerCardActionBar,
@@ -183,6 +184,140 @@ function formatDismissedLabel(dismissedAtIso: string | null): string {
   return `Dismissed ${new Date(dismissedAtIso).toLocaleString()}`;
 }
 
+function AdminFeedbackDetailPanel({
+  selected,
+  isDismissPending,
+  dismissRow,
+  copyRowAsMarkdown,
+  onClose,
+}: {
+  readonly selected: FeedbackRow | null;
+  readonly isDismissPending: (id: string) => boolean;
+  readonly dismissRow: (item: FeedbackRow) => Promise<void>;
+  readonly copyRowAsMarkdown: (item: FeedbackRow) => Promise<void>;
+  readonly onClose: () => void;
+}) {
+  return (
+    <EntitySidebarShell
+      isOpen={Boolean(selected)}
+      width={560}
+      ariaLabel='Feedback details'
+      scrollStrategy='shell'
+      onClose={onClose}
+      headerMode='minimal'
+      hideMinimalHeaderBar
+      isEmpty={!selected}
+      emptyMessage='Select a feedback row to view details.'
+      entityHeader={
+        selected ? (
+          <DrawerSurfaceCard variant='card' className='overflow-hidden p-3.5'>
+            <EntityHeaderCard
+              eyebrow='Feedback'
+              title={getFeedbackUserLabel(selected.user)}
+              subtitle={selected.user.email ?? 'No email available'}
+              meta={
+                <div className='space-y-1 text-xs leading-4 text-secondary-token'>
+                  <p>
+                    Source: {selected.source} ·{' '}
+                    {new Date(selected.createdAtIso).toLocaleString()}
+                  </p>
+                  <p className='text-tertiary-token'>
+                    {selected.status === 'dismissed'
+                      ? formatDismissedLabel(selected.dismissedAtIso)
+                      : 'Marked as pending'}
+                  </p>
+                </div>
+              }
+              actions={
+                <DrawerCardActionBar
+                  primaryActions={
+                    [
+                      ...(selected.status === 'dismissed'
+                        ? []
+                        : [
+                            {
+                              id: 'dismiss-feedback',
+                              label: 'Dismiss',
+                              icon: XCircle,
+                              disabled: isDismissPending(selected.id),
+                              onClick: () => {
+                                dismissRow(selected);
+                              },
+                            } satisfies DrawerHeaderAction,
+                          ]),
+                      {
+                        id: 'copy-feedback-markdown',
+                        label: 'Copy As Markdown',
+                        icon: ClipboardCopy,
+                        onClick: () => {
+                          copyRowAsMarkdown(selected);
+                        },
+                      } satisfies DrawerHeaderAction,
+                    ] satisfies readonly DrawerHeaderAction[]
+                  }
+                  onClose={onClose}
+                  overflowTriggerPlacement='card-top-right'
+                  overflowTriggerIcon='vertical'
+                  className='border-0 bg-transparent px-0 py-0'
+                />
+              }
+              bodyClassName='pr-9'
+            />
+          </DrawerSurfaceCard>
+        ) : undefined
+      }
+    >
+      {selected ? (
+        <>
+          <DrawerSection title='User' className='space-y-1.5' surface='card'>
+            <div className='space-y-1'>
+              <DrawerPropertyRow
+                label='User'
+                labelWidth={84}
+                value={getFeedbackUserLabel(selected.user)}
+              />
+              <DrawerPropertyRow
+                label='Email'
+                labelWidth={84}
+                value={selected.user.email ?? 'No email available'}
+              />
+              <DrawerPropertyRow
+                label='Clerk ID'
+                labelWidth={84}
+                value={selected.user.clerkId ?? 'N/A'}
+              />
+            </div>
+          </DrawerSection>
+
+          <DrawerSection
+            title='Feedback'
+            collapsible={false}
+            className='space-y-1.5'
+            surface='card'
+          >
+            <div className='rounded-md bg-surface-0 px-2.5 py-2 text-xs leading-[19px] whitespace-pre-wrap text-primary-token'>
+              {selected.message}
+            </div>
+          </DrawerSection>
+
+          <DrawerSection
+            title='Context'
+            collapsible={false}
+            className='space-y-1.5'
+            surface='card'
+          >
+            <div className='overflow-auto rounded-md bg-surface-0 p-0'>
+              <pre className='p-2.5 text-3xs leading-4 text-secondary-token'>
+                {JSON.stringify(selected.context, null, 2)}
+              </pre>
+            </div>
+          </DrawerSection>
+        </>
+      ) : null}
+    </EntitySidebarShell>
+  );
+}
+
 export function AdminFeedbackTable({
   items,
   loadError = null,
@@ -295,179 +430,71 @@ export function AdminFeedbackTable({
     [selectedId]
   );
 
-  return (
-    <div className='flex h-full min-h-155 overflow-hidden'>
-      <div className='h-full w-full border-r border-subtle bg-(--app-shell-content-surface) lg:w-[58%]'>
-        <AdminTableHeader
-          title='Feedback'
-          subtitle='Triage product feedback and close the loop with clear status.'
-        />
-        <AdminTableSubheader
-          start={
-            <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
-              {rows.length} item{rows.length === 1 ? '' : 's'}
-            </span>
-          }
-          end={
-            <PageToolbarActionButton
-              label='Copy All As Markdown'
-              ariaLabel='Copy all feedback as Markdown'
-              tooltipLabel='Copy all as Markdown'
-              iconOnly
-              disabled={rows.length === 0}
-              onClick={copyAllAsMarkdown}
-              icon={<ClipboardCopy className='h-3.5 w-3.5' />}
-            />
-          }
-        />
-        <AdminTableShell testId='admin-feedback-table'>
-          {() => (
-            <AdminDataTable
-              data={rows}
-              columns={columns}
-              getRowId={row => row.id}
-              getRowClassName={getRowClassName}
-              onRowClick={row => setSelectedId(row.id)}
-              onFocusedRowChange={handleFocusedRowChange}
-              getContextMenuItems={getContextMenuItems}
-              emptyState={
-                <TableEmptyState
-                  icon={
-                    <MessageSquareText className='h-5 w-5' aria-hidden='true' />
-                  }
-                  title={
-                    loadError ? 'Feedback unavailable' : 'No feedback found'
-                  }
-                  description={
-                    loadError
-                      ? 'The feedback table could not load. Check the server logs before treating this as zero feedback.'
-                      : 'New feedback will appear here once users submit it.'
-                  }
-                  className='min-h-55 rounded-none border-x-0 border-b-0 shadow-none'
-                />
-              }
-            />
-          )}
-        </AdminTableShell>
-      </div>
-
-      <EntitySidebarShell
-        isOpen={Boolean(selected)}
-        width={560}
-        ariaLabel='Feedback details'
-        scrollStrategy='shell'
+  const detailPanel = useMemo(
+    () => (
+      <AdminFeedbackDetailPanel
+        selected={selected}
+        isDismissPending={isDismissPending}
+        dismissRow={dismissRow}
+        copyRowAsMarkdown={copyRowAsMarkdown}
         onClose={() => setSelectedId(null)}
-        headerMode='minimal'
-        hideMinimalHeaderBar
-        isEmpty={!selected}
-        emptyMessage='Select a feedback row to view details.'
-        entityHeader={
-          selected ? (
-            <DrawerSurfaceCard variant='card' className='overflow-hidden p-3.5'>
-              <EntityHeaderCard
-                eyebrow='Feedback'
-                title={getFeedbackUserLabel(selected.user)}
-                subtitle={selected.user.email ?? 'No email available'}
-                meta={
-                  <div className='space-y-1 text-xs leading-4 text-secondary-token'>
-                    <p>
-                      Source: {selected.source} ·{' '}
-                      {new Date(selected.createdAtIso).toLocaleString()}
-                    </p>
-                    <p className='text-tertiary-token'>
-                      {selected.status === 'dismissed'
-                        ? formatDismissedLabel(selected.dismissedAtIso)
-                        : 'Marked as pending'}
-                    </p>
-                  </div>
-                }
-                actions={
-                  <DrawerCardActionBar
-                    primaryActions={
-                      [
-                        ...(selected.status === 'dismissed'
-                          ? []
-                          : [
-                              {
-                                id: 'dismiss-feedback',
-                                label: 'Dismiss',
-                                icon: XCircle,
-                                disabled: isDismissPending(selected.id),
-                                onClick: () => {
-                                  dismissRow(selected);
-                                },
-                              } satisfies DrawerHeaderAction,
-                            ]),
-                        {
-                          id: 'copy-feedback-markdown',
-                          label: 'Copy As Markdown',
-                          icon: ClipboardCopy,
-                          onClick: () => {
-                            copyRowAsMarkdown(selected);
-                          },
-                        } satisfies DrawerHeaderAction,
-                      ] satisfies readonly DrawerHeaderAction[]
-                    }
-                    onClose={() => setSelectedId(null)}
-                    overflowTriggerPlacement='card-top-right'
-                    overflowTriggerIcon='vertical'
-                    className='border-0 bg-transparent px-0 py-0'
-                  />
-                }
-                bodyClassName='pr-9'
-              />
-            </DrawerSurfaceCard>
-          ) : undefined
+      />
+    ),
+    [copyRowAsMarkdown, dismissRow, isDismissPending, selected]
+  );
+  useAdminPeopleRightPanel(detailPanel);
+
+  return (
+    <div className='h-full min-h-155 overflow-hidden bg-(--app-shell-content-surface)'>
+      <AdminTableHeader
+        title='Feedback'
+        subtitle='Triage product feedback and close the loop with clear status.'
+      />
+      <AdminTableSubheader
+        start={
+          <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+            {rows.length} item{rows.length === 1 ? '' : 's'}
+          </span>
         }
-      >
-        {selected ? (
-          <>
-            <DrawerSection title='User' className='space-y-1.5' surface='card'>
-              <div className='space-y-1'>
-                <DrawerPropertyRow
-                  label='User'
-                  labelWidth={84}
-                  value={getFeedbackUserLabel(selected.user)}
-                />
-                <DrawerPropertyRow
-                  label='Email'
-                  labelWidth={84}
-                  value={selected.user.email ?? 'No email available'}
-                />
-                <DrawerPropertyRow
-                  label='Clerk ID'
-                  labelWidth={84}
-                  value={selected.user.clerkId ?? 'N/A'}
-                />
-              </div>
-            </DrawerSection>
-
-            <DrawerSection
-              title='Feedback'
-              collapsible={false}
-              className='space-y-1.5'
-              surface='card'
-            >
-              <div className='rounded-md bg-surface-0 px-2.5 py-2 text-xs leading-[19px] whitespace-pre-wrap text-primary-token'>
-                {selected.message}
-              </div>
-            </DrawerSection>
-
-            <DrawerSection
-              title='Context'
-              collapsible={false}
-              className='space-y-1.5'
-              surface='card'
-            >
-              <div className='overflow-auto rounded-md bg-surface-0 p-0'>
-                <pre className='p-2.5 text-3xs leading-4 text-secondary-token'>
-                  {JSON.stringify(selected.context, null, 2)}
-                </pre>
-              </div>
-            </DrawerSection>
-          </>
-        ) : null}
-      </EntitySidebarShell>
+        end={
+          <PageToolbarActionButton
+            label='Copy All As Markdown'
+            ariaLabel='Copy all feedback as Markdown'
+            tooltipLabel='Copy all as Markdown'
+            iconOnly
+            disabled={rows.length === 0}
+            onClick={copyAllAsMarkdown}
+            icon={<ClipboardCopy className='h-3.5 w-3.5' />}
+          />
+        }
+      />
+      <AdminTableShell testId='admin-feedback-table'>
+        {() => (
+          <AdminDataTable
+            data={rows}
+            columns={columns}
+            getRowId={row => row.id}
+            getRowClassName={getRowClassName}
+            onRowClick={row => setSelectedId(row.id)}
+            onFocusedRowChange={handleFocusedRowChange}
+            getContextMenuItems={getContextMenuItems}
+            emptyState={
+              <TableEmptyState
+                icon={
+                  <MessageSquareText className='h-5 w-5' aria-hidden='true' />
+                }
+                title={loadError ? 'Feedback unavailable' : 'No feedback found'}
+                description={
+                  loadError
+                    ? 'The feedback table could not load. Check the server logs before treating this as zero feedback.'
+                    : 'New feedback will appear here once users submit it.'
+                }
+                className='min-h-55 rounded-none border-x-0 border-b-0 shadow-none'
+              />
+            }
+          />
+        )}
+      </AdminTableShell>
     </div>
   );
 }

--- a/apps/web/tests/unit/components/admin/AdminPeopleRightPanelProvider.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminPeopleRightPanelProvider.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  RightPanelProvider,
+  useRightPanel,
+} from '@/contexts/RightPanelContext';
+import {
+  AdminPeopleRightPanelProvider,
+  useAdminPeopleRightPanel,
+} from '@/features/admin/AdminPeopleRightPanelProvider';
+
+function RightPanelOutlet() {
+  return <aside data-testid='global-right-rail'>{useRightPanel()}</aside>;
+}
+
+function AdminPeopleFixture() {
+  const [selection, setSelection] = useState<'user' | 'feedback' | null>(null);
+  useAdminPeopleRightPanel(
+    selection ? (
+      <div data-testid={`${selection}-detail-panel`}>
+        {selection === 'user' ? 'User detail' : 'Feedback detail'}
+      </div>
+    ) : null
+  );
+
+  return (
+    <main data-testid='admin-people-content'>
+      <button type='button' onClick={() => setSelection('user')}>
+        Open User
+      </button>
+      <button type='button' onClick={() => setSelection('feedback')}>
+        Open Feedback
+      </button>
+      <button type='button' onClick={() => setSelection(null)}>
+        Close Detail
+      </button>
+    </main>
+  );
+}
+
+describe('AdminPeopleRightPanelProvider', () => {
+  it('mounts the selected detail panel in the shell rail, outside table content', () => {
+    render(
+      <RightPanelProvider>
+        <AdminPeopleRightPanelProvider>
+          <AdminPeopleFixture />
+        </AdminPeopleRightPanelProvider>
+        <RightPanelOutlet />
+      </RightPanelProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open User' }));
+    const rail = screen.getByTestId('global-right-rail');
+    expect(rail).toContainElement(screen.getByTestId('user-detail-panel'));
+    expect(screen.getByTestId('admin-people-content')).not.toContainElement(
+      screen.getByTestId('user-detail-panel')
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Feedback' }));
+    expect(rail).toContainElement(screen.getByTestId('feedback-detail-panel'));
+    expect(screen.queryByTestId('user-detail-panel')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Detail' }));
+    expect(rail).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/tests/unit/components/admin/AdminUsersTableUnified.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminUsersTableUnified.test.tsx
@@ -3,7 +3,12 @@ import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { HeaderActionsProvider } from '@/contexts/HeaderActionsContext';
+import {
+  RightPanelProvider,
+  useRightPanel,
+} from '@/contexts/RightPanelContext';
 import { TableMetaProvider } from '@/contexts/TableMetaContext';
+import { AdminPeopleRightPanelProvider } from '@/features/admin/AdminPeopleRightPanelProvider';
 import { AdminUsersTableUnified } from '@/features/admin/admin-users-table/AdminUsersTableUnified';
 
 const mockUseBreakpointDown = vi.fn<
@@ -111,6 +116,34 @@ const userRow = {
   suppressionFailedAt: null,
 };
 
+function RightPanelOutlet() {
+  return <div data-testid='global-right-rail'>{useRightPanel()}</div>;
+}
+
+function renderUsersTable() {
+  return render(
+    <TooltipProvider>
+      <RightPanelProvider>
+        <AdminPeopleRightPanelProvider>
+          <HeaderActionsProvider>
+            <TableMetaProvider>
+              <AdminUsersTableUnified
+                users={[userRow]}
+                page={1}
+                pageSize={20}
+                total={1}
+                search=''
+                sort='created_desc'
+              />
+            </TableMetaProvider>
+          </HeaderActionsProvider>
+        </AdminPeopleRightPanelProvider>
+        <RightPanelOutlet />
+      </RightPanelProvider>
+    </TooltipProvider>
+  );
+}
+
 describe('AdminUsersTableUnified', () => {
   it('renders mobile cards on small screens', () => {
     mockUseBreakpointDown.mockReturnValue(true);
@@ -129,22 +162,7 @@ describe('AdminUsersTableUnified', () => {
       clearSelection: vi.fn(),
     });
 
-    render(
-      <TooltipProvider>
-        <HeaderActionsProvider>
-          <TableMetaProvider>
-            <AdminUsersTableUnified
-              users={[userRow]}
-              page={1}
-              pageSize={20}
-              total={1}
-              search=''
-              sort='created_desc'
-            />
-          </TableMetaProvider>
-        </HeaderActionsProvider>
-      </TooltipProvider>
-    );
+    renderUsersTable();
 
     expect(screen.getByText('Ari Lane')).toBeInTheDocument();
     expect(screen.getByLabelText('Select Ari Lane')).toBeInTheDocument();
@@ -168,22 +186,7 @@ describe('AdminUsersTableUnified', () => {
       clearSelection: vi.fn(),
     });
 
-    render(
-      <TooltipProvider>
-        <HeaderActionsProvider>
-          <TableMetaProvider>
-            <AdminUsersTableUnified
-              users={[userRow]}
-              page={1}
-              pageSize={20}
-              total={1}
-              search=''
-              sort='created_desc'
-            />
-          </TableMetaProvider>
-        </HeaderActionsProvider>
-      </TooltipProvider>
-    );
+    renderUsersTable();
 
     expect(screen.getByTestId('desktop-table')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- register the active Admin People detail surface through one route-level shared right-panel adapter
- remove local Users and Feedback rail mounts so desktop allocation stays in AppShellRightRail
- add a contract test for selection, tab replacement, close cleanup, and rail placement outside content

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/admin/AdminUsersTableUnified.test.tsx tests/unit/components/admin/AdminPeopleRightPanelProvider.test.tsx` (3/3)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check <changed paths>`
- `git diff --check`

Taste review is advisory; deterministic CI/native queue owns admission.