### PR TITLE
fix(marketing): remove duplicate free-to-start sr-only copy (JOV-4503)

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileHero.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHero.tsx
@@ -1,6 +1,5 @@
 import { HomeHeroCTA } from '@/components/features/home/HomeHeroCTA';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
-import { getClaimProfileIntent } from '@/data/marketingCtaIntents';
 import { MarketingContainer } from '../MarketingContainer';
 import './ArtistProfileHero.css';
 
@@ -9,8 +8,6 @@ interface ArtistProfileHeroProps {
 }
 
 export function ArtistProfileHero({ hero }: Readonly<ArtistProfileHeroProps>) {
-  const claimIntent = getClaimProfileIntent();
-
   return (
     <section
       data-testid='homepage-hero'
@@ -42,7 +39,6 @@ export function ArtistProfileHero({ hero }: Readonly<ArtistProfileHeroProps>) {
           <p className='mt-4 font-mono text-xs tracking-tight text-tertiary-token'>
             {hero.signature}
           </p>
-          <p className='sr-only'>{claimIntent.support}</p>
         </div>
       </MarketingContainer>
     </section>


### PR DESCRIPTION
## Summary

Follow-up to the merged proof-led Artist Profiles landing rebuild (#15261 / JOV-4503).

- Removes a redundant `sr-only` free-to-start paragraph in `ArtistProfileHero` that duplicated the support line already rendered by `HomeHeroCTA` (Sentry a11y finding on #15261).
- Screen readers no longer announce the same free-to-start copy twice.

### Parent ship (already on `main` via #15261)

- Shared CTA intent registry (`marketingCtaIntents.ts`)
- Shared `MarketingSnapRail` for outcomes horizon
- Hero claim form as focal control + free-to-start support
- Narrative differentiation from homepage; no decorative eyebrows
- Final CTA via registry + `public-action-primary` (no press-scale)

## Test plan / results

- [x] Pre-push: biome on touched file — clean
- [x] Pre-push: typecheck (cache hit) — clean
- [x] Pre-push: affected unit tests — 2 passed (`arbitrary-values-ratchet`)
- [x] Pre-commit: eslint, a11y staged check, typecheck — clean
- [x] Diff is 4 deletions only in `ArtistProfileHero.tsx`

Fixes JOV-4503

<!-- linear-issue-id:JOV-4503 -->