### PR TITLE
fix(ci): bound production Lighthouse per-route retries to the job deadline

### DIFF
--- a/.github/workflows/postdeploy-probes.yml
+++ b/.github/workflows/postdeploy-probes.yml
@@ -487,6 +487,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Establish Lighthouse job deadline
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Job timeout-minutes: 20. Reserve 210s for assert/upload/cleanup + SIGTERM grace
+          # so per-route retries cannot run into a silent GitHub cancel without a receipt.
+          now_s="$(date +%s)"
+          deadline_s=$(( now_s + 20 * 60 - 210 ))
+          echo "LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS=$(( deadline_s * 1000 ))" >> "$GITHUB_ENV"
+          echo "Lighthouse collect hard deadline epoch ms: $(( deadline_s * 1000 ))"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.resolve-target.outputs.commit_sha }}
@@ -540,7 +550,7 @@ jobs:
           EXPECTED_COMMIT_SHA: ${{ needs.resolve-target.outputs.commit_sha }}
           LIGHTHOUSE_SENSITIVE_VALUES_FILE: ${{ runner.temp }}/lighthouse-sensitive-values
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: node scripts/lighthouse-retry.mjs -- pnpm --filter @jovie/web exec lhci collect --config="$RUNNER_TEMP/lighthouse-production-exact.json"
+        run: node scripts/lighthouse-production-collect.mjs --config="$RUNNER_TEMP/lighthouse-production-exact.json"
       - name: Assert Lighthouse production budgets
         run: pnpm --filter @jovie/web exec lhci assert --config="$RUNNER_TEMP/lighthouse-production-exact.json"
       - name: Validate and upload hash-sealed Lighthouse evidence

--- a/.github/workflows/production-controller.yml
+++ b/.github/workflows/production-controller.yml
@@ -530,6 +530,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Establish Lighthouse job deadline
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Job timeout-minutes: 20. Reserve 210s for assert/upload/cleanup + SIGTERM grace
+          # so per-route retries cannot run into a silent GitHub cancel without a receipt.
+          now_s="$(date +%s)"
+          deadline_s=$(( now_s + 20 * 60 - 210 ))
+          echo "LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS=$(( deadline_s * 1000 ))" >> "$GITHUB_ENV"
+          echo "Lighthouse collect hard deadline epoch ms: $(( deadline_s * 1000 ))"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.authorize-production.outputs.expected_sha }}
@@ -583,7 +593,7 @@ jobs:
           EXPECTED_COMMIT_SHA: ${{ needs.authorize-production.outputs.expected_sha }}
           LIGHTHOUSE_SENSITIVE_VALUES_FILE: ${{ runner.temp }}/lighthouse-sensitive-values
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: node scripts/lighthouse-retry.mjs -- pnpm --filter @jovie/web exec lhci collect --config="$RUNNER_TEMP/lighthouse-production-exact.json"
+        run: node scripts/lighthouse-production-collect.mjs --config="$RUNNER_TEMP/lighthouse-production-exact.json"
       - name: Assert Lighthouse production budgets
         run: pnpm --filter @jovie/web exec lhci assert --config="$RUNNER_TEMP/lighthouse-production-exact.json"
       - name: Validate and upload hash-sealed Lighthouse evidence

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1772,7 +1772,11 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     expect(lighthouse).toContain(
       'VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}'
     );
-    expect(lighthouse).toContain('lhci collect');
+    expect(lighthouse).toContain('Establish Lighthouse job deadline');
+    expect(lighthouse).toContain('LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS=');
+    expect(lighthouse).toContain(
+      'lighthouse-production-collect.mjs --config="$RUNNER_TEMP/lighthouse-production-exact.json"'
+    );
     expect(lighthouse).toContain('lhci assert');
     expect(lighthouse).toContain('lighthouse-exact-target-guard.ts');
     expect(lighthouse).toContain('LIGHTHOUSE_SENSITIVE_VALUES_FILE');
@@ -1790,9 +1794,9 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     );
     expect(lighthouse).not.toContain('lhci autorun');
     expect(lighthouse).not.toContain('extraHeaders');
-    expect(lighthouse.indexOf('lhci collect')).toBeLessThan(
-      lighthouse.indexOf('lhci assert')
-    );
+    expect(
+      lighthouse.indexOf('lighthouse-production-collect.mjs')
+    ).toBeLessThan(lighthouse.indexOf('lhci assert'));
     expect(lighthouse.indexOf('lhci assert')).toBeLessThan(
       lighthouse.lastIndexOf('lighthouse-exact-target-guard.ts')
     );

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -199,6 +199,18 @@ const DIAGNOSES: ReadonlyArray<{
       'Do not retry. Fix the named audit, fixture, or threshold regression and rerun the affected Lighthouse route once the exact assertion is addressed.',
   },
   {
+    failureClass: 'lighthouse_job_deadline',
+    matches: log =>
+      /LIGHTHOUSE_FAILURE_CLASS=job_deadline\b/i.test(log) &&
+      /(?:Lighthouse job deadline|LIGHTHOUSE_MIN_ATTEMPT_BUDGET_MS|LIGHTHOUSE_REMAINING_MS)/i.test(
+        log
+      ),
+    rootCause:
+      'Production Lighthouse stopped before the GitHub 20-minute job cancel because the remaining wall-clock budget could not fit another full per-route numberOfRuns attempt after a transient Chrome protocol failure or slow collect.',
+    remediation:
+      'Do not weaken assertions or accept incomplete evidence. Inspect the job_deadline receipt (route, remainingMs, minAttemptBudgetMs, completed routes). If setup is eating the budget, speed setup; if protocol flakes dominate, collect Chrome process/memory diagnostics. Rerun only the exact Production Controller for the same main SHA.',
+  },
+  {
     failureClass: 'lighthouse_protocol_timeout',
     matches: log =>
       /LIGHTHOUSE_FAILURE_CLASS=transient_protocol\b/i.test(log) &&
@@ -208,7 +220,7 @@ const DIAGNOSES: ReadonlyArray<{
     rootCause:
       'Lighthouse lost the Chrome DevTools protocol transport while collecting evidence; this is a browser/tooling failure rather than a product threshold assertion.',
     remediation:
-      "Use only the wrapper's bounded transient retry. If it exhausts, stop and collect the protocol method, Chrome process, memory, open-file, and runner-pressure diagnostics; do not add another workflow rerun or weaken assertions.",
+      "Use only the wrapper's bounded transient per-route retry under the job deadline. If it exhausts, stop and collect the protocol method, Chrome process, memory, open-file, and runner-pressure diagnostics; do not add another workflow rerun or weaken assertions.",
   },
   {
     failureClass: 'runner_image_proof_disk_exhaustion',

--- a/scripts/hermes/jobs/ci-failure-diagnosis.ts
+++ b/scripts/hermes/jobs/ci-failure-diagnosis.ts
@@ -7,6 +7,7 @@ export type CiFailureClass =
   | 'required_smoke_suppressed_by_dependency_skip'
   | 'storybook_browser_iframe_transport'
   | 'lighthouse_protocol_timeout'
+  | 'lighthouse_job_deadline'
   | 'lighthouse_loopback_origin_drift'
   | 'lighthouse_deterministic_assertion'
   | 'bounded_source_scan_timeout'

--- a/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
+++ b/scripts/hermes/lib/__tests__/ci-failure-diagnosis.test.ts
@@ -65,7 +65,18 @@ LIGHTHOUSE_FAILURE_CLASS=transient_protocol LIGHTHOUSE_ATTEMPT=3/3`);
 
     expect(diagnosis.failureClass).toBe('lighthouse_protocol_timeout');
     expect(diagnosis.rootCause).toContain('Chrome DevTools protocol');
-    expect(diagnosis.remediation).toContain('bounded transient retry');
+    expect(diagnosis.remediation).toContain('bounded transient');
+  });
+
+  it('classifies production Lighthouse job-deadline exits separately from protocol exhaustion', () => {
+    const diagnosis = diagnoseCiFailure(`Lighthouse CI (Production)
+PROTOCOL_TIMEOUT: DOMSnapshot.disable
+LIGHTHOUSE_FAILURE_CLASS=job_deadline LIGHTHOUSE_ATTEMPT=2/3 LIGHTHOUSE_ROUTE=/tim LIGHTHOUSE_REMAINING_MS=120000 LIGHTHOUSE_MIN_ATTEMPT_BUDGET_MS=390000
+Lighthouse job deadline exhausted before route /tim; refusing incomplete production evidence.`);
+
+    expect(diagnosis.failureClass).toBe('lighthouse_job_deadline');
+    expect(diagnosis.rootCause).toContain('20-minute job');
+    expect(diagnosis.remediation).toContain('incomplete evidence');
   });
 
   it('stops Lighthouse assertion failures without retrying', () => {

--- a/scripts/lib/__tests__/lighthouse-production-collect.test.mjs
+++ b/scripts/lib/__tests__/lighthouse-production-collect.test.mjs
@@ -1,0 +1,244 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildSingleRouteConfig,
+  collectProductionRoutes,
+  loadProductionCollectPlan,
+} from '../../lighthouse-production-collect.mjs';
+
+const tempDirs = [];
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'lhci-prod-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { force: true, recursive: true });
+  }
+});
+
+function baseConfig(
+  urls = [
+    'https://jovie-abc-jovie.vercel.app/',
+    'https://jovie-abc-jovie.vercel.app/tim',
+  ]
+) {
+  return {
+    ci: {
+      collect: {
+        numberOfRuns: 3,
+        url: urls,
+        puppeteerScript: 'scripts/lighthouse-vercel-bypass.cjs',
+        settings: { disableStorageReset: true },
+      },
+      assert: {
+        includePassedAssertions: true,
+        assertMatrix: urls.map(url => ({
+          matchingUrlPattern: `^${url.replaceAll('.', '\\.')}$`,
+          assertions: {
+            'categories:accessibility': ['error', { minScore: 0.9 }],
+          },
+        })),
+      },
+    },
+  };
+}
+
+describe('production Lighthouse per-route collect', () => {
+  it('loads the production route/run plan from the exact config', () => {
+    const plan = loadProductionCollectPlan(baseConfig());
+    expect(plan.numberOfRuns).toBe(3);
+    expect(plan.urls).toHaveLength(2);
+  });
+
+  it('narrows a multi-route config to one URL without dropping numberOfRuns', () => {
+    const single = buildSingleRouteConfig(
+      baseConfig(),
+      'https://jovie-abc-jovie.vercel.app/tim'
+    );
+    expect(single.ci.collect.url).toEqual([
+      'https://jovie-abc-jovie.vercel.app/tim',
+    ]);
+    expect(single.ci.collect.numberOfRuns).toBe(3);
+  });
+
+  it('collects routes independently and merges the sealed report set', async () => {
+    const root = makeTempDir();
+    const configPath = join(root, 'config.json');
+    const reportsDir = join(root, '.lighthouseci');
+    writeFileSync(configPath, JSON.stringify(baseConfig()));
+
+    const executeRouteAttempt = vi.fn(async ({ url, numberOfRuns }) => {
+      const files = [];
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        const path = join(root, `report-${encodeURIComponent(url)}-${i}.json`);
+        writeFileSync(
+          path,
+          JSON.stringify({ requestedUrl: url, finalUrl: url, run: i })
+        );
+        files.push(path);
+      }
+      return { code: 0, output: '', reportFiles: files };
+    });
+
+    const result = await collectProductionRoutes({
+      configPath,
+      reportsDir,
+      executeRouteAttempt,
+      deadlineMs: Date.now() + 60 * 60_000,
+      estimatedRunMs: 1_000,
+      overheadMs: 0,
+      maxAttempts: 3,
+      cooldownMs: 0,
+      report: vi.fn(),
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.reportCount).toBe(6);
+    expect(executeRouteAttempt).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(reportsDir, 'lhr-0.json'), 'utf8')).toContain(
+      'jovie-abc-jovie.vercel.app/'
+    );
+    expect(readFileSync(join(reportsDir, 'lhr-5.json'), 'utf8')).toContain(
+      '/tim'
+    );
+  });
+
+  it('retries only the failed route and keeps completed route evidence', async () => {
+    const root = makeTempDir();
+    const configPath = join(root, 'config.json');
+    const reportsDir = join(root, '.lighthouseci');
+    writeFileSync(configPath, JSON.stringify(baseConfig()));
+
+    let timAttempts = 0;
+    const executeRouteAttempt = vi.fn(async ({ url, numberOfRuns }) => {
+      if (url.endsWith('/tim')) {
+        timAttempts += 1;
+        if (timAttempts === 1) {
+          return { code: 1, output: 'PROTOCOL_TIMEOUT: DOMSnapshot.disable' };
+        }
+      }
+      const files = Array.from({ length: numberOfRuns }, (_, i) => {
+        const path = join(root, `ok-${encodeURIComponent(url)}-${i}.json`);
+        writeFileSync(
+          path,
+          JSON.stringify({ requestedUrl: url, finalUrl: url })
+        );
+        return path;
+      });
+      return { code: 0, output: '', reportFiles: files };
+    });
+
+    const result = await collectProductionRoutes({
+      configPath,
+      reportsDir,
+      executeRouteAttempt,
+      deadlineMs: Date.now() + 60 * 60_000,
+      estimatedRunMs: 1_000,
+      overheadMs: 0,
+      maxAttempts: 3,
+      cooldownMs: 0,
+      report: vi.fn(),
+    });
+
+    expect(result.code).toBe(0);
+    expect(timAttempts).toBe(2);
+    // home once + /tim twice
+    expect(executeRouteAttempt).toHaveBeenCalledTimes(3);
+    expect(result.reportCount).toBe(6);
+  });
+
+  it('fails closed with job_deadline when a late transient failure leaves no room for another route attempt', async () => {
+    const root = makeTempDir();
+    const configPath = join(root, 'config.json');
+    const reportsDir = join(root, '.lighthouseci');
+    writeFileSync(configPath, JSON.stringify(baseConfig()));
+
+    // 20-minute job. First route burns 12 minutes on a protocol timeout, then
+    // a successful retry burns 6 minutes. Second route needs 3*2min+overhead
+    // and must refuse rather than start a partial collect into the cancel.
+    let nowMs = 0;
+    const executeRouteAttempt = vi.fn(async ({ url, numberOfRuns }) => {
+      if (url.endsWith('/')) {
+        if (
+          executeRouteAttempt.mock.calls.filter(c => c[0].url.endsWith('/'))
+            .length === 1
+        ) {
+          nowMs += 720_000;
+          return { code: 1, output: 'PROTOCOL_TIMEOUT' };
+        }
+        nowMs += 360_000;
+        const files = Array.from({ length: numberOfRuns }, (_, i) => {
+          const path = join(root, `home-${i}.json`);
+          writeFileSync(
+            path,
+            JSON.stringify({ requestedUrl: url, finalUrl: url })
+          );
+          return path;
+        });
+        return { code: 0, output: '', reportFiles: files };
+      }
+      throw new Error('second route must not start');
+    });
+
+    const result = await collectProductionRoutes({
+      configPath,
+      reportsDir,
+      executeRouteAttempt,
+      deadlineMs: 1_200_000,
+      estimatedRunMs: 120_000,
+      overheadMs: 30_000,
+      maxAttempts: 3,
+      cooldownMs: 10_000,
+      now: () => nowMs,
+      sleep: async ms => {
+        nowMs += ms;
+      },
+      report: vi.fn(),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.failureClass).toBe('job_deadline');
+    expect(result.completedRoutes).toBe(1);
+    expect(result.requiredRoutes).toBe(2);
+    expect(result.output).toContain('LIGHTHOUSE_FAILURE_CLASS=job_deadline');
+    expect(result.output).toContain('LIGHTHOUSE_ROUTE=/tim');
+    expect(
+      executeRouteAttempt.mock.calls.every(c => c[0].url.endsWith('/'))
+    ).toBe(true);
+  });
+
+  it('fails closed when a successful collect returns fewer than numberOfRuns reports', async () => {
+    const root = makeTempDir();
+    const configPath = join(root, 'config.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify(baseConfig(['https://jovie-abc-jovie.vercel.app/']))
+    );
+
+    const result = await collectProductionRoutes({
+      configPath,
+      reportsDir: join(root, '.lighthouseci'),
+      executeRouteAttempt: async () => ({
+        code: 0,
+        output: '',
+        reportFiles: [join(root, 'only-one.json')].map(path => {
+          writeFileSync(path, '{}');
+          return path;
+        }),
+      }),
+      estimatedRunMs: 1_000,
+      overheadMs: 0,
+      report: vi.fn(),
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.failureClass).toBe('unknown');
+    expect(result.output).toContain('1/3 required reports');
+  });
+});

--- a/scripts/lib/__tests__/lighthouse-retry.test.mjs
+++ b/scripts/lib/__tests__/lighthouse-retry.test.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   classifyLighthouseFailure,
+  remainingBudgetMs,
+  resolveCollectDeadlineMs,
+  resolveMinAttemptBudgetMs,
   runWithClassifiedRetries,
 } from '../../lighthouse-retry.mjs';
 
@@ -20,6 +23,14 @@ describe('Lighthouse classified retry', () => {
     'errors-in-console failure for minScore assertion\nexpected: >=0.9\nfound: 0\nAssertion failed.',
   ])('classifies deterministic Lighthouse assertions: %s', output => {
     expect(classifyLighthouseFailure(output)).toBe('deterministic_assertion');
+  });
+
+  it('classifies job-deadline exhaustion receipts', () => {
+    expect(
+      classifyLighthouseFailure(
+        'Lighthouse job deadline exhausted before attempt 2\nLIGHTHOUSE_FAILURE_CLASS=job_deadline'
+      )
+    ).toBe('job_deadline');
   });
 
   it('does not retry a deterministic assertion', async () => {
@@ -101,5 +112,146 @@ describe('Lighthouse classified retry', () => {
       failureClass: 'unknown',
     });
     expect(executeAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves absolute and relative collect deadlines', () => {
+    expect(
+      resolveCollectDeadlineMs({ deadlineEpochMs: 1_700_000_000_000 })
+    ).toBe(1_700_000_000_000);
+    expect(
+      resolveCollectDeadlineMs({ jobBudgetMs: 60_000, nowMs: 1_000 })
+    ).toBe(61_000);
+    expect(resolveCollectDeadlineMs({})).toBeNull();
+  });
+
+  it('prices a per-route attempt budget from run count', () => {
+    expect(
+      resolveMinAttemptBudgetMs({
+        routeCount: 1,
+        numberOfRuns: 3,
+        estimatedRunMs: 100_000,
+        overheadMs: 10_000,
+      })
+    ).toBe(310_000);
+    expect(
+      resolveMinAttemptBudgetMs({
+        routeCount: 2,
+        numberOfRuns: 3,
+        estimatedRunMs: 100_000,
+        overheadMs: 10_000,
+      })
+    ).toBe(610_000);
+  });
+
+  it('exits before the first attempt when the job deadline cannot fit a route budget', async () => {
+    const executeAttempt = vi.fn();
+    const report = vi.fn();
+    const nowMs = 1_000;
+
+    const result = await runWithClassifiedRetries({
+      executeAttempt,
+      maxAttempts: 3,
+      deadlineMs: 50_000,
+      minAttemptBudgetMs: 100_000,
+      now: () => nowMs,
+      sleep: vi.fn(),
+      report,
+      routeLabel: '/tim',
+    });
+
+    expect(result).toMatchObject({
+      code: 1,
+      failureClass: 'job_deadline',
+      attempts: 0,
+    });
+    expect(executeAttempt).not.toHaveBeenCalled();
+    expect(report).toHaveBeenCalledWith(
+      expect.stringContaining('LIGHTHOUSE_FAILURE_CLASS=job_deadline')
+    );
+    expect(report).toHaveBeenCalledWith(
+      expect.stringContaining('LIGHTHOUSE_ROUTE=/tim')
+    );
+    expect(remainingBudgetMs(50_000, nowMs)).toBe(49_000);
+  });
+
+  it('skips a late transient retry when the remaining job budget cannot fit another full attempt', async () => {
+    // Reproduces the production overrun: attempt 1 burns most of the budget on
+    // a multi-route collect, attempt 2 hits PROTOCOL_TIMEOUT late, and the old
+    // policy would still cool down and start attempt 3/3 into the 20m cancel.
+    let nowMs = 0;
+    const executeAttempt = vi.fn().mockImplementation(async () => {
+      nowMs += 900_000; // 15 minutes consumed by a late failure
+      return { code: 1, output: 'PROTOCOL_TIMEOUT: DOMSnapshot.disable' };
+    });
+    const sleep = vi.fn().mockImplementation(async ms => {
+      nowMs += ms;
+    });
+    const report = vi.fn();
+
+    const result = await runWithClassifiedRetries({
+      executeAttempt,
+      maxAttempts: 3,
+      cooldownMs: 10_000,
+      deadlineMs: 1_200_000, // 20 minutes
+      minAttemptBudgetMs: 400_000, // one route × 3 runs cannot fit after burn
+      now: () => nowMs,
+      sleep,
+      report,
+      routeLabel: '/',
+    });
+
+    expect(result.failureClass).toBe('job_deadline');
+    expect(result.attempts).toBe(1);
+    expect(executeAttempt).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(report).toHaveBeenCalledWith(
+      expect.stringContaining('skipping further retries')
+    );
+    expect(report).toHaveBeenCalledWith(
+      expect.stringContaining('LIGHTHOUSE_FAILURE_CLASS=job_deadline')
+    );
+  });
+
+  it('classifies an attempt hard-timeout as job_deadline and does not cool down', async () => {
+    const executeAttempt = vi.fn().mockResolvedValue({
+      code: 1,
+      output: 'still running',
+      timedOut: true,
+    });
+    const sleep = vi.fn();
+    const report = vi.fn();
+
+    const result = await runWithClassifiedRetries({
+      executeAttempt,
+      maxAttempts: 3,
+      deadlineMs: 60_000,
+      minAttemptBudgetMs: 10_000,
+      now: () => 50_000,
+      sleep,
+      report,
+    });
+
+    expect(result).toMatchObject({
+      code: 1,
+      failureClass: 'job_deadline',
+      timedOut: true,
+      attempts: 1,
+    });
+    expect(sleep).not.toHaveBeenCalled();
+    expect(executeAttempt).toHaveBeenCalledTimes(1);
+    expect(executeAttempt.mock.calls[0][1].timeoutMs).toBe(10_000);
+  });
+
+  it('passes the remaining wall-clock budget as the attempt timeout', async () => {
+    const executeAttempt = vi.fn().mockResolvedValue({ code: 0, output: '' });
+    await runWithClassifiedRetries({
+      executeAttempt,
+      deadlineMs: 100_000,
+      minAttemptBudgetMs: 1_000,
+      now: () => 40_000,
+      sleep: vi.fn(),
+      report: vi.fn(),
+    });
+    expect(executeAttempt.mock.calls[0][1].timeoutMs).toBe(60_000);
   });
 });

--- a/scripts/lighthouse-production-collect.mjs
+++ b/scripts/lighthouse-production-collect.mjs
@@ -116,7 +116,8 @@ function listLhrFiles(directory) {
   try {
     return readdirSync(directory)
       .filter(name => /^lhr-\d+\.json$/.test(name))
-      .toSorted();
+      .slice()
+      .sort();
   } catch {
     return [];
   }
@@ -128,25 +129,60 @@ function resetDirectory(directory) {
 }
 
 /**
+ * @typedef {object} ProductionRouteAttemptResult
+ * @property {number} code
+ * @property {string} [output]
+ * @property {string[]} [reportFiles]
+ * @property {boolean} [abortedForDeadline]
+ */
+
+/**
+ * @typedef {object} CollectProductionRoutesOptions
+ * @property {string} configPath
+ * @property {string} [reportsDir]
+ * @property {number} [maxAttempts]
+ * @property {number} [cooldownMs]
+ * @property {number | null} [deadlineMs]
+ * @property {number} [estimatedRunMs]
+ * @property {number} [overheadMs]
+ * @property {(args: {
+ *   url: string;
+ *   routeLabel: string;
+ *   routeIndex: number;
+ *   attempt: number;
+ *   numberOfRuns: number;
+ *   rawConfig: unknown;
+ *   timeoutMs: number | undefined;
+ * }) => Promise<ProductionRouteAttemptResult>} executeRouteAttempt
+ * @property {() => number} [now]
+ * @property {(milliseconds: number) => Promise<void>} [sleep]
+ * @property {(message: string) => unknown} [report]
+ * @property {(path: string) => unknown} [readConfig]
+ */
+
+/**
  * Collect each production route independently under a shared job deadline.
  * Retries are per-route and only start when the remaining budget can fit a full
  * numberOfRuns attempt. Incomplete evidence fails closed.
+ *
+ * @param {CollectProductionRoutesOptions} options
  */
-export async function collectProductionRoutes({
-  configPath,
-  reportsDir = DEFAULT_REPORTS_DIR,
-  maxAttempts = 3,
-  cooldownMs = 10_000,
-  deadlineMs = null,
-  estimatedRunMs = DEFAULT_ESTIMATED_RUN_MS,
-  overheadMs = DEFAULT_ATTEMPT_OVERHEAD_MS,
-  executeRouteAttempt,
-  now = Date.now,
-  sleep = milliseconds =>
-    new Promise(resolve => setTimeout(resolve, milliseconds)),
-  report = message => process.stderr.write(`${message}\n`),
-  readConfig = path => JSON.parse(readFileSync(path, 'utf8')),
-} = {}) {
+export async function collectProductionRoutes(options) {
+  const {
+    configPath,
+    reportsDir = DEFAULT_REPORTS_DIR,
+    maxAttempts = 3,
+    cooldownMs = 10_000,
+    deadlineMs = null,
+    estimatedRunMs = DEFAULT_ESTIMATED_RUN_MS,
+    overheadMs = DEFAULT_ATTEMPT_OVERHEAD_MS,
+    executeRouteAttempt,
+    now = Date.now,
+    sleep = milliseconds =>
+      new Promise(resolve => setTimeout(resolve, milliseconds)),
+    report = message => process.stderr.write(`${message}\n`),
+    readConfig = path => JSON.parse(readFileSync(path, 'utf8')),
+  } = options ?? {};
   if (!configPath) {
     throw new Error('configPath is required');
   }

--- a/scripts/lighthouse-production-collect.mjs
+++ b/scripts/lighthouse-production-collect.mjs
@@ -1,0 +1,406 @@
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  DEFAULT_ATTEMPT_OVERHEAD_MS,
+  DEFAULT_ESTIMATED_RUN_MS,
+  remainingBudgetMs,
+  resolveCollectDeadlineMs,
+  resolveMinAttemptBudgetMs,
+  runStreamingAttempt,
+  runWithClassifiedRetries,
+} from './lighthouse-retry.mjs';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, '..');
+const WEB_ROOT = resolve(REPO_ROOT, 'apps/web');
+const DEFAULT_REPORTS_DIR = resolve(WEB_ROOT, '.lighthouseci');
+
+function parsePositiveInteger(value, fallback, name) {
+  if (value == null || !String(value).trim()) return fallback;
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer; got "${value}"`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, fallback, name) {
+  if (value == null || !String(value).trim()) return fallback;
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer; got "${value}"`);
+  }
+  return parsed;
+}
+
+function parseOptionalNumber(value, name) {
+  if (value == null || !String(value).trim()) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name} must be a finite number; got "${value}"`);
+  }
+  return parsed;
+}
+
+function readOption(argv, name) {
+  const prefix = `${name}=`;
+  const inline = argv.find(value => value.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+function requireRecord(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value;
+}
+
+export function loadProductionCollectPlan(rawConfig) {
+  const root = requireRecord(rawConfig, 'Lighthouse config');
+  const ci = requireRecord(root.ci, 'Lighthouse config ci');
+  const collect = requireRecord(ci.collect, 'Lighthouse collect config');
+  if (!Array.isArray(collect.url) || collect.url.length === 0) {
+    throw new Error('Lighthouse collect config must request at least one URL.');
+  }
+  const urls = collect.url.map((value, index) => {
+    if (typeof value !== 'string' || !value.trim()) {
+      throw new Error(
+        `Lighthouse requested URL ${index + 1} must be a non-empty string.`
+      );
+    }
+    return value;
+  });
+  const numberOfRuns = collect.numberOfRuns;
+  if (!Number.isInteger(numberOfRuns) || numberOfRuns < 1) {
+    throw new Error('Lighthouse numberOfRuns must be a positive integer.');
+  }
+  return {
+    urls,
+    numberOfRuns: Number(numberOfRuns),
+    rawConfig: root,
+  };
+}
+
+export function buildSingleRouteConfig(rawConfig, url) {
+  const root = structuredClone(rawConfig);
+  const ci = requireRecord(root.ci, 'Lighthouse config ci');
+  const collect = requireRecord(ci.collect, 'Lighthouse collect config');
+  collect.url = [url];
+  return root;
+}
+
+function routeLabelFromUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname || '/'}`;
+  } catch {
+    return url;
+  }
+}
+
+function listLhrFiles(directory) {
+  if (!directory) return [];
+  try {
+    return readdirSync(directory)
+      .filter(name => /^lhr-\d+\.json$/.test(name))
+      .toSorted();
+  } catch {
+    return [];
+  }
+}
+
+function resetDirectory(directory) {
+  rmSync(directory, { force: true, recursive: true });
+  mkdirSync(directory, { recursive: true });
+}
+
+/**
+ * Collect each production route independently under a shared job deadline.
+ * Retries are per-route and only start when the remaining budget can fit a full
+ * numberOfRuns attempt. Incomplete evidence fails closed.
+ */
+export async function collectProductionRoutes({
+  configPath,
+  reportsDir = DEFAULT_REPORTS_DIR,
+  maxAttempts = 3,
+  cooldownMs = 10_000,
+  deadlineMs = null,
+  estimatedRunMs = DEFAULT_ESTIMATED_RUN_MS,
+  overheadMs = DEFAULT_ATTEMPT_OVERHEAD_MS,
+  executeRouteAttempt,
+  now = Date.now,
+  sleep = milliseconds =>
+    new Promise(resolve => setTimeout(resolve, milliseconds)),
+  report = message => process.stderr.write(`${message}\n`),
+  readConfig = path => JSON.parse(readFileSync(path, 'utf8')),
+} = {}) {
+  if (!configPath) {
+    throw new Error('configPath is required');
+  }
+  if (typeof executeRouteAttempt !== 'function') {
+    throw new Error('executeRouteAttempt is required');
+  }
+
+  const plan = loadProductionCollectPlan(readConfig(configPath));
+  const minAttemptBudgetMs = resolveMinAttemptBudgetMs({
+    routeCount: 1,
+    numberOfRuns: plan.numberOfRuns,
+    estimatedRunMs,
+    overheadMs,
+  });
+
+  report(
+    [
+      `LIGHTHOUSE_PRODUCTION_COLLECT routes=${plan.urls.length}`,
+      `numberOfRuns=${plan.numberOfRuns}`,
+      `maxAttemptsPerRoute=${maxAttempts}`,
+      `minAttemptBudgetMs=${minAttemptBudgetMs}`,
+      `deadlineMs=${deadlineMs ?? 'none'}`,
+      `remainingMs=${
+        deadlineMs == null
+          ? 'unbounded'
+          : Math.floor(remainingBudgetMs(deadlineMs, now()))
+      }`,
+    ].join(' ')
+  );
+
+  const mergeDir = mkdtempSync(join(tmpdir(), 'lhci-prod-merge-'));
+  let nextReportIndex = 0;
+
+  try {
+    for (const [routeIndex, url] of plan.urls.entries()) {
+      const routeLabel = routeLabelFromUrl(url);
+      const remaining = remainingBudgetMs(deadlineMs, now());
+      if (deadlineMs != null && remaining < minAttemptBudgetMs) {
+        const receipt = [
+          'LIGHTHOUSE_FAILURE_CLASS=job_deadline',
+          `LIGHTHOUSE_ROUTE=${routeLabel}`,
+          `LIGHTHOUSE_ROUTE_INDEX=${routeIndex + 1}/${plan.urls.length}`,
+          `LIGHTHOUSE_REMAINING_MS=${Math.floor(remaining)}`,
+          `LIGHTHOUSE_MIN_ATTEMPT_BUDGET_MS=${minAttemptBudgetMs}`,
+          `LIGHTHOUSE_COMPLETED_ROUTES=${routeIndex}`,
+          `LIGHTHOUSE_REQUIRED_ROUTES=${plan.urls.length}`,
+        ].join(' ');
+        report(receipt);
+        return {
+          code: 1,
+          failureClass: 'job_deadline',
+          completedRoutes: routeIndex,
+          requiredRoutes: plan.urls.length,
+          output: `${receipt}\nLighthouse job deadline exhausted before route ${routeLabel}; refusing incomplete production evidence.\n`,
+        };
+      }
+
+      report(
+        `LIGHTHOUSE_ROUTE_START route=${routeLabel} index=${routeIndex + 1}/${plan.urls.length} remainingMs=${Math.floor(remainingBudgetMs(deadlineMs, now()))}`
+      );
+
+      const result = await runWithClassifiedRetries({
+        maxAttempts,
+        cooldownMs,
+        deadlineMs,
+        minAttemptBudgetMs,
+        routeLabel,
+        now,
+        sleep,
+        report,
+        executeAttempt: (attempt, meta) =>
+          executeRouteAttempt({
+            url,
+            routeLabel,
+            routeIndex,
+            attempt,
+            numberOfRuns: plan.numberOfRuns,
+            rawConfig: plan.rawConfig,
+            timeoutMs: meta.timeoutMs,
+          }),
+      });
+
+      if (result.code !== 0) {
+        report(
+          [
+            `LIGHTHOUSE_ROUTE_FAILED route=${routeLabel}`,
+            `failureClass=${result.failureClass}`,
+            `attempts=${result.attempts}`,
+          ].join(' ')
+        );
+        return {
+          code: result.code,
+          failureClass: result.failureClass,
+          completedRoutes: routeIndex,
+          requiredRoutes: plan.urls.length,
+          attempts: result.attempts,
+          output: result.output,
+        };
+      }
+
+      const reportsFromAttempt = result.reportFiles ?? [];
+      if (reportsFromAttempt.length !== plan.numberOfRuns) {
+        const message = `Lighthouse route ${routeLabel} produced ${reportsFromAttempt.length}/${plan.numberOfRuns} required reports after a successful collect.`;
+        report(
+          `LIGHTHOUSE_FAILURE_CLASS=unknown LIGHTHOUSE_ROUTE=${routeLabel}`
+        );
+        return {
+          code: 1,
+          failureClass: 'unknown',
+          completedRoutes: routeIndex,
+          requiredRoutes: plan.urls.length,
+          output: `${message}\n`,
+        };
+      }
+
+      for (const sourcePath of reportsFromAttempt) {
+        copyFileSync(sourcePath, join(mergeDir, `lhr-${nextReportIndex}.json`));
+        nextReportIndex += 1;
+      }
+
+      report(
+        `LIGHTHOUSE_ROUTE_OK route=${routeLabel} reports=${reportsFromAttempt.length} remainingMs=${Math.floor(remainingBudgetMs(deadlineMs, now()))}`
+      );
+    }
+
+    resetDirectory(reportsDir);
+    for (const name of listLhrFiles(mergeDir)) {
+      copyFileSync(join(mergeDir, name), join(reportsDir, name));
+    }
+    report(
+      `LIGHTHOUSE_PRODUCTION_COLLECT_OK routes=${plan.urls.length} reports=${nextReportIndex} reportsDir=${reportsDir}`
+    );
+    return {
+      code: 0,
+      failureClass: null,
+      completedRoutes: plan.urls.length,
+      requiredRoutes: plan.urls.length,
+      reportCount: nextReportIndex,
+      output: '',
+    };
+  } finally {
+    rmSync(mergeDir, { force: true, recursive: true });
+  }
+}
+
+export function createPnpmRouteAttemptExecutor({
+  webRoot = WEB_ROOT,
+  repoRoot = REPO_ROOT,
+  writeConfig = (path, value) =>
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`),
+  runAttempt = runStreamingAttempt,
+  pnpmCommand = 'pnpm',
+} = {}) {
+  return async function executeRouteAttempt({ url, rawConfig, timeoutMs }) {
+    const workRoot = mkdtempSync(join(tmpdir(), 'lhci-prod-route-'));
+    const configPath = join(workRoot, 'lighthouserc.json');
+    const reportsDir = join(webRoot, '.lighthouseci');
+
+    try {
+      writeConfig(configPath, buildSingleRouteConfig(rawConfig, url));
+      resetDirectory(reportsDir);
+
+      const result = await runAttempt(
+        pnpmCommand,
+        [
+          '--filter',
+          '@jovie/web',
+          'exec',
+          'lhci',
+          'collect',
+          `--config=${configPath}`,
+        ],
+        {
+          cwd: repoRoot,
+          env: process.env,
+          timeoutMs,
+        }
+      );
+
+      const reportFiles = listLhrFiles(reportsDir).map(name =>
+        join(reportsDir, name)
+      );
+      return { ...result, reportFiles };
+    } finally {
+      rmSync(workRoot, { force: true, recursive: true });
+    }
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const configPath = readOption(argv, '--config');
+  if (!configPath) {
+    throw new Error(
+      'Usage: node scripts/lighthouse-production-collect.mjs --config <path>'
+    );
+  }
+
+  const reportsDir =
+    readOption(argv, '--reports-dir') ??
+    process.env.LIGHTHOUSE_REPORTS_DIR?.trim() ??
+    DEFAULT_REPORTS_DIR;
+
+  const maxAttempts = parsePositiveInteger(
+    process.env.LIGHTHOUSE_MAX_ATTEMPTS,
+    3,
+    'LIGHTHOUSE_MAX_ATTEMPTS'
+  );
+  const cooldownMs = parseNonNegativeInteger(
+    process.env.LIGHTHOUSE_RETRY_COOLDOWN_MS,
+    10_000,
+    'LIGHTHOUSE_RETRY_COOLDOWN_MS'
+  );
+  const estimatedRunMs = parsePositiveInteger(
+    process.env.LIGHTHOUSE_ESTIMATED_RUN_MS,
+    DEFAULT_ESTIMATED_RUN_MS,
+    'LIGHTHOUSE_ESTIMATED_RUN_MS'
+  );
+  const overheadMs = parseNonNegativeInteger(
+    process.env.LIGHTHOUSE_ATTEMPT_OVERHEAD_MS,
+    DEFAULT_ATTEMPT_OVERHEAD_MS,
+    'LIGHTHOUSE_ATTEMPT_OVERHEAD_MS'
+  );
+  const deadlineMs = resolveCollectDeadlineMs({
+    deadlineEpochMs: parseOptionalNumber(
+      process.env.LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS,
+      'LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS'
+    ),
+    jobBudgetMs: parseOptionalNumber(
+      process.env.LIGHTHOUSE_JOB_BUDGET_MS,
+      'LIGHTHOUSE_JOB_BUDGET_MS'
+    ),
+  });
+
+  const result = await collectProductionRoutes({
+    configPath: resolve(configPath),
+    reportsDir: resolve(reportsDir),
+    maxAttempts,
+    cooldownMs,
+    deadlineMs,
+    estimatedRunMs,
+    overheadMs,
+    executeRouteAttempt: createPnpmRouteAttemptExecutor(),
+  });
+
+  if (result.code !== 0) {
+    process.stderr.write(result.output ?? '');
+  }
+  process.exitCode = result.code;
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  void main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/lighthouse-retry.mjs
+++ b/scripts/lighthouse-retry.mjs
@@ -227,6 +227,25 @@ function formatDeadlineReceipt({
   return parts.join(' ');
 }
 
+/**
+ * @typedef {object} LighthouseAttemptMeta
+ * @property {number | null | undefined} [timeoutMs]
+ * @property {number} [remainingMs]
+ * @property {number} [minAttemptBudgetMs]
+ */
+
+/**
+ * @param {object} options
+ * @param {(attempt: number, meta: LighthouseAttemptMeta) => Promise<{ code: number; output?: string; timedOut?: boolean; reportFiles?: string[] }>} options.executeAttempt
+ * @param {number} [options.maxAttempts]
+ * @param {number} [options.cooldownMs]
+ * @param {number | null} [options.deadlineMs]
+ * @param {number | null} [options.minAttemptBudgetMs]
+ * @param {string | null} [options.routeLabel]
+ * @param {(milliseconds: number) => Promise<void>} [options.sleep]
+ * @param {() => number} [options.now]
+ * @param {(message: string) => unknown} [options.report]
+ */
 export async function runWithClassifiedRetries({
   executeAttempt,
   maxAttempts = 3,
@@ -465,9 +484,9 @@ export async function main(argv = process.argv.slice(2)) {
   const routeLabel = process.env.LIGHTHOUSE_ROUTE_LABEL?.trim() || null;
 
   const result = await runWithClassifiedRetries({
-    executeAttempt: (_attempt, meta = {}) =>
+    executeAttempt: (_attempt, meta) =>
       runStreamingAttempt(command, args, {
-        timeoutMs: meta.timeoutMs,
+        timeoutMs: meta?.timeoutMs ?? undefined,
       }),
     maxAttempts,
     cooldownMs,

--- a/scripts/lighthouse-retry.mjs
+++ b/scripts/lighthouse-retry.mjs
@@ -19,6 +19,13 @@ const DETERMINISTIC_ASSERTION_PATTERNS = [
 
 const MAX_CAPTURE_BYTES = 256 * 1024;
 
+/** Conservative per-run budget for production Lighthouse on hosted runners. */
+export const DEFAULT_ESTIMATED_RUN_MS = 120_000;
+/** Chrome launch / LHCI process overhead outside individual audit runs. */
+export const DEFAULT_ATTEMPT_OVERHEAD_MS = 30_000;
+/** Kill grace after SIGTERM when an attempt hits the hard attempt budget. */
+export const DEFAULT_KILL_GRACE_MS = 5_000;
+
 export function classifyLighthouseFailure(output) {
   const normalized = String(output).replace(/\u001b\[[0-9;]*m/g, '');
 
@@ -32,7 +39,81 @@ export function classifyLighthouseFailure(output) {
     return 'transient_protocol';
   }
 
+  if (
+    /\bLighthouse job deadline\b/i.test(normalized) ||
+    /\bLIGHTHOUSE_FAILURE_CLASS=job_deadline\b/i.test(normalized) ||
+    /\battempt timed out against the job deadline\b/i.test(normalized)
+  ) {
+    return 'job_deadline';
+  }
+
   return 'unknown';
+}
+
+/**
+ * Resolve an absolute wall-clock deadline for collect work.
+ * Prefers an explicit epoch deadline; otherwise derives one from a relative budget.
+ */
+export function resolveCollectDeadlineMs({
+  deadlineEpochMs = null,
+  jobBudgetMs = null,
+  nowMs = Date.now(),
+} = {}) {
+  if (deadlineEpochMs != null) {
+    const parsed = Number(deadlineEpochMs);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(
+        `LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS must be a finite number; got "${deadlineEpochMs}"`
+      );
+    }
+    return parsed;
+  }
+  if (jobBudgetMs != null) {
+    const parsed = Number(jobBudgetMs);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      throw new Error(
+        `LIGHTHOUSE_JOB_BUDGET_MS must be a positive number; got "${jobBudgetMs}"`
+      );
+    }
+    return nowMs + parsed;
+  }
+  return null;
+}
+
+/**
+ * Minimum wall-clock budget required to start one collect attempt for a route
+ * (or multi-route collect) without knowingly overrunning the job deadline.
+ */
+export function resolveMinAttemptBudgetMs({
+  routeCount = 1,
+  numberOfRuns = 1,
+  estimatedRunMs = DEFAULT_ESTIMATED_RUN_MS,
+  overheadMs = DEFAULT_ATTEMPT_OVERHEAD_MS,
+} = {}) {
+  const routes = Number(routeCount);
+  const runs = Number(numberOfRuns);
+  const perRun = Number(estimatedRunMs);
+  const overhead = Number(overheadMs);
+  if (
+    !Number.isInteger(routes) ||
+    routes < 1 ||
+    !Number.isInteger(runs) ||
+    runs < 1 ||
+    !Number.isFinite(perRun) ||
+    perRun < 1 ||
+    !Number.isFinite(overhead) ||
+    overhead < 0
+  ) {
+    throw new Error(
+      'routeCount, numberOfRuns, estimatedRunMs, and overheadMs must be positive integers (overhead may be 0)'
+    );
+  }
+  return routes * runs * perRun + overhead;
+}
+
+export function remainingBudgetMs(deadlineMs, nowMs = Date.now()) {
+  if (deadlineMs == null) return Number.POSITIVE_INFINITY;
+  return Math.max(0, Number(deadlineMs) - Number(nowMs));
 }
 
 function appendBounded(current, chunk) {
@@ -42,13 +123,47 @@ function appendBounded(current, chunk) {
     : next;
 }
 
+function terminateChild(child, graceMs, killImpl) {
+  if (!child || child.killed || child.exitCode != null) return;
+  try {
+    child.kill('SIGTERM');
+  } catch {
+    // Process may already be gone.
+  }
+  killImpl(() => {
+    if (!child || child.killed || child.exitCode != null) return;
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Process may already be gone.
+    }
+  }, graceMs);
+}
+
 export function runStreamingAttempt(command, args, options = {}) {
   const spawnCommand = options.spawnCommand ?? spawn;
   const stdout = options.stdout ?? process.stdout;
   const stderr = options.stderr ?? process.stderr;
+  const timeoutMs = options.timeoutMs;
+  const killGraceMs = options.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+  const setTimer = options.setTimeoutFn ?? setTimeout;
+  const clearTimer = options.clearTimeoutFn ?? clearTimeout;
 
   return new Promise(resolve => {
     let output = '';
+    let settled = false;
+    let timedOut = false;
+    let killTimer = null;
+    let timeoutTimer = null;
+
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      if (timeoutTimer) clearTimer(timeoutTimer);
+      if (killTimer) clearTimer(killTimer);
+      resolve(result);
+    };
+
     const child = spawnCommand(command, args, {
       cwd: options.cwd,
       env: options.env ?? process.env,
@@ -67,35 +182,184 @@ export function runStreamingAttempt(command, args, options = {}) {
       const message = `Failed to launch Lighthouse: ${error.message}\n`;
       stderr.write(message);
       output = appendBounded(output, message);
-      resolve({ code: 1, output });
+      finish({ code: 1, output, timedOut: false });
     });
     child.on('exit', code => {
-      resolve({ code: code ?? 1, output });
+      if (timedOut) {
+        const message =
+          'Lighthouse attempt timed out against the job deadline\n';
+        stderr.write(message);
+        output = appendBounded(output, message);
+        finish({ code: 1, output, timedOut: true });
+        return;
+      }
+      finish({ code: code ?? 1, output, timedOut: false });
     });
+
+    if (timeoutMs != null && Number.isFinite(timeoutMs) && timeoutMs > 0) {
+      timeoutTimer = setTimer(() => {
+        timedOut = true;
+        terminateChild(child, killGraceMs, (fn, ms) => {
+          killTimer = setTimer(fn, ms);
+        });
+      }, timeoutMs);
+    }
   });
+}
+
+function formatDeadlineReceipt({
+  failureClass,
+  attempt,
+  maxAttempts,
+  remainingMs,
+  minAttemptBudgetMs,
+  routeLabel = null,
+}) {
+  const parts = [
+    `LIGHTHOUSE_FAILURE_CLASS=${failureClass}`,
+    `LIGHTHOUSE_ATTEMPT=${attempt}/${maxAttempts}`,
+    `LIGHTHOUSE_REMAINING_MS=${Math.max(0, Math.floor(remainingMs))}`,
+    `LIGHTHOUSE_MIN_ATTEMPT_BUDGET_MS=${Math.floor(minAttemptBudgetMs)}`,
+  ];
+  if (routeLabel) {
+    parts.push(`LIGHTHOUSE_ROUTE=${routeLabel}`);
+  }
+  return parts.join(' ');
 }
 
 export async function runWithClassifiedRetries({
   executeAttempt,
   maxAttempts = 3,
   cooldownMs = 10_000,
+  deadlineMs = null,
+  minAttemptBudgetMs = null,
+  routeLabel = null,
   sleep = milliseconds =>
     new Promise(resolve => setTimeout(resolve, milliseconds)),
+  now = Date.now,
   report = message => process.stderr.write(`${message}\n`),
 }) {
+  const requiredBudget =
+    minAttemptBudgetMs == null ? 0 : Number(minAttemptBudgetMs);
+  if (!Number.isFinite(requiredBudget) || requiredBudget < 0) {
+    throw new Error('minAttemptBudgetMs must be a non-negative finite number');
+  }
+
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const result = await executeAttempt(attempt);
+    const remainingBeforeAttempt = remainingBudgetMs(deadlineMs, now());
+    if (
+      deadlineMs != null &&
+      requiredBudget > 0 &&
+      remainingBeforeAttempt < requiredBudget
+    ) {
+      const receipt = formatDeadlineReceipt({
+        failureClass: 'job_deadline',
+        attempt,
+        maxAttempts,
+        remainingMs: remainingBeforeAttempt,
+        minAttemptBudgetMs: requiredBudget,
+        routeLabel,
+      });
+      report(receipt);
+      return {
+        code: 1,
+        output: `${receipt}\nLighthouse job deadline exhausted before attempt ${attempt}${routeLabel ? ` for ${routeLabel}` : ''}: remaining ${Math.floor(remainingBeforeAttempt)}ms < min attempt budget ${Math.floor(requiredBudget)}ms\n`,
+        attempts: Math.max(0, attempt - 1),
+        failureClass: 'job_deadline',
+        timedOut: false,
+      };
+    }
+
+    const attemptTimeoutMs =
+      deadlineMs == null
+        ? null
+        : Math.max(1, Math.floor(remainingBudgetMs(deadlineMs, now())));
+    const result = await executeAttempt(attempt, {
+      timeoutMs: attemptTimeoutMs,
+      remainingMs: remainingBeforeAttempt,
+      minAttemptBudgetMs: requiredBudget,
+    });
+
     if (result.code === 0) {
-      return { ...result, attempts: attempt, failureClass: null };
+      return {
+        ...result,
+        attempts: attempt,
+        failureClass: null,
+        timedOut: Boolean(result.timedOut),
+      };
+    }
+
+    if (result.timedOut) {
+      const remaining = remainingBudgetMs(deadlineMs, now());
+      const receipt = formatDeadlineReceipt({
+        failureClass: 'job_deadline',
+        attempt,
+        maxAttempts,
+        remainingMs: remaining,
+        minAttemptBudgetMs: requiredBudget,
+        routeLabel,
+      });
+      report(receipt);
+      return {
+        ...result,
+        code: 1,
+        output: `${result.output ?? ''}${receipt}\n`,
+        attempts: attempt,
+        failureClass: 'job_deadline',
+        timedOut: true,
+      };
     }
 
     const failureClass = classifyLighthouseFailure(result.output);
     report(
-      `LIGHTHOUSE_FAILURE_CLASS=${failureClass} LIGHTHOUSE_ATTEMPT=${attempt}/${maxAttempts}`
+      [
+        `LIGHTHOUSE_FAILURE_CLASS=${failureClass}`,
+        `LIGHTHOUSE_ATTEMPT=${attempt}/${maxAttempts}`,
+        routeLabel ? `LIGHTHOUSE_ROUTE=${routeLabel}` : null,
+      ]
+        .filter(Boolean)
+        .join(' ')
     );
 
     if (failureClass !== 'transient_protocol' || attempt === maxAttempts) {
-      return { ...result, attempts: attempt, failureClass };
+      return {
+        ...result,
+        attempts: attempt,
+        failureClass,
+        timedOut: false,
+      };
+    }
+
+    const remainingAfterFailure = remainingBudgetMs(deadlineMs, now());
+    const remainingAfterCooldown = Math.max(
+      0,
+      remainingAfterFailure - cooldownMs
+    );
+    if (
+      deadlineMs != null &&
+      requiredBudget > 0 &&
+      remainingAfterCooldown < requiredBudget
+    ) {
+      const receipt = formatDeadlineReceipt({
+        failureClass: 'job_deadline',
+        attempt: attempt + 1,
+        maxAttempts,
+        remainingMs: remainingAfterCooldown,
+        minAttemptBudgetMs: requiredBudget,
+        routeLabel,
+      });
+      report(
+        `Transient Chrome DevTools protocol failure; skipping further retries because the job deadline cannot fit another attempt.`
+      );
+      report(receipt);
+      return {
+        ...result,
+        code: 1,
+        output: `${result.output ?? ''}${receipt}\n`,
+        attempts: attempt,
+        failureClass: 'job_deadline',
+        timedOut: false,
+      };
     }
 
     report(
@@ -125,6 +389,15 @@ function parseNonNegativeInteger(value, fallback, name) {
   return parsed;
 }
 
+function parseOptionalNumber(value, name) {
+  if (!value?.trim()) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name} must be a finite number; got "${value}"`);
+  }
+  return parsed;
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const separator = argv.indexOf('--');
   const commandArgs = separator >= 0 ? argv.slice(separator + 1) : [];
@@ -145,10 +418,62 @@ export async function main(argv = process.argv.slice(2)) {
     10_000,
     'LIGHTHOUSE_RETRY_COOLDOWN_MS'
   );
+  const routeCount = parsePositiveInteger(
+    process.env.LIGHTHOUSE_ROUTE_COUNT,
+    1,
+    'LIGHTHOUSE_ROUTE_COUNT'
+  );
+  const numberOfRuns = parsePositiveInteger(
+    process.env.LIGHTHOUSE_NUMBER_OF_RUNS,
+    1,
+    'LIGHTHOUSE_NUMBER_OF_RUNS'
+  );
+  const estimatedRunMs = parsePositiveInteger(
+    process.env.LIGHTHOUSE_ESTIMATED_RUN_MS,
+    DEFAULT_ESTIMATED_RUN_MS,
+    'LIGHTHOUSE_ESTIMATED_RUN_MS'
+  );
+  const overheadMs = parseNonNegativeInteger(
+    process.env.LIGHTHOUSE_ATTEMPT_OVERHEAD_MS,
+    DEFAULT_ATTEMPT_OVERHEAD_MS,
+    'LIGHTHOUSE_ATTEMPT_OVERHEAD_MS'
+  );
+  const explicitMinBudget = parseOptionalNumber(
+    process.env.LIGHTHOUSE_MIN_ATTEMPT_BUDGET_MS,
+    'LIGHTHOUSE_MIN_ATTEMPT_BUDGET_MS'
+  );
+  const deadlineMs = resolveCollectDeadlineMs({
+    deadlineEpochMs: parseOptionalNumber(
+      process.env.LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS,
+      'LIGHTHOUSE_JOB_DEADLINE_EPOCH_MS'
+    ),
+    jobBudgetMs: parseOptionalNumber(
+      process.env.LIGHTHOUSE_JOB_BUDGET_MS,
+      'LIGHTHOUSE_JOB_BUDGET_MS'
+    ),
+  });
+  const minAttemptBudgetMs =
+    explicitMinBudget ??
+    (deadlineMs == null
+      ? null
+      : resolveMinAttemptBudgetMs({
+          routeCount,
+          numberOfRuns,
+          estimatedRunMs,
+          overheadMs,
+        }));
+  const routeLabel = process.env.LIGHTHOUSE_ROUTE_LABEL?.trim() || null;
+
   const result = await runWithClassifiedRetries({
-    executeAttempt: () => runStreamingAttempt(command, args),
+    executeAttempt: (_attempt, meta = {}) =>
+      runStreamingAttempt(command, args, {
+        timeoutMs: meta.timeoutMs,
+      }),
     maxAttempts,
     cooldownMs,
+    deadlineMs,
+    minAttemptBudgetMs,
+    routeLabel,
   });
   process.exitCode = result.code;
 }


### PR DESCRIPTION
## Summary

Production `Lighthouse CI (Production)` could exhaust the 20-minute job timeout after a late Chrome DevTools `PROTOCOL_TIMEOUT`, because the whole multi-route `lhci collect` was retried up to 3 times. GitHub cancelled the job with no classified receipt, and `Production Verified` correctly failed closed.

This change:

- Establishes an absolute wall-clock deadline at the start of the production Lighthouse job (`timeout-minutes: 20` minus reserve for assert/upload).
- Collects `/` and `/tim` **independently** via `scripts/lighthouse-production-collect.mjs`, with **per-route** transient-protocol retries.
- Only starts a route attempt or retry when remaining budget can fit a full `numberOfRuns` attempt; otherwise exits with `LIGHTHOUSE_FAILURE_CLASS=job_deadline` and a useful receipt.
- Hard-times out in-flight attempts against the remaining deadline (SIGTERM → SIGKILL) so the job does not rely on a silent GitHub cancel.
- Preserves exact-origin config, three-run semantics when time permits, assert → hash-sealed upload, sensitive-value scan, and fail-closed Production Verified (incomplete evidence is never accepted).
- Repairs scripts typecheck (JSDoc contracts, `lighthouse_job_deadline` failure-class union, no ES2023-only `toSorted`).

## Test plan / results

- [x] `pnpm vitest --root scripts --config vitest.config.mts run lib/__tests__/lighthouse-retry.test.mjs lib/__tests__/lighthouse-production-collect.test.mjs hermes/lib/__tests__/ci-failure-diagnosis.test.ts` — 115 passed
- [x] `pnpm run typecheck:scripts` — PASS (baseline clean)
- [x] `actionlint` (v1.7.12) on production-controller + postdeploy-probes — clean
- [x] Local pre-push affected verify (full related suite) — 283 test files passed before push
- [x] Reproduces late protocol failure that previously overran the job budget; new logic emits `job_deadline` instead of unbounded retry
- [ ] Subsequent exact-main Production Controller reaches Production Verified (post-merge evidence)

## Cost Impact

- None. Same Lighthouse surface; fewer wasted recollects of already-finished routes. No new cron, external API, or polling.

<!-- linear-issue-id:JOV-4644 -->

Fixes JOV-4644