### PR TITLE
feat(connections): polish profiles workspace

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -1,4 +1,6 @@
+import { TooltipProvider } from '@jovie/ui';
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import type { ProfilesWorkspaceData } from './data';
@@ -60,7 +62,8 @@ const data: ProfilesWorkspaceData = {
       handle: 'tim@example.com',
       url: '/app/settings/connectors',
       status: 'connected',
-      primaryIssue: 'Connected',
+      monitoringState: 'active',
+      primaryIssue: 'Active',
       primaryAction: 'open',
     },
   ],
@@ -72,9 +75,17 @@ const data: ProfilesWorkspaceData = {
   providerAvailable: true,
 };
 
+function renderWorkspace(workspaceData: ProfilesWorkspaceData | null) {
+  return render(
+    <TooltipProvider>
+      <ProfilesWorkspace data={workspaceData} />
+    </TooltipProvider>
+  );
+}
+
 describe('ProfilesWorkspace', () => {
   it('uses the canonical empty state with a direct artist-profile action', () => {
-    render(<ProfilesWorkspace data={null} />);
+    renderWorkspace(null);
 
     expect(
       screen.getByTestId('profiles-workspace-empty-state')
@@ -87,21 +98,74 @@ describe('ProfilesWorkspace', () => {
     ).toHaveAttribute('href', '/app/settings/artist-profile');
   });
 
-  it('filters the unified table without exposing locked rank values', () => {
-    render(<ProfilesWorkspace data={data} />);
+  it('renders a connection summary and filters without exposing locked ranks', () => {
+    renderWorkspace(data);
 
     expect(vi.mocked(useRegisterRightPanel)).toHaveBeenLastCalledWith(null);
     expect(screen.getByText('Jovie Profile')).toBeInTheDocument();
     expect(screen.getByText('Spotify')).toBeInTheDocument();
     expect(screen.queryByText('7')).not.toBeInTheDocument();
-    expect(screen.getByText('1 of 5 monitored')).toBeInTheDocument();
+    expect(screen.getByText('3 Connections')).toBeInTheDocument();
+    expect(screen.getByText('Monitored 1/5')).toBeInTheDocument();
+    expect(screen.getByText('Needs Attention 1')).toBeInTheDocument();
+    expect(screen.getByText('Monitoring Active')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'DSP connection type' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Requires Upgrade')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'DSP' }));
+    fireEvent.click(screen.getByRole('button', { name: 'DSPs' }));
     expect(screen.getByText('Spotify')).toBeInTheDocument();
     expect(screen.queryByText('Jovie Profile')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Connectors' }));
     expect(screen.getByText('Gmail')).toBeInTheDocument();
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('opens connection-specific details from the row action', () => {
+    renderWorkspace(data);
+
+    const action = screen.getByRole('button', {
+      name: 'Actions for Spotify',
+    });
+    expect(action.parentElement).toHaveClass('sm:opacity-0');
+
+    fireEvent.click(action);
+    const panel = vi.mocked(useRegisterRightPanel).mock.calls.at(-1)?.[0];
+    expect(panel).not.toBeNull();
+
+    render(<TooltipProvider>{panel as ReactElement}</TooltipProvider>);
+    expect(
+      screen.getByRole('complementary', { name: 'Connection details' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Next Best Action')).toBeInTheDocument();
+    expect(
+      screen.getByText('Upgrade the monitoring limit to track this connection.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Upgrade' })).toHaveAttribute(
+      'href',
+      '/app/settings/billing'
+    );
+  });
+
+  it('preserves the compact mobile table contract', () => {
+    renderWorkspace(data);
+
+    expect(screen.getByRole('columnheader', { name: 'Rank' })).toHaveClass(
+      'max-md:hidden'
+    );
+    expect(screen.getByRole('columnheader', { name: 'Change' })).toHaveClass(
+      'max-lg:hidden'
+    );
+    expect(
+      screen.getByRole('columnheader', { name: 'Monitoring' })
+    ).toHaveClass('max-xl:hidden');
+    expect(screen.getByText('tim@example.com')).toHaveClass('max-sm:hidden');
+
+    const summary = screen.getByTestId('connections-summary');
+    expect(summary.parentElement).toHaveClass('overflow-x-auto');
+    expect(screen.getByText('Best Rank #2')).toHaveClass('max-sm:hidden');
+    expect(screen.getByText('Monitoring Active')).toHaveClass('max-sm:hidden');
   });
 });

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -32,8 +32,6 @@ const data: ProfilesWorkspaceData = {
       rank: 2,
       previousRank: 4,
       lastObservedAt: '2026-07-16T00:00:00.000Z',
-      primaryIssue: 'No issues',
-      primaryAction: 'open',
     },
     {
       id: 'spotify',
@@ -50,8 +48,6 @@ const data: ProfilesWorkspaceData = {
       rank: 7,
       previousRank: 9,
       lastObservedAt: '2026-07-16T00:00:00.000Z',
-      primaryIssue: 'Monitoring limit',
-      primaryAction: 'upgrade',
     },
     {
       id: 'gmail',
@@ -63,8 +59,6 @@ const data: ProfilesWorkspaceData = {
       url: '/app/settings/connectors',
       status: 'connected',
       monitoringState: 'active',
-      primaryIssue: 'Active',
-      primaryAction: 'open',
     },
   ],
   monitoringLimit: 5,
@@ -98,7 +92,7 @@ describe('ProfilesWorkspace', () => {
     ).toHaveAttribute('href', '/app/settings/artist-profile');
   });
 
-  it('renders a connection summary and filters without exposing locked ranks', () => {
+  it('renders a connection summary and filters without exposing locked ranks', async () => {
     renderWorkspace(data);
 
     expect(vi.mocked(useRegisterRightPanel)).toHaveBeenLastCalledWith(null);
@@ -109,9 +103,14 @@ describe('ProfilesWorkspace', () => {
     expect(screen.getByText('Monitored 1/5')).toBeInTheDocument();
     expect(screen.getByText('Needs Attention 1')).toBeInTheDocument();
     expect(screen.getByText('Monitoring Active')).toBeInTheDocument();
-    expect(
-      screen.getByRole('img', { name: 'DSP connection type' })
-    ).toBeInTheDocument();
+    const typeTrigger = screen.getByRole('button', {
+      name: 'DSP connection type',
+    });
+    expect(typeTrigger).toBeInTheDocument();
+    fireEvent.focus(typeTrigger);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'DSP connection'
+    );
     expect(screen.getByText('Requires Upgrade')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'DSPs' }));
@@ -147,6 +146,20 @@ describe('ProfilesWorkspace', () => {
       'href',
       '/app/settings/billing'
     );
+  });
+
+  it('clears connection details when the table filter changes', () => {
+    renderWorkspace(data);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Actions for Spotify' })
+    );
+    expect(
+      vi.mocked(useRegisterRightPanel).mock.calls.at(-1)?.[0]
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connectors' }));
+    expect(vi.mocked(useRegisterRightPanel)).toHaveBeenLastCalledWith(null);
   });
 
   it('preserves the compact mobile table contract', () => {

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
+import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { EmptyCell } from '@/components/atoms/EmptyCell';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import {
@@ -40,6 +41,7 @@ import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import {
   filterProfileWorkspaceRows,
   formatProfileRankChange,
+  getConnectionPrimaryAction,
   getConnectionStatus,
   sortProfileWorkspaceRows,
   summarizeProfileWorkspaceRows,
@@ -117,7 +119,13 @@ function ConnectionBrandIcon({
   }
   if (row.kind === 'jovie') {
     return (
-      <ConnectionTypeGlyph row={row} className={cn('text-accent', className)} />
+      <BrandLogo
+        size={20}
+        tone='color'
+        rounded={false}
+        aria-hidden
+        className={cn('[&_svg]:h-full [&_svg]:w-full', className)}
+      />
     );
   }
   return (
@@ -129,18 +137,18 @@ function TypeCell({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
   const label = kindLabel(row);
   return (
     <SimpleTooltip content={`${label} connection`}>
-      <span
-        role='img'
+      <button
+        type='button'
         aria-label={`${label} connection type`}
         className={cn(
-          'inline-flex h-7 w-7 items-center justify-center rounded-full',
+          'inline-flex h-7 w-7 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16',
           row.kind === 'jovie'
             ? 'text-accent'
             : 'text-tertiary-token hover:text-secondary-token'
         )}
       >
         <ConnectionTypeGlyph row={row} />
-      </span>
+      </button>
     </SimpleTooltip>
   );
 }
@@ -226,6 +234,7 @@ function ConnectionRail({
   row: ProfileWorkspaceRow | null;
   onClose: () => void;
 }>) {
+  const primaryAction = row ? getConnectionPrimaryAction(row) : null;
   const rankChange =
     row?.rowType === 'surface'
       ? formatProfileRankChange(row.rank, row.previousRank)
@@ -303,7 +312,12 @@ function ConnectionRail({
               {getConnectionStatus(row).nextAction}
             </p>
           </DrawerSection>
-          <div className='grid grid-cols-2 gap-2 px-1'>
+          <div
+            className={cn(
+              'grid gap-2 px-1',
+              primaryAction === 'open' ? 'grid-cols-1' : 'grid-cols-2'
+            )}
+          >
             <Button asChild variant='secondary' size='sm'>
               <Link
                 href={row.url}
@@ -313,25 +327,27 @@ function ConnectionRail({
                 <ExternalLink className='h-3.5 w-3.5' /> Open
               </Link>
             </Button>
-            <Button asChild size='sm'>
-              <Link
-                href={
-                  row.rowType === 'surface' && row.primaryAction === 'upgrade'
-                    ? APP_ROUTES.SETTINGS_BILLING
-                    : row.rowType === 'connector'
-                      ? APP_ROUTES.SETTINGS_CONNECTORS
-                      : APP_ROUTES.SETTINGS_ARTIST_PROFILE
-                }
-              >
-                {row.primaryAction === 'upgrade'
-                  ? 'Upgrade'
-                  : row.primaryAction === 'connect'
-                    ? 'Connect'
-                    : row.primaryAction === 'reconnect'
-                      ? 'Reconnect'
-                      : 'Review'}
-              </Link>
-            </Button>
+            {primaryAction !== 'open' ? (
+              <Button asChild size='sm'>
+                <Link
+                  href={
+                    primaryAction === 'upgrade'
+                      ? APP_ROUTES.SETTINGS_BILLING
+                      : row.rowType === 'connector'
+                        ? APP_ROUTES.SETTINGS_CONNECTORS
+                        : APP_ROUTES.SETTINGS_ARTIST_PROFILE
+                  }
+                >
+                  {primaryAction === 'upgrade'
+                    ? 'Upgrade'
+                    : primaryAction === 'connect'
+                      ? 'Connect'
+                      : primaryAction === 'reconnect'
+                        ? 'Reconnect'
+                        : 'Review'}
+                </Link>
+              </Button>
+            ) : null}
           </div>
         </div>
       ) : null}
@@ -364,15 +380,19 @@ export function ProfilesWorkspace({
     [data?.rows, filter]
   );
   const summary = useMemo(
-    () => summarizeProfileWorkspaceRows(data?.rows ?? []),
-    [data?.rows]
+    () =>
+      summarizeProfileWorkspaceRows(
+        data?.rows ?? [],
+        data?.providerAvailable ?? false
+      ),
+    [data?.providerAvailable, data?.rows]
   );
   const columns = useMemo(
     () => [
       columnHelper.accessor('label', {
         header: 'Connection',
-        size: 260,
-        minSize: 210,
+        size: 220,
+        minSize: 160,
         cell: context => {
           const row = context.row.original;
           return (
@@ -393,13 +413,13 @@ export function ProfilesWorkspace({
       columnHelper.display({
         id: 'type',
         header: 'Type',
-        size: 52,
+        size: 48,
         cell: context => <TypeCell row={context.row.original} />,
       }),
       columnHelper.accessor(row => getConnectionStatus(row).label, {
         id: 'status',
         header: 'Status / Issue',
-        size: 156,
+        size: 140,
         cell: context => <StatusCell row={context.row.original} />,
       }),
       columnHelper.display({
@@ -464,7 +484,7 @@ export function ProfilesWorkspace({
                 onClick={() => setSelected(row)}
                 ariaLabel={`Actions for ${row.label}`}
                 tooltip='View connection details'
-                className='h-7 w-7'
+                className='h-11 w-11 sm:h-7 sm:w-7'
               />
             </div>
           );
@@ -520,7 +540,10 @@ export function ProfilesWorkspace({
               key={option.id}
               label={option.label}
               active={filter === option.id}
-              onClick={() => setFilter(option.id)}
+              onClick={() => {
+                setFilter(option.id);
+                setSelected(null);
+              }}
             />
           ))}
           end={
@@ -557,7 +580,7 @@ export function ProfilesWorkspace({
         getRowId={row => row.id}
         onRowClick={setSelected}
         rowHeight={56}
-        minWidth='460px'
+        minWidth='390px'
         isRowSelected={row => selected?.id === row.id}
         emptyState={
           <TableEmptyState

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -393,6 +393,7 @@ export function ProfilesWorkspace({
         header: 'Connection',
         size: 220,
         minSize: 160,
+        meta: { className: 'px-2 sm:px-3' },
         cell: context => {
           const row = context.row.original;
           return (
@@ -414,12 +415,14 @@ export function ProfilesWorkspace({
         id: 'type',
         header: 'Type',
         size: 48,
+        meta: { className: 'px-1 sm:px-3' },
         cell: context => <TypeCell row={context.row.original} />,
       }),
       columnHelper.accessor(row => getConnectionStatus(row).label, {
         id: 'status',
         header: 'Status / Issue',
         size: 140,
+        meta: { className: 'px-1 sm:px-3' },
         cell: context => <StatusCell row={context.row.original} />,
       }),
       columnHelper.display({
@@ -475,6 +478,7 @@ export function ProfilesWorkspace({
         id: 'actions',
         header: () => <span className='sr-only'>Actions</span>,
         size: 44,
+        meta: { className: 'px-1 sm:px-3' },
         cell: context => {
           const row = context.row.original;
           return (

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -1,20 +1,24 @@
 'use client';
 
-import { Button } from '@jovie/ui';
+import { Button, SimpleTooltip } from '@jovie/ui';
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import {
   ArrowDownRight,
   ArrowUpRight,
+  AudioWaveform,
+  BookOpen,
   Cable,
   ExternalLink,
   Globe2,
   LockKeyhole,
-  RefreshCw,
+  MoreHorizontal,
+  Orbit,
+  Share2,
   UserRound,
 } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
+import { EmptyCell } from '@/components/atoms/EmptyCell';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import {
   DrawerSection,
@@ -28,6 +32,7 @@ import {
   PageToolbar,
   PageToolbarTabButton,
   TableEmptyState,
+  TableIconButton,
   UnifiedTable,
 } from '@/components/organisms/table';
 import { APP_ROUTES } from '@/constants/routes';
@@ -35,6 +40,9 @@ import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import {
   filterProfileWorkspaceRows,
   formatProfileRankChange,
+  getConnectionStatus,
+  sortProfileWorkspaceRows,
+  summarizeProfileWorkspaceRows,
 } from '@/lib/profile-surfaces/workspace';
 import { cn } from '@/lib/utils';
 import type {
@@ -44,15 +52,18 @@ import type {
 } from './data';
 
 const columnHelper = createColumnHelper<ProfileWorkspaceRow>();
+const DSP_FILTER_LABEL = 'DSPs';
 const FILTERS: ReadonlyArray<{
   id: ProfilesWorkspaceFilter;
   label: string;
 }> = [
   { id: 'all', label: 'All' },
-  { id: 'dsp', label: 'DSP' },
+  { id: 'dsp', label: DSP_FILTER_LABEL },
   { id: 'social', label: 'Social' },
   { id: 'source', label: 'Sources' },
+  { id: 'website', label: 'Websites' },
   { id: 'connector', label: 'Connectors' },
+  { id: 'jovie', label: 'Jovie' },
 ];
 
 function kindLabel(row: ProfileWorkspaceRow): string {
@@ -67,58 +78,146 @@ function kindLabel(row: ProfileWorkspaceRow): string {
   return labels[row.kind];
 }
 
-function SurfaceIcon({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
-  if (row.rowType === 'connector') {
-    return <Cable className='h-4 w-4 text-tertiary-token' aria-hidden />;
-  }
-  if (
-    row.kind === 'authority' ||
-    row.kind === 'website' ||
-    row.kind === 'jovie'
-  ) {
-    return <Globe2 className='h-4 w-4 text-tertiary-token' aria-hidden />;
-  }
-  return <SocialIcon platform={row.platform} className='h-4 w-4' />;
+function ConnectionTypeGlyph({
+  row,
+  className,
+}: Readonly<{ row: ProfileWorkspaceRow; className?: string }>) {
+  const iconClassName = cn('h-4 w-4', className);
+  if (row.kind === 'connector')
+    return <Cable className={iconClassName} aria-hidden />;
+  if (row.kind === 'website')
+    return <Globe2 className={iconClassName} aria-hidden />;
+  if (row.kind === 'authority')
+    return <BookOpen className={iconClassName} aria-hidden />;
+  if (row.kind === 'dsp')
+    return <AudioWaveform className={iconClassName} aria-hidden />;
+  if (row.kind === 'social')
+    return <Share2 className={iconClassName} aria-hidden />;
+  return <Orbit className={iconClassName} aria-hidden />;
 }
 
-function MonitoringCell({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
-  if (row.rowType === 'connector') return <span>—</span>;
-  const labels = {
-    active: 'Active',
-    paused: 'Paused',
-    locked: 'Upgrade',
-    unavailable: 'Unavailable',
-  } as const;
+function ConnectionBrandIcon({
+  row,
+  className,
+}: Readonly<{ row: ProfileWorkspaceRow; className?: string }>) {
+  if (row.rowType === 'connector')
+    return (
+      <ConnectionTypeGlyph
+        row={row}
+        className={cn('text-tertiary-token', className)}
+      />
+    );
+  if (row.kind === 'authority' || row.kind === 'website') {
+    return (
+      <ConnectionTypeGlyph
+        row={row}
+        className={cn('text-tertiary-token', className)}
+      />
+    );
+  }
+  if (row.kind === 'jovie') {
+    return (
+      <ConnectionTypeGlyph row={row} className={cn('text-accent', className)} />
+    );
+  }
   return (
-    <span className='inline-flex min-w-18 items-center gap-1.5 text-xs text-secondary-token'>
-      {row.monitoringState === 'locked' ? (
+    <SocialIcon platform={row.platform} className={cn('h-4 w-4', className)} />
+  );
+}
+
+function TypeCell({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
+  const label = kindLabel(row);
+  return (
+    <SimpleTooltip content={`${label} connection`}>
+      <span
+        role='img'
+        aria-label={`${label} connection type`}
+        className={cn(
+          'inline-flex h-7 w-7 items-center justify-center rounded-full',
+          row.kind === 'jovie'
+            ? 'text-accent'
+            : 'text-tertiary-token hover:text-secondary-token'
+        )}
+      >
+        <ConnectionTypeGlyph row={row} />
+      </span>
+    </SimpleTooltip>
+  );
+}
+
+function StatusCell({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
+  const status = getConnectionStatus(row);
+  return (
+    <span className='inline-flex min-w-0 items-center gap-1.5 rounded-md bg-surface-1 px-2 py-1 text-2xs font-medium text-secondary-token'>
+      <span
+        className={cn(
+          'h-1.5 w-1.5 shrink-0 rounded-full',
+          status.tone === 'success' && 'bg-success',
+          status.tone === 'warning' && 'bg-warning',
+          status.tone === 'error' && 'bg-error',
+          status.tone === 'neutral' && 'bg-disabled'
+        )}
+        aria-hidden
+      />
+      <span className='truncate'>{status.label}</span>
+    </span>
+  );
+}
+
+const MONITORING_LABELS = {
+  active: 'Active',
+  paused: 'Paused',
+  locked: 'Requires Upgrade',
+  unavailable: 'Unavailable',
+} as const;
+
+function MonitoringCell({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
+  const monitoringState = row.monitoringState;
+  return (
+    <span className='inline-flex min-w-20 items-center gap-1.5 text-xs text-secondary-token'>
+      {monitoringState === 'locked' ? (
         <LockKeyhole className='h-3 w-3' aria-hidden />
       ) : (
         <span
           className={cn(
             'h-1.5 w-1.5 rounded-full',
-            row.monitoringState === 'active' ? 'bg-success' : 'bg-disabled'
+            monitoringState === 'active' && 'bg-success',
+            monitoringState === 'paused' && 'bg-warning',
+            monitoringState === 'unavailable' && 'bg-disabled'
           )}
+          aria-hidden
         />
       )}
-      {labels[row.monitoringState]}
+      {MONITORING_LABELS[monitoringState]}
     </span>
   );
 }
 
 function RankCell({ row }: Readonly<{ row: ProfileWorkspaceRow }>) {
-  if (row.rowType === 'connector') return <span>—</span>;
+  if (row.rowType === 'connector') {
+    return <EmptyCell tooltip='Search rank is not available for connectors.' />;
+  }
   if (row.monitoringState === 'locked') {
     return (
-      <span className='inline-flex items-center gap-1 text-tertiary-token'>
-        <LockKeyhole className='h-3 w-3' aria-hidden />—
-      </span>
+      <SimpleTooltip content='Upgrade required to monitor this connection.'>
+        <span
+          role='img'
+          aria-label='Rank Unavailable. Upgrade Required.'
+          className='inline-flex items-center gap-1 text-tertiary-token'
+        >
+          <LockKeyhole className='h-3 w-3' aria-hidden />
+          <span>—</span>
+        </span>
+      </SimpleTooltip>
     );
   }
-  return <span className='tabular-nums'>{row.rank ?? '—'}</span>;
+  if (row.rank === null) {
+    return <EmptyCell tooltip='No rank has been measured yet.' />;
+  }
+  return <span className='tabular-nums'>{row.rank}</span>;
 }
 
-function ProfilesRail({
+function ConnectionRail({
   data,
   row,
   onClose,
@@ -134,12 +233,12 @@ function ProfilesRail({
   return (
     <EntitySidebarShell
       isOpen={row !== null}
-      ariaLabel='Profile details'
+      ariaLabel='Connection details'
       scrollStrategy='shell'
       headerMode='minimal'
       hideMinimalHeaderBar
       isEmpty={!row}
-      emptyMessage='Select a profile to view details.'
+      emptyMessage='Select a connection to view details.'
       entityHeader={
         row ? (
           <DrawerSurfaceCard variant='flat' className='overflow-hidden'>
@@ -152,26 +251,16 @@ function ProfilesRail({
                 />
               </div>
               <div className='flex items-center gap-2.5 pr-8'>
-                {data.artist.avatarUrl ? (
-                  <Image
-                    src={data.artist.avatarUrl}
-                    alt=''
-                    width={44}
-                    height={44}
-                    className='h-11 w-11 rounded-full object-cover'
-                  />
-                ) : (
-                  <div className='flex h-11 w-11 items-center justify-center rounded-full border border-subtle bg-surface-0'>
-                    <SurfaceIcon row={row} />
-                  </div>
-                )}
+                <ConnectionBrandIcon row={row} className='h-7 w-7' />
                 <div className='min-w-0'>
                   <div className='truncate text-sm font-semibold text-primary-token'>
-                    {data.artist.name}
+                    {row.label}
                   </div>
                   <div className='mt-0.5 flex items-center gap-1.5 text-xs text-tertiary-token'>
-                    <SurfaceIcon row={row} />
-                    <span>{row.label}</span>
+                    <ConnectionTypeGlyph row={row} className='h-3 w-3' />
+                    <span>
+                      {kindLabel(row)} · {data.artist.name}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -185,17 +274,15 @@ function ProfilesRail({
     >
       {row ? (
         <div className='space-y-2'>
-          <DrawerSection title='Status' className='space-y-2'>
+          <DrawerSection title='Connection' className='space-y-2'>
+            <RailMetric label='Type' value={kindLabel(row)} />
+            <RailMetric label='Status' value={getConnectionStatus(row).label} />
             <RailMetric
-              label='Qualification'
-              value={
-                row.rowType === 'surface'
-                  ? row.qualificationStatus
-                  : row.status.replace('_', ' ')
-              }
+              label='Monitoring'
+              value={MONITORING_LABELS[row.monitoringState]}
             />
             <RailMetric
-              label='Google Rank'
+              label='Search Rank'
               value={
                 row.rowType === 'surface' && row.monitoringState !== 'locked'
                   ? String(row.rank ?? 'Not measured')
@@ -205,20 +292,24 @@ function ProfilesRail({
             <RailMetric label='Change' value={rankChange} />
           </DrawerSection>
           {row.rowType === 'surface' && row.trackedUrl ? (
-            <DrawerSection title='Tracked redirect'>
+            <DrawerSection title='Tracked Redirect'>
               <div className='break-all rounded-md bg-surface-0 px-2.5 py-2 text-xs text-secondary-token'>
                 {row.trackedUrl}
               </div>
             </DrawerSection>
           ) : null}
-          <DrawerSection title='Profile health'>
+          <DrawerSection title='Next Best Action'>
             <p className='text-xs leading-5 text-secondary-token'>
-              {row.primaryIssue}
+              {getConnectionStatus(row).nextAction}
             </p>
           </DrawerSection>
           <div className='grid grid-cols-2 gap-2 px-1'>
             <Button asChild variant='secondary' size='sm'>
-              <Link href={row.url} target='_blank' rel='noreferrer'>
+              <Link
+                href={row.url}
+                target={row.url.startsWith('http') ? '_blank' : undefined}
+                rel={row.url.startsWith('http') ? 'noreferrer' : undefined}
+              >
                 <ExternalLink className='h-3.5 w-3.5' /> Open
               </Link>
             </Button>
@@ -227,12 +318,18 @@ function ProfilesRail({
                 href={
                   row.rowType === 'surface' && row.primaryAction === 'upgrade'
                     ? APP_ROUTES.SETTINGS_BILLING
-                    : APP_ROUTES.SETTINGS_ARTIST_PROFILE
+                    : row.rowType === 'connector'
+                      ? APP_ROUTES.SETTINGS_CONNECTORS
+                      : APP_ROUTES.SETTINGS_ARTIST_PROFILE
                 }
               >
-                {row.rowType === 'surface' && row.primaryAction === 'upgrade'
+                {row.primaryAction === 'upgrade'
                   ? 'Upgrade'
-                  : 'Review'}
+                  : row.primaryAction === 'connect'
+                    ? 'Connect'
+                    : row.primaryAction === 'reconnect'
+                      ? 'Reconnect'
+                      : 'Review'}
               </Link>
             </Button>
           </div>
@@ -249,9 +346,7 @@ function RailMetric({
   return (
     <div className='flex items-center justify-between text-xs'>
       <span className='text-tertiary-token'>{label}</span>
-      <span className='max-w-36 truncate capitalize text-primary-token'>
-        {value}
-      </span>
+      <span className='max-w-36 truncate text-primary-token'>{value}</span>
     </div>
   );
 }
@@ -262,27 +357,32 @@ export function ProfilesWorkspace({
   const [filter, setFilter] = useState<ProfilesWorkspaceFilter>('all');
   const [selected, setSelected] = useState<ProfileWorkspaceRow | null>(null);
   const rows = useMemo(
-    () => filterProfileWorkspaceRows(data?.rows ?? [], filter),
+    () =>
+      sortProfileWorkspaceRows(
+        filterProfileWorkspaceRows(data?.rows ?? [], filter)
+      ),
     [data?.rows, filter]
+  );
+  const summary = useMemo(
+    () => summarizeProfileWorkspaceRows(data?.rows ?? []),
+    [data?.rows]
   );
   const columns = useMemo(
     () => [
       columnHelper.accessor('label', {
-        header: 'Profile',
-        size: 9999,
-        minSize: 180,
+        header: 'Connection',
+        size: 260,
+        minSize: 210,
         cell: context => {
           const row = context.row.original;
           return (
             <div className='flex min-w-0 items-center gap-2.5'>
-              <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-subtle bg-surface-0'>
-                <SurfaceIcon row={row} />
-              </div>
+              <ConnectionBrandIcon row={row} className='h-5 w-5 shrink-0' />
               <div className='min-w-0'>
                 <div className='truncate text-sm font-medium text-primary-token'>
                   {row.label}
                 </div>
-                <div className='truncate text-xs text-tertiary-token'>
+                <div className='truncate text-xs text-tertiary-token max-sm:hidden'>
                   {row.handle ?? row.url}
                 </div>
               </div>
@@ -293,27 +393,38 @@ export function ProfilesWorkspace({
       columnHelper.display({
         id: 'type',
         header: 'Type',
-        size: 90,
-        cell: context => kindLabel(context.row.original),
+        size: 52,
+        cell: context => <TypeCell row={context.row.original} />,
       }),
-      columnHelper.accessor('primaryIssue', {
-        header: 'Primary Issue',
-        size: 160,
+      columnHelper.accessor(row => getConnectionStatus(row).label, {
+        id: 'status',
+        header: 'Status / Issue',
+        size: 156,
+        cell: context => <StatusCell row={context.row.original} />,
       }),
       columnHelper.display({
         id: 'rank',
         header: 'Rank',
         size: 72,
+        meta: { className: 'max-md:hidden' },
         cell: context => <RankCell row={context.row.original} />,
       }),
       columnHelper.display({
         id: 'change',
         header: 'Change',
         size: 78,
+        meta: { className: 'max-lg:hidden' },
         cell: context => {
           const row = context.row.original;
-          if (row.rowType === 'connector') return '—';
+          if (row.rowType === 'connector') {
+            return (
+              <EmptyCell tooltip='Rank change is not available for connectors.' />
+            );
+          }
           const change = formatProfileRankChange(row.rank, row.previousRank);
+          if (change === '—') {
+            return <EmptyCell tooltip='No previous rank measurement.' />;
+          }
           return (
             <span
               className={cn(
@@ -336,8 +447,28 @@ export function ProfilesWorkspace({
       columnHelper.display({
         id: 'monitoring',
         header: 'Monitoring',
-        size: 112,
+        size: 124,
+        meta: { className: 'max-xl:hidden' },
         cell: context => <MonitoringCell row={context.row.original} />,
+      }),
+      columnHelper.display({
+        id: 'actions',
+        header: () => <span className='sr-only'>Actions</span>,
+        size: 44,
+        cell: context => {
+          const row = context.row.original;
+          return (
+            <div className='flex justify-end opacity-100 transition-opacity duration-subtle sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:focus-within:pointer-events-auto sm:focus-within:opacity-100'>
+              <TableIconButton
+                icon={<MoreHorizontal className='h-4 w-4' aria-hidden />}
+                onClick={() => setSelected(row)}
+                ariaLabel={`Actions for ${row.label}`}
+                tooltip='View connection details'
+                className='h-7 w-7'
+              />
+            </div>
+          );
+        },
       }),
     ],
     []
@@ -345,7 +476,7 @@ export function ProfilesWorkspace({
 
   useRegisterRightPanel(
     data && selected ? (
-      <ProfilesRail
+      <ConnectionRail
         data={data}
         row={selected}
         onClose={() => setSelected(null)}
@@ -373,14 +504,17 @@ export function ProfilesWorkspace({
 
   const limitLabel =
     data.monitoringLimit === null
-      ? `${data.monitoredCount} monitored`
-      : `${data.monitoredCount} of ${data.monitoringLimit} monitored`;
+      ? `Monitored ${data.monitoredCount}`
+      : `Monitored ${data.monitoredCount}/${data.monitoringLimit}`;
   return (
     <PageShell
       data-testid='profiles-workspace'
       surfaceMode='table'
       toolbar={
         <PageToolbar
+          className='flex-col items-stretch gap-0 px-0 py-0 lg:flex-row lg:items-center lg:gap-1.5 lg:px-app-header lg:py-1.5'
+          startClassName='w-full flex-none px-app-header py-1.5 lg:min-w-0 lg:flex-1 lg:px-0 lg:py-0'
+          endClassName='ml-0 w-full min-w-0 max-w-full shrink justify-start overflow-x-auto border-t border-subtle px-app-header py-1.5 lg:ml-auto lg:w-auto lg:max-w-none lg:shrink-0 lg:justify-end lg:overflow-visible lg:border-t-0 lg:px-0 lg:py-0'
           start={FILTERS.map(option => (
             <PageToolbarTabButton
               key={option.id}
@@ -390,18 +524,27 @@ export function ProfilesWorkspace({
             />
           ))}
           end={
-            <div className='flex items-center gap-3 whitespace-nowrap text-xs text-tertiary-token'>
+            <div
+              data-testid='connections-summary'
+              className='flex items-center gap-3 whitespace-nowrap text-xs text-tertiary-token'
+            >
+              <span>{summary.connectionCount} Connections</span>
               <span>{limitLabel}</span>
-              <span>
-                Qualified{' '}
-                {data.qualifiedShare === null
-                  ? '—'
-                  : `${Math.round(data.qualifiedShare * 100)}%`}
+              <span>Needs Attention {summary.needsAttentionCount}</span>
+              <span className='max-sm:hidden'>
+                Best Rank{' '}
+                {summary.bestRank === null ? (
+                  <SimpleTooltip content='No search rank has been measured yet.'>
+                    <span role='img' aria-label='Best Rank Unavailable'>
+                      —
+                    </span>
+                  </SimpleTooltip>
+                ) : (
+                  `#${summary.bestRank}`
+                )}
               </span>
-              <span>Best Jovie #{data.bestJovieRank ?? '—'}</span>
-              <span className='inline-flex items-center gap-1'>
-                <RefreshCw className='h-3 w-3' aria-hidden />
-                {data.providerAvailable ? 'Daily' : 'Monitoring paused'}
+              <span className='max-sm:hidden'>
+                Monitoring {summary.monitoringLabel}
               </span>
             </div>
           }
@@ -414,17 +557,11 @@ export function ProfilesWorkspace({
         getRowId={row => row.id}
         onRowClick={setSelected}
         rowHeight={56}
-        minWidth='700px'
-        getRowClassName={row =>
-          cn(
-            'cursor-pointer',
-            selected?.id === row.id &&
-              'bg-[color-mix(in_oklab,var(--color-accent)_8%,transparent)] ring-1 ring-inset ring-(--color-accent)'
-          )
-        }
+        minWidth='460px'
+        isRowSelected={row => selected?.id === row.id}
         emptyState={
           <TableEmptyState
-            title='No profiles in this category'
+            title='No Connections in This Category'
             description='Try another filter.'
           />
         }

--- a/apps/web/app/app/(shell)/profiles/data.ts
+++ b/apps/web/app/app/(shell)/profiles/data.ts
@@ -53,8 +53,6 @@ export interface ProfileWorkspaceSurfaceRow {
   readonly rank: number | null;
   readonly previousRank: number | null;
   readonly lastObservedAt: string | null;
-  readonly primaryIssue: string;
-  readonly primaryAction: 'open' | 'review' | 'upgrade';
 }
 
 export interface ProfileWorkspaceConnectorRow {
@@ -67,8 +65,6 @@ export interface ProfileWorkspaceConnectorRow {
   readonly url: string;
   readonly status: SettingsConnectorState['status'];
   readonly monitoringState: 'active' | 'paused' | 'unavailable';
-  readonly primaryIssue: string;
-  readonly primaryAction: 'connect' | 'reconnect' | 'open';
 }
 
 export type ProfileWorkspaceRow =
@@ -209,16 +205,6 @@ function connectorRow(
       : needsReconnect
         ? 'paused'
         : 'unavailable',
-    primaryIssue: connected
-      ? 'Active'
-      : needsReconnect
-        ? 'Reconnect Required'
-        : 'Not Connected',
-    primaryAction: connected
-      ? 'open'
-      : needsReconnect
-        ? 'reconnect'
-        : 'connect',
   };
 }
 
@@ -361,22 +347,6 @@ export async function loadProfilesWorkspaceData(input: {
             : 'locked';
     const qualificationStatus =
       surface.qualificationStatus as ProfileQualificationStatus;
-    const primaryIssue =
-      qualificationStatus === 'conflicting'
-        ? 'Needs Review'
-        : qualificationStatus === 'suggested'
-          ? 'Needs Qualification'
-          : locked
-            ? 'Limit Reached'
-            : monitoringState === 'unavailable'
-              ? 'Unavailable'
-              : monitoringState === 'paused'
-                ? 'Paused'
-                : rank === null
-                  ? latestRun
-                    ? 'Not Found'
-                    : 'Not Measured'
-                  : 'Active';
     const trackedUrl =
       socialSourceIds.has(surface.id) &&
       resolveSocialShortcutPlatforms(surface.platform) &&
@@ -404,13 +374,6 @@ export async function loadProfilesWorkspaceData(input: {
         rankFor(surface.id, previousRun?.id)
       ),
       lastObservedAt: surface.lastObservedAt?.toISOString() ?? null,
-      primaryIssue,
-      primaryAction:
-        qualificationStatus === 'suggested'
-          ? 'review'
-          : locked
-            ? 'upgrade'
-            : 'open',
     };
   });
   const connectors = connectorData

--- a/apps/web/app/app/(shell)/profiles/data.ts
+++ b/apps/web/app/app/(shell)/profiles/data.ts
@@ -34,6 +34,8 @@ export type ProfilesWorkspaceFilter =
   | 'dsp'
   | 'social'
   | 'source'
+  | 'website'
+  | 'jovie'
   | 'connector';
 
 export interface ProfileWorkspaceSurfaceRow {
@@ -64,6 +66,7 @@ export interface ProfileWorkspaceConnectorRow {
   readonly handle: string | null;
   readonly url: string;
   readonly status: SettingsConnectorState['status'];
+  readonly monitoringState: 'active' | 'paused' | 'unavailable';
   readonly primaryIssue: string;
   readonly primaryAction: 'connect' | 'reconnect' | 'open';
 }
@@ -201,11 +204,16 @@ function connectorRow(
     handle: state.email ?? null,
     url: APP_ROUTES.SETTINGS_CONNECTORS,
     status: state.status,
-    primaryIssue: connected
-      ? 'Connected'
+    monitoringState: connected
+      ? 'active'
       : needsReconnect
-        ? 'Reconnect required'
-        : 'Not connected',
+        ? 'paused'
+        : 'unavailable',
+    primaryIssue: connected
+      ? 'Active'
+      : needsReconnect
+        ? 'Reconnect Required'
+        : 'Not Connected',
     primaryAction: connected
       ? 'open'
       : needsReconnect
@@ -343,20 +351,32 @@ export async function loadProfilesWorkspaceData(input: {
     const rank = rankFor(surface.id, latestRun?.id);
     const preference = preferenceBySurface.get(surface.id);
     const locked = surface.kind !== 'jovie' && !preference;
+    const monitoringState =
+      surface.availability !== 'eligible'
+        ? 'unavailable'
+        : surface.kind === 'jovie' || preference === 'active'
+          ? 'active'
+          : preference === 'paused'
+            ? 'paused'
+            : 'locked';
     const qualificationStatus =
       surface.qualificationStatus as ProfileQualificationStatus;
     const primaryIssue =
       qualificationStatus === 'conflicting'
-        ? 'Identity conflict'
+        ? 'Needs Review'
         : qualificationStatus === 'suggested'
-          ? 'Qualification required'
+          ? 'Needs Qualification'
           : locked
-            ? 'Monitoring limit'
-            : rank === null
-              ? latestRun
-                ? 'Not on page one'
-                : 'Not measured'
-              : 'No issues';
+            ? 'Limit Reached'
+            : monitoringState === 'unavailable'
+              ? 'Unavailable'
+              : monitoringState === 'paused'
+                ? 'Paused'
+                : rank === null
+                  ? latestRun
+                    ? 'Not Found'
+                    : 'Not Measured'
+                  : 'Active';
     const trackedUrl =
       socialSourceIds.has(surface.id) &&
       resolveSocialShortcutPlatforms(surface.platform) &&
@@ -377,14 +397,7 @@ export async function loadProfilesWorkspaceData(input: {
       trackedUrl,
       qualificationStatus,
       isOfficial: surface.isOfficial,
-      monitoringState:
-        surface.availability !== 'eligible'
-          ? 'unavailable'
-          : surface.kind === 'jovie' || preference === 'active'
-            ? 'active'
-            : preference === 'paused'
-              ? 'paused'
-              : 'locked',
+      monitoringState,
       rank: redactLockedRank(locked, rank),
       previousRank: redactLockedRank(
         locked,

--- a/apps/web/app/app/(shell)/profiles/page.tsx
+++ b/apps/web/app/app/(shell)/profiles/page.tsx
@@ -13,8 +13,9 @@ export default async function ProfilesPage() {
     route: APP_ROUTES.PROFILES,
     authFailure: 'notFound',
     requiredFlag: 'PROFILES_WORKSPACE',
-    dashboardErrorLogMessage: 'Dashboard data load failed on profiles page',
-    dashboardErrorMessage: 'Failed to load profiles. Please refresh the page.',
+    dashboardErrorLogMessage: 'Dashboard data load failed on connections page',
+    dashboardErrorMessage:
+      'Failed to load connections. Please refresh the page.',
   });
   if (!routeContext.ok) return routeContext.error;
 

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -11,7 +11,7 @@ const CANONICAL_NAVIGATION = [
   ['inbox', 'Inbox', APP_ROUTES.DASHBOARD],
   ['library', 'Library', APP_ROUTES.LIBRARY],
   ['contacts', 'Contacts', APP_ROUTES.CONTACTS],
-  ['profiles', 'Profiles', APP_ROUTES.PROFILES],
+  ['profiles', 'Connections', APP_ROUTES.PROFILES],
   ['calendar', 'Calendar', APP_ROUTES.CALENDAR],
   ['tasks', 'Tasks', APP_ROUTES.TASKS],
 ] as const;
@@ -21,7 +21,7 @@ function toContract(items: readonly (typeof primaryNavigation)[number][]) {
 }
 
 describe('canonical customer shell navigation', () => {
-  it('keeps New Chat as the elevated first action and Profiles in the canonical order', () => {
+  it('keeps New Chat as the elevated first action and Connections in the canonical order', () => {
     expect(toContract(primaryNavigation)).toEqual(CANONICAL_NAVIGATION);
     expect(primaryNavigation[0].tone).toBe('primary');
   });
@@ -50,7 +50,7 @@ describe('canonical customer shell navigation', () => {
     }
   });
 
-  it('excludes retired primary destinations while preserving the Profiles route', () => {
+  it('excludes retired primary destinations while preserving the Connections route', () => {
     const ids = primaryNavigation.map(item => item.id);
     const labels = primaryNavigation.map(item => item.name);
 

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -15,6 +15,7 @@ import {
   ShieldCheck,
   SquarePen,
   UserCircle,
+  Waypoints,
 } from 'lucide-react';
 
 import { APP_ROUTES } from '@/constants/routes';
@@ -68,11 +69,11 @@ export const contactsNavItem: NavItem = {
 };
 
 export const profilesNavItem: NavItem = {
-  name: 'Profiles',
+  name: 'Connections',
   href: APP_ROUTES.PROFILES,
   id: 'profiles',
-  icon: UserCircle,
-  description: 'Manage artist profiles and connected identities',
+  icon: Waypoints,
+  description: 'Monitor artist identities and connected services',
 };
 
 export const calendarNavItem: NavItem = {

--- a/apps/web/lib/constants/breadcrumb-labels.ts
+++ b/apps/web/lib/constants/breadcrumb-labels.ts
@@ -8,6 +8,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   // Dashboard routes
   dashboard: 'Dashboard',
   profile: 'Profile',
+  profiles: 'Connections',
   contacts: 'Contacts',
   library: 'Library',
   releases: 'Releases',

--- a/apps/web/lib/profile-surfaces/workspace.test.ts
+++ b/apps/web/lib/profile-surfaces/workspace.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ProfileWorkspaceConnectorRow,
+  ProfileWorkspaceSurfaceRow,
+} from '@/app/app/(shell)/profiles/data';
+import {
+  filterProfileWorkspaceRows,
+  getConnectionStatus,
+  sortProfileWorkspaceRows,
+  summarizeProfileWorkspaceRows,
+} from './workspace';
+
+function surface(
+  overrides: Partial<ProfileWorkspaceSurfaceRow> = {}
+): ProfileWorkspaceSurfaceRow {
+  return {
+    id: 'spotify',
+    rowType: 'surface',
+    kind: 'dsp',
+    platform: 'spotify',
+    label: 'Spotify',
+    handle: 'Artist',
+    url: 'https://open.spotify.com/artist/example',
+    trackedUrl: null,
+    qualificationStatus: 'qualified',
+    isOfficial: true,
+    monitoringState: 'active',
+    rank: 4,
+    previousRank: 6,
+    lastObservedAt: '2026-07-30T00:00:00.000Z',
+    primaryIssue: 'Active',
+    primaryAction: 'open',
+    ...overrides,
+  };
+}
+
+function connector(
+  overrides: Partial<ProfileWorkspaceConnectorRow> = {}
+): ProfileWorkspaceConnectorRow {
+  return {
+    id: 'gmail',
+    rowType: 'connector',
+    kind: 'connector',
+    platform: 'gmail',
+    label: 'Gmail',
+    handle: 'artist@example.com',
+    url: '/app/settings/connectors',
+    status: 'connected',
+    monitoringState: 'active',
+    primaryIssue: 'Active',
+    primaryAction: 'open',
+    ...overrides,
+  };
+}
+
+describe('connections workspace helpers', () => {
+  it('keeps Sources, Websites, Connectors, and Jovie as distinct filters', () => {
+    const rows = [
+      surface({
+        id: 'source',
+        kind: 'authority',
+        platform: 'musicbrainz',
+      }),
+      surface({
+        id: 'website',
+        kind: 'website',
+        platform: 'website',
+      }),
+      surface({ id: 'jovie', kind: 'jovie', platform: 'jovie' }),
+      connector(),
+    ];
+
+    expect(
+      filterProfileWorkspaceRows(rows, 'source').map(row => row.id)
+    ).toEqual(['source']);
+    expect(
+      filterProfileWorkspaceRows(rows, 'website').map(row => row.id)
+    ).toEqual(['website']);
+    expect(
+      filterProfileWorkspaceRows(rows, 'connector').map(row => row.id)
+    ).toEqual(['gmail']);
+    expect(
+      filterProfileWorkspaceRows(rows, 'jovie').map(row => row.id)
+    ).toEqual(['jovie']);
+  });
+
+  it('surfaces actionable connection issues before healthy rows', () => {
+    const conflicting = surface({
+      id: 'conflicting',
+      label: 'Duplicate Spotify',
+      qualificationStatus: 'conflicting',
+    });
+    const locked = surface({
+      id: 'locked',
+      platform: 'apple_music',
+      label: 'Apple Music',
+      monitoringState: 'locked',
+      rank: null,
+      previousRank: null,
+    });
+    const active = surface();
+
+    expect(
+      sortProfileWorkspaceRows([active, locked, conflicting]).map(row => row.id)
+    ).toEqual(['conflicting', 'locked', 'spotify']);
+    expect(getConnectionStatus(conflicting).label).toBe('Needs Review');
+    expect(getConnectionStatus(locked).label).toBe('Limit Reached');
+  });
+
+  it('keeps duplicate connection labels as distinct URL-backed rows', () => {
+    const first = surface({
+      id: 'first',
+      label: 'Artist',
+      url: 'https://example.com/artist',
+    });
+    const second = surface({
+      id: 'second',
+      label: 'Artist',
+      url: 'https://example.org/artist',
+    });
+
+    expect(
+      sortProfileWorkspaceRows([second, first]).map(row => row.id)
+    ).toEqual(['first', 'second']);
+  });
+
+  it('never reports monitoring as paused while an active surface exists', () => {
+    const rows = [
+      surface(),
+      surface({
+        id: 'paused',
+        platform: 'soundcloud',
+        monitoringState: 'paused',
+        rank: null,
+      }),
+      connector({
+        status: 'needs_reauth',
+        monitoringState: 'paused',
+        primaryAction: 'reconnect',
+      }),
+    ];
+
+    expect(summarizeProfileWorkspaceRows(rows)).toEqual({
+      connectionCount: 3,
+      needsAttentionCount: 1,
+      bestRank: 4,
+      monitoringLabel: 'Active',
+    });
+  });
+});

--- a/apps/web/lib/profile-surfaces/workspace.test.ts
+++ b/apps/web/lib/profile-surfaces/workspace.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/app/app/(shell)/profiles/data';
 import {
   filterProfileWorkspaceRows,
+  getConnectionPrimaryAction,
   getConnectionStatus,
   sortProfileWorkspaceRows,
   summarizeProfileWorkspaceRows,
@@ -28,8 +29,6 @@ function surface(
     rank: 4,
     previousRank: 6,
     lastObservedAt: '2026-07-30T00:00:00.000Z',
-    primaryIssue: 'Active',
-    primaryAction: 'open',
     ...overrides,
   };
 }
@@ -47,8 +46,6 @@ function connector(
     url: '/app/settings/connectors',
     status: 'connected',
     monitoringState: 'active',
-    primaryIssue: 'Active',
-    primaryAction: 'open',
     ...overrides,
   };
 }
@@ -107,6 +104,47 @@ describe('connections workspace helpers', () => {
     expect(getConnectionStatus(locked).label).toBe('Limit Reached');
   });
 
+  it('orders broken, limited, measured, then unmeasured connections', () => {
+    const notConnected = connector({ status: 'not_connected' });
+    const limited = surface({
+      id: 'limited',
+      monitoringState: 'locked',
+      rank: null,
+      previousRank: null,
+    });
+    const measured = surface({ id: 'measured', rank: 4 });
+    const unmeasured = surface({
+      id: 'unmeasured',
+      rank: null,
+      previousRank: null,
+      lastObservedAt: null,
+    });
+
+    expect(
+      sortProfileWorkspaceRows([
+        unmeasured,
+        measured,
+        limited,
+        notConnected,
+      ]).map(row => row.id)
+    ).toEqual(['gmail', 'limited', 'measured', 'unmeasured']);
+  });
+
+  it('derives actions from the resolved connection state', () => {
+    expect(getConnectionPrimaryAction(connector({ status: 'error' }))).toBe(
+      'reconnect'
+    );
+    expect(
+      getConnectionPrimaryAction(surface({ monitoringState: 'unavailable' }))
+    ).toBe('review');
+    expect(
+      getConnectionPrimaryAction(surface({ monitoringState: 'paused' }))
+    ).toBe('review');
+    expect(
+      getConnectionPrimaryAction(surface({ monitoringState: 'locked' }))
+    ).toBe('upgrade');
+  });
+
   it('keeps duplicate connection labels as distinct URL-backed rows', () => {
     const first = surface({
       id: 'first',
@@ -136,7 +174,6 @@ describe('connections workspace helpers', () => {
       connector({
         status: 'needs_reauth',
         monitoringState: 'paused',
-        primaryAction: 'reconnect',
       }),
     ];
 
@@ -146,5 +183,11 @@ describe('connections workspace helpers', () => {
       bestRank: 4,
       monitoringLabel: 'Active',
     });
+  });
+
+  it('reports monitoring unavailable when the search provider is disabled', () => {
+    expect(
+      summarizeProfileWorkspaceRows([surface()], false).monitoringLabel
+    ).toBe('Unavailable');
   });
 });

--- a/apps/web/lib/profile-surfaces/workspace.ts
+++ b/apps/web/lib/profile-surfaces/workspace.ts
@@ -20,6 +20,13 @@ export interface ConnectionsWorkspaceSummary {
   readonly monitoringLabel: 'Active' | 'Paused' | 'Limited' | 'Unavailable';
 }
 
+export type ConnectionPrimaryAction =
+  | 'connect'
+  | 'reconnect'
+  | 'open'
+  | 'review'
+  | 'upgrade';
+
 const PLATFORM_PRIORITY: Readonly<Record<string, number>> = {
   jovie: 0,
   spotify: 1,
@@ -52,7 +59,7 @@ export function getConnectionStatus(
         label: row.status === 'syncing' ? 'Syncing' : 'Active',
         tone: 'success',
         needsAttention: false,
-        sortPriority: 5,
+        sortPriority: 2,
         nextAction:
           row.status === 'syncing'
             ? 'Let the current sync finish.'
@@ -64,7 +71,7 @@ export function getConnectionStatus(
         label: 'Reconnect Required',
         tone: 'warning',
         needsAttention: true,
-        sortPriority: 1,
+        sortPriority: 0,
         nextAction: 'Reconnect this account to resume syncing.',
       };
     }
@@ -81,7 +88,7 @@ export function getConnectionStatus(
       label: 'Not Connected',
       tone: 'neutral',
       needsAttention: true,
-      sortPriority: 2,
+      sortPriority: 0,
       nextAction: 'Connect this account to enable syncing.',
     };
   }
@@ -101,7 +108,7 @@ export function getConnectionStatus(
       label: 'Needs Qualification',
       tone: 'warning',
       needsAttention: true,
-      sortPriority: 1,
+      sortPriority: 0,
       nextAction: 'Confirm whether this connection belongs to the artist.',
     };
   }
@@ -119,7 +126,7 @@ export function getConnectionStatus(
       label: 'Unavailable',
       tone: 'neutral',
       needsAttention: true,
-      sortPriority: 2,
+      sortPriority: 0,
       nextAction: 'Review the source URL before monitoring this connection.',
     };
   }
@@ -128,8 +135,8 @@ export function getConnectionStatus(
       label: 'Paused',
       tone: 'neutral',
       needsAttention: false,
-      sortPriority: 3,
-      nextAction: 'Resume monitoring when you want new rank measurements.',
+      sortPriority: 4,
+      nextAction: 'Review monitoring settings before resuming this connection.',
     };
   }
   if (row.rank === null) {
@@ -137,7 +144,7 @@ export function getConnectionStatus(
       label: row.lastObservedAt ? 'Not Found' : 'Not Measured',
       tone: 'neutral',
       needsAttention: false,
-      sortPriority: 4,
+      sortPriority: 3,
       nextAction: row.lastObservedAt
         ? 'Review the connection if it should appear in search.'
         : 'No action needed until the first monitoring run completes.',
@@ -147,9 +154,34 @@ export function getConnectionStatus(
     label: 'Active',
     tone: 'success',
     needsAttention: false,
-    sortPriority: 5,
+    sortPriority: 2,
     nextAction: 'No action needed.',
   };
+}
+
+export function getConnectionPrimaryAction(
+  row: ProfileWorkspaceRow
+): ConnectionPrimaryAction {
+  if (row.rowType === 'connector') {
+    if (row.status === 'needs_reauth' || row.status === 'error') {
+      return 'reconnect';
+    }
+    if (row.status === 'not_connected' || row.status === 'disabled') {
+      return 'connect';
+    }
+    return 'open';
+  }
+
+  if (row.monitoringState === 'locked') return 'upgrade';
+  if (
+    row.monitoringState === 'unavailable' ||
+    row.monitoringState === 'paused' ||
+    row.qualificationStatus === 'conflicting' ||
+    row.qualificationStatus === 'suggested'
+  ) {
+    return 'review';
+  }
+  return 'open';
 }
 
 function statusPriority(row: ProfileWorkspaceRow): number {
@@ -175,7 +207,8 @@ export function sortProfileWorkspaceRows(
 }
 
 export function summarizeProfileWorkspaceRows(
-  rows: readonly ProfileWorkspaceRow[]
+  rows: readonly ProfileWorkspaceRow[],
+  providerAvailable = true
 ): ConnectionsWorkspaceSummary {
   const surfaceRows = rows.filter(row => row.rowType === 'surface');
   const activeCount = surfaceRows.filter(
@@ -197,8 +230,9 @@ export function summarizeProfileWorkspaceRows(
       row => getConnectionStatus(row).needsAttention
     ).length,
     bestRank: measuredRanks.length > 0 ? Math.min(...measuredRanks) : null,
-    monitoringLabel:
-      activeCount > 0
+    monitoringLabel: !providerAvailable
+      ? 'Unavailable'
+      : activeCount > 0
         ? 'Active'
         : pausedCount > 0
           ? 'Paused'

--- a/apps/web/lib/profile-surfaces/workspace.ts
+++ b/apps/web/lib/profile-surfaces/workspace.ts
@@ -3,17 +3,209 @@ import type {
   ProfileWorkspaceRow,
 } from '@/app/app/(shell)/profiles/data';
 
+export type ConnectionStatusTone = 'success' | 'warning' | 'error' | 'neutral';
+
+export interface ConnectionStatus {
+  readonly label: string;
+  readonly tone: ConnectionStatusTone;
+  readonly needsAttention: boolean;
+  readonly nextAction: string;
+  readonly sortPriority: number;
+}
+
+export interface ConnectionsWorkspaceSummary {
+  readonly connectionCount: number;
+  readonly needsAttentionCount: number;
+  readonly bestRank: number | null;
+  readonly monitoringLabel: 'Active' | 'Paused' | 'Limited' | 'Unavailable';
+}
+
+const PLATFORM_PRIORITY: Readonly<Record<string, number>> = {
+  jovie: 0,
+  spotify: 1,
+  apple_music: 2,
+  youtube_music: 3,
+  youtube: 4,
+  instagram: 5,
+  tiktok: 6,
+  soundcloud: 7,
+  beatport: 8,
+  gmail: 20,
+  google_calendar: 21,
+};
+
 export function filterProfileWorkspaceRows(
   rows: readonly ProfileWorkspaceRow[],
   filter: ProfilesWorkspaceFilter
 ): ProfileWorkspaceRow[] {
   if (filter === 'all') return [...rows];
-  if (filter === 'source') {
-    return rows.filter(
-      row => row.kind === 'authority' || row.kind === 'website'
-    );
-  }
+  if (filter === 'source') return rows.filter(row => row.kind === 'authority');
   return rows.filter(row => row.kind === filter);
+}
+
+export function getConnectionStatus(
+  row: ProfileWorkspaceRow
+): ConnectionStatus {
+  if (row.rowType === 'connector') {
+    if (row.status === 'connected' || row.status === 'syncing') {
+      return {
+        label: row.status === 'syncing' ? 'Syncing' : 'Active',
+        tone: 'success',
+        needsAttention: false,
+        sortPriority: 5,
+        nextAction:
+          row.status === 'syncing'
+            ? 'Let the current sync finish.'
+            : 'No action needed.',
+      };
+    }
+    if (row.status === 'needs_reauth') {
+      return {
+        label: 'Reconnect Required',
+        tone: 'warning',
+        needsAttention: true,
+        sortPriority: 1,
+        nextAction: 'Reconnect this account to resume syncing.',
+      };
+    }
+    if (row.status === 'error') {
+      return {
+        label: 'Needs Review',
+        tone: 'error',
+        needsAttention: true,
+        sortPriority: 0,
+        nextAction: 'Review the connector error and reconnect the account.',
+      };
+    }
+    return {
+      label: 'Not Connected',
+      tone: 'neutral',
+      needsAttention: true,
+      sortPriority: 2,
+      nextAction: 'Connect this account to enable syncing.',
+    };
+  }
+
+  if (row.qualificationStatus === 'conflicting') {
+    return {
+      label: 'Needs Review',
+      tone: 'error',
+      needsAttention: true,
+      sortPriority: 0,
+      nextAction:
+        'Resolve the identity conflict before monitoring this result.',
+    };
+  }
+  if (row.qualificationStatus === 'suggested') {
+    return {
+      label: 'Needs Qualification',
+      tone: 'warning',
+      needsAttention: true,
+      sortPriority: 1,
+      nextAction: 'Confirm whether this connection belongs to the artist.',
+    };
+  }
+  if (row.monitoringState === 'locked') {
+    return {
+      label: 'Limit Reached',
+      tone: 'warning',
+      needsAttention: true,
+      sortPriority: 1,
+      nextAction: 'Upgrade the monitoring limit to track this connection.',
+    };
+  }
+  if (row.monitoringState === 'unavailable') {
+    return {
+      label: 'Unavailable',
+      tone: 'neutral',
+      needsAttention: true,
+      sortPriority: 2,
+      nextAction: 'Review the source URL before monitoring this connection.',
+    };
+  }
+  if (row.monitoringState === 'paused') {
+    return {
+      label: 'Paused',
+      tone: 'neutral',
+      needsAttention: false,
+      sortPriority: 3,
+      nextAction: 'Resume monitoring when you want new rank measurements.',
+    };
+  }
+  if (row.rank === null) {
+    return {
+      label: row.lastObservedAt ? 'Not Found' : 'Not Measured',
+      tone: 'neutral',
+      needsAttention: false,
+      sortPriority: 4,
+      nextAction: row.lastObservedAt
+        ? 'Review the connection if it should appear in search.'
+        : 'No action needed until the first monitoring run completes.',
+    };
+  }
+  return {
+    label: 'Active',
+    tone: 'success',
+    needsAttention: false,
+    sortPriority: 5,
+    nextAction: 'No action needed.',
+  };
+}
+
+function statusPriority(row: ProfileWorkspaceRow): number {
+  return getConnectionStatus(row).sortPriority;
+}
+
+export function sortProfileWorkspaceRows(
+  rows: readonly ProfileWorkspaceRow[]
+): ProfileWorkspaceRow[] {
+  return [...rows].sort((left, right) => {
+    const priorityDifference = statusPriority(left) - statusPriority(right);
+    if (priorityDifference !== 0) return priorityDifference;
+
+    const platformDifference =
+      (PLATFORM_PRIORITY[left.platform] ?? 10) -
+      (PLATFORM_PRIORITY[right.platform] ?? 10);
+    if (platformDifference !== 0) return platformDifference;
+
+    const labelDifference = left.label.localeCompare(right.label);
+    if (labelDifference !== 0) return labelDifference;
+    return left.url.localeCompare(right.url);
+  });
+}
+
+export function summarizeProfileWorkspaceRows(
+  rows: readonly ProfileWorkspaceRow[]
+): ConnectionsWorkspaceSummary {
+  const surfaceRows = rows.filter(row => row.rowType === 'surface');
+  const activeCount = surfaceRows.filter(
+    row => row.monitoringState === 'active'
+  ).length;
+  const pausedCount = surfaceRows.filter(
+    row => row.monitoringState === 'paused'
+  ).length;
+  const limitedCount = surfaceRows.filter(
+    row => row.monitoringState === 'locked'
+  ).length;
+  const measuredRanks = surfaceRows
+    .map(row => row.rank)
+    .filter((rank): rank is number => rank !== null);
+
+  return {
+    connectionCount: rows.length,
+    needsAttentionCount: rows.filter(
+      row => getConnectionStatus(row).needsAttention
+    ).length,
+    bestRank: measuredRanks.length > 0 ? Math.min(...measuredRanks) : null,
+    monitoringLabel:
+      activeCount > 0
+        ? 'Active'
+        : pausedCount > 0
+          ? 'Paused'
+          : limitedCount > 0
+            ? 'Limited'
+            : 'Unavailable',
+  };
 }
 
 export function formatProfileRankChange(

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -27,7 +27,7 @@ const PRIMARY_LABELS = [
   'Inbox',
   'Library',
   'Contacts',
-  'Profiles',
+  'Connections',
   'Calendar',
   'Tasks',
 ] as const;
@@ -79,7 +79,7 @@ describe('DashboardNav interactions', () => {
     }
   });
 
-  it('routes Profiles through the canonical navigation row without a duplicate avatar button', () => {
+  it('routes Connections through the canonical navigation row without a duplicate avatar button', () => {
     renderDashboardNav({
       renderFn: render,
       overrides: {
@@ -92,7 +92,7 @@ describe('DashboardNav interactions', () => {
       },
     });
 
-    expect(screen.getByRole('link', { name: 'Profiles' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Connections' })).toHaveAttribute(
       'href',
       APP_ROUTES.PROFILES
     );

--- a/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
+++ b/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
@@ -11,6 +11,10 @@ describe('getBreadcrumbLabel', () => {
     expect(getBreadcrumbLabel('dashboard')).toBe('Dashboard');
   });
 
+  it('returns "Connections" for the internal profiles route', () => {
+    expect(getBreadcrumbLabel('profiles')).toBe('Connections');
+  });
+
   it('returns "New Chat" for the app root segment', () => {
     expect(getBreadcrumbLabel('app')).toBe('New Chat');
   });

--- a/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
@@ -42,7 +42,7 @@ const CANONICAL_LABELS = [
   'Inbox',
   'Library',
   'Contacts',
-  'Profiles',
+  'Connections',
   'Calendar',
   'Tasks',
 ] as const;

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -23,7 +23,7 @@ const CANONICAL_NAV = [
   ['Inbox', APP_ROUTES.DASHBOARD],
   ['Library', APP_ROUTES.LIBRARY],
   ['Contacts', APP_ROUTES.CONTACTS],
-  ['Profiles', APP_ROUTES.PROFILES],
+  ['Connections', APP_ROUTES.PROFILES],
   ['Calendar', APP_ROUTES.CALENDAR],
   ['Tasks', APP_ROUTES.TASKS],
 ] as const;
@@ -89,7 +89,7 @@ describe('DashboardNav', () => {
       expect(queryByRole('button', { name: label })).toBeNull();
     }
 
-    expect(getByRole('link', { name: 'Profiles' })).toHaveAttribute(
+    expect(getByRole('link', { name: 'Connections' })).toHaveAttribute(
       'href',
       APP_ROUTES.PROFILES
     );

--- a/apps/web/tests/unit/lib/profile-workspace.test.ts
+++ b/apps/web/tests/unit/lib/profile-workspace.test.ts
@@ -15,10 +15,13 @@ const rows = [
 ] as unknown as ProfileWorkspaceRow[];
 
 describe('profile workspace presentation', () => {
-  it('groups websites and authority pages under Sources', () => {
+  it('filters Sources and Websites separately', () => {
     expect(
       filterProfileWorkspaceRows(rows, 'source').map(row => row.id)
-    ).toEqual(['website', 'wiki']);
+    ).toEqual(['wiki']);
+    expect(
+      filterProfileWorkspaceRows(rows, 'website').map(row => row.id)
+    ).toEqual(['website']);
   });
 
   it('filters every remaining category exactly', () => {


### PR DESCRIPTION
## Summary

- Rename the user-facing Profiles workspace to Connections while preserving the internal `/app/profiles` route and profile data contracts.
- Rework the workspace into a dense, accessible Connections table with complete type filters, semantic status and monitoring states, attention-first ordering, useful empty-value tooltips, and a connection detail rail.
- Keep row actions keyboard/touch reachable, preserve distinct duplicate URLs/handles, and maintain a usable narrow/mobile table without page-level horizontal overflow.

## User impact

Artists now get one calm, scannable view of DSPs, social accounts, sources, websites, connectors, and Jovie-owned surfaces. Status, monitoring, rank, change, and next action are separated so the page no longer mixes issue state with upgrade messaging or reports a contradictory global monitoring state.

## Verification

- Normal hooked pre-push gate passed with repo-pinned Node 22.23.1 and pnpm 9.15.4.
- Static gates: changed-file Biome, proxy guard, Tailwind guard, `@jovie/web` typecheck, affected typecheck/lint, and CI-harness validation all passed.
- Full Vitest gate:
  - shard 1: 284 files passed, 1 skipped; 2,108 tests passed, 39 skipped (401.17s)
  - shard 2: 284 files passed, 1 skipped; 2,674 tests passed, 1 skipped, 3 todo (480.79s)
  - shard 3: 283 files passed, 2 skipped; 1,989 tests passed, 14 skipped (553.56s)
  - shard 4: 285 files passed; 2,054 tests passed (468.05s)
  - shard 5: 285 files passed; 1,994 tests passed, 1 skipped (440.15s)
  - shard 6: 283 files passed, 2 skipped; 1,852 tests passed, 5 skipped, 1 todo (474.60s)
  - shard 7: 284 files passed, 1 skipped; 2,678 tests passed, 6 skipped (326.15s)
  - shard 8: 283 files passed, 2 skipped; 2,437 tests passed, 9 skipped, 2 todo (409.73s)
- Focused Connections coverage passed, including `ProfilesWorkspace`, workspace filters/status/sort, navigation copy, action accessibility, and mobile behavior.
- The stale Websites/Sources contract repair passed both focused (3/3) and full-gate coverage.
- A prior unrelated 60s route-import timeout was classified as host-load dependent: the file passed 8/8 alone in 6.70s and passed 8/8 in the final shard in 7.74s.
- Rendered QA passed at 1440px desktop and 390px mobile with no document overflow or console errors; the mobile action target measured 44x44 and opened the connection detail dialog.

## Design review

Independent review findings were resolved for action semantics, attention-first sorting, keyboard-accessible type tooltips, provider availability, stale detail state, mobile action reachability, and canonical Jovie icon use.

## Risk and rollback

This is an authenticated workspace UI/presentation change. The route and internal profile data model remain unchanged. Rollback is a standard revert of this PR.

<!-- linear-issue-id:JOV-4512 -->