### PR TITLE
fix(admin/settings): point Settings ops discovery to Ops panel (JOV-2103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Admin operational toggles live only on Ops (JOV-2103):** waitlist, growth defaults, and environment helpers stay on the Ops control panel; Settings keeps a short “Ops Controls” pointer (with tooltip) that redirects admins to Ops instead of hosting live toggles.
 - [internal] **Merge-group CI event handling hardened (JOV-4446):** Path Changes and Risk Classifier resolve diffs from exact `merge_group` SHAs only (no push/PR field fall-through), empty combined-head diffs fail closed, and `ci-fast` always writes `ci-fast-lanes.json` so the upload step never fails on a missing artifact.
 - [internal] **Customer nav capacity guard with one canonical More menu (JOV-4515):** documented desktop/mobile caps keep approved core destinations on the primary rail, overflow only experimental extras into a single More surface, and promote the active route so it is never hidden.
 - [internal] **Better Auth OAuth token tables cover the pinned provider schema (JOV-4587):** client, access-token, refresh-token, and consent columns now include fields such as `authorizationCodeId`, with a contract test that fails on mapping drift so LYB Apple sign-in can complete `/oauth2/token` exchange.

--- a/apps/web/components/features/settings/SettingsSidebar.tsx
+++ b/apps/web/components/features/settings/SettingsSidebar.tsx
@@ -48,10 +48,10 @@ export function SettingsSidebar({ className }: SettingsSidebarProps) {
           value={query}
           onChange={event => setQuery(event.target.value)}
           placeholder='Search settings'
-          aria-label='Search settings'
+          aria-label='Search Settings'
           data-testid='settings-sidebar-search'
         />
-        <nav aria-label='Settings navigation' className='space-y-4'>
+        <nav aria-label='Settings Navigation' className='space-y-4'>
           {groups.map(group => {
             const groupActive = group.items.some(item =>
               isSettingsItemActive(pathname, item.href)
@@ -75,6 +75,7 @@ export function SettingsSidebar({ className }: SettingsSidebarProps) {
                       <li key={item.id}>
                         <Link
                           href={item.href}
+                          title={item.title}
                           aria-current={active ? 'page' : undefined}
                           className={getSidebarNavRowClassName({
                             active,

--- a/apps/web/components/features/settings/settings-sidebar-config.test.ts
+++ b/apps/web/components/features/settings/settings-sidebar-config.test.ts
@@ -99,6 +99,28 @@ describe('filterSettingsGroups', () => {
     const ids = groups.flatMap(group => group.items.map(item => item.id));
     expect(ids).not.toContain('admin');
   });
+
+  it('surfaces Ops controls for admins searching operational keywords', () => {
+    const groups = filterSettingsGroups(SETTINGS_SIDEBAR_GROUPS, 'ops', {
+      isAdmin: true,
+    });
+    const ids = groups.flatMap(group => group.items.map(item => item.id));
+    expect(ids).toContain('admin');
+  });
+});
+
+describe('settings Ops controls discovery (JOV-2103)', () => {
+  it('points the admin-only row at the legacy settings admin redirect', () => {
+    const adminItem = SETTINGS_SIDEBAR_GROUPS.flatMap(
+      group => group.items
+    ).find(item => item.id === 'admin');
+
+    expect(adminItem).toBeDefined();
+    expect(adminItem?.label).toBe('Ops Controls');
+    expect(adminItem?.href).toBe(APP_ROUTES.SETTINGS_ADMIN);
+    expect(adminItem?.adminOnly).toBe(true);
+    expect(adminItem?.title).toMatch(/Ops control panel/i);
+  });
 });
 
 describe('isSettingsItemActive', () => {

--- a/apps/web/components/features/settings/settings-sidebar-config.ts
+++ b/apps/web/components/features/settings/settings-sidebar-config.ts
@@ -28,6 +28,11 @@ export interface SettingsSidebarItem {
   readonly icon: LucideIcon;
   /** Only rendered when the current user is an admin. */
   readonly adminOnly?: boolean;
+  /**
+   * Optional native tooltip. Used for discovery rows that leave Settings
+   * (e.g. Ops controls) so admins know why the item exists.
+   */
+  readonly title?: string;
 }
 
 export interface SettingsSidebarGroup {
@@ -43,7 +48,7 @@ export const SETTINGS_SIDEBAR_GROUPS: readonly SettingsSidebarGroup[] = [
     items: [
       {
         id: 'artist-profile',
-        label: 'Artist profile',
+        label: 'Artist Profile',
         href: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
         icon: UserRound,
       },
@@ -73,13 +78,13 @@ export const SETTINGS_SIDEBAR_GROUPS: readonly SettingsSidebarGroup[] = [
       },
       {
         id: 'data-privacy',
-        label: 'Data & privacy',
+        label: 'Data & Privacy',
         href: APP_ROUTES.SETTINGS_DATA_PRIVACY,
         icon: Lock,
       },
       {
         id: 'delete-account',
-        label: 'Delete account',
+        label: 'Delete Account',
         href: APP_ROUTES.SETTINGS_DELETE_ACCOUNT,
         icon: Trash2,
       },
@@ -97,16 +102,21 @@ export const SETTINGS_SIDEBAR_GROUPS: readonly SettingsSidebarGroup[] = [
       },
       {
         id: 'retargeting-ads',
-        label: 'Retargeting ads',
+        label: 'Retargeting Ads',
         href: APP_ROUTES.SETTINGS_RETARGETING_ADS,
         icon: Target,
       },
       {
         id: 'admin',
-        label: 'Admin',
+        // Live operational toggles (waitlist gate, growth defaults, dev
+        // toolbar) live on Ops — this row is a discovery pointer only.
+        // `/app/settings/admin` redirects to ADMIN_OPS (JOV-2103).
+        label: 'Ops Controls',
         href: APP_ROUTES.SETTINGS_ADMIN,
         icon: Wrench,
         adminOnly: true,
+        title:
+          'Live operational toggles live on the Ops control panel — waitlist, growth defaults, and environment helpers.',
       },
     ],
   },

--- a/apps/web/tests/unit/app/admin-ops-controls-moved.test.ts
+++ b/apps/web/tests/unit/app/admin-ops-controls-moved.test.ts
@@ -1,0 +1,117 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * JOV-2103 — operational on/off controls must not live under Settings.
+ * They belong on the Ops OperationalControlPanel; Settings keeps only a
+ * redirect/discovery pointer for admins.
+ */
+
+function findSourceFile(...candidates: string[]): string {
+  const found = candidates.find(candidate => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `Could not find source file. Checked: ${candidates.join(', ')}`
+    );
+  }
+  return found;
+}
+
+function collectTsxFiles(dir: string): string[] {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...collectTsxFiles(fullPath));
+      continue;
+    }
+    if (entry.endsWith('.tsx') || entry.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const SETTINGS_ADMIN_PAGE = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/settings/admin/page.tsx'),
+  resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/admin/page.tsx')
+);
+
+const OPERATIONAL_CONTROL_PANEL = findSourceFile(
+  resolve(
+    process.cwd(),
+    'components/features/admin/OperationalControlPanel.tsx'
+  ),
+  resolve(
+    process.cwd(),
+    'apps/web/components/features/admin/OperationalControlPanel.tsx'
+  )
+);
+
+const OPS_PAGE = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/admin/ops/page.tsx'),
+  resolve(process.cwd(), 'apps/web/app/app/(shell)/admin/ops/page.tsx')
+);
+
+const SETTINGS_ROUTE_DIR = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/settings'),
+  resolve(process.cwd(), 'apps/web/app/app/(shell)/settings')
+);
+
+const OPERATIONAL_PANEL_MARKERS = [
+  'WaitlistSettingsPanel',
+  'CampaignSettingsPanel',
+  'OperationalControlPanel',
+  'Toggle waitlist gate',
+  'Toggle auto-accept',
+  'Toggle dev toolbar',
+  'Manual approval gate',
+] as const;
+
+describe('JOV-2103 operational controls moved to Ops', () => {
+  it('keeps /settings/admin as a redirect-only pointer to Ops', () => {
+    const source = readFileSync(SETTINGS_ADMIN_PAGE, 'utf8');
+
+    expect(source).toContain('redirect(APP_ROUTES.ADMIN_OPS)');
+    expect(source).toContain('routeContext.dashboardData.isAdmin');
+    expect(source).not.toContain('WaitlistSettingsPanel');
+    expect(source).not.toContain('CampaignSettingsPanel');
+    expect(source).not.toContain('OperationalControlPanel');
+    expect(source).not.toContain('SettingsToggleRow');
+  });
+
+  it('mounts the consolidated operational control panel on Ops', () => {
+    const opsPage = readFileSync(OPS_PAGE, 'utf8');
+    const panel = readFileSync(OPERATIONAL_CONTROL_PANEL, 'utf8');
+
+    expect(opsPage).toContain('OperationalControlPanel');
+    expect(opsPage).toContain('<OperationalControlPanel');
+    expect(panel).toContain("data-testid='operational-control-panel'");
+    expect(panel).toContain('WaitlistSettingsPanel');
+    expect(panel).toContain('CampaignSettingsPanel');
+    expect(panel).toContain('Dev toolbar');
+  });
+
+  it('does not reintroduce operational control panels under Settings routes', () => {
+    const settingsFiles = collectTsxFiles(SETTINGS_ROUTE_DIR);
+
+    expect(settingsFiles.length).toBeGreaterThan(0);
+
+    for (const filePath of settingsFiles) {
+      const source = readFileSync(filePath, 'utf8');
+      for (const marker of OPERATIONAL_PANEL_MARKERS) {
+        // The admin redirect page may mention ADMIN_OPS / isAdmin only.
+        expect(source).not.toContain(marker);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes out **JOV-2103** (move operational controls out of Settings into Ops).

The Ops control panel (`OperationalControlPanel` on `/app/admin/ops`) already hosts the live operational controls:

- Dev toolbar
- People intake defaults (waitlist gate + auto-accept)
- Growth defaults (campaign qualification / pacing)

`/app/settings/admin` already redirects admins to Ops. This PR finishes the Settings UX so admins are not sent looking for live toggles in configuration Settings:

- Rename the admin-only Settings nav row to **Ops Controls**
- Add a tooltip explaining operational toggles live on the Ops control panel
- Keep the legacy `/app/settings/admin` redirect for bookmarks/deep links
- Add acceptance unit tests that forbid reintroducing operational panels under Settings routes

## Test plan / results

- [x] `pnpm --filter web exec vitest run tests/unit/app/admin-ops-controls-moved.test.ts components/features/settings/settings-sidebar-config.test.ts tests/unit/components/admin/OperationalControlPanel.test.tsx tests/unit/app/admin-ops-shell-normalization.test.ts` → **29 passed**
- [x] Rebased onto latest `main` (single-commit PR)

Manual (optional): as admin, open Settings → Workspace → **Ops Controls** → lands on Ops with `operational-control-panel` visible.

## Fixes

Fixes JOV-2103

<!-- linear-issue-id:JOV-2103 -->