### PR TITLE
fix(ci): stop false production-controller manual recovery incidents (JOV-4487)

### DIFF
--- a/.github/workflows/production-controller-health.yml
+++ b/.github/workflows/production-controller-health.yml
@@ -312,12 +312,66 @@ jobs:
           controller="$(jq -c '.[0] // empty' <<<"$controller_matches")"
           if [ -n "$controller" ]; then
             controller_id="$(jq -r '.id' <<<"$controller")"
-            controller_status="$(jq -r '.status' <<<"$controller")"
+            # Re-read the exact run before failing closed. Listing payloads can
+            # lag, and production-mutation concurrency parks runs in pending /
+            # waiting / requested — not only queued or in_progress.
+            live_controller="$(gh api "repos/$REPOSITORY/actions/runs/$controller_id")"
+            jq -e --argjson run_id "$controller_id" --arg sha "$current_sha" \
+              --arg repo "$REPOSITORY" --argjson workflow_id "$controller_workflow_id" '
+              .id == $run_id and
+              .workflow_id == $workflow_id and
+              .path == ".github/workflows/production-controller.yml" and
+              .head_sha == $sha and .head_branch == "main" and
+              .head_repository.full_name == $repo and
+              .event == "workflow_run" and
+              (.status | type == "string" and length > 0) and
+              ((.conclusion | type) == "string" or .conclusion == null)
+            ' >/dev/null <<<"$live_controller" || incident changed_controller_run
+            controller_status="$(jq -r '.status' <<<"$live_controller")"
+            controller_conclusion="$(jq -r '.conclusion // empty' <<<"$live_controller")"
             echo "run_url=https://github.com/$REPOSITORY/actions/runs/$controller_id" \
               >> "$GITHUB_OUTPUT"
-            if [ "$controller_status" = "queued" ] || [ "$controller_status" = "in_progress" ]; then
-              echo "Controller run $controller_id is still $controller_status."
+            case "$controller_status" in
+              queued|in_progress|pending|requested|waiting)
+                echo "Controller run $controller_id is still $controller_status."
+                exit 0
+                ;;
+            esac
+            if [ "$controller_status" != "completed" ] || [ -z "$controller_conclusion" ]; then
+              echo "Controller run $controller_id is not terminal yet ($controller_status/${controller_conclusion:-null})."
               exit 0
+            fi
+            # Successful controllers should upload a marker. Re-classify once
+            # before failing closed so artifact listing lag cannot open an
+            # incident while Production Verified is still materializing truth.
+            if [ "$controller_conclusion" = "success" ]; then
+              marker_state_json="$(node .github/scripts/production-marker-state.mjs \
+                --sha "$current_sha" \
+                --repo "$REPOSITORY" \
+                --controller-workflow-id "$controller_workflow_id")"
+              jq -e '
+                type == "object" and
+                (.state | IN("none", "pending", "recovery_available", "verified", "manual")) and
+                (.reason | type == "string" and length > 0)
+              ' >/dev/null <<<"$marker_state_json" || incident malformed_marker_classification
+              marker_state="$(jq -r '.state' <<<"$marker_state_json")"
+              marker_reason="$(jq -r '.reason' <<<"$marker_state_json")"
+              case "$marker_state" in
+                verified)
+                  echo "Current main $current_sha has exact verified production evidence after recheck."
+                  exit 0
+                  ;;
+                pending)
+                  echo "Production marker recovery is already pending after recheck ($marker_reason)."
+                  exit 0
+                  ;;
+                recovery_available|manual)
+                  # A live successful controller cannot own interrupted-marker
+                  # recovery authority; fail closed with the classifier reason.
+                  incident "$marker_reason"
+                  ;;
+                none) ;;
+              esac
             fi
             incident controller_completed_without_marker
           fi

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -4281,6 +4281,21 @@ describe('production promotion exact-artifact contract', () => {
       '(.conclusion | IN("cancelled", "failure", "startup_failure", "timed_out"))'
     );
     expect(health).toContain('recovery_lease_already_exists');
+    // production-mutation concurrency parks newer generations in pending /
+    // waiting / requested; do not treat those as completed-without-marker.
+    expect(healthEvaluation).toContain(
+      'queued|in_progress|pending|requested|waiting)'
+    );
+    expect(healthEvaluation).toContain(
+      'gh api "repos/$REPOSITORY/actions/runs/$controller_id"'
+    );
+    expect(healthEvaluation).toContain('changed_controller_run');
+    expect(healthEvaluation).toContain(
+      'has exact verified production evidence after recheck'
+    );
+    expect(healthEvaluation).toContain(
+      'incident controller_completed_without_marker'
+    );
     expect(health).toContain(
       "always() && steps.evaluate.outputs.needs_manual == 'true'"
     );


### PR DESCRIPTION
## Summary

Production Controller Health was opening `controller_completed_without_marker` incidents while a generation was still running (or while the verified marker was still materializing). For JOV-4487, controller run [30266167222](https://github.com/JovieInc/Jovie/actions/runs/30266167222) later completed successfully with an exact verified marker (`exact_attempt_verified` / deployment `dpl_Ap3tZK6aiCpNmrf9fRrfCW9KdDiv`), so **no production mutation recovery was required**.

Root cause in health evaluation:
1. Only `queued` / `in_progress` were treated as active. `production-mutation` concurrency with `order: max` parks newer runs in **`pending` / `waiting` / `requested`**, so health falsely failed closed mid-run.
2. Successful terminal runs were not re-probed for marker evidence before opening an incident (artifact listing lag).

### Fix
- Treat `queued|in_progress|pending|requested|waiting` as still active.
- Re-fetch the exact controller run before failing closed.
- Require a true terminal `completed` + conclusion before incidenting.
- On successful conclusion, reclassify production marker state once before `controller_completed_without_marker`.

## Test plan / results
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts tests/unit/ci/production-marker-state.test.ts` → **112 passed**
- [x] Pre-push gate (typecheck, lint, affected unit suites, ci harness) passed
- [x] Online evidence for SHA `1701922…`: marker classifies as `verified` / `exact_attempt_verified` (no manual recovery action)

## Evidence (JOV-4487)
- Controller: https://github.com/JovieInc/Jovie/actions/runs/30266167222 (success, Production Verified)
- Marker artifact: `production-generation-verified-1701922de0b204c1cd25a0da41f21eb523210b61`
- Health incident run that false-alarmed mid-controller: https://github.com/JovieInc/Jovie/actions/runs/30266413450 (12:33Z vs controller finish 13:09Z)

Fixes JOV-4487

<!-- linear-issue-id:JOV-4487 -->