### PR TITLE
fix(agents): name public skill registry as partial catalog (JOV-3013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- [internal] **Admin Overview is a health dashboard only (JOV-2098):** one linked signal each for Business, Growth, Ops, and People; funnel, outreach, and reliability detail stay on their home screens with matching nav copy.
+- [internal] **Public skill registry is an explicit partial catalog (JOV-3013):** `PUBLIC_SKILL_REGISTRY` names the admin/playbook/postbuild product-skill catalog (alias `SKILL_REGISTRY`); docs and drift tests make clear live chat tools are assembled and gated elsewhere, so `skills_catalog` is never mistaken for “what the model can call.”
 - [internal] **Noir Ion D workspace surfaces (JOV-4648):** shell-scoped table hover/selected/focus, PageToolbar, drawer/popover/tooltip elevation, and skeleton colors now resolve to the Noir Ion contract without global bleed; compact specimen + focused tests included.
 - [internal] **Better Auth OAuth token tables cover the pinned provider schema (JOV-4587):** client, access-token, refresh-token, and consent columns now include fields such as `authorizationCodeId`, with a contract test that fails on mapping drift so LYB Apple sign-in can complete `/oauth2/token` exchange.
 - [internal] **Native Gmail brand-deal qualification is fail-closed (JOV-4578):** Jovie now surfaces only the highest-ranked current brief with explicit buyer, company, budget, deposit, rights, and revision terms; provenance comes from the connected Gmail record, Calendar is optional, and pending or approved sponsor work blocks another campaign.

--- a/apps/web/lib/agents/registry.test.ts
+++ b/apps/web/lib/agents/registry.test.ts
@@ -1,22 +1,31 @@
 /**
- * SKILL_REGISTRY type-shape and invariant tests.
+ * PUBLIC_SKILL_REGISTRY / SKILL_REGISTRY type-shape and invariant tests.
  *
  * No DB connection required — purely validates the code-side registry
  * against the SkillDefinition contract and business invariants.
  */
 
 import { describe, expect, it } from 'vitest';
-import { SKILL_REGISTRY } from './registry';
+import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
+import {
+  PUBLIC_SKILL_CHAT_TOOL_IDS,
+  PUBLIC_SKILL_REGISTRY,
+  SKILL_REGISTRY,
+} from './registry';
 
-describe('SKILL_REGISTRY', () => {
-  const skills = Object.entries(SKILL_REGISTRY);
+describe('PUBLIC_SKILL_REGISTRY', () => {
+  const skills = Object.entries(PUBLIC_SKILL_REGISTRY);
+
+  it('exports SKILL_REGISTRY as a back-compat alias of PUBLIC_SKILL_REGISTRY', () => {
+    expect(SKILL_REGISTRY).toBe(PUBLIC_SKILL_REGISTRY);
+  });
 
   it('has at least one skill entry', () => {
     expect(skills.length).toBeGreaterThanOrEqual(1);
   });
 
   it('contains the retouch skill', () => {
-    expect(SKILL_REGISTRY).toHaveProperty('retouch');
+    expect(PUBLIC_SKILL_REGISTRY).toHaveProperty('retouch');
   });
 
   it.each(skills)('%s has required string fields', (_key, skill) => {
@@ -54,7 +63,7 @@ describe('SKILL_REGISTRY', () => {
   });
 
   describe('retouch skill', () => {
-    const retouch = SKILL_REGISTRY.retouch;
+    const retouch = PUBLIC_SKILL_REGISTRY.retouch;
 
     it('uses the expected model', () => {
       expect(retouch.model).toBe('google/gemini-2.5-flash-image');
@@ -76,6 +85,53 @@ describe('SKILL_REGISTRY', () => {
 
     it('is version 1.0.0', () => {
       expect(retouch.version).toBe('1.0.0');
+    });
+  });
+
+  /**
+   * JOV-3013 — partial catalog intent.
+   *
+   * PUBLIC_SKILL_REGISTRY is the admin/playbook/postbuild product-skill
+   * catalog. Live chat tools are a larger, plan-gated surface. These tests
+   * fail if cataloged chat-facing skills drift from TOOL_UI_REGISTRY, and
+   * document that the live tool set is intentionally larger.
+   */
+  describe('partial catalog vs live chat tools (JOV-3013)', () => {
+    it('is intentionally smaller than the live chat UI tool registry', () => {
+      const catalogSize = Object.keys(PUBLIC_SKILL_REGISTRY).length;
+      const liveUiSize = Object.keys(TOOL_UI_REGISTRY).length;
+      expect(liveUiSize).toBeGreaterThan(catalogSize);
+    });
+
+    it('maps every cataloged chat-facing skill to a live TOOL_UI_REGISTRY id', () => {
+      for (const [skillId, chatToolId] of Object.entries(
+        PUBLIC_SKILL_CHAT_TOOL_IDS
+      )) {
+        expect(
+          TOOL_UI_REGISTRY[chatToolId as keyof typeof TOOL_UI_REGISTRY],
+          `catalog skill "${skillId}" maps to missing chat tool "${chatToolId}"`
+        ).toBeDefined();
+      }
+    });
+
+    it('keeps PUBLIC_SKILL_CHAT_TOOL_IDS keys inside PUBLIC_SKILL_REGISTRY', () => {
+      for (const skillId of Object.keys(PUBLIC_SKILL_CHAT_TOOL_IDS)) {
+        expect(PUBLIC_SKILL_REGISTRY).toHaveProperty(skillId);
+      }
+    });
+
+    it('documents partial-catalog intent in the registry module source', async () => {
+      const { readFile } = await import('node:fs/promises');
+      const { fileURLToPath } = await import('node:url');
+      const path = await import('node:path');
+      const registryPath = path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        'registry.ts'
+      );
+      const source = await readFile(registryPath, 'utf8');
+      expect(source).toMatch(/partial catalog/i);
+      expect(source).toContain('PUBLIC_SKILL_REGISTRY');
+      expect(source).toMatch(/NOT.*exhaustive list of tools/i);
     });
   });
 });

--- a/apps/web/lib/agents/registry.ts
+++ b/apps/web/lib/agents/registry.ts
@@ -1,23 +1,44 @@
 /**
- * Agent Skill Registry
+ * Public Skill Registry (partial catalog by design — JOV-3013)
  *
- * Code-side source of truth for all deployed skills. The DB mirror
- * (skills_catalog) is kept in sync at deploy time by
- * scripts/sync-skills-catalog.ts via the postbuild hook.
+ * Code-side source of truth for **cataloged product skills** that are
+ * mirrored into `skills_catalog` / `tools_catalog` at deploy time by
+ * `scripts/sync-skills-catalog.ts` (postbuild). Admin system map, playbook
+ * compile resolution, and skill lifecycle tooling read this registry.
  *
- * To add a new skill:
- * 1. Add an entry here.
+ * ## Partial catalog intent
+ *
+ * This registry is **NOT** the exhaustive list of tools the chat model can
+ * call. Live chat tools are assembled in `app/api/chat/route.ts`
+ * (`buildFreeChatTools` / `buildChatTools`), gated by plan + entitlements
+ * (`lib/chat/tool-access.ts`, `lib/chat/locked-tools.ts`), and UI-labeled in
+ * `lib/chat/tool-ui-registry.ts` (`TOOL_UI_REGISTRY`).
+ *
+ * Do **not** treat `skills_catalog` / this registry as "what the model has."
+ * Only product skills that need admin visibility, playbook compile
+ * resolution, or DB lifecycle tracking belong here.
+ *
+ * To add a **cataloged** skill:
+ * 1. Add an entry here (`PUBLIC_SKILL_REGISTRY`).
  * 2. Add the corresponding entitlement to lib/entitlements/registry.ts.
  * 3. Create the style/prompt markdown at promptPath (if applicable).
  * 4. Run `pnpm --filter web drizzle:generate` if new enum values are needed.
  * 5. The postbuild hook will sync the catalog on next deploy.
+ *
+ * To add a **live chat tool** only: register it in the chat route builders +
+ * `TOOL_UI_REGISTRY` (+ `TOOL_SCHEMAS` when eval coverage is needed). Catalog
+ * it here only when it is a product skill surface.
  */
 
 import type { SkillDefinition, ToolDefinition } from './types';
 
 type RegistryDefinition = SkillDefinition | ToolDefinition;
 
-export const SKILL_REGISTRY = {
+/**
+ * Cataloged product skills/tools for admin, playbook compile, and postbuild
+ * DB sync. Intentionally a **partial** subset of live chat capabilities.
+ */
+export const PUBLIC_SKILL_REGISTRY = {
   generateReleasePitch: {
     id: 'generateReleasePitch',
     name: 'Generate pitch',
@@ -107,8 +128,28 @@ export const SKILL_REGISTRY = {
       surface: 'image',
       action: 'retouch_image',
       style: 'white-space',
+      /** Live chat tool name when this skill is exposed on chat (id may differ). */
+      chatToolId: 'retouchImage',
     },
   },
 } as const satisfies Record<string, RegistryDefinition>;
 
-export type SkillId = keyof typeof SKILL_REGISTRY;
+/**
+ * Back-compat alias for `PUBLIC_SKILL_REGISTRY`. Prefer the public name in
+ * new code so partial-catalog intent stays obvious (JOV-3013).
+ */
+export const SKILL_REGISTRY = PUBLIC_SKILL_REGISTRY;
+
+export type SkillId = keyof typeof PUBLIC_SKILL_REGISTRY;
+
+/**
+ * Catalog skill id → live chat tool name when the skill is (or maps onto) a
+ * chat tool. Skills without a chat mapping are catalog/playbook-only.
+ *
+ * Used by drift tests: catalog entries that claim a chat surface must stay
+ * aligned with `TOOL_UI_REGISTRY`.
+ */
+export const PUBLIC_SKILL_CHAT_TOOL_IDS = {
+  generateReleasePitch: 'generateReleasePitch',
+  retouch: 'retouchImage',
+} as const satisfies Partial<Record<SkillId, string>>;

--- a/apps/web/lib/agents/types.ts
+++ b/apps/web/lib/agents/types.ts
@@ -1,9 +1,13 @@
 /**
  * Agent Registry Types
  *
- * Shared contract for skill and tool definitions. Used by SKILL_REGISTRY,
- * TOOL_REGISTRY, and the DB sync script. Keep this file free of runtime
- * dependencies — it is imported by both server code and the sync script.
+ * Shared contract for skill and tool definitions. Used by
+ * PUBLIC_SKILL_REGISTRY (alias SKILL_REGISTRY — partial product-skill catalog)
+ * and the DB sync script. Keep this file free of runtime dependencies — it is
+ * imported by both server code and the sync script.
+ *
+ * Live chat tools are a separate surface (`TOOL_UI_REGISTRY` + chat route
+ * builders); they are not required to appear in the public skill catalog.
  */
 
 import type { BooleanEntitlement } from '@/lib/entitlements/registry';

--- a/apps/web/scripts/sync-skills-catalog.ts
+++ b/apps/web/scripts/sync-skills-catalog.ts
@@ -1,8 +1,9 @@
 /**
  * sync-skills-catalog.ts
  *
- * Idempotent upsert script. Walks SKILL_REGISTRY and upserts into
- * skills_catalog + tools_catalog (for kind='tool' entries — empty in v1).
+ * Idempotent upsert script. Walks PUBLIC_SKILL_REGISTRY (SKILL_REGISTRY alias)
+ * and upserts into skills_catalog + tools_catalog for cataloged product
+ * skills only (partial catalog by design — JOV-3013; not live chat tools).
  *
  * Wired into package.json postbuild so it runs on every deploy.
  * Safe to re-run: second run produces no diff (upsert on PK with onConflictDoUpdate).

--- a/docs/SCHEMA_MAP.md
+++ b/docs/SCHEMA_MAP.md
@@ -12,7 +12,9 @@ All schema files live in `apps/web/lib/db/schema/`. Import tables and types from
 |-------------|--------|---------------|
 | `agents.ts` | `skills_catalog`, `skills_catalog_versions`, `skill_run_events`, `tools_catalog`, `retouch_jobs` | `skills_catalog.id` is the slug PK (e.g. `retouch`) with `lifecycle` + `active_version`; version history in `skills_catalog_versions (skill_id, version)`; per-invocation telemetry in `skill_run_events.invocation_id` (unique); `tools_catalog.id` same shape; `retouch_jobs.userId` → `users` cascade |
 
-**Sync:** `skills_catalog` and `tools_catalog` are upserted from `SKILL_REGISTRY` at deploy time by `apps/web/scripts/sync-skills-catalog.ts` (wired into `postbuild`). Do not hand-edit these rows.
+**Sync:** `skills_catalog` and `tools_catalog` are upserted from `PUBLIC_SKILL_REGISTRY` (`SKILL_REGISTRY` alias) at deploy time by `apps/web/scripts/sync-skills-catalog.ts` (wired into `postbuild`). Do not hand-edit these rows.
+
+**Partial catalog (JOV-3013):** `PUBLIC_SKILL_REGISTRY` is intentionally **not** the exhaustive live chat tool list. Chat tools are assembled in `app/api/chat/route.ts` and gated by plan/entitlements (`lib/chat/tool-access.ts`). Treat `skills_catalog` as admin/playbook/lifecycle source of truth only — not "what the model can call."
 
 **Enums:** `skillKindEnum` (`vertical_agent`, `tool`, `style`); `retouchJobStatusEnum` (`queued`, `running`, `identity_check_failed`, `identity_check_retrying`, `completed`, `failed`, `rejected_by_user`, `accepted_by_user`).
 


### PR DESCRIPTION
## Summary
- Renames the product-skill catalog surface to **`PUBLIC_SKILL_REGISTRY`** (keeps `SKILL_REGISTRY` as a back-compat alias) so it is no longer mistaken for “all tools the chat model can call.”
- Documents partial-catalog intent: catalog entries sync to `skills_catalog` / `tools_catalog` for admin, playbook compile, and postbuild; live chat tools stay in `app/api/chat/route.ts` and are plan-gated via `tool-access` / entitlements, with UI in `TOOL_UI_REGISTRY`.
- Adds `PUBLIC_SKILL_CHAT_TOOL_IDS` mapping for cataloged chat-facing skills and unit tests that fail if those map to missing UI tool ids or if the catalog is treated as exhaustive.

## Why this approach
Acceptance allowed either expanding the registry to every chat tool with a ⊆ assertion, or rename + doc. Expanding would pollute the DB catalog with ~25 operational chat tools (merch, free profile tools, etc.) that are not product-skill lifecycle surfaces. Rename + explicit partial intent is the smallest correct fix for the drift trap.

## Test plan / results
- [x] `pnpm --filter web exec vitest run lib/agents/registry.test.ts scripts/sync-skills-catalog.test.ts` — **49 passed**
- [x] `pnpm --filter @jovie/web run typecheck` — pass
- [x] Biome check on touched TS files — pass
- [x] Pre-push affected verify (typecheck/lint/full web unit shards) — pass

## Fixes
Fixes JOV-3013

<!-- linear-issue-id:b76a39cb-1d46-4982-8ae2-130804aff5bc -->