### PR TITLE
test: send trusted origin for protected OAuth smoke

### DIFF
--- a/apps/web/tests/e2e/smoke-prod-auth.spec.ts
+++ b/apps/web/tests/e2e/smoke-prod-auth.spec.ts
@@ -210,6 +210,10 @@ async function verifyProductionIosOAuthTokenFlow(
     const initialTokens = await readOAuthTokenSet(
       await request.post(`${expectedOrigin}/api/auth/oauth2/token`, {
         failOnStatusCode: false,
+        // The exact Vercel deployment is protected by an origin-bound bypass
+        // cookie. Better Auth therefore requires a trusted Origin on POST even
+        // though the real native client has no cookies.
+        headers: { origin: expectedOrigin },
         form: {
           grant_type: 'authorization_code',
           client_id: IOS_OAUTH_CLIENT_ID,
@@ -232,6 +236,7 @@ async function verifyProductionIosOAuthTokenFlow(
     const refreshedTokens = await readOAuthTokenSet(
       await request.post(`${expectedOrigin}/api/auth/oauth2/token`, {
         failOnStatusCode: false,
+        headers: { origin: expectedOrigin },
         form: {
           grant_type: 'refresh_token',
           client_id: IOS_OAUTH_CLIENT_ID,
@@ -253,6 +258,7 @@ async function verifyProductionIosOAuthTokenFlow(
         `${expectedOrigin}/api/auth/oauth2/revoke`,
         {
           failOnStatusCode: false,
+          headers: { origin: expectedOrigin },
           form: {
             client_id: IOS_OAUTH_CLIENT_ID,
             token: value,

--- a/apps/web/tests/unit/e2e/production-auth-smoke-serialization.test.ts
+++ b/apps/web/tests/unit/e2e/production-auth-smoke-serialization.test.ts
@@ -27,6 +27,9 @@ describe('production auth smoke session contract', () => {
     ).toHaveLength(1);
     expect(source).toContain("grant_type: 'authorization_code'");
     expect(source).toContain("grant_type: 'refresh_token'");
+    expect(source.match(/headers: \{ origin: expectedOrigin \}/g)).toHaveLength(
+      3
+    );
     expect(source).toContain('/api/auth/oauth2/userinfo');
     expect(source).toContain('/api/auth/oauth2/revoke');
     expect(source).toContain('recordPlaywrightSensitiveValues(');


### PR DESCRIPTION
## Why
Production Controller run 30601148717 completed rendered sign-in and authorization, then the exact-build OAuth token exchange failed with HTTP 403 on all three attempts. The protected Vercel deployment gives Playwright an origin-bound bypass cookie; Better Auth therefore applies its cookie CSRF check and requires a trusted Origin header on POST. The real native client sends no cookies, so this is a protected-smoke transport mismatch rather than an iOS OAuth runtime change.

## Change
- send the exact trusted deployment origin on authorization-code, refresh-token, and revoke POSTs in the protected production smoke
- lock the three protected POSTs into the serialization contract test
- leave product/runtime and workflow code unchanged

## Validation
- pnpm --filter @jovie/web test -- --run tests/unit/e2e/production-auth-smoke-serialization.test.ts
- pnpm --filter @jovie/web typecheck
- pnpm --filter @jovie/web lint

A local exact-deployment replay was unavailable because this identity cannot read restricted production smoke secrets; Production Controller owns the credentialed end-to-end proof.