### PR TITLE
fix(nav): guard customer sidebar capacity with one More menu (JOV-4515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Customer nav capacity guard with one canonical More menu (JOV-4515):** documented desktop/mobile caps keep approved core destinations on the primary rail, overflow only experimental extras into a single More surface, and promote the active route so it is never hidden.
 - [internal] **Better Auth OAuth token tables cover the pinned provider schema (JOV-4587):** client, access-token, refresh-token, and consent columns now include fields such as `authorizationCodeId`, with a contract test that fails on mapping drift so LYB Apple sign-in can complete `/oauth2/token` exchange.
 - [internal] **Native Gmail brand-deal qualification is fail-closed (JOV-4578):** Jovie now surfaces only the highest-ranked current brief with explicit buyer, company, budget, deposit, rights, and revision terms; provenance comes from the connected Gmail record, Calendar is optional, and pending or approved sponsor work blocks another campaign.
 - **Verified brand deals can enter Jovie's Inbox for one explicit decision (JOV-4578):** provenance-checked opportunities now appear as Brand Deals with budget, source, and ranking evidence; rejecting moves on, while approving authorizes preparation only and never sends outreach or creates a campaign without a separate commercial approval and deposit.

--- a/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Music } from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+import { CustomerNavMoreMenu } from './CustomerNavMoreMenu';
+import type { NavItem } from './types';
+
+const moreItems: NavItem[] = [
+  {
+    id: 'labs',
+    name: 'Labs',
+    href: '/app/labs',
+    icon: Music,
+    tier: 'experimental',
+  },
+  {
+    id: 'signals',
+    name: 'Signals',
+    href: '/app/signals',
+    icon: Music,
+    tier: 'experimental',
+  },
+];
+
+describe('CustomerNavMoreMenu', () => {
+  it('renders nothing when there are no overflow destinations', () => {
+    const { container } = render(
+      <ul>
+        <CustomerNavMoreMenu items={[]} isItemActive={() => false} />
+      </ul>
+    );
+    expect(container.querySelector('[data-customer-nav-more]')).toBeNull();
+  });
+
+  it('exposes one More trigger and keyboard-accessible overflow links', async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+
+    render(
+      <ul>
+        <CustomerNavMoreMenu
+          items={moreItems}
+          isItemActive={item => item.id === 'signals'}
+          onActivate={onActivate}
+        />
+      </ul>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'More options' });
+    expect(trigger).toHaveAttribute('data-has-active-overflow', 'true');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    trigger.focus();
+    await user.keyboard('{Enter}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const menu = screen.getByRole('menu');
+    expect(menu).toHaveAttribute('aria-label', 'More Navigation');
+    const links = within(menu).getAllByRole('menuitem');
+    expect(links.map(link => link.textContent?.trim())).toEqual([
+      'Labs',
+      'Signals',
+    ]);
+    expect(links[1]).toHaveAttribute('aria-current', 'page');
+
+    links[0]!.addEventListener('click', event => event.preventDefault());
+    await user.click(links[0]!);
+    expect(onActivate).toHaveBeenCalledWith(
+      moreItems[0],
+      expect.stringMatching(/pointer|keyboard/)
+    );
+  });
+});

--- a/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@jovie/ui';
+import { MoreHorizontal } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { SidebarMenuItem } from '@/components/organisms/Sidebar';
+import {
+  getSidebarNavIconClassName,
+  getSidebarNavRowClassName,
+} from '@/components/shell/SidebarNavItem';
+import { Tooltip } from '@/components/shell/Tooltip';
+import type { NavigationInputMethod } from '@/lib/tracking/navigation-telemetry-contract';
+import { cn } from '@/lib/utils';
+
+import type { NavItem } from './types';
+
+export interface CustomerNavMoreMenuProps {
+  readonly items: readonly NavItem[];
+  readonly isItemActive: (item: NavItem) => boolean;
+  readonly onActivate?: (
+    item: NavItem,
+    inputMethod: NavigationInputMethod
+  ) => void;
+  readonly onPrefetch?: (itemId: string) => void;
+}
+
+/**
+ * Single canonical More menu for customer primary-rail overflow (JOV-4515).
+ * Desktop sidebar only — mobile uses the shared LiquidGlassMenu More surface
+ * fed by the same capacity partition.
+ */
+export function CustomerNavMoreMenu({
+  items,
+  isItemActive,
+  onActivate,
+  onPrefetch,
+}: CustomerNavMoreMenuProps) {
+  const [open, setOpen] = useState(false);
+  const hasActiveOverflow = items.some(item => isItemActive(item));
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <SidebarMenuItem>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <Tooltip label='More' side='right' block>
+          <DropdownMenuTrigger asChild>
+            <button
+              type='button'
+              aria-label={open ? 'Close menu' : 'More options'}
+              aria-expanded={open}
+              aria-haspopup='menu'
+              data-customer-nav-more='true'
+              data-has-active-overflow={hasActiveOverflow ? 'true' : 'false'}
+              className={getSidebarNavRowClassName({
+                active: hasActiveOverflow && !open,
+                className: cn(
+                  'group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0',
+                  open && 'bg-sidebar-accent text-primary-token'
+                ),
+              })}
+            >
+              <MoreHorizontal
+                className={getSidebarNavIconClassName({
+                  active: hasActiveOverflow || open,
+                })}
+                strokeWidth={2.25}
+                aria-hidden='true'
+              />
+              <span className='min-w-0 truncate text-left justify-self-start group-data-[collapsible=icon]:hidden'>
+                More
+              </span>
+              {hasActiveOverflow ? (
+                <span
+                  className='h-1.5 w-1.5 shrink-0 justify-self-end rounded-full bg-accent group-data-[collapsible=icon]:hidden'
+                  aria-hidden='true'
+                />
+              ) : null}
+            </button>
+          </DropdownMenuTrigger>
+        </Tooltip>
+        <DropdownMenuContent
+          side='right'
+          align='start'
+          sideOffset={8}
+          className='min-w-44'
+          aria-label='More Navigation'
+        >
+          {items.map(item => {
+            const active = isItemActive(item);
+            const Icon = item.icon;
+            return (
+              <DropdownMenuItem key={item.id} asChild>
+                <Link
+                  href={item.href}
+                  aria-current={active ? 'page' : undefined}
+                  data-customer-nav-more-item={item.id}
+                  onMouseEnter={() => onPrefetch?.(item.id)}
+                  onFocus={() => onPrefetch?.(item.id)}
+                  onClick={event => {
+                    if (
+                      event.button === 0 &&
+                      !event.metaKey &&
+                      !event.ctrlKey &&
+                      !event.shiftKey &&
+                      !event.altKey
+                    ) {
+                      onActivate?.(
+                        item,
+                        event.detail === 0 ? 'keyboard' : 'pointer'
+                      );
+                    }
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2',
+                    active && 'font-medium text-primary-token'
+                  )}
+                >
+                  <Icon className='h-3.5 w-3.5 shrink-0' aria-hidden='true' />
+                  <span className='min-w-0 truncate'>{item.name}</span>
+                </Link>
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </SidebarMenuItem>
+  );
+}

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -33,8 +33,11 @@ import {
   startNavigationTelemetry,
   trackNavigationImpressions,
 } from '@/lib/tracking/navigation-telemetry';
+import { CustomerNavMoreMenu } from './CustomerNavMoreMenu';
 import {
   artistSettingsNavigation,
+  CUSTOMER_NAV_CAPACITY,
+  partitionCustomerNavigation,
   primaryNavigation,
   userSettingsNavigation,
 } from './config';
@@ -159,7 +162,7 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
     seenAt: tasksSeenAt,
   });
   const isInSettings = pathname.startsWith(APP_ROUTES.SETTINGS);
-  const visiblePrimaryNavigation = useMemo(
+  const eligiblePrimaryNavigation = useMemo(
     () =>
       primaryNavigation.filter(
         item =>
@@ -171,6 +174,24 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
       ),
     [inboxNavigation, pathname]
   );
+  const activePrimaryItemId = useMemo(() => {
+    const active = eligiblePrimaryNavigation.find(item => {
+      if (item.id === 'chat' && item.href === APP_ROUTES.CHAT) {
+        return normalizeTrailingSlash(pathname) === APP_ROUTES.CHAT;
+      }
+      return isItemActive(pathname, item);
+    });
+    return active?.id ?? null;
+  }, [eligiblePrimaryNavigation, pathname]);
+  const { visible: visiblePrimaryNavigation, more: morePrimaryNavigation } =
+    useMemo(
+      () =>
+        partitionCustomerNavigation(eligiblePrimaryNavigation, {
+          visibleCap: CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible,
+          activeItemId: activePrimaryItemId,
+        }),
+      [activePrimaryItemId, eligiblePrimaryNavigation]
+    );
   const threadsVisible =
     !isDemo &&
     !isInSettings &&
@@ -241,9 +262,8 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
 
   const artistSettingsLabel = 'Artist';
 
-  // Memoize nav sections for dashboard (non-settings) mode
-  const navSections = useMemo<readonly DashboardNavSection[]>(() => {
-    const decorateItem = (item: NavItem): NavItem => {
+  const decorateItem = useCallback(
+    (item: NavItem): NavItem => {
       if (item.id === 'tasks') {
         const taskCount = canAccessTasksWorkspace
           ? formatTaskBadge(taskStats, tasksSeenAt)
@@ -268,21 +288,24 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
       }
 
       return item;
-    };
+    },
+    [canAccessTasksWorkspace, isPlanGateLoading, taskStats, tasksSeenAt]
+  );
 
-    return [
+  // Memoize nav sections for dashboard (non-settings) mode
+  const navSections = useMemo<readonly DashboardNavSection[]>(
+    () => [
       {
         key: 'primary',
         items: visiblePrimaryNavigation.map(decorateItem),
       },
-    ];
-  }, [
-    canAccessTasksWorkspace,
-    isPlanGateLoading,
-    taskStats,
-    tasksSeenAt,
-    visiblePrimaryNavigation,
-  ]);
+    ],
+    [decorateItem, visiblePrimaryNavigation]
+  );
+  const moreNavItems = useMemo(
+    () => morePrimaryNavigation.map(decorateItem),
+    [decorateItem, morePrimaryNavigation]
+  );
 
   // Debounced prefetch: avoid firing on fast mouse sweeps across nav items
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -462,12 +485,33 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
 
   // Memoize renderSection to prevent creating new functions on every render
   const renderSection = useCallback(
-    (items: readonly NavItem[]) => (
+    (items: readonly NavItem[], options?: { includeMore?: boolean }) => (
       <SidebarMenu className='gap-px'>
         {items.map((item, index) => renderNavItem(item, index))}
+        {options?.includeMore && moreNavItems.length > 0 ? (
+          <CustomerNavMoreMenu
+            items={moreNavItems}
+            isItemActive={item => {
+              if (item.id === 'chat' && item.href === APP_ROUTES.CHAT) {
+                return normalizeTrailingSlash(pathname) === APP_ROUTES.CHAT;
+              }
+              return isItemActive(pathname, item);
+            }}
+            onActivate={(item, inputMethod) =>
+              startNavigationTelemetry({
+                itemId: item.id,
+                sourcePathname: pathname,
+                destinationHref: item.href,
+                inputMethod,
+                context: telemetryContext,
+              })
+            }
+            onPrefetch={handlePrefetch}
+          />
+        ) : null}
       </SidebarMenu>
     ),
-    [renderNavItem]
+    [handlePrefetch, moreNavItems, pathname, renderNavItem, telemetryContext]
   );
 
   return (
@@ -503,7 +547,9 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
                       defaultOpen
                       storageKey={`dashboard.${section.key}`}
                     >
-                      {renderSection(section.items)}
+                      {renderSection(section.items, {
+                        includeMore: index === 0,
+                      })}
                     </SidebarCollapsibleGroup>
                   ) : (
                     <>
@@ -516,7 +562,9 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
                           {searchSurface}
                         </div>
                       ) : null}
-                      {renderSection(section.items.slice(1))}
+                      {renderSection(section.items.slice(1), {
+                        includeMore: index === 0,
+                      })}
                     </>
                   )}
                 </div>

--- a/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
@@ -1,0 +1,196 @@
+import { CalendarDays, CheckSquare, Music, SquarePen } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  CUSTOMER_NAV_CAPACITY,
+  customerNavVisibleCap,
+  partitionCustomerNavigation,
+} from './capacity';
+import {
+  mobileExpandedNavigation,
+  mobilePrimaryNavigation,
+  primaryNavigation,
+} from './config';
+import type { NavItem } from './types';
+
+function experimentalItem(id: string, name: string): NavItem {
+  return {
+    id,
+    name,
+    href: `/app/${id}`,
+    icon: Music,
+    tier: 'experimental',
+  };
+}
+
+describe('CUSTOMER_NAV_CAPACITY', () => {
+  it('documents desktop and mobile caps that preserve the approved core rail', () => {
+    expect(CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible).toBe(7);
+    expect(CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible).toBe(3);
+    expect(customerNavVisibleCap('desktopPrimaryVisible')).toBe(7);
+    expect(customerNavVisibleCap('mobilePrimaryVisible')).toBe(3);
+  });
+
+  it('requires every approved core destination to fit the desktop rail', () => {
+    const coreItems = primaryNavigation.filter(
+      item => (item.tier ?? 'core') === 'core'
+    );
+    expect(coreItems).toHaveLength(primaryNavigation.length);
+    expect(coreItems.length).toBeLessThanOrEqual(
+      CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible
+    );
+  });
+});
+
+describe('partitionCustomerNavigation', () => {
+  it('keeps the default mobile primary + More split in source order', () => {
+    const partition = partitionCustomerNavigation(primaryNavigation, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
+    });
+
+    expect(partition.visible.map(item => item.id)).toEqual([
+      'chat',
+      'inbox',
+      'library',
+    ]);
+    expect(partition.more.map(item => item.id)).toEqual([
+      'contacts',
+      'profiles',
+      'calendar',
+      'tasks',
+    ]);
+    expect(partition.visible).toEqual(mobilePrimaryNavigation);
+    expect(partition.more).toEqual(mobileExpandedNavigation);
+  });
+
+  it('keeps the full approved core set on the desktop rail with an empty More', () => {
+    const partition = partitionCustomerNavigation(primaryNavigation, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible,
+    });
+
+    expect(partition.visible.map(item => item.id)).toEqual(
+      primaryNavigation.map(item => item.id)
+    );
+    expect(partition.more).toEqual([]);
+  });
+
+  it('overflows only experimental extras after the cap into one More list', () => {
+    const items: NavItem[] = [
+      ...primaryNavigation,
+      experimentalItem('labs', 'Labs'),
+      experimentalItem('signals', 'Signals'),
+    ];
+
+    const partition = partitionCustomerNavigation(items, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible,
+    });
+
+    expect(partition.visible.map(item => item.id)).toEqual(
+      primaryNavigation.map(item => item.id)
+    );
+    expect(partition.more.map(item => item.id)).toEqual(['labs', 'signals']);
+    expect(partition.more.every(item => item.tier === 'experimental')).toBe(
+      true
+    );
+  });
+
+  it('fills remaining desktop slots with experimental items before overflowing', () => {
+    const coreSlice = primaryNavigation.slice(0, 5);
+    const items: NavItem[] = [
+      ...coreSlice,
+      experimentalItem('labs', 'Labs'),
+      experimentalItem('signals', 'Signals'),
+    ];
+
+    const partition = partitionCustomerNavigation(items, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible,
+    });
+
+    expect(partition.visible.map(item => item.id)).toEqual([
+      ...coreSlice.map(item => item.id),
+      'labs',
+      'signals',
+    ]);
+    expect(partition.more).toEqual([]);
+  });
+
+  it('never hides the active route — promotes active overflow into visible', () => {
+    const partition = partitionCustomerNavigation(primaryNavigation, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
+      activeItemId: 'tasks',
+    });
+
+    expect(partition.visible.map(item => item.id)).toContain('tasks');
+    expect(partition.visible).toHaveLength(
+      CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible
+    );
+    expect(partition.more.map(item => item.id)).not.toContain('tasks');
+    // Prefer displacing the last non-promoted slot while preserving order.
+    expect(partition.visible.map(item => item.id)).toEqual([
+      'chat',
+      'inbox',
+      'tasks',
+    ]);
+  });
+
+  it('promotes an active experimental destination ahead of passive experimental slots', () => {
+    const items: NavItem[] = [
+      {
+        id: 'chat',
+        name: 'New Chat',
+        href: APP_ROUTES.CHAT,
+        icon: SquarePen,
+        tier: 'core',
+      },
+      {
+        id: 'library',
+        name: 'Library',
+        href: APP_ROUTES.LIBRARY,
+        icon: Music,
+        tier: 'core',
+      },
+      {
+        id: 'calendar',
+        name: 'Calendar',
+        href: APP_ROUTES.CALENDAR,
+        icon: CalendarDays,
+        tier: 'core',
+      },
+      experimentalItem('labs', 'Labs'),
+      experimentalItem('signals', 'Signals'),
+      {
+        id: 'tasks',
+        name: 'Tasks',
+        href: APP_ROUTES.TASKS,
+        icon: CheckSquare,
+        tier: 'experimental',
+      },
+    ];
+
+    const partition = partitionCustomerNavigation(items, {
+      visibleCap: 4,
+      activeItemId: 'tasks',
+    });
+
+    expect(partition.visible.map(item => item.id)).toEqual([
+      'chat',
+      'library',
+      'calendar',
+      'tasks',
+    ]);
+    expect(partition.more.map(item => item.id)).toEqual(['labs', 'signals']);
+  });
+
+  it('preserves object identity from the source list', () => {
+    const partition = partitionCustomerNavigation(primaryNavigation, {
+      visibleCap: 3,
+      activeItemId: 'calendar',
+    });
+
+    for (const item of [...partition.visible, ...partition.more]) {
+      expect(primaryNavigation.find(source => source.id === item.id)).toBe(
+        item
+      );
+    }
+  });
+});

--- a/apps/web/components/features/dashboard/dashboard-nav/capacity.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/capacity.ts
@@ -1,0 +1,152 @@
+import type { CustomerNavTier, NavItem } from './types';
+
+/**
+ * Documented capacity for the founder-approved customer primary rail (JOV-4515).
+ *
+ * Core destinations always take priority. Experimental destinations may fill
+ * remaining slots under the cap; extras share one canonical More menu.
+ * This is a transitional safety valve — not permission to expand permanent IA.
+ */
+export const CUSTOMER_NAV_CAPACITY = {
+  /**
+   * Desktop sidebar direct rows. Sized to the approved core set so every core
+   * destination stays on the rail; experimental extras overflow into More.
+   */
+  desktopPrimaryVisible: 7,
+  /**
+   * Mobile bottom-bar direct tabs. Remaining destinations (core that do not
+   * fit + experimental extras) share the single More menu.
+   */
+  mobilePrimaryVisible: 3,
+} as const;
+
+export type CustomerNavCapacityBreakpoint = keyof typeof CUSTOMER_NAV_CAPACITY;
+
+export interface CustomerNavPartition {
+  readonly visible: readonly NavItem[];
+  readonly more: readonly NavItem[];
+}
+
+export interface PartitionCustomerNavigationOptions {
+  /** Max destinations rendered as direct primary rows/tabs. */
+  readonly visibleCap: number;
+  /**
+   * Active destination id. When set, the active item is always kept in
+   * `visible` (promoted out of More if needed) so the active route is never
+   * hidden from the primary rail/tabs.
+   */
+  readonly activeItemId?: string | null;
+}
+
+function navTier(item: NavItem): CustomerNavTier {
+  return item.tier ?? 'core';
+}
+
+function sortBySourceOrder(
+  items: readonly NavItem[],
+  source: readonly NavItem[]
+): NavItem[] {
+  const order = new Map(source.map((item, index) => [item.id, index]));
+  return [...items].sort(
+    (a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0)
+  );
+}
+
+/**
+ * Partition customer navigation into direct-visible vs one shared More menu.
+ *
+ * Rules:
+ * 1. Core destinations fill visible slots first.
+ * 2. Experimental destinations fill remaining slots under the cap.
+ * 3. Everything else goes into a single More list (no route-specific overflow).
+ * 4. When `activeItemId` is provided and would land in More, promote it into
+ *    visible (displacing the last experimental, else the last visible item).
+ */
+export function partitionCustomerNavigation(
+  items: readonly NavItem[],
+  { visibleCap, activeItemId = null }: PartitionCustomerNavigationOptions
+): CustomerNavPartition {
+  if (visibleCap < 0) {
+    throw new Error('visibleCap must be >= 0');
+  }
+
+  if (items.length === 0 || visibleCap === 0) {
+    return {
+      visible: activeItemId
+        ? items.filter(item => item.id === activeItemId).slice(0, 1)
+        : [],
+      more: activeItemId
+        ? items.filter(item => item.id !== activeItemId)
+        : [...items],
+    };
+  }
+
+  const core: NavItem[] = [];
+  const experimental: NavItem[] = [];
+  for (const item of items) {
+    if (navTier(item) === 'experimental') {
+      experimental.push(item);
+    } else {
+      core.push(item);
+    }
+  }
+
+  const visible: NavItem[] = [];
+  const more: NavItem[] = [];
+
+  for (const item of core) {
+    if (visible.length < visibleCap) {
+      visible.push(item);
+    } else {
+      more.push(item);
+    }
+  }
+
+  for (const item of experimental) {
+    if (visible.length < visibleCap) {
+      visible.push(item);
+    } else {
+      more.push(item);
+    }
+  }
+
+  if (activeItemId) {
+    const activeInVisible = visible.some(item => item.id === activeItemId);
+    const activeInMoreIndex = more.findIndex(item => item.id === activeItemId);
+
+    if (!activeInVisible && activeInMoreIndex >= 0) {
+      const [activeItem] = more.splice(activeInMoreIndex, 1);
+      if (activeItem) {
+        if (visible.length >= visibleCap) {
+          let displaceIndex = -1;
+          for (let index = visible.length - 1; index >= 0; index -= 1) {
+            if (navTier(visible[index]!) === 'experimental') {
+              displaceIndex = index;
+              break;
+            }
+          }
+          if (displaceIndex < 0) {
+            displaceIndex = visible.length - 1;
+          }
+          const [displaced] = visible.splice(displaceIndex, 1);
+          if (displaced) {
+            more.push(displaced);
+          }
+        }
+        visible.push(activeItem);
+      }
+    }
+  }
+
+  return {
+    visible: sortBySourceOrder(visible, items),
+    more: sortBySourceOrder(more, items),
+  };
+}
+
+/** Resolve the visible cap for a named breakpoint. */
+export function customerNavVisibleCap(
+  breakpoint: CustomerNavCapacityBreakpoint
+): number {
+  return CUSTOMER_NAV_CAPACITY[breakpoint];
+}

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  CUSTOMER_NAV_CAPACITY,
+  desktopMoreNavigation,
+  desktopPrimaryNavigation,
   mobileExpandedNavigation,
   mobilePrimaryNavigation,
+  partitionCustomerNavigation,
   primaryNavigation,
 } from './config';
 
@@ -24,6 +28,7 @@ describe('canonical customer shell navigation', () => {
   it('keeps New Chat as the elevated first action and Connections in the canonical order', () => {
     expect(toContract(primaryNavigation)).toEqual(CANONICAL_NAVIGATION);
     expect(primaryNavigation[0].tone).toBe('primary');
+    expect(primaryNavigation.every(item => item.tier === 'core')).toBe(true);
   });
 
   it('detects missing and reordered canonical destinations', () => {
@@ -35,9 +40,13 @@ describe('canonical customer shell navigation', () => {
     );
   });
 
-  it('derives mobile primary + More destinations from the same object identities', () => {
-    expect(mobilePrimaryNavigation).toEqual(primaryNavigation.slice(0, 3));
-    expect(mobileExpandedNavigation).toEqual(primaryNavigation.slice(3));
+  it('derives mobile primary + More destinations from the capacity partition', () => {
+    const partition = partitionCustomerNavigation(primaryNavigation, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
+    });
+
+    expect(mobilePrimaryNavigation).toEqual(partition.visible);
+    expect(mobileExpandedNavigation).toEqual(partition.more);
     expect([...mobilePrimaryNavigation, ...mobileExpandedNavigation]).toEqual(
       primaryNavigation
     );
@@ -48,6 +57,16 @@ describe('canonical customer shell navigation', () => {
     ].entries()) {
       expect(item).toBe(primaryNavigation[index]);
     }
+  });
+
+  it('keeps the full approved core set on desktop with no More overflow', () => {
+    expect(desktopPrimaryNavigation.map(item => item.id)).toEqual(
+      primaryNavigation.map(item => item.id)
+    );
+    expect(desktopMoreNavigation).toEqual([]);
+    expect(primaryNavigation.length).toBeLessThanOrEqual(
+      CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible
+    );
   });
 
   it('excludes retired primary destinations while preserving the Connections route', () => {

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -20,6 +20,7 @@ import {
 
 import { APP_ROUTES } from '@/constants/routes';
 
+import { CUSTOMER_NAV_CAPACITY, partitionCustomerNavigation } from './capacity';
 import type { NavItem } from './types';
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,7 @@ export const dashboardHome: NavItem = {
   href: APP_ROUTES.CHAT,
   id: 'overview',
   icon: Home,
+  tier: 'core',
   description: 'Start a new chat',
 };
 
@@ -40,6 +42,7 @@ export const inboxNavItem: NavItem = {
   href: APP_ROUTES.DASHBOARD,
   id: 'inbox',
   icon: Inbox,
+  tier: 'core',
   description: 'Review pending opportunities',
 };
 
@@ -49,6 +52,7 @@ export const chatNavItem: NavItem = {
   id: 'chat',
   icon: SquarePen,
   tone: 'primary',
+  tier: 'core',
   description: 'Start a new conversation',
 };
 
@@ -57,6 +61,7 @@ export const libraryNavItem: NavItem = {
   href: APP_ROUTES.LIBRARY,
   id: 'library',
   icon: Music,
+  tier: 'core',
   description: 'Browse releases, audio, video, images, and files',
 };
 
@@ -65,6 +70,7 @@ export const contactsNavItem: NavItem = {
   href: APP_ROUTES.CONTACTS,
   id: 'contacts',
   icon: IdCard,
+  tier: 'core',
   description: 'Manage artist contacts',
 };
 
@@ -73,6 +79,7 @@ export const profilesNavItem: NavItem = {
   href: APP_ROUTES.PROFILES,
   id: 'profiles',
   icon: Waypoints,
+  tier: 'core',
   description: 'Monitor artist identities and connected services',
 };
 
@@ -81,6 +88,7 @@ export const calendarNavItem: NavItem = {
   href: APP_ROUTES.CALENDAR,
   id: 'calendar',
   icon: CalendarDays,
+  tier: 'core',
   description: 'See release dates, events, and calendar moments',
 };
 
@@ -89,12 +97,18 @@ export const tasksNavItem: NavItem = {
   href: APP_ROUTES.TASKS,
   id: 'tasks',
   icon: CheckSquare,
+  tier: 'core',
   description: 'Track release work and general artist operations',
 };
 
 /**
  * Founder-approved customer shell IA. This ordered tuple is the only source
  * consumed by desktop and mobile navigation (JOV-3763).
+ *
+ * Capacity (JOV-4515): every entry here is `core` and must fit the desktop
+ * primary rail. Mark new trial destinations `experimental` so they overflow
+ * into the single shared More menu after the documented cap — do not grow
+ * permanent IA without an explicit product decision.
  */
 export const primaryNavigation = [
   chatNavItem,
@@ -190,17 +204,51 @@ export const settingsNavigation: NavItem[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Mobile bottom-bar groupings (derived from shared items above)
+// Capacity-derived primary / More groupings (desktop + mobile)
 // ---------------------------------------------------------------------------
 
+const desktopDefaultPartition = partitionCustomerNavigation(primaryNavigation, {
+  visibleCap: CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible,
+});
+
+const mobileDefaultPartition = partitionCustomerNavigation(primaryNavigation, {
+  visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
+});
+
 /**
- * Items shown as icons in the bottom tab bar (max 3).
- *
- * Picked by id from the canonical `primaryNavigation` — never redefine a
- * NavItem here. A mobile-only nav item is a third source of truth that
- * drifts from desktop.
+ * Desktop direct rows when no route is active for promotion. Experimental
+ * extras beyond the desktop cap land in {@link desktopMoreNavigation}.
  */
-export const mobilePrimaryNavigation: NavItem[] = primaryNavigation.slice(0, 3);
+export const desktopPrimaryNavigation: readonly NavItem[] =
+  desktopDefaultPartition.visible;
+
+/** Desktop destinations that share the single canonical More menu. */
+export const desktopMoreNavigation: readonly NavItem[] =
+  desktopDefaultPartition.more;
+
+/**
+ * Items shown as icons in the bottom tab bar (capacity-capped).
+ *
+ * Derived from `primaryNavigation` via {@link partitionCustomerNavigation} —
+ * never redefine a NavItem here. Runtime mobile rendering re-partitions with
+ * the active route so the current destination is never hidden.
+ */
+export const mobilePrimaryNavigation: NavItem[] = [
+  ...mobileDefaultPartition.visible,
+];
 
 /** Items shown in the expanded "more" menu on mobile. */
-export const mobileExpandedNavigation: NavItem[] = primaryNavigation.slice(3);
+export const mobileExpandedNavigation: NavItem[] = [
+  ...mobileDefaultPartition.more,
+];
+
+export type {
+  CustomerNavCapacityBreakpoint,
+  CustomerNavPartition,
+  PartitionCustomerNavigationOptions,
+} from './capacity';
+export {
+  CUSTOMER_NAV_CAPACITY,
+  customerNavVisibleCap,
+  partitionCustomerNavigation,
+} from './capacity';

--- a/apps/web/components/features/dashboard/dashboard-nav/index.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/index.ts
@@ -1,13 +1,24 @@
+export { CustomerNavMoreMenu } from './CustomerNavMoreMenu';
+export type {
+  CustomerNavCapacityBreakpoint,
+  CustomerNavPartition,
+  PartitionCustomerNavigationOptions,
+} from './config';
 export {
   artistSettingsNavigation,
+  CUSTOMER_NAV_CAPACITY,
   calendarNavItem,
   chatNavItem,
   contactsNavItem,
+  customerNavVisibleCap,
   dashboardHome,
+  desktopMoreNavigation,
+  desktopPrimaryNavigation,
   inboxNavItem,
   libraryNavItem,
   mobileExpandedNavigation,
   mobilePrimaryNavigation,
+  partitionCustomerNavigation,
   primaryNavigation,
   settingsNavItem,
   settingsNavigation,
@@ -16,5 +27,9 @@ export {
 } from './config';
 export { DashboardNav } from './DashboardNav';
 export { isLibraryNavigationRoute } from './navigation-state';
-export type { DashboardNavProps, NavItem } from './types';
+export type {
+  CustomerNavTier,
+  DashboardNavProps,
+  NavItem,
+} from './types';
 export { copyToClipboard, fallbackCopy } from './utils';

--- a/apps/web/components/features/dashboard/dashboard-nav/types.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/types.ts
@@ -1,5 +1,12 @@
 import type { ComponentType, ReactNode, SVGProps } from 'react';
 
+/**
+ * Core destinations are founder-approved and always take primary-rail slots
+ * first. Experimental destinations may fill remaining capacity and overflow
+ * into the single shared More menu (JOV-4515).
+ */
+export type CustomerNavTier = 'core' | 'experimental';
+
 export interface NavItem {
   name: string;
   href: string;
@@ -7,6 +14,11 @@ export interface NavItem {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   /** Gives the one primary sidebar action the shared elevated row treatment. */
   tone?: 'default' | 'primary';
+  /**
+   * Capacity tier. Defaults to `core` when omitted so existing entries stay
+   * on the approved rail until explicitly marked experimental.
+   */
+  tier?: CustomerNavTier;
   description?: string;
   badge?: ReactNode;
   children?: NavItem[];

--- a/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
@@ -4,9 +4,10 @@ import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useMemo } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  CUSTOMER_NAV_CAPACITY,
   isLibraryNavigationRoute,
-  mobileExpandedNavigation,
-  mobilePrimaryNavigation,
+  partitionCustomerNavigation,
+  primaryNavigation,
   settingsNavItem,
 } from '@/features/dashboard/dashboard-nav';
 import type { NavItem } from '@/features/dashboard/dashboard-nav/types';
@@ -26,9 +27,23 @@ function toMenuItem(item: NavItem): LiquidGlassMenuItem {
   return { id: item.id, label: item.name, href: item.href, icon: item.icon };
 }
 
-const PRIMARY_ITEMS = mobilePrimaryNavigation.map(toMenuItem);
-const EXPANDED_ITEMS = mobileExpandedNavigation.map(toMenuItem);
 const UTILITY_ITEMS = [settingsNavItem].map(toMenuItem);
+
+function isMobileNavItemActive(
+  item: Pick<NavItem, 'id' | 'href'>,
+  pathname: string
+): boolean {
+  if (item.id === 'library') {
+    return isLibraryNavigationRoute(pathname);
+  }
+  if (item.href === APP_ROUTES.DASHBOARD) {
+    return pathname === item.href;
+  }
+  if (item.id === 'chat' && item.href === APP_ROUTES.CHAT) {
+    return pathname === APP_ROUTES.CHAT;
+  }
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
+}
 
 export interface DashboardMobileTabsProps {
   readonly className?: string;
@@ -50,14 +65,32 @@ export function DashboardMobileTabs({
     [isElectron]
   );
 
+  const activeItemId = useMemo(() => {
+    const active = primaryNavigation.find(item =>
+      isMobileNavItemActive(item, pathname)
+    );
+    return active?.id ?? null;
+  }, [pathname]);
+
+  const { primaryItems, expandedItems } = useMemo(() => {
+    const partition = partitionCustomerNavigation(primaryNavigation, {
+      visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
+      activeItemId,
+    });
+    return {
+      primaryItems: partition.visible.map(toMenuItem),
+      expandedItems: partition.more.map(toMenuItem),
+    };
+  }, [activeItemId]);
+
   useEffect(() => {
     if (!isMobile) return;
     trackNavigationImpressions(
-      PRIMARY_ITEMS.map(item => item.id),
+      primaryItems.map(item => item.id),
       pathname,
       telemetryContext
     );
-  }, [isMobile, pathname, telemetryContext]);
+  }, [isMobile, pathname, primaryItems, telemetryContext]);
 
   const handleItemActivate = useCallback(
     (
@@ -92,24 +125,15 @@ export function DashboardMobileTabs({
 
   return (
     <LiquidGlassMenu
-      primaryItems={PRIMARY_ITEMS}
-      expandedItems={EXPANDED_ITEMS}
+      primaryItems={primaryItems}
+      expandedItems={expandedItems}
       utilityItems={UTILITY_ITEMS}
       onItemActivate={handleItemActivate}
       onExpandedItemsVisible={handleExpandedItemsVisible}
       onSignOut={handleSignOut}
-      isItemActive={(item, currentPathname) => {
-        if (item.id === 'library') {
-          return isLibraryNavigationRoute(currentPathname);
-        }
-        if (item.href === APP_ROUTES.DASHBOARD) {
-          return currentPathname === item.href;
-        }
-        return (
-          currentPathname === item.href ||
-          currentPathname.startsWith(`${item.href}/`)
-        );
-      }}
+      isItemActive={(item, currentPathname) =>
+        isMobileNavItemActive(item, currentPathname)
+      }
       inFlow
       className={cn('lg:hidden', className)}
     />

--- a/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
@@ -188,4 +188,21 @@ describe('DashboardMobileTabs', () => {
       'page'
     );
   });
+
+  it('promotes an active overflow destination into the primary tab strip', () => {
+    mockPathname.mockReturnValue(APP_ROUTES.TASKS);
+    render(<DashboardMobileTabs />);
+
+    const tabs = screen.getByRole('navigation', { name: 'Dashboard Tabs' });
+    const directLinks = within(tabs).getAllByRole('link');
+    expect(directLinks.map(link => link.textContent?.trim())).toEqual([
+      'New Chat',
+      'Inbox',
+      'Tasks',
+    ]);
+    expect(within(tabs).getByRole('link', { name: 'Tasks' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds a documented capacity guard for customer primary navigation so the approved core rail stays scannable while experimental destinations can only overflow into **one** canonical More menu.

- Document `CUSTOMER_NAV_CAPACITY` (desktop `7`, mobile `3`) and mark current destinations as `core`
- Pure `partitionCustomerNavigation()` fills core first, then experimental, and **always promotes the active route** into the visible set
- Desktop uses the partition for the sidebar and renders `CustomerNavMoreMenu` only when overflow exists
- Mobile re-partitions with the active route so overflow destinations remain visible in the primary tab strip when active
- Config + unit coverage for capacity, experimental overflow, active promotion, and More a11y

This is a transitional safety valve, not permission to expand permanent IA. Today all seven approved core destinations fit the desktop rail, so desktop More stays empty unless experimental items are added.

## Test plan / results

- [x] `pnpm --filter web exec vitest run components/features/dashboard/dashboard-nav/capacity.test.ts components/features/dashboard/dashboard-nav/config.test.ts components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx tests/unit/dashboard/DashboardMobileTabs.test.tsx`
  - **23/23 passed**
- [x] `pnpm --filter web exec vitest run tests/unit/dashboard/DashboardNav.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx`
  - **31/31 passed**
- [x] Pre-commit: Biome, ESLint, a11y staged, typecheck `@jovie/web`
- [x] Pre-push hooks (biome/typecheck/affected tests) green

## Notes

- Never hides the active route (promotion out of More)
- One More surface concept: desktop `CustomerNavMoreMenu` + existing mobile LiquidGlass More, both fed by the same partition
- Keyboard: More trigger uses Enter/Escape; items keep accessible names and `aria-current`

Fixes JOV-4515

<!-- linear-issue-id:JOV-4515 -->