### PR TITLE
test(ci): bound installer success harness [JOV-4669]

### DIFF
--- a/apps/web/tests/unit/ci/runner-host-capacity.test.ts
+++ b/apps/web/tests/unit/ci/runner-host-capacity.test.ts
@@ -272,31 +272,40 @@ describe('Gem runner process-capacity contract', () => {
     ).toBe(false);
   });
 
-  it('preflights before installation and starts the enabled timer last', () => {
-    const result = runInstaller({});
+  it(
+    'preflights before installation and starts the enabled timer last',
+    () => {
+      const result = runInstaller({});
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain('runner_capacity_preflight=passed');
-    expect(result.events.slice(0, 4)).toEqual([
-      'systemctl show ci-runner-autoscaler.service --property Environment --value',
-      'systemctl show ci-runners.slice --property TasksMax --value',
-      'systemctl show ci-runners.slice --property TasksCurrent --value',
-      expect.stringMatching(/^install /u),
-    ]);
-    const reconciliation = result.events.findIndex(event =>
-      event.startsWith('systemctl set-property ci-runners.slice')
-    );
-    const timerEnable = result.events.indexOf(
-      'systemctl enable ci-runner-capacity-reconcile.timer'
-    );
-    const timerStart = result.events.indexOf(
-      'systemctl start ci-runner-capacity-reconcile.timer'
-    );
-    expect(reconciliation).toBeGreaterThan(3);
-    expect(timerEnable).toBeLessThan(reconciliation);
-    expect(timerStart).toBeGreaterThan(reconciliation);
-    expect(timerStart).toBe(result.events.length - 1);
-  });
+      expect(
+        result.durationMs,
+        `installer success harness took ${result.durationMs.toFixed(0)}ms`
+      ).toBeLessThan(HARNESS_PROCESS_BUDGET_MS);
+      expect(result.mockProcessIds).toHaveLength(3);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('runner_capacity_preflight=passed');
+      expect(result.events.slice(0, 4)).toEqual([
+        'systemctl show ci-runner-autoscaler.service --property Environment --value',
+        'systemctl show ci-runners.slice --property TasksMax --value',
+        'systemctl show ci-runners.slice --property TasksCurrent --value',
+        expect.stringMatching(/^install /u),
+      ]);
+      const reconciliation = result.events.findIndex(event =>
+        event.startsWith('systemctl set-property ci-runners.slice')
+      );
+      const timerEnable = result.events.indexOf(
+        'systemctl enable ci-runner-capacity-reconcile.timer'
+      );
+      const timerStart = result.events.indexOf(
+        'systemctl start ci-runner-capacity-reconcile.timer'
+      );
+      expect(reconciliation).toBeGreaterThan(3);
+      expect(timerEnable).toBeLessThan(reconciliation);
+      expect(timerStart).toBeGreaterThan(reconciliation);
+      expect(timerStart).toBe(result.events.length - 1);
+    },
+    HARNESS_PROCESS_BUDGET_MS
+  );
 
   it('starts the timer and preserves a saturated reconciliation failure', () => {
     const result = runInstaller({ current: '1700', maximum: '2048' });


### PR DESCRIPTION
## Summary
- give the successful runner-capacity installer path the existing 10-second harness diagnostic budget as its explicit per-test ceiling
- assert the successful path stays within that budget and preserves the expected three-process installer/reconciler topology
- leave production runner-capacity and installer scripts unchanged

## Root cause
JOV-4665 removed per-command Bash forks, but the successful installer path still legitimately executes preflight plus installed reconciliation. Under shard pressure it crossed Vitest's default 5-second ceiling (observed 6.057s focused and an exact 5,000ms gate failure) while remaining below the existing 10-second harness budget.

## Verification
- focused Node 22.23.1: 21/21 passed in 10.00s; formerly failing test 6.057s and under the bounded 10s diagnostic ceiling
- exact shard 8/8: 284 files passed / 2 skipped; 2,445 tests passed / 9 skipped / 2 todo; 183.86s
- target file in shard: 21/21 in 4.225s; formerly failing test 752ms
- normal pre-push: Biome, proxy, Tailwind, typecheck, lint, affected 21/21, CI harness validation/docs all passed

No global timeout or production behavior changed.
