### PR TITLE
fix(profile): stabilize compact row disclosure [JOV-4617]

### DIFF
--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -746,6 +746,8 @@ export function ProfilePacCard({
     state.kind === 'prompt' ||
     state.kind === 'submitting' ||
     state.kind === 'error';
+  const usesFullWidthCaptureLayout =
+    isProfileLandscape && (isCaptureState || state.kind === 'success');
 
   // Art zone: state-relevant artwork. The merch state shows the merch image;
   // every other state shows the release artwork (artist image as fallback).
@@ -782,7 +784,7 @@ export function ProfilePacCard({
       data-dismiss-affordance={assignment.dismissAffordance}
       data-layout={layout}
       className={cn(
-        'flex h-full w-full min-w-0 overflow-hidden rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl',
+        'relative flex h-full w-full min-w-0 overflow-hidden rounded-(--profile-inner-radius) border border-(--profile-pearl-border) bg-(--profile-pearl-bg) shadow-(--profile-pearl-shadow) backdrop-blur-2xl',
         isProfileLandscape ? 'flex-row p-1.5' : 'flex-col',
         className
       )}
@@ -791,7 +793,10 @@ export function ProfilePacCard({
         className={cn(
           'relative aspect-square flex-none overflow-hidden bg-surface-2',
           isProfileLandscape
-            ? cn('self-stretch w-auto rounded', isCaptureState && 'hidden')
+            ? cn(
+                'self-stretch w-auto rounded',
+                usesFullWidthCaptureLayout && 'invisible'
+              )
             : 'w-full border-b border-subtle'
         )}
       >
@@ -819,7 +824,11 @@ export function ProfilePacCard({
       <div
         className={cn(
           'flex min-h-0 min-w-0 flex-1 flex-col gap-1.5',
-          isProfileLandscape ? 'justify-center py-2 pl-3 pr-2' : 'px-3 py-1.5'
+          isProfileLandscape
+            ? usesFullWidthCaptureLayout
+              ? 'absolute inset-1.5 z-10 justify-center p-2'
+              : 'justify-center py-2 pl-3 pr-2'
+            : 'px-3 py-1.5'
         )}
       >
         {/* Text zone — clips under tight card heights so the action footer

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -239,10 +239,14 @@ describe('EntityCarousel profile geometry', () => {
 
     const previous = screen.getByRole('button', { name: 'Previous Item' });
     const next = screen.getByRole('button', { name: 'Next Item' });
+    expect(carousel.parentElement).toHaveClass('h-fit');
     expect(previous).toBeDisabled();
     expect(next).toBeEnabled();
+    expect(previous.className).toContain(
+      '[@media(min-width:768px)_and_(hover:hover)_and_(pointer:fine)]:inline-flex'
+    );
+    expect(next.className).not.toContain('md:inline-flex');
     expect(previous.className).toContain('group-hover/carousel:opacity-100');
-    expect(next.className).toContain('md:inline-flex');
     expect(screen.getByText('Item 1 of 2')).toBeInTheDocument();
 
     fireEvent.click(next);

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -200,7 +200,12 @@ export function EntityCarousel({
   );
 
   return (
-    <div className='group/carousel relative h-full min-h-0'>
+    <div
+      className={cn(
+        'group/carousel relative min-h-0',
+        layout === 'profile-landscape' ? 'h-fit w-full' : 'h-full'
+      )}
+    >
       <ul
         ref={trackRef}
         className={cn(
@@ -268,7 +273,7 @@ export function EntityCarousel({
             aria-label='Previous Item'
             disabled={currentIndex === 0}
             onClick={() => scrollToIndex(currentIndex - 1)}
-            className='absolute left-1 top-1/2 z-10 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-secondary-token opacity-0 shadow-(--profile-pearl-shadow) backdrop-blur-xl transition-opacity duration-subtle hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:pointer-events-none disabled:invisible group-focus-within/carousel:opacity-100 group-hover/carousel:opacity-100 md:inline-flex'
+            className='absolute left-1 top-1/2 z-10 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-secondary-token opacity-0 shadow-(--profile-pearl-shadow) backdrop-blur-xl transition-opacity duration-subtle [@media(min-width:768px)_and_(hover:hover)_and_(pointer:fine)]:inline-flex hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:pointer-events-none disabled:invisible group-focus-within/carousel:opacity-100 group-hover/carousel:opacity-100'
           >
             <ChevronLeft className='h-4 w-4' aria-hidden='true' />
           </button>
@@ -277,7 +282,7 @@ export function EntityCarousel({
             aria-label='Next Item'
             disabled={currentIndex === slotCount - 1}
             onClick={() => scrollToIndex(currentIndex + 1)}
-            className='absolute right-1 top-1/2 z-10 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-secondary-token opacity-0 shadow-(--profile-pearl-shadow) backdrop-blur-xl transition-opacity duration-subtle hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:pointer-events-none disabled:invisible group-focus-within/carousel:opacity-100 group-hover/carousel:opacity-100 md:inline-flex'
+            className='absolute right-1 top-1/2 z-10 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-secondary-token opacity-0 shadow-(--profile-pearl-shadow) backdrop-blur-xl transition-opacity duration-subtle [@media(min-width:768px)_and_(hover:hover)_and_(pointer:fine)]:inline-flex hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:pointer-events-none disabled:invisible group-focus-within/carousel:opacity-100 group-hover/carousel:opacity-100'
           >
             <ChevronRight className='h-4 w-4' aria-hidden='true' />
           </button>

--- a/apps/web/tests/unit/profile/ProfilePacCard.layout.test.tsx
+++ b/apps/web/tests/unit/profile/ProfilePacCard.layout.test.tsx
@@ -92,6 +92,9 @@ describe('ProfilePacCard landscape states', () => {
       screen.getByRole('textbox', { name: /email address/i })
     ).toBeVisible();
     expect(screen.getByRole('button', { name: 'Get Updates' })).toBeVisible();
-    expect(card.querySelector('.aspect-square')).toHaveClass('hidden');
+    expect(card.querySelector('.aspect-square')).toHaveClass('invisible');
+    expect(screen.getByRole('textbox').closest('.absolute')).toHaveClass(
+      'inset-1.5'
+    );
   });
 });

--- a/design-qa.md
+++ b/design-qa.md
@@ -68,7 +68,7 @@ is tracked as candidate follow-up JOV-4627.
 - [Mobile implementation](docs/screenshots/profile-latest/profile-rows-after-mobile-final.png)
 - [Mobile side-by-side](docs/screenshots/profile-latest/profile-rows-comparison-mobile-final.png)
 - [Desktop implementation](docs/screenshots/profile-latest/profile-rows-after-desktop-final.png)
-- [Desktop implementation after progressive-disclosure control verification](docs/screenshots/profile-latest/profile-rows-after-desktop-controls-final.png)
+- [Desktop implementation used for control-geometry verification](docs/screenshots/profile-latest/profile-rows-after-desktop-controls-final.png)
 - [Desktop side-by-side](docs/screenshots/profile-latest/profile-rows-comparison-desktop-final.png)
 - [Selected catalog item](docs/screenshots/profile-latest/profile-rows-mobile-second-item-v1.png)
 
@@ -85,10 +85,12 @@ is tracked as candidate follow-up JOV-4627.
    preview and DSP destinations.
 5. Mobile 390 × 844 and desktop 1440 × 900 comparisons found no clipped
    content, awkward wraps, dock movement, or profile-shell layout shift.
-6. The release review found two discovery/state gaps before merge. Capture
-   states now suppress nonessential art so the email form owns the narrow copy
-   column, and desktop previous/next controls reveal on hover or focus while
-   preserving the chromeless resting state.
+6. The release reviews found three disclosure/layout gaps before merge.
+   Capture and success states now keep the media slot invisibly reserved while
+   an absolute overlay uses the full row, preserving geometry. Previous/next
+   controls are centered to the compact row wrapper and only display for
+   fine-pointer hover-capable devices, while keyboard focus and touch swipe
+   retain their native paths.
 
 ## Severity audit
 


### PR DESCRIPTION
## Summary

Follow-up to #15236 after the merge queue landed the primary redesign before the final independent review corrections were pushed.

- centers previous/next controls on the compact 9:4 row instead of the full stage
- displays those controls only on fine-pointer, hover-capable desktop devices
- preserves the PAC media slot invisibly while capture/success overlays use the full row, preventing layout shift

## Verification

- pre-push typecheck and lint passed
- affected tests: 6 files, 29 tests passed
- CI harness validation passed
- focused carousel/PAC tests: 12 tests passed
- live browser geometry: row center and control center matched exactly (0px delta)
- independent review: 3 findings, 3 fixed

## Release state

Draft until required CI is green and the land-and-deploy dry run is confirmed.

<!-- linear-issue-id:460b8954-06e2-42a1-9a49-7e5edd880200 -->