### PR TITLE
feat(design-system): implement Jovie Noir Ion dark shell palette (JOV-4635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- [internal] **Customer nav capacity guard with one canonical More menu (JOV-4515):** documented desktop/mobile caps keep approved core destinations on the primary rail, overflow only experimental extras into a single More surface, and promote the active route so it is never hidden.
+- **Authenticated shell adopts Jovie Noir Ion dark color system (JOV-4635):** stepped near-black surfaces, cool graphite borders, and electric-blue (Ion) focus/selection replace the prior carbon dark palette; agent, creative, system, and status accents keep their approved meanings.
 - [internal] **Better Auth OAuth token tables cover the pinned provider schema (JOV-4587):** client, access-token, refresh-token, and consent columns now include fields such as `authorizationCodeId`, with a contract test that fails on mapping drift so LYB Apple sign-in can complete `/oauth2/token` exchange.
 - [internal] **Native Gmail brand-deal qualification is fail-closed (JOV-4578):** Jovie now surfaces only the highest-ranked current brief with explicit buyer, company, budget, deposit, rights, and revision terms; provenance comes from the connected Gmail record, Calendar is optional, and pending or approved sponsor work blocks another campaign.
 - **Verified brand deals can enter Jovie's Inbox for one explicit decision (JOV-4578):** provenance-checked opportunities now appear as Brand Deals with budget, source, and ranking evidence; rejecting moves on, while approving authorizes preparation only and never sends outreach or creates a campaign without a separate commercial approval and deposit.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -316,25 +316,50 @@ Three input variables generate the entire palette:
 | Accent | `#7170ff` | — | Focus rings, active states, links |
 | Accent hover | `#828fff` | — | Hover state |
 
-### App Colors — Dark Mode (System B)
+### App Colors — Dark Mode (System B · **Jovie Noir Ion**, JOV-4635)
 
-| Token | Value | Hex | Usage |
-|-------|-------|-----|-------|
-| `--color-bg-base` | `#06070a` | — | Sidebar, page background (carbon palette) |
-| `--color-bg-surface-0` | `#0a0b0e` | — | Primary app surface (carbon palette) |
-| `--color-bg-surface-1` | `#101216` | — | Cards, panels (carbon palette) |
-| `--color-bg-surface-2` | `#161a20` | — | Inputs, elevated (carbon palette) |
-| `--color-bg-surface-3` | `#2a2c32` | — | Modals, tooltips |
-| Text primary | `lch(100% 0 282)` | `#ffffff` | Headings |
-| Text secondary | `lch(90.65% 1.35 282)` | `#E3E4E6` | Body, labels (bright!) |
-| Text tertiary | `lch(62.6% 1.35 282)` | `#969799` | Descriptions, meta |
-| Text quaternary | `#62666d` | — | Placeholders |
-| Content text | `#6b6f76` | — | Content/meta |
-| Highlight text | `#ffffff` | — | Highlighted content |
-| Border subtle | `rgba(255,255,255,0.05)` | — | Dividers |
-| Border default | `rgba(255,255,255,0.08)` | — | Borders |
-| Border strong | `rgba(255,255,255,0.10)` | — | Emphasis |
-| Accent | `#7170ff` | — | Same as light mode |
+Dark mode is the authenticated product default. Neutral near-black graphite
+carries structure; bright color is sparse intent (~90% neutral / 7% soft accent
+/ 3% bright accent). Neon is seasoning. Canonical anchors live as `--noir-ion-*`
+in `apps/web/styles/design-system.css` and map into product tokens (rollback path:
+remap product tokens to prior anchors without a second theme provider).
+
+| Role | Anchor | Product token(s) | Usage |
+|------|--------|------------------|-------|
+| Canvas | `#030407` | `--color-bg-base`, `--color-bg-page`, `--linear-bg-page` | App page |
+| Shell | `#06080D` | `--color-bg-surface-0`, sidebar rgb `6 8 13` | Sidebar / chrome |
+| Panel | `#0A0D16` | `--linear-app-content-surface`, `--linear-panel-bg` | Framed main pane |
+| Card | `#0F1420` | `--linear-bg-surface-1` → `--color-bg-surface-1` | Cards |
+| Elevated | `#151B2A` | `--color-bg-surface-2` | Inputs, raised |
+| Floating | `#1B2436` | `--color-bg-surface-3` | Modals, tooltips |
+| Text primary | `#F5F7FB` | `--color-text-primary-token` | Body / headings |
+| Text secondary | `#D7DCE8` | `--color-text-secondary-token` | Labels |
+| Text muted | `#A8B0C3` | `--color-text-tertiary-token` | Meta |
+| Text tertiary | `#7D879D` | `--color-text-quaternary-token` | Placeholders |
+| Text disabled | `#525D75` | `--color-text-disabled-token` | Disabled |
+| Text inverse | `#020307` | `--linear-text-inverse` | On light CTAs |
+| Border subtle | `rgba(168,176,195,.10)` | `--color-border-subtle` | Dividers |
+| Border default | `rgba(168,176,195,.16)` | `--color-border-default` | Borders |
+| Border strong | `rgba(199,237,255,.26)` | `--color-border-strong` | Emphasis |
+| Focus / selection | Ion `#11AFFF` | `--color-accent`, `--color-border-focus`, `--linear-row-selected` | Focus, links, active nav, selection |
+
+**Accent semantics (dark):**
+
+| Role | Hex | Soft | Meaning |
+|------|-----|------|---------|
+| Ion (blue) | `#11AFFF` | `rgba(17,175,255,.12)` | Primary action intent, focus, active nav, links, selection |
+| Ultra (violet) | `#A982FF` | `rgba(169,130,255,.12)` | Agent intelligence, ranking, recommendations |
+| Pulse (pink) | `#FF48D2` | `rgba(255,72,210,.12)` | Creative energy, launches, merch |
+| Aqua (cyan) | `#24F6D2` | `rgba(36,246,210,.10)` | System signal, sync, API/tool state (`--color-info`) |
+| Mint (green) | `#39E58C` | `rgba(57,229,140,.12)` | Success |
+| Gold | `#FFC857` | `rgba(255,200,87,.12)` | Warning |
+| Flare (coral) | `#FF677D` | `rgba(255,103,125,.12)` | Danger / error |
+
+CTAs remain high-contrast light pills (not saturated Ion fills) per the
+neutral-CTA rule. Ion carries focus, links, selection, and active navigation.
+Every status also uses text, icon, shape, or pattern — color alone never carries meaning.
+
+Specimen: Storybook `Design System/Noir Ion Specimen`.
 
 ### Marketing Colors (System A — Dark by Default)
 
@@ -356,16 +381,16 @@ Three input variables generate the entire palette:
 
 ### Feature Accent Colors (supporting, never brand)
 
-These colors differentiate features in bento grids and semantic indicators. They are supporting cast, never used for CTAs or brand identity.
+These colors differentiate features in bento grids and semantic indicators. They are supporting cast, never used for CTAs or brand identity. Dark values follow Noir Ion (JOV-4635).
 
-| Token | Light | Dark | Feature |
-|-------|-------|------|---------|
-| `--accent-analytics` | `#2563ff` | `#4d7dff` | Analytics |
-| `--accent-conv` | `#8b1eff` | `#9b4dff` | Conversion |
-| `--accent-beauty` | `#d61a7f` | `#ea4a9c` | Beauty/Design |
-| `--accent-links` | `#0f9b8e` | `#22b8a7` | Smart Links |
-| `--accent-speed` | `#2f9e44` | `#43b85c` | Speed |
-| `--accent-pro` | `#ff9800` | `#ffab2e` | Pro Tools |
+| Token | Light | Dark (Noir Ion) | Feature |
+|-------|-------|-----------------|---------|
+| `--accent-analytics` | `#2563ff` | `#11AFFF` (Ion) | Analytics |
+| `--accent-conv` | `#8b1eff` | `#A982FF` (Ultra) | Conversion / agent |
+| `--accent-beauty` | `#d61a7f` | `#FF48D2` (Pulse) | Beauty/Design |
+| `--accent-links` | `#0f9b8e` | `#24F6D2` (Aqua) | Smart Links / system |
+| `--accent-speed` | `#2f9e44` | `#39E58C` (Mint) | Speed / success |
+| `--accent-pro` | `#ff9800` | `#FFC857` (Gold) | Pro Tools / warning |
 
 **Usage rules:**
 - Apply accent color to feature card **title text only** via `text-[color:var(--accent-*)]`

--- a/apps/web/components/features/dev/NoirIonSpecimen.stories.tsx
+++ b/apps/web/components/features/dev/NoirIonSpecimen.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { type ReactNode, useEffect } from 'react';
+import { NoirIonSpecimen } from './NoirIonSpecimen';
+
+/**
+ * Noir Ion anchors are declared under `:root.dark`. Storybook must put
+ * `dark` on <html> so product tokens resolve (not a nested .dark wrapper).
+ */
+function DarkRootDecorator({ children }: { readonly children: ReactNode }) {
+  useEffect(() => {
+    const root = document.documentElement;
+    const hadDark = root.classList.contains('dark');
+    root.classList.add('dark');
+    return () => {
+      if (!hadDark) root.classList.remove('dark');
+    };
+  }, []);
+  return children;
+}
+
+const meta = {
+  title: 'Design System/Noir Ion Specimen',
+  component: NoirIonSpecimen,
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: { default: 'dark' },
+  },
+  decorators: [
+    Story => (
+      <DarkRootDecorator>
+        <Story />
+      </DarkRootDecorator>
+    ),
+  ],
+} satisfies Meta<typeof NoirIonSpecimen>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Full elevation, accent, table/selection, and primary-action reference. */
+export const Default: Story = {};

--- a/apps/web/components/features/dev/NoirIonSpecimen.tsx
+++ b/apps/web/components/features/dev/NoirIonSpecimen.tsx
@@ -1,0 +1,414 @@
+/**
+ * Dev/Storybook specimen for the Jovie Noir Ion dark color system (JOV-4635).
+ * Not mounted in production routes — reference surface only.
+ */
+
+const SURFACES = [
+  { name: 'Canvas', token: 'var(--noir-ion-canvas)', role: 'App page' },
+  { name: 'Shell', token: 'var(--noir-ion-shell)', role: 'Sidebar / chrome' },
+  { name: 'Panel', token: 'var(--noir-ion-panel)', role: 'Main content' },
+  { name: 'Card', token: 'var(--noir-ion-card)', role: 'Cards' },
+  {
+    name: 'Elevated',
+    token: 'var(--noir-ion-elevated)',
+    role: 'Inputs / raised',
+  },
+  {
+    name: 'Floating',
+    token: 'var(--noir-ion-floating)',
+    role: 'Modals / tooltips',
+  },
+] as const;
+
+const TEXT_ROLES = [
+  { name: 'Strong', color: 'var(--noir-ion-text-strong)' },
+  { name: 'Primary', color: 'var(--noir-ion-text-primary)' },
+  { name: 'Secondary', color: 'var(--noir-ion-text-secondary)' },
+  { name: 'Muted', color: 'var(--noir-ion-text-muted)' },
+  { name: 'Tertiary', color: 'var(--noir-ion-text-tertiary)' },
+  { name: 'Disabled', color: 'var(--noir-ion-text-disabled)' },
+] as const;
+
+const ACCENTS = [
+  {
+    name: 'Ion',
+    role: 'Primary action / focus / selection',
+    color: 'var(--noir-ion-ion)',
+    soft: 'var(--noir-ion-ion-soft)',
+  },
+  {
+    name: 'Ultra',
+    role: 'Agent intelligence',
+    color: 'var(--noir-ion-ultra)',
+    soft: 'var(--noir-ion-ultra-soft)',
+  },
+  {
+    name: 'Pulse',
+    role: 'Creative energy',
+    color: 'var(--noir-ion-pulse)',
+    soft: 'var(--noir-ion-pulse-soft)',
+  },
+  {
+    name: 'Aqua',
+    role: 'System signal',
+    color: 'var(--noir-ion-aqua)',
+    soft: 'var(--noir-ion-aqua-soft)',
+  },
+  {
+    name: 'Mint',
+    role: 'Success',
+    color: 'var(--noir-ion-mint)',
+    soft: 'var(--noir-ion-mint-soft)',
+  },
+  {
+    name: 'Gold',
+    role: 'Warning',
+    color: 'var(--noir-ion-gold)',
+    soft: 'var(--noir-ion-gold-soft)',
+  },
+  {
+    name: 'Flare',
+    role: 'Danger / error',
+    color: 'var(--noir-ion-flare)',
+    soft: 'var(--noir-ion-flare-soft)',
+  },
+] as const;
+
+const ROW_STATES = [
+  { label: 'Default', className: '' },
+  { label: 'Hover', style: { background: 'var(--linear-row-hover)' } },
+  {
+    label: 'Selected',
+    style: { background: 'var(--noir-ion-selected)' },
+  },
+  {
+    label: 'Selected Strong',
+    style: { background: 'var(--noir-ion-selected-strong)' },
+  },
+] as const;
+
+export function NoirIonSpecimen() {
+  return (
+    <div
+      className='dark min-h-dvh p-6 text-primary-token'
+      style={{
+        background: 'var(--noir-ion-canvas)',
+        color: 'var(--noir-ion-text-primary)',
+        fontFamily: 'var(--font-sans, Inter, system-ui, sans-serif)',
+      }}
+      data-testid='noir-ion-specimen'
+    >
+      <div
+        className='mx-auto flex max-w-5xl flex-col gap-8 rounded-xl border p-6'
+        style={{
+          background: 'var(--noir-ion-panel)',
+          borderColor: 'var(--noir-ion-border-default)',
+        }}
+      >
+        <header className='flex flex-wrap items-end justify-between gap-4'>
+          <div>
+            <p
+              className='text-xs font-medium'
+              style={{ color: 'var(--noir-ion-text-muted)' }}
+            >
+              Design System · Authenticated Shell
+            </p>
+            <h1
+              className='text-xl font-semibold tracking-tight'
+              style={{ color: 'var(--noir-ion-text-strong)' }}
+            >
+              Jovie Noir Ion
+            </h1>
+            <p
+              className='mt-1 max-w-xl text-sm'
+              style={{ color: 'var(--noir-ion-text-secondary)' }}
+            >
+              Dark-first product palette. ~90% neutral surfaces, sparse accent.
+              One section, one dominant action.
+            </p>
+          </div>
+          <button
+            type='button'
+            className='inline-flex h-9 items-center rounded-full px-4 text-sm font-medium'
+            style={{
+              background: 'var(--color-btn-primary-bg)',
+              color: 'var(--color-btn-primary-fg)',
+            }}
+          >
+            Primary Action
+          </button>
+        </header>
+
+        <section aria-labelledby='noir-surfaces'>
+          <h2
+            id='noir-surfaces'
+            className='mb-3 text-sm font-medium'
+            style={{ color: 'var(--noir-ion-text-secondary)' }}
+          >
+            Surfaces
+          </h2>
+          <div className='grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6'>
+            {SURFACES.map(surface => (
+              <div
+                key={surface.name}
+                className='flex flex-col gap-2 rounded-lg border p-3'
+                style={{
+                  background: surface.token,
+                  borderColor: 'var(--noir-ion-border-subtle)',
+                }}
+              >
+                <div
+                  className='h-10 rounded-md border'
+                  style={{
+                    background: surface.token,
+                    borderColor: 'var(--noir-ion-border-default)',
+                  }}
+                />
+                <div className='text-xs font-medium'>{surface.name}</div>
+                <div
+                  className='text-[11px]'
+                  style={{ color: 'var(--noir-ion-text-tertiary)' }}
+                >
+                  {surface.role}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby='noir-text'>
+          <h2
+            id='noir-text'
+            className='mb-3 text-sm font-medium'
+            style={{ color: 'var(--noir-ion-text-secondary)' }}
+          >
+            Text Hierarchy
+          </h2>
+          <div className='flex flex-col gap-1.5'>
+            {TEXT_ROLES.map(role => (
+              <p
+                key={role.name}
+                className='text-sm'
+                style={{ color: role.color }}
+              >
+                {role.name} — The quick brown fox jumps over the lazy dog.
+              </p>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby='noir-accents'>
+          <h2
+            id='noir-accents'
+            className='mb-3 text-sm font-medium'
+            style={{ color: 'var(--noir-ion-text-secondary)' }}
+          >
+            Accents (Seasoning)
+          </h2>
+          <div className='grid gap-2 sm:grid-cols-2 lg:grid-cols-4'>
+            {ACCENTS.map(accent => (
+              <div
+                key={accent.name}
+                className='rounded-lg border p-3'
+                style={{
+                  background: accent.soft,
+                  borderColor: 'var(--noir-ion-border-subtle)',
+                }}
+              >
+                <div className='flex items-center gap-2'>
+                  <span
+                    className='inline-block size-3 rounded-full'
+                    style={{ background: accent.color }}
+                    aria-hidden
+                  />
+                  <span
+                    className='text-sm font-medium'
+                    style={{ color: accent.color }}
+                  >
+                    {accent.name}
+                  </span>
+                </div>
+                <p
+                  className='mt-1 text-[11px]'
+                  style={{ color: 'var(--noir-ion-text-muted)' }}
+                >
+                  {accent.role}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby='noir-states'>
+          <h2
+            id='noir-states'
+            className='mb-3 text-sm font-medium'
+            style={{ color: 'var(--noir-ion-text-secondary)' }}
+          >
+            Row States · Focus · Status
+          </h2>
+          <div
+            className='overflow-hidden rounded-lg border'
+            style={{
+              background: 'var(--noir-ion-card)',
+              borderColor: 'var(--noir-ion-border-default)',
+            }}
+          >
+            <table className='w-full text-left text-sm'>
+              <thead>
+                <tr
+                  style={{
+                    borderBottom: '1px solid var(--noir-ion-border-subtle)',
+                    color: 'var(--noir-ion-text-muted)',
+                  }}
+                >
+                  <th className='px-3 py-2 font-medium'>State</th>
+                  <th className='px-3 py-2 font-medium'>Track</th>
+                  <th className='px-3 py-2 font-medium'>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ROW_STATES.map(row => (
+                  <tr
+                    key={row.label}
+                    style={{
+                      ...('style' in row ? row.style : undefined),
+                      borderBottom: '1px solid var(--noir-ion-border-subtle)',
+                    }}
+                  >
+                    <td className='px-3 py-2'>{row.label}</td>
+                    <td
+                      className='px-3 py-2'
+                      style={{ color: 'var(--noir-ion-text-secondary)' }}
+                    >
+                      Midnight Protocol
+                    </td>
+                    <td className='px-3 py-2'>
+                      <span
+                        className='inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium'
+                        style={{
+                          background: 'var(--noir-ion-mint-soft)',
+                          color: 'var(--noir-ion-mint)',
+                        }}
+                      >
+                        <span
+                          className='size-1.5 rounded-full'
+                          style={{ background: 'var(--noir-ion-mint)' }}
+                          aria-hidden
+                        />
+                        Live
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+                <tr
+                  style={{
+                    outline: '2px solid var(--noir-ion-focus-ring)',
+                    outlineOffset: '-2px',
+                  }}
+                >
+                  <td className='px-3 py-2'>Focus Visible</td>
+                  <td
+                    className='px-3 py-2'
+                    style={{ color: 'var(--noir-ion-ion)' }}
+                  >
+                    Ion focus ring
+                  </td>
+                  <td className='px-3 py-2'>
+                    <span
+                      className='inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium'
+                      style={{
+                        background: 'var(--noir-ion-gold-soft)',
+                        color: 'var(--noir-ion-gold)',
+                      }}
+                    >
+                      <span
+                        className='size-1.5 rounded-full'
+                        style={{ background: 'var(--noir-ion-gold)' }}
+                        aria-hidden
+                      />
+                      Attention
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td className='px-3 py-2'>Error</td>
+                  <td
+                    className='px-3 py-2'
+                    style={{ color: 'var(--noir-ion-text-secondary)' }}
+                  >
+                    Failed sync
+                  </td>
+                  <td className='px-3 py-2'>
+                    <span
+                      className='inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium'
+                      style={{
+                        background: 'var(--noir-ion-flare-soft)',
+                        color: 'var(--noir-ion-flare)',
+                      }}
+                    >
+                      <span
+                        className='size-1.5 rounded-full'
+                        style={{ background: 'var(--noir-ion-flare)' }}
+                        aria-hidden
+                      />
+                      Blocked
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p
+            className='mt-2 text-[11px]'
+            style={{ color: 'var(--noir-ion-text-tertiary)' }}
+          >
+            Status uses color plus label and shape. Color alone never carries
+            meaning.
+          </p>
+        </section>
+
+        <section aria-labelledby='noir-link'>
+          <h2
+            id='noir-link'
+            className='mb-2 text-sm font-medium'
+            style={{ color: 'var(--noir-ion-text-secondary)' }}
+          >
+            Links · Disabled
+          </h2>
+          <div className='flex flex-wrap items-center gap-4 text-sm'>
+            <a
+              href='#noir-ion-specimen'
+              className='underline-offset-2 hover:underline'
+              style={{ color: 'var(--color-link-default)' }}
+            >
+              Ion link
+            </a>
+            <button
+              type='button'
+              disabled
+              className='rounded-full border px-3 py-1.5 text-sm'
+              style={{
+                color: 'var(--noir-ion-text-disabled)',
+                borderColor: 'var(--noir-ion-border-subtle)',
+                opacity: 'var(--state-disabled-opacity)',
+              }}
+            >
+              Disabled
+            </button>
+            <span
+              className='rounded-full border px-3 py-1.5 text-sm'
+              style={{
+                color: 'var(--noir-ion-ion)',
+                borderColor: 'var(--noir-ion-border-interactive)',
+                background: 'var(--noir-ion-ion-soft)',
+              }}
+            >
+              Interactive border
+            </span>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/design/tokens.json
+++ b/apps/web/design/tokens.json
@@ -39,29 +39,30 @@
     "dark": {
       "gray": "#8d8d93",
       "gray-subtle": "rgb(127 127 133 / 0.18)",
-      "blue": "#4d7dff",
-      "blue-subtle": "rgb(37 99 255 / 0.18)",
-      "purple": "#9b4dff",
-      "purple-subtle": "rgb(139 30 255 / 0.18)",
-      "pink": "#ea4a9c",
-      "pink-subtle": "rgb(214 26 127 / 0.18)",
-      "red": "#ff4d5f",
-      "red-subtle": "rgb(243 18 45 / 0.18)",
-      "orange": "#ffab2e",
-      "orange-subtle": "rgb(255 152 0 / 0.18)",
-      "green": "#43b85c",
-      "green-subtle": "rgb(47 158 68 / 0.18)",
-      "teal": "#22b8a7",
-      "teal-subtle": "rgb(15 155 142 / 0.18)"
+      "blue": "#11afff",
+      "blue-subtle": "rgba(17, 175, 255, 0.12)",
+      "purple": "#a982ff",
+      "purple-subtle": "rgba(169, 130, 255, 0.12)",
+      "pink": "#ff48d2",
+      "pink-subtle": "rgba(255, 72, 210, 0.12)",
+      "red": "#ff677d",
+      "red-subtle": "rgba(255, 103, 125, 0.12)",
+      "orange": "#ffc857",
+      "orange-subtle": "rgba(255, 200, 87, 0.12)",
+      "green": "#39e58c",
+      "green-subtle": "rgba(57, 229, 140, 0.12)",
+      "teal": "#24f6d2",
+      "teal-subtle": "rgba(36, 246, 210, 0.1)"
     }
   },
   "interactive": {
-    "$description": "Interactive accent (focus, links, active). Canonical Jovie DS #7170ff, decoupled from the purple feature accent.",
+    "$description": "Interactive accent (focus, links, active). Dark mode uses Noir Ion electric blue (#11AFFF). Light mode retains System B #7170ff until a light-mode Noir Ion pass.",
     "accent": "#7170ff",
     "accent-hover-light": "#9a46ff",
     "accent-active-light": "#7612df",
-    "accent-hover-dark": "#b06bff",
-    "accent-active-dark": "#8a37f4"
+    "accent-dark": "#11afff",
+    "accent-hover-dark": "#3bc0ff",
+    "accent-active-dark": "#0088ff"
   },
   "radius": {
     "$description": "System B radius scale (styles/design-system.css).",
@@ -86,9 +87,9 @@
   "divergences": {
     "$description": "Known same-concept/different-value pairs across legacy namespaces, tracked for the namespace-collapse wave. Do NOT silently unify these — each is a visual change requiring its own migration slice.",
     "accent-blue": {
-      "canonical-dark": "#4d7dff",
+      "canonical-dark": "#11afff",
       "linear-marketing": "#2563ff",
-      "note": "--color-accent-blue (dark carbon palette) vs --linear-accent-blue (System A marketing). Unification tracked under the namespace-collapse wave of #12009."
+      "note": "--color-accent-blue dark is Noir Ion electric blue (JOV-4635). --linear-accent-blue remains marketing System A until namespace-collapse."
     }
   }
 }

--- a/apps/web/lib/design/generated/design-tokens.manifest.json
+++ b/apps/web/lib/design/generated/design-tokens.manifest.json
@@ -4,9 +4,9 @@
   "divergences": {
     "$description": "Known same-concept/different-value pairs across legacy namespaces, tracked for the namespace-collapse wave. Do NOT silently unify these — each is a visual change requiring its own migration slice.",
     "accent-blue": {
-      "canonical-dark": "#4d7dff",
+      "canonical-dark": "#11afff",
       "linear-marketing": "#2563ff",
-      "note": "--color-accent-blue (dark carbon palette) vs --linear-accent-blue (System A marketing). Unification tracked under the namespace-collapse wave of #12009."
+      "note": "--color-accent-blue dark is Noir Ion electric blue (JOV-4635). --linear-accent-blue remains marketing System A until namespace-collapse."
     }
   },
   "tokens": [
@@ -211,98 +211,98 @@
     {
       "cssVar": "--color-accent-blue",
       "mode": "dark",
-      "value": "#4d7dff",
+      "value": "#11afff",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-blue-subtle",
       "mode": "dark",
-      "value": "rgb(37 99 255 / 0.18)",
+      "value": "rgba(17, 175, 255, 0.12)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-purple",
       "mode": "dark",
-      "value": "#9b4dff",
+      "value": "#a982ff",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-purple-subtle",
       "mode": "dark",
-      "value": "rgb(139 30 255 / 0.18)",
+      "value": "rgba(169, 130, 255, 0.12)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-pink",
       "mode": "dark",
-      "value": "#ea4a9c",
+      "value": "#ff48d2",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-pink-subtle",
       "mode": "dark",
-      "value": "rgb(214 26 127 / 0.18)",
+      "value": "rgba(255, 72, 210, 0.12)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-red",
       "mode": "dark",
-      "value": "#ff4d5f",
+      "value": "#ff677d",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-red-subtle",
       "mode": "dark",
-      "value": "rgb(243 18 45 / 0.18)",
+      "value": "rgba(255, 103, 125, 0.12)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-orange",
       "mode": "dark",
-      "value": "#ffab2e",
+      "value": "#ffc857",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-orange-subtle",
       "mode": "dark",
-      "value": "rgb(255 152 0 / 0.18)",
+      "value": "rgba(255, 200, 87, 0.12)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-green",
       "mode": "dark",
-      "value": "#43b85c",
+      "value": "#39e58c",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-green-subtle",
       "mode": "dark",
-      "value": "rgb(47 158 68 / 0.18)",
+      "value": "rgba(57, 229, 140, 0.12)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-teal",
       "mode": "dark",
-      "value": "#22b8a7",
+      "value": "#24f6d2",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },
     {
       "cssVar": "--color-accent-teal-subtle",
       "mode": "dark",
-      "value": "rgb(15 155 142 / 0.18)",
+      "value": "rgba(36, 246, 210, 0.1)",
       "status": "canonical",
       "emittedBy": "styles/design-system.css"
     },

--- a/apps/web/lib/design/generated/design-tokens.ts
+++ b/apps/web/lib/design/generated/design-tokens.ts
@@ -38,29 +38,30 @@ export const DESIGN_TOKENS = {
     "dark": {
       "gray": "#8d8d93",
       "gray-subtle": "rgb(127 127 133 / 0.18)",
-      "blue": "#4d7dff",
-      "blue-subtle": "rgb(37 99 255 / 0.18)",
-      "purple": "#9b4dff",
-      "purple-subtle": "rgb(139 30 255 / 0.18)",
-      "pink": "#ea4a9c",
-      "pink-subtle": "rgb(214 26 127 / 0.18)",
-      "red": "#ff4d5f",
-      "red-subtle": "rgb(243 18 45 / 0.18)",
-      "orange": "#ffab2e",
-      "orange-subtle": "rgb(255 152 0 / 0.18)",
-      "green": "#43b85c",
-      "green-subtle": "rgb(47 158 68 / 0.18)",
-      "teal": "#22b8a7",
-      "teal-subtle": "rgb(15 155 142 / 0.18)"
+      "blue": "#11afff",
+      "blue-subtle": "rgba(17, 175, 255, 0.12)",
+      "purple": "#a982ff",
+      "purple-subtle": "rgba(169, 130, 255, 0.12)",
+      "pink": "#ff48d2",
+      "pink-subtle": "rgba(255, 72, 210, 0.12)",
+      "red": "#ff677d",
+      "red-subtle": "rgba(255, 103, 125, 0.12)",
+      "orange": "#ffc857",
+      "orange-subtle": "rgba(255, 200, 87, 0.12)",
+      "green": "#39e58c",
+      "green-subtle": "rgba(57, 229, 140, 0.12)",
+      "teal": "#24f6d2",
+      "teal-subtle": "rgba(36, 246, 210, 0.1)"
     }
   },
   "interactive": {
-    "$description": "Interactive accent (focus, links, active). Canonical Jovie DS #7170ff, decoupled from the purple feature accent.",
+    "$description": "Interactive accent (focus, links, active). Dark mode uses Noir Ion electric blue (#11AFFF). Light mode retains System B #7170ff until a light-mode Noir Ion pass.",
     "accent": "#7170ff",
     "accent-hover-light": "#9a46ff",
     "accent-active-light": "#7612df",
-    "accent-hover-dark": "#b06bff",
-    "accent-active-dark": "#8a37f4"
+    "accent-dark": "#11afff",
+    "accent-hover-dark": "#3bc0ff",
+    "accent-active-dark": "#0088ff"
   },
   "radius": {
     "$description": "System B radius scale (styles/design-system.css).",
@@ -85,9 +86,9 @@ export const DESIGN_TOKENS = {
   "divergences": {
     "$description": "Known same-concept/different-value pairs across legacy namespaces, tracked for the namespace-collapse wave. Do NOT silently unify these — each is a visual change requiring its own migration slice.",
     "accent-blue": {
-      "canonical-dark": "#4d7dff",
+      "canonical-dark": "#11afff",
       "linear-marketing": "#2563ff",
-      "note": "--color-accent-blue (dark carbon palette) vs --linear-accent-blue (System A marketing). Unification tracked under the namespace-collapse wave of #12009."
+      "note": "--color-accent-blue dark is Noir Ion electric blue (JOV-4635). --linear-accent-blue remains marketing System A until namespace-collapse."
     }
   }
 } as const;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -965,137 +965,148 @@ html[data-profile-initial-mode]
      --font-size-regular: 15px, --font-size-large: 18px */
 }
 
-/* Dark mode - same generation logic, inverted lightness */
+/* Dark mode — Jovie Noir Ion (JOV-4635 / #15244).
+   Dark-first authenticated product palette. Neutral graphite surfaces carry
+   structure; electric blue (Ion) carries routine action/focus/selection.
+   Semantic mapping: --noir-ion-* anchors → product tokens (rollback path). */
 :root.dark {
-  /* Dark mode surfaces — matched to shell-v1 Carbon palette */
-  --color-bg-base: #06070a;
-  /* sidebar/page bg */
-  --color-bg-surface-0: #0a0b0e;
-  /* primary app surface — matches --linear-bg-surface-0 */
+  /* —— Noir Ion anchors (canonical approved values) —— */
+  --noir-ion-canvas: #030407;
+  --noir-ion-shell: #06080d;
+  --noir-ion-panel: #0a0d16;
+  --noir-ion-card: #0f1420;
+  --noir-ion-elevated: #151b2a;
+  --noir-ion-floating: #1b2436;
+  --noir-ion-text-strong: #ffffff;
+  --noir-ion-text-primary: #f5f7fb;
+  --noir-ion-text-secondary: #d7dce8;
+  --noir-ion-text-muted: #a8b0c3;
+  --noir-ion-text-tertiary: #7d879d;
+  --noir-ion-text-disabled: #525d75;
+  --noir-ion-text-inverse: #020307;
+  --noir-ion-ion: #11afff;
+  --noir-ion-ion-solid: #0088ff;
+  --noir-ion-ion-soft: rgba(17, 175, 255, 0.12);
+  --noir-ion-pulse: #ff48d2;
+  --noir-ion-pulse-solid: #f725b8;
+  --noir-ion-pulse-soft: rgba(255, 72, 210, 0.12);
+  --noir-ion-ultra: #a982ff;
+  --noir-ion-ultra-solid: #8b5cf6;
+  --noir-ion-ultra-soft: rgba(169, 130, 255, 0.12);
+  --noir-ion-aqua: #24f6d2;
+  --noir-ion-aqua-solid: #00d7c2;
+  --noir-ion-aqua-soft: rgba(36, 246, 210, 0.1);
+  --noir-ion-mint: #39e58c;
+  --noir-ion-mint-solid: #10c76e;
+  --noir-ion-mint-soft: rgba(57, 229, 140, 0.12);
+  --noir-ion-gold: #ffc857;
+  --noir-ion-gold-solid: #f59e0b;
+  --noir-ion-gold-soft: rgba(255, 200, 87, 0.12);
+  --noir-ion-flare: #ff677d;
+  --noir-ion-flare-solid: #ff3b5c;
+  --noir-ion-flare-soft: rgba(255, 103, 125, 0.12);
+  --noir-ion-selected: rgba(17, 175, 255, 0.1);
+  --noir-ion-selected-strong: rgba(17, 175, 255, 0.16);
+  --noir-ion-border-subtle: rgba(168, 176, 195, 0.1);
+  --noir-ion-border-default: rgba(168, 176, 195, 0.16);
+  --noir-ion-border-strong: rgba(199, 237, 255, 0.26);
+  --noir-ion-border-interactive: rgba(17, 175, 255, 0.48);
+  --noir-ion-focus-ring: rgba(17, 175, 255, 0.72);
+
+  /* Dark mode surfaces — Noir Ion stepped near-black ladder */
+  --color-bg-base: var(--noir-ion-canvas);
+  /* app canvas */
+  --color-bg-surface-0: var(--noir-ion-shell);
+  /* recessed wells / shell-adjacent */
   --color-bg-surface-1: var(--linear-bg-surface-1);
-  /* Shared card surface inside the dark app shell */
-  --color-bg-surface-2: #161a20;
-  /* inputs, elevated */
-  --color-bg-surface-3: #2a2c32;
-  /* modals, tooltips */
+  /* Shared card surface (maps to --noir-ion-card via linear tokens) */
+  --color-bg-surface-2: var(--noir-ion-elevated);
+  /* elevated / inputs */
+  --color-bg-surface-3: var(--noir-ion-floating);
+  /* floating / modals / tooltips */
 
   /* Additional dark surface levels */
-  --color-bg-page: #06070a;
-  /* Same as base */
-  --color-bg-hover: rgba(255, 255, 255, 0.04);
-  /* Row/item hover */
-  --color-bg-elevated: #0a0b0e;
-  /* Same as surface-0 */
-  --color-bg-input: #101216;
-  /* Same as surface-1 */
-  --color-bg-active: #161a20;
-  /* Same as surface-2 */
-  --color-bg-primary: lch(9.894% 0.5 282);
-  --color-bg-secondary: lch(14.44% 0.5 282);
-  --color-bg-button: #2a2c32;
-  /* Same as surface-3 */
-  --color-bg-tooltip: #2a2c32;
-  /* Matches surface-3 in dark mode */
+  --color-bg-page: var(--noir-ion-canvas);
+  --color-bg-hover: rgba(168, 176, 195, 0.06);
+  /* Row/item hover — graphite, not pure white */
+  --color-bg-elevated: var(--noir-ion-panel);
+  --color-bg-input: var(--noir-ion-card);
+  --color-bg-active: var(--noir-ion-elevated);
+  --color-bg-primary: var(--noir-ion-panel);
+  --color-bg-secondary: var(--noir-ion-shell);
+  --color-bg-button: var(--noir-ion-elevated);
+  --color-bg-tooltip: var(--noir-ion-floating);
   --color-bg-paper: #f7f8f8;
   /* Paper surface remains light for explicit light reading modes */
 
-  /* Text hierarchy - inverted for dark mode
-     Extracted from Linear.app live (2026-02-15):
-       Primary:   lch(100% 0 272)       → oklch ~100% — pure white headings
-       Secondary: lch(90.65% 1.35 272) → oklch ~91% — body text, labels (bright!)
-       Tertiary:  lch(62.6% 1.35 272)   → oklch ~63% — descriptions, meta
-       Quaternary: lch(38.29% 1.35 272) → oklch ~38% — placeholders, disabled
-     Key insight: Linear's secondary is MUCH brighter than typical (90% not 65%) */
-  /* Text hierarchy — extracted from Linear CSS vars (2026-02-17)
-     --color-text-primary:    lch(100% 0 272)       = pure white
-     --color-text-secondary:  lch(90.65% 1.35 272)  = #E3E4E6
-     --color-text-tertiary:   lch(62.6% 1.35 272)   = #969799
-     --color-text-quaternary: lch(38.29% 1.35 272)   = #5A5B5D
-     --content-color:         #6b6f76               = content/meta text */
-  --color-text-primary-token: lch(100% 0 282);
-  /* Pure white — Linear exact (hue 282 per March 2026 refresh) */
-  --color-text-secondary-token: lch(90.65% 1.35 282);
-  /* #E3E4E6 — Linear exact */
-  --color-text-tertiary-token: lch(68% 1.35 282);
-  /* #969799 — Linear exact */
-  --color-text-quaternary-token: #62666d;
-  /* Linear: --color-text-quaternary = #62666d (extracted 2026-03-16) */
-  /* JOV-1780: disabled text lifted from oklch(28%) to oklch(45%) so
-     disabled form controls remain legible against page bg `#08090a`. */
-  --color-text-disabled-token: oklch(45% 0.006 282);
-  --color-text-tooltip: lch(100% 0 282);
-  /* White text on dark tooltips */
+  /* Text hierarchy — Noir Ion */
+  --color-text-primary-token: var(--noir-ion-text-primary);
+  --color-text-secondary-token: var(--noir-ion-text-secondary);
+  --color-text-tertiary-token: var(--noir-ion-text-muted);
+  --color-text-quaternary-token: var(--noir-ion-text-tertiary);
+  --color-text-disabled-token: var(--noir-ion-text-disabled);
+  --color-text-tooltip: var(--noir-ion-text-strong);
 
   /* Logo muted tokens for label logos bar */
-  --color-logo-muted: rgba(255, 255, 255, 0.55);
-  --color-logo-muted-hover: rgba(255, 255, 255, 0.75);
+  --color-logo-muted: rgba(245, 247, 251, 0.55);
+  --color-logo-muted-hover: rgba(245, 247, 251, 0.75);
 
-  /* Border system - extracted from Linear marketing (2026-02-16)
-     Subtle:  rgba(255,255,255,0.05) — card borders, dividers
-     Default: rgba(255,255,255,0.08) — frame borders, input borders
-     Strong:  rgba(255,255,255,0.10) — panel outlines */
-  /* JOV-1780: dark-mode border contrast bump so cards, panels, inputs and
-     dividers have clear boundaries against surface-1 `#17171a`. Previous
-     values (0.04 / 0.07 / 0.12) disappeared on dark surfaces. */
-  --color-border-subtle: rgba(255, 255, 255, 0.07);
-  --color-border-default: rgba(255, 255, 255, 0.11);
-  --color-border-strong: rgba(255, 255, 255, 0.18);
-  --color-border-focus: #7170ff;
-  /* Linear accent for focus */
+  /* Borders — Noir Ion cool graphite + ion focus */
+  --color-border-subtle: var(--noir-ion-border-subtle);
+  --color-border-default: var(--noir-ion-border-default);
+  --color-border-strong: var(--noir-ion-border-strong);
+  --color-border-focus: var(--noir-ion-ion);
+  /* Ion focus */
 
-  /* Accent palette rotation */
+  /* Accent palette rotation — Noir Ion semantics
+     blue/Ion: primary action · purple/Ultra: agent · pink/Pulse: creative
+     teal/Aqua: system · green/Mint: success · orange/Gold: warning
+     red/Flare: danger */
   --color-accent-gray: #8d8d93;
   --color-accent-gray-subtle: rgb(127 127 133 / 0.18);
-  --color-accent-blue: #4d7dff;
-  --color-accent-blue-subtle: rgb(37 99 255 / 0.18);
-  --color-accent-purple: #9b4dff;
-  --color-accent-purple-subtle: rgb(139 30 255 / 0.18);
-  --color-accent-pink: #ea4a9c;
-  --color-accent-pink-subtle: rgb(214 26 127 / 0.18);
-  --color-accent-red: #ff4d5f;
-  --color-accent-red-subtle: rgb(243 18 45 / 0.18);
-  --color-accent-orange: #ffab2e;
-  --color-accent-orange-subtle: rgb(255 152 0 / 0.18);
-  --color-accent-green: #43b85c;
-  --color-accent-green-subtle: rgb(47 158 68 / 0.18);
-  --color-accent-teal: #22b8a7;
-  --color-accent-teal-subtle: rgb(15 155 142 / 0.18);
+  --color-accent-blue: #11afff;
+  --color-accent-blue-subtle: rgba(17, 175, 255, 0.12);
+  --color-accent-purple: #a982ff;
+  --color-accent-purple-subtle: rgba(169, 130, 255, 0.12);
+  --color-accent-pink: #ff48d2;
+  --color-accent-pink-subtle: rgba(255, 72, 210, 0.12);
+  --color-accent-red: #ff677d;
+  --color-accent-red-subtle: rgba(255, 103, 125, 0.12);
+  --color-accent-orange: #ffc857;
+  --color-accent-orange-subtle: rgba(255, 200, 87, 0.12);
+  --color-accent-green: #39e58c;
+  --color-accent-green-subtle: rgba(57, 229, 140, 0.12);
+  --color-accent-teal: #24f6d2;
+  --color-accent-teal-subtle: rgba(36, 246, 210, 0.1);
 
-  /* Interactive accent (focus, links, active) — canonical Jovie DS #7170ff,
-     decoupled from the purple feature accent (carbon palette, title text only) */
-  --color-accent: #7170ff;
-  --color-accent-hover: #b06bff;
-  --color-accent-active: #8a37f4;
-  --color-accent-subtle: var(--color-accent-purple-subtle);
+  /* Interactive accent — Ion electric blue (focus, links, active selection).
+     CTAs remain high-contrast light pills per DESIGN.md; Ion carries intent. */
+  --color-accent: var(--noir-ion-ion);
+  --color-accent-hover: #3bc0ff;
+  --color-accent-active: var(--noir-ion-ion-solid);
+  --color-accent-subtle: var(--noir-ion-ion-soft);
 
-  /* Primary button - inverted for dark mode (Linear: rgb(230,230,230)) */
+  /* Primary button — light-on-dark (restrained; not saturated Ion fill) */
   --color-btn-primary-bg: #e6e6e6;
-  --color-btn-primary-fg: #06070a;
+  --color-btn-primary-fg: var(--noir-ion-text-inverse);
   --color-btn-primary-hover: #f0f0f0;
 
   /* Secondary button */
-  --color-btn-secondary-bg: oklch(
-    19% var(--theme-base-chroma) var(--theme-base-hue)
-  );
-  --color-btn-secondary-fg: oklch(90% 0 0);
-  --color-btn-secondary-hover: oklch(
-    24% var(--theme-base-chroma) var(--theme-base-hue)
-  );
+  --color-btn-secondary-bg: var(--noir-ion-elevated);
+  --color-btn-secondary-fg: var(--noir-ion-text-primary);
+  --color-btn-secondary-hover: var(--noir-ion-floating);
 
-  /* Interactive states - white-based (Linear uses semi-transparent overlays)
-     Extracted: hover rows = rgba(255,255,255,0.02-0.03), buttons = 0.05, active = 0.05 */
-  --color-interactive-hover: rgba(255, 255, 255, 0.05);
-  --color-interactive-active: rgba(255, 255, 255, 0.05);
+  /* Interactive states */
+  --color-interactive-hover: rgba(168, 176, 195, 0.06);
+  --color-interactive-active: var(--noir-ion-selected);
 
-  /* Badge/tag styles — extracted from Linear marketing demo (2026-02-16)
-     bg: rgba(255,255,255,0.05), border: 1px solid rgba(255,255,255,0.05)
-     radius: 2px, font: 10px/510 */
-  --color-badge-bg: rgba(255, 255, 255, 0.05);
-  --color-badge-border: rgba(255, 255, 255, 0.05);
-  --color-badge-text: rgb(247, 248, 248);
+  /* Badge/tag styles */
+  --color-badge-bg: rgba(168, 176, 195, 0.08);
+  --color-badge-border: var(--noir-ion-border-subtle);
+  --color-badge-text: var(--noir-ion-text-primary);
 
-  /* Table cell hover — same as surface-2 rgb(22,23,24) */
-  --color-cell-hover: #161718;
+  /* Table cell hover — elevated step */
+  --color-cell-hover: var(--noir-ion-elevated);
 
   /* Shadows — extracted from Linear CSS vars (2026-02-17)
      --shadow-tiny: 0px 4px 4px -1px #0000000f, 0px 1px 1px 0px #0000001e
@@ -1202,14 +1213,16 @@ html[data-profile-initial-mode]
     24% var(--theme-base-chroma) var(--theme-base-hue)
   );
 
-  /* Cross-cutting interaction state tokens (state-matrix.md) */
-  --color-link-default: var(--linear-accent-blue);
+  /* Cross-cutting interaction state tokens (state-matrix.md)
+     Links/focus use Ion blue — not marketing linear-accent-blue. */
+  --color-link-default: var(--noir-ion-ion);
   --color-link-hover: color-mix(
     in oklab,
-    var(--linear-accent-blue) 78%,
-    var(--linear-text-primary)
+    var(--noir-ion-ion) 78%,
+    var(--noir-ion-text-primary)
   );
-  --color-link-visited: var(--linear-accent-purple);
+  --color-link-visited: var(--noir-ion-ultra);
+  --color-focus-ring: var(--noir-ion-focus-ring);
   --state-disabled-opacity: 0.5;
   --state-partial-opacity: 0.62;
   --state-offline-bg: var(--color-warning-subtle);
@@ -1226,6 +1239,10 @@ html[data-profile-initial-mode]
     var(--color-warning) 20%,
     transparent
   );
+  /* Selection roles */
+  --color-bg-selected: var(--noir-ion-selected);
+  --color-bg-selected-strong: var(--noir-ion-selected-strong);
+  --color-border-interactive: var(--noir-ion-border-interactive);
 }
 
 /* ============================================
@@ -1573,21 +1590,21 @@ html[data-profile-initial-mode]
 }
 
 :root.dark {
-  /* Success - brighter in dark mode */
+  /* Success — Mint */
   --color-success: var(--color-accent-green);
   --color-success-subtle: var(--color-accent-green-subtle);
 
-  /* Warning */
+  /* Warning — Gold */
   --color-warning: var(--color-accent-orange);
   --color-warning-subtle: var(--color-accent-orange-subtle);
 
-  /* Error */
+  /* Error — Flare */
   --color-error: var(--color-accent-red);
   --color-error-subtle: var(--color-accent-red-subtle);
 
-  /* Info */
-  --color-info: var(--color-accent-blue);
-  --color-info-subtle: var(--color-accent-blue-subtle);
+  /* Info — Aqua/system signal (not Ion blue; Ion is action/focus) */
+  --color-info: var(--color-accent-teal);
+  --color-info-subtle: var(--color-accent-teal-subtle);
 }
 
 /* ============================================
@@ -1870,37 +1887,24 @@ html[data-profile-initial-mode]
 }
 
 :root.dark {
-  /* Sidebar tokens - RGB format for Tailwind opacity modifiers */
-  /* Keep the sidebar on the darker shell canvas so the framed main pane reads above it. */
+  /* Sidebar tokens — Noir Ion shell; active uses Ion selection tint */
   --sidebar-background: var(--linear-app-sidebar-background-rgb);
-  /* Linear: --linear-app-sidebar-background-rgb */
-  --sidebar-foreground: 227 228 229;
-  /* Linear: --linear-app-sidebar-foreground-rgb */
-  --sidebar-primary: 227 228 229;
-  --sidebar-primary-foreground: 12 12 12;
-  --sidebar-accent: 255 255 255 / 0.03;
-  /* Linear: --linear-app-sidebar-accent-rgb */
-  --sidebar-accent-active: 255 255 255 / 0.05;
-  /* Linear: --linear-app-sidebar-accent-active-rgb */
-  --sidebar-accent-foreground: 227 228 229;
-  --sidebar-border: 255 255 255 / 0.06;
-  /* Linear: --linear-app-sidebar-border-rgb */
-  --sidebar-ring: 109 119 230 / 0.55;
-  --sidebar-muted: 138 143 152;
-  /* Linear: --linear-app-sidebar-muted-rgb */
-  --sidebar-muted-foreground: 138 143 152;
+  --sidebar-foreground: 245 247 251;
+  --sidebar-primary: 245 247 251;
+  --sidebar-primary-foreground: 2 3 7;
+  --sidebar-accent: 168 176 195 / 0.06;
+  --sidebar-accent-active: 17 175 255 / 0.1;
+  --sidebar-accent-foreground: 245 247 251;
+  --sidebar-border: 168 176 195 / 0.1;
+  --sidebar-ring: 17 175 255 / 0.72;
+  --sidebar-muted: 125 135 157;
+  --sidebar-muted-foreground: 125 135 157;
   --sidebar-surface: var(--linear-app-sidebar-background-rgb);
-  /* Matches sidebar background */
-  --sidebar-surface-hover: 255 255 255 / 0.04;
-  /* Matches sidebar accent */
-  --sidebar-input-background: 255 255 255 / 0.06;
-  --sidebar-input-border: 255 255 255 / 0.06;
-  --sidebar-item-foreground: 214 218 226;
-  /* Linear: --linear-app-sidebar-item-foreground-rgb */
-  --sidebar-item-icon: 116 120 128;
-  /* Linear: --linear-app-sidebar-item-icon-rgb */
-  --sidebar-accent-active: 255 255 255 / 0.06;
-  /* Linear: --linear-app-sidebar-accent-active-rgb */
+  --sidebar-surface-hover: 168 176 195 / 0.06;
+  --sidebar-input-background: 15 20 32 / 1;
+  --sidebar-input-border: 168 176 195 / 0.16;
+  --sidebar-item-foreground: 215 220 232;
+  --sidebar-item-icon: 125 135 157;
 }
 
 /* ============================================

--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -383,100 +383,91 @@
 :root.dark,
 .system-b-marketing.dark,
 [data-theme="linear"].dark {
-  /* Text — extracted directly from linear.app computed styles (2026-03-10):
-     --color-text-primary: #f7f8f8  (rgb 247,248,248)
-     --color-text-secondary: #d0d6e0 (much brighter than previous)
-     --color-text-tertiary: #8a8f98  (rgb 138,143,152) */
-  --linear-text-primary: #f7f8f8;
-  --linear-text-secondary: #d0d6e0;
-  --linear-text-tertiary: #8a8f98;
-  --linear-text-quaternary: #62666d;
-  --linear-text-inverse: oklch(5% 0.005 282);
-  /* Backgrounds — extracted from linear.app computed styles (2026-03-10):
-     --color-bg-primary: #08090a  body bg
-     --color-bg-secondary: #1c1c1f  cards/panels
-     --color-bg-tertiary: #232326  elevated surfaces */
-  --linear-bg-page: #06070a;
+  /* Text — Jovie Noir Ion (JOV-4635) */
+  --linear-text-primary: #f5f7fb;
+  --linear-text-secondary: #d7dce8;
+  --linear-text-tertiary: #a8b0c3;
+  --linear-text-quaternary: #7d879d;
+  --linear-text-inverse: #020307;
+  /* Backgrounds — Noir Ion stepped surfaces */
+  --linear-bg-page: #030407;
+  /* app canvas */
   --linear-bg-header: transparent;
-  --linear-bg-surface-0: #0a0b0e;
-  /* recessed wells / deepest app surface */
-  --linear-bg-surface-1: #101216;
-  /* shared card surface inside the app shell */
-  --linear-bg-surface-2: #161a20;
-  /* elevated controls and stronger separation */
-  --linear-panel-bg: #0a0b0e;
-  --linear-panel-ring: #23252a;
-  --linear-bg-button: #2a2a2e;
-  --linear-bg-footer: #06070a;
-  --linear-border-footer: #2a2a2e;
-  --linear-bg-hover: rgba(255, 255, 255, 0.06);
-  /* Borders — JOV-1780: dark-mode contrast bump (prev 0.04/0.07/0.12 blended
-     into surface-1 `#17171a` and page `#08090a`, making cards/panels/inputs
-     edge-less in dark mode). */
-  --linear-border-subtle: rgba(255, 255, 255, 0.07);
-  /* Low-emphasis separators inside shell chrome must stay quieter than a frame seam. */
-  --linear-border-default: rgba(255, 255, 255, 0.11);
-  --linear-border-strong: rgba(255, 255, 255, 0.18);
-  --linear-border-focus: rgba(255, 255, 255, 0.32);
-  /* Buttons — white primary on dark bg, matching Linear.app */
+  --linear-bg-surface-0: #06080d;
+  /* shell / recessed wells */
+  --linear-bg-surface-1: #0f1420;
+  /* card */
+  --linear-bg-surface-2: #151b2a;
+  /* elevated */
+  --linear-panel-bg: #0a0d16;
+  /* panel */
+  --linear-panel-ring: rgba(199, 237, 255, 0.26);
+  --linear-bg-button: #151b2a;
+  --linear-bg-footer: #030407;
+  --linear-border-footer: rgba(168, 176, 195, 0.16);
+  --linear-bg-hover: rgba(168, 176, 195, 0.06);
+  /* Borders — Noir Ion cool graphite */
+  --linear-border-subtle: rgba(168, 176, 195, 0.1);
+  --linear-border-default: rgba(168, 176, 195, 0.16);
+  --linear-border-strong: rgba(199, 237, 255, 0.26);
+  --linear-border-focus: rgba(17, 175, 255, 0.72);
+  /* Ion focus */
+  /* Buttons — white primary on dark (restrained CTA; Ion is focus/selection) */
   --linear-btn-primary-bg: #ffffff;
-  --linear-btn-primary-fg: #06070a;
+  --linear-btn-primary-fg: #020307;
   --linear-btn-primary-hover: #e8e9ec;
   --linear-btn-primary-border: #ffffff;
-  --linear-btn-secondary-bg: #232326;
-  --linear-btn-secondary-fg: #f7f8f8;
-  --linear-btn-secondary-hover: #2a2a2e;
-  /* Hero-specific */
+  --linear-btn-secondary-bg: #151b2a;
+  --linear-btn-secondary-fg: #f5f7fb;
+  --linear-btn-secondary-hover: #1b2436;
+  /* Hero-specific — cool ion atmosphere (sparse) */
   --linear-hero-glow: radial-gradient(
     ellipse 80% 60% at 50% 0%,
-    oklch(20% 0.02 265 / 0.6),
+    rgba(17, 175, 255, 0.08),
     transparent 70%
   );
-  /* Section glow backgrounds — dark mode */
   --linear-section-glow-primary: radial-gradient(
     ellipse 70% 50% at 50% 30%,
-    oklch(14% 0.03 270 / 0.5),
+    rgba(169, 130, 255, 0.06),
     transparent 70%
   );
   --linear-cta-glow: radial-gradient(
     ellipse 60% 50% at 50% 40%,
-    oklch(16% 0.035 265 / 0.6),
+    rgba(17, 175, 255, 0.07),
     transparent 65%
   );
-  --linear-hero-gradient-from: #f7f8f8;
-  --linear-hero-gradient-to: #8a8f98;
-  --linear-separator-from: rgba(255, 255, 255, 0.06);
-  --linear-separator-via: rgba(255, 255, 255, 0.03);
-  /* Shadows — deeper on dark. JOV-1780: ring bumped from 0.06 → 0.12 so
-     popovers/dropdowns/menus have a clearly visible rim against the app
-     shell in dark mode. */
+  --linear-hero-gradient-from: #f5f7fb;
+  --linear-hero-gradient-to: #a8b0c3;
+  --linear-separator-from: rgba(168, 176, 195, 0.1);
+  --linear-separator-via: rgba(168, 176, 195, 0.04);
+  /* Shadows — restrained depth on near-black */
   --linear-shadow-card: 0px 4px 24px rgba(0, 0, 0, 0.4);
   --linear-shadow-card-elevated:
-    0 0 0 1px rgba(255, 255, 255, 0.12), 0px 8px 40px rgba(0, 0, 0, 0.55);
-  --linear-app-content-surface: #0a0c0f;
-  /* primary framed main-pane surface */
+    0 0 0 1px rgba(168, 176, 195, 0.12), 0px 8px 40px rgba(0, 0, 0, 0.55);
+  --linear-app-content-surface: #0a0d16;
+  /* panel — primary framed main-pane surface */
   --linear-app-card-shadow: none;
-  /* JOV-1780: panel/frame seams bumped so card & panel boundaries are
-     visible in dark mode (prev 0.03 / 0.035 read as no edge at all). */
-  --linear-app-shell-border: #171a20;
-  --linear-app-shell-sidebar-seam: rgba(255, 255, 255, 0.08);
-  --linear-app-frame-seam: rgba(255, 255, 255, 0.07);
+  --linear-app-shell-border: rgba(168, 176, 195, 0.12);
+  --linear-app-shell-sidebar-seam: rgba(168, 176, 195, 0.1);
+  --linear-app-frame-seam: rgba(168, 176, 195, 0.1);
   --linear-app-shell-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.025), 0 14px 36px rgba(0, 0, 0, 0.18);
+    0 0 0 1px rgba(168, 176, 195, 0.06), 0 14px 36px rgba(0, 0, 0, 0.22);
   --linear-app-sidebar-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.02), 0 12px 28px rgba(0, 0, 0, 0.16);
+    0 0 0 1px rgba(168, 176, 195, 0.05), 0 12px 28px rgba(0, 0, 0, 0.18);
   --linear-app-drawer-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.042), 0 18px 42px rgba(0, 0, 0, 0.3);
-  --linear-row-hover: rgba(255, 255, 255, 0.022);
-  --linear-row-selected: rgba(255, 255, 255, 0.048);
-  --linear-app-sidebar-background-rgb: 6 7 10;
-  --linear-app-sidebar-foreground-rgb: 227 228 229;
-  --linear-app-sidebar-border-rgb: 255 255 255 / 0.06;
-  --linear-app-sidebar-accent-rgb: 255 255 255 / 0.03;
-  --linear-app-sidebar-accent-active-rgb: 255 255 255 / 0.05;
-  --linear-app-sidebar-item-foreground-rgb: 214 218 226;
-  --linear-app-sidebar-item-icon-rgb: 116 120 128;
-  --linear-app-sidebar-muted-rgb: 107 111 118;
+    0 0 0 1px rgba(168, 176, 195, 0.1), 0 18px 42px rgba(0, 0, 0, 0.32);
+  --linear-row-hover: rgba(168, 176, 195, 0.06);
+  --linear-row-selected: rgba(17, 175, 255, 0.1);
+  /* Ion selection */
+  --linear-app-sidebar-background-rgb: 6 8 13;
+  /* shell #06080D */
+  --linear-app-sidebar-foreground-rgb: 245 247 251;
+  --linear-app-sidebar-border-rgb: 168 176 195 / 0.1;
+  --linear-app-sidebar-accent-rgb: 168 176 195 / 0.06;
+  --linear-app-sidebar-accent-active-rgb: 17 175 255 / 0.1;
+  --linear-app-sidebar-item-foreground-rgb: 215 220 232;
+  --linear-app-sidebar-item-icon-rgb: 125 135 157;
+  --linear-app-sidebar-muted-rgb: 125 135 157;
 }
 
 /* ============================================

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -63,10 +63,10 @@ describe('surface elevation guardrails', () => {
       /:root\.dark[\s\S]*--sidebar-background:\s*var\(--linear-app-sidebar-background-rgb\);/
     );
     expect(linearTokens).toMatch(
-      /:root\.dark[\s\S]*--linear-app-content-surface:\s*#0a0c0f;/
+      /:root\.dark[\s\S]*--linear-app-content-surface:\s*#0a0d16;/
     );
     expect(linearTokens).toMatch(
-      /:root\.dark[\s\S]*--linear-app-sidebar-background-rgb:\s*6 7 10;/
+      /:root\.dark[\s\S]*--linear-app-sidebar-background-rgb:\s*6 8 13;/
     );
   });
 
@@ -80,8 +80,9 @@ describe('surface elevation guardrails', () => {
       'utf-8'
     );
 
+    // Noir Ion focus ring (electric blue) — not a white halo
     expect(linearTokens).toContain(
-      '--linear-border-focus: rgba(255, 255, 255, 0.32);'
+      '--linear-border-focus: rgba(17, 175, 255, 0.72);'
     );
     expect(designSystem).toContain('--focus-ring-width: 1px;');
     expect(designSystem).toMatch(

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -211,10 +211,10 @@ describe('UnifiedSidebar library route', () => {
       /--linear-app-frame-seam:\s*rgba\(0, 0, 0, 0\.045\);/
     );
     expect(linearTokens).toMatch(
-      /:root\.dark[\s\S]*--linear-border-subtle:\s*rgba\(255, 255, 255, 0\.07\);/
+      /:root\.dark[\s\S]*--linear-border-subtle:\s*rgba\(168, 176, 195, 0\.1\);/
     );
     expect(linearTokens).toMatch(
-      /:root\.dark[\s\S]*--linear-app-frame-seam:\s*rgba\(255, 255, 255, 0\.07\);/
+      /:root\.dark[\s\S]*--linear-app-frame-seam:\s*rgba\(168, 176, 195, 0\.1\);/
     );
     expect(linearTokens).not.toMatch(/--linear-border-divider-subtle/);
   });

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1731
+  "count": 1718
 }

--- a/apps/web/tests/unit/design-system/noir-ion-tokens.test.ts
+++ b/apps/web/tests/unit/design-system/noir-ion-tokens.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Jovie Noir Ion dark-mode contract (JOV-4635 / #15244).
+ *
+ * Locks approved anchors into the live token emitters so agents cannot
+ * silently regress to carbon-palette dark values or introduce a second theme.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WEB_ROOT = join(__dirname, '..', '..', '..');
+
+const designSystem = readFileSync(
+  join(WEB_ROOT, 'styles', 'design-system.css'),
+  'utf8'
+);
+const linearTokens = readFileSync(
+  join(WEB_ROOT, 'styles', 'linear-tokens.css'),
+  'utf8'
+);
+
+/** Find a dark block that contains a distinctive Noir Ion marker. */
+function darkBlockContaining(css: string, marker: string): string {
+  const blocks = css.match(/:root\.dark(?:\s*,[^{]+)?\s*\{[\s\S]*?\n\}/g) ?? [];
+  const hit = blocks.find(block => block.includes(marker));
+  expect(hit, `expected a :root.dark block containing ${marker}`).toBeTruthy();
+  return hit ?? '';
+}
+
+describe('Noir Ion — approved dark anchors', () => {
+  // Surface/accent anchors live in the large Noir Ion :root.dark block.
+  const dsDark = darkBlockContaining(designSystem, '--noir-ion-canvas');
+  const linearDark = darkBlockContaining(
+    linearTokens,
+    '--linear-app-content-surface: #0a0d16'
+  );
+
+  it('defines Noir Ion surface anchors and maps product tokens to them', () => {
+    expect(dsDark).toContain('--noir-ion-canvas: #030407;');
+    expect(dsDark).toContain('--noir-ion-shell: #06080d;');
+    expect(dsDark).toContain('--noir-ion-panel: #0a0d16;');
+    expect(dsDark).toContain('--noir-ion-card: #0f1420;');
+    expect(dsDark).toContain('--noir-ion-elevated: #151b2a;');
+    expect(dsDark).toContain('--noir-ion-floating: #1b2436;');
+
+    expect(dsDark).toContain('--color-bg-base: var(--noir-ion-canvas);');
+    expect(dsDark).toContain('--color-bg-page: var(--noir-ion-canvas);');
+    expect(dsDark).toContain('--color-bg-surface-0: var(--noir-ion-shell);');
+    expect(dsDark).toContain('--color-bg-surface-2: var(--noir-ion-elevated);');
+    expect(dsDark).toContain('--color-bg-surface-3: var(--noir-ion-floating);');
+  });
+
+  it('maps shell canvas + sidebar to Noir Ion shell ladder', () => {
+    expect(linearDark).toContain('--linear-bg-page: #030407;');
+    expect(linearDark).toContain('--linear-app-content-surface: #0a0d16;');
+    expect(linearDark).toContain('--linear-bg-surface-1: #0f1420;');
+    expect(linearDark).toContain(
+      '--linear-app-sidebar-background-rgb: 6 8 13;'
+    );
+  });
+
+  it('uses Ion electric blue for routine action, focus, and selection', () => {
+    expect(dsDark).toContain('--noir-ion-ion: #11afff;');
+    expect(dsDark).toContain('--color-accent-blue: #11afff;');
+    expect(dsDark).toContain('--color-accent: var(--noir-ion-ion);');
+    expect(dsDark).toContain('--color-border-focus: var(--noir-ion-ion);');
+    expect(dsDark).toContain('--color-focus-ring: var(--noir-ion-focus-ring);');
+    expect(dsDark).toContain('--color-bg-selected: var(--noir-ion-selected);');
+
+    expect(linearDark).toContain(
+      '--linear-border-focus: rgba(17, 175, 255, 0.72);'
+    );
+    expect(linearDark).toContain(
+      '--linear-row-selected: rgba(17, 175, 255, 0.1);'
+    );
+  });
+
+  it('keeps accent semantics for Ultra, Pulse, Aqua, Mint, Gold, Flare', () => {
+    expect(dsDark).toContain('--color-accent-purple: #a982ff;');
+    expect(dsDark).toContain('--color-accent-pink: #ff48d2;');
+    expect(dsDark).toContain('--color-accent-teal: #24f6d2;');
+    expect(dsDark).toContain('--color-accent-green: #39e58c;');
+    expect(dsDark).toContain('--color-accent-orange: #ffc857;');
+    expect(dsDark).toContain('--color-accent-red: #ff677d;');
+  });
+
+  it('maps info to Aqua (system), not Ion blue', () => {
+    // Second :root.dark status block — search whole file
+    expect(designSystem).toMatch(
+      /:root\.dark\s*\{[\s\S]*--color-info:\s*var\(--color-accent-teal\);/
+    );
+  });
+
+  it('does not introduce a parallel theme provider class for the palette', () => {
+    // Rollback is semantic mapping via --noir-ion-* vars, not a second DS.
+    expect(designSystem).not.toMatch(/\.theme-noir-ion\s*\{/);
+    expect(designSystem).not.toMatch(/data-theme\s*=\s*["']noir-ion["']/);
+  });
+});

--- a/apps/web/tests/unit/icon-contrast.test.ts
+++ b/apps/web/tests/unit/icon-contrast.test.ts
@@ -57,11 +57,12 @@ const SURFACES = {
     'surface-3': '#e6e6e6',
   },
   dark: {
-    base: '#06070a',
-    'surface-0': '#0a0b0e',
-    'surface-1': '#101216',
-    'surface-2': '#161a20',
-    'surface-3': '#2a2c32',
+    // Jovie Noir Ion (JOV-4635)
+    base: '#030407',
+    'surface-0': '#06080d',
+    'surface-1': '#0f1420',
+    'surface-2': '#151b2a',
+    'surface-3': '#1b2436',
   },
 } as const;
 
@@ -71,7 +72,7 @@ const TEXT_TOKENS = {
     'secondary-token': '#555558', // oklch(40% 0.015 272)
   },
   dark: {
-    'secondary-token': '#e3e4e5', // oklch(92% 0.005 272)
+    'secondary-token': '#d7dce8', // Noir Ion secondary
   },
 } as const;
 
@@ -177,7 +178,7 @@ function socialLinkColors(
   }
 
   // hover and active: mirrors SocialLink.tsx hoverColor logic
-  const hoverBg = isDark ? '#101216' : '#fcfcfc';
+  const hoverBg = isDark ? '#0f1420' : '#fcfcfc';
   const effectiveColor =
     isDark && isBrandDark(brandHex)
       ? '#ffffff'
@@ -202,7 +203,7 @@ function dspIconColors(
   surface: 'surface-1' | 'surface-2'
 ): ColorPair {
   const isDark = theme === 'dark';
-  const bgHex = isDark ? '#101216' : '#fcfcfc';
+  const bgHex = isDark ? '#0f1420' : '#fcfcfc';
   const effectiveColor =
     isDark && isBrandDark(`#${brandHex}`)
       ? '#ffffff'

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -103,7 +103,10 @@ are not described by the marketing or public-surface shell libraries.
 
 Shell V1 app chrome should prefer the semantic `--app-shell-*` aliases for
 shared geometry and surfaces. These aliases live in `design-system.css` and
-resolve to the current Linear-derived values:
+resolve to Linear-derived geometry with **Jovie Noir Ion** dark color anchors
+(JOV-4635): canvas `#030407`, shell `#06080D`, panel `#0A0D16`, card `#0F1420`,
+Ion focus/selection `#11AFFF`. Product tokens map from `--noir-ion-*` anchors
+in `design-system.css` (no parallel theme provider).
 
 - `--app-shell-sidebar-width`
 - `--app-shell-header-height`

--- a/docs/design-system/token-inventory.md
+++ b/docs/design-system/token-inventory.md
@@ -204,7 +204,7 @@ Defined primarily in `apps/web/styles/linear-tokens.css` and consumed through cl
 - `--linear-app-shell-gap: 8px`
 - `--linear-app-shell-radius: 12px`
 - `--linear-app-content-surface: var(--linear-bg-surface-0)` in light mode,
-  `#0a0c0f` in dark mode
+  `#0a0d16` (Noir Ion panel) in dark mode
 - `--linear-app-audio-bar-max-height: 120px`
 - `--linear-app-audio-compact-height: 64px`
 


### PR DESCRIPTION
## Summary

Implements the approved **Jovie Noir Ion** dark-first color system for the authenticated dashboard shell (JOV-4635 / GH #15244).

- Maps dark product tokens to approved anchors: canvas `#030407`, shell `#06080D`, panel `#0A0D16`, card `#0F1420`, elevated `#151B2A`, floating `#1B2436`
- Cool graphite borders + Ion electric-blue (`#11AFFF`) for focus, links, selection, and active navigation
- Semantic accents: Ultra (agent), Pulse (creative), Aqua (system/info), Mint (success), Gold (warning), Flare (danger)
- Single source of truth via `--noir-ion-*` anchors mapped into existing product tokens (rollback path: remap tokens; no parallel theme provider)
- CTAs remain high-contrast light pills (DESIGN.md neutral-CTA rule); Ion carries intent, not filled primary buttons
- Storybook specimen `Design System/Noir Ion Specimen` + contract tests + agent docs (`DESIGN.md`, token inventory)

## Test plan / results

- [x] `vitest` design-system suite: noir-ion tokens, design-tokens-source, computed-contrast, surface-elevation, icon-contrast — **367 passed**
- [x] UnifiedSidebar library border assertions updated — **11 passed**
- [x] Pre-commit typecheck + eslint + a11y staged checks
- [x] Pre-push full affected unit suite (8 shards) — **green**
- [ ] Storybook visual review of `Design System/Noir Ion Specimen` (CI / local)
- [ ] Spot-check authenticated `/app` shell dark surfaces vs visual target

## Fixes

Fixes JOV-4635

<!-- linear-issue-id:9470b513-9210-45ba-ac86-2d0964ef3a30 -->