### PR TITLE
fix(agents): fail-closed chat tool inventory drift guard (JOV-3013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- [internal] **Public skill registry is an explicit partial catalog (JOV-3013):** `PUBLIC_SKILL_REGISTRY` names the admin/playbook/postbuild product-skill catalog (alias `SKILL_REGISTRY`); docs and drift tests make clear live chat tools are assembled and gated elsewhere, so `skills_catalog` is never mistaken for “what the model can call.”
+- [internal] **Chat tool inventory drift guard (JOV-3013):** live chat tools are listed in `CHAT_ROUTE_TOOL_IDS` with `assertChatToolsRegistered` on the chat route and unit tests that fail closed on unregistered tools; `PUBLIC_SKILL_REGISTRY` remains the productized partial catalog.
 - [internal] **Noir Ion D workspace surfaces (JOV-4648):** shell-scoped table hover/selected/focus, PageToolbar, drawer/popover/tooltip elevation, and skeleton colors now resolve to the Noir Ion contract without global bleed; compact specimen + focused tests included.
 - [internal] **Better Auth OAuth token tables cover the pinned provider schema (JOV-4587):** client, access-token, refresh-token, and consent columns now include fields such as `authorizationCodeId`, with a contract test that fails on mapping drift so LYB Apple sign-in can complete `/oauth2/token` exchange.
 - [internal] **Native Gmail brand-deal qualification is fail-closed (JOV-4578):** Jovie now surfaces only the highest-ranked current brief with explicit buyer, company, budget, deposit, rights, and revision terms; provenance comes from the connected Gmail record, Calendar is optional, and pending or approved sponsor work blocks another campaign.

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -56,6 +56,7 @@ import {
   detectAlbumArtGenerationIntent,
   resolveAlbumArtCapability,
 } from '@/lib/chat/album-art-capability';
+import { assertChatToolsRegistered } from '@/lib/chat/chat-tool-inventory';
 import {
   buildLockedToolPromptInfo,
   buildLockedToolSet,
@@ -2897,6 +2898,9 @@ export async function POST(req: Request) {
       ...paidTools,
       ...lockedToolSet,
     };
+    // JOV-3013: fail closed if a live tool is missing from CHAT_ROUTE_TOOL_IDS.
+    // PUBLIC_SKILL_REGISTRY is intentionally partial and is not this inventory.
+    assertChatToolsRegistered(tools);
 
     // Telemetry hooks bind Sentry into `executeChatTurn` without coupling
     // the pure pipeline to Sentry. Eval scripts pass a no-op telemetry.

--- a/apps/web/lib/agents/registry.ts
+++ b/apps/web/lib/agents/registry.ts
@@ -13,6 +13,8 @@
  * (`buildFreeChatTools` / `buildChatTools`), gated by plan + entitlements
  * (`lib/chat/tool-access.ts`, `lib/chat/locked-tools.ts`), and UI-labeled in
  * `lib/chat/tool-ui-registry.ts` (`TOOL_UI_REGISTRY`).
+ * Fail-closed inventory of live route tool ids lives in
+ * `lib/chat/chat-tool-inventory.ts` (`CHAT_ROUTE_TOOL_IDS`).
  *
  * Do **not** treat `skills_catalog` / this registry as "what the model has."
  * Only product skills that need admin visibility, playbook compile
@@ -25,9 +27,9 @@
  * 4. Run `pnpm --filter web drizzle:generate` if new enum values are needed.
  * 5. The postbuild hook will sync the catalog on next deploy.
  *
- * To add a **live chat tool** only: register it in the chat route builders +
- * `TOOL_UI_REGISTRY` (+ `TOOL_SCHEMAS` when eval coverage is needed). Catalog
- * it here only when it is a product skill surface.
+ * To add a **live chat tool** only: register it in `CHAT_ROUTE_TOOL_IDS`, the
+ * chat route builders, and `TOOL_UI_REGISTRY` (+ `TOOL_SCHEMAS` when eval
+ * coverage is needed). Catalog it here only when it is a product skill surface.
  */
 
 import type { SkillDefinition, ToolDefinition } from './types';

--- a/apps/web/lib/chat/chat-tool-inventory.test.ts
+++ b/apps/web/lib/chat/chat-tool-inventory.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Chat tool inventory drift guard (JOV-3013).
+ *
+ * Ensures live chat tool ids stay registered in CHAT_ROUTE_TOOL_IDS and that
+ * PUBLIC_SKILL_REGISTRY is treated as a productized subset — not the chat
+ * tool surface of truth.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PUBLIC_SKILL_REGISTRY, SKILL_REGISTRY } from '@/lib/agents/registry';
+import {
+  assertChatToolsRegistered,
+  CHAT_ROUTE_TOOL_ID_SET,
+  CHAT_ROUTE_TOOL_IDS,
+} from './chat-tool-inventory';
+
+const REPO_WEB_ROOT = join(__dirname, '../..');
+
+function extractRouteToolKeys(functionName: string): string[] {
+  const routePath = join(REPO_WEB_ROOT, 'app/api/chat/route.ts');
+  const source = readFileSync(routePath, 'utf8');
+  const start = source.indexOf(`function ${functionName}`);
+  expect(start, `expected ${functionName} in chat route`).toBeGreaterThan(-1);
+  const end = source.indexOf('\nfunction ', start + 1);
+  const body = source.slice(start, end === -1 ? undefined : end);
+  const keys = body.matchAll(
+    /(?:^|\n)\s+([a-zA-Z][a-zA-Z0-9_]*):\s*(?:create[A-Za-z0-9_]*\(|tool\()/g
+  );
+  return [...new Set([...keys].map(match => match[1]))];
+}
+
+function extractAccountToolKeys(): string[] {
+  const path = join(REPO_WEB_ROOT, 'lib/chat/account-tools.ts');
+  const source = readFileSync(path, 'utf8');
+  const keys = source.matchAll(
+    /(?:^|\n)\s{4}([a-zA-Z][a-zA-Z0-9_]*):\s*tool\(/g
+  );
+  return [...new Set([...keys].map(match => match[1]))];
+}
+
+describe('CHAT_ROUTE_TOOL_IDS inventory', () => {
+  it('has unique ids', () => {
+    expect(new Set(CHAT_ROUTE_TOOL_IDS).size).toBe(CHAT_ROUTE_TOOL_IDS.length);
+  });
+
+  it('covers free, paid, account, and locked tools wired in the chat route', () => {
+    const freeKeys = extractRouteToolKeys('buildFreeChatTools');
+    const paidKeys = extractRouteToolKeys('buildChatTools');
+    const accountKeys = extractAccountToolKeys();
+    // manageTasks is plan-locked via locked-tools (not built in free/paid factories).
+    const liveKeys = new Set([
+      ...freeKeys,
+      ...paidKeys,
+      ...accountKeys,
+      'manageTasks',
+    ]);
+
+    const missing = [...liveKeys].filter(
+      name => !CHAT_ROUTE_TOOL_ID_SET.has(name)
+    );
+    expect(missing, `unregistered live tools: ${missing.join(', ')}`).toEqual(
+      []
+    );
+
+    // Inventory should not lag far behind live surface size.
+    expect(liveKeys.size).toBeGreaterThanOrEqual(25);
+    expect(CHAT_ROUTE_TOOL_IDS.length).toBeGreaterThanOrEqual(liveKeys.size);
+  });
+
+  it('assertChatToolsRegistered accepts inventory members', () => {
+    const tools = Object.fromEntries(
+      CHAT_ROUTE_TOOL_IDS.map(id => [id, { ok: true }])
+    );
+    expect(() => assertChatToolsRegistered(tools)).not.toThrow();
+  });
+
+  it('assertChatToolsRegistered fails closed on unregistered tools', () => {
+    expect(() =>
+      assertChatToolsRegistered({
+        proposeAvatarUpload: {},
+        totallyFakeTool: {},
+      })
+    ).toThrow(/totallyFakeTool/);
+  });
+});
+
+describe('PUBLIC_SKILL_REGISTRY partial-catalog boundary (JOV-3013)', () => {
+  it('exports PUBLIC_SKILL_REGISTRY as the same object as SKILL_REGISTRY', () => {
+    expect(PUBLIC_SKILL_REGISTRY).toBe(SKILL_REGISTRY);
+  });
+
+  it('is intentionally smaller than the live chat tool inventory', () => {
+    const catalogSize = Object.keys(PUBLIC_SKILL_REGISTRY).length;
+    expect(catalogSize).toBeGreaterThanOrEqual(1);
+    expect(catalogSize).toBeLessThan(CHAT_ROUTE_TOOL_IDS.length);
+  });
+
+  it('documents partial-catalog intent in the registry module source', () => {
+    const source = readFileSync(
+      join(REPO_WEB_ROOT, 'lib/agents/registry.ts'),
+      'utf8'
+    );
+    expect(source).toContain('PUBLIC_SKILL_REGISTRY');
+    expect(source).toMatch(/partial catalog/i);
+    expect(source).toContain('CHAT_ROUTE_TOOL_IDS');
+  });
+
+  it('does not require every chat tool id to exist in the skill catalog', () => {
+    const chatOnlyExamples = [
+      'proposeProfileEdit',
+      'submitFeedback',
+      'showAccountStatus',
+      'voicePromo',
+      'updateMerchCard',
+    ] as const;
+
+    for (const id of chatOnlyExamples) {
+      expect(CHAT_ROUTE_TOOL_ID_SET.has(id)).toBe(true);
+      expect(
+        Object.hasOwn(PUBLIC_SKILL_REGISTRY, id),
+        `${id} must stay chat-inventory-only unless productized`
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/web/lib/chat/chat-tool-inventory.ts
+++ b/apps/web/lib/chat/chat-tool-inventory.ts
@@ -1,0 +1,97 @@
+/**
+ * Canonical inventory of tool ids the main authenticated chat route may
+ * expose (free + paid + plan-locked stubs).
+ *
+ * Runtime plan gating can hide or lock tools, so this is the **union** of
+ * possible ids — not the always-on set.
+ *
+ * ## Boundary with PUBLIC_SKILL_REGISTRY / SKILL_REGISTRY
+ *
+ * `PUBLIC_SKILL_REGISTRY` (`apps/web/lib/agents/registry.ts`) is a
+ * **productized skill catalog** synced to `skills_catalog` / `tools_catalog`
+ * for admin, playbook compile, and lifecycle. It is intentionally a subset
+ * and must **not** be treated as the source of truth for which tools the
+ * chat model can call.
+ *
+ * Chat tool access is plan-driven (`tool-access.ts`, `locked-tools.ts`).
+ * When adding a chat tool:
+ * 1. Register it here (`CHAT_ROUTE_TOOL_IDS`).
+ * 2. Wire it in `app/api/chat/route.ts` (or account/onboarding builders).
+ * 3. Add UI copy in `tool-ui-registry.ts` when the tool needs a status row.
+ * 4. Only add to `PUBLIC_SKILL_REGISTRY` if productizing (lifecycle, admin,
+ *    playbook compile, catalog sync).
+ */
+
+export const CHAT_ROUTE_TOOL_IDS = [
+  // Free-tier profile / feedback
+  'proposeAvatarUpload',
+  'proposeSocialLink',
+  'proposeSocialLinkRemoval',
+  'submitFeedback',
+  // Account (all plans)
+  'showAccountStatus',
+  'showUsage',
+  'openBillingPortal',
+  // Paid-tier creative / profile tools
+  'showTopInsights',
+  'proposeProfileEdit',
+  'importBioFromUrl',
+  'checkCanvasStatus',
+  'suggestRelatedArtists',
+  'writeWorldClassBio',
+  'generateCanvasPlan',
+  'generateAlbumArt',
+  'retouchImage',
+  'createPromoStrategy',
+  'voicePromo',
+  'markCanvasUploaded',
+  'formatLyrics',
+  'createRelease',
+  'generateReleasePitch',
+  // Merch suite
+  'createMerch',
+  'previewMerchOptions',
+  'selectMerchDesign',
+  'createMerchAlternativeItem',
+  'updateMerchCard',
+  'publishMerchCard',
+  'pauseMerchCard',
+  'unpauseMerchCard',
+  'deleteOrArchiveMerchCard',
+  'reorderMerchCards',
+  'optimizeMerchCards',
+  'showMerchSales',
+  'showArtistPayouts',
+  // Feature-flagged / locked stubs
+  'proposeVideoRecording',
+  'manageTasks',
+] as const;
+
+export type ChatRouteToolId = (typeof CHAT_ROUTE_TOOL_IDS)[number];
+
+export const CHAT_ROUTE_TOOL_ID_SET: ReadonlySet<string> = new Set(
+  CHAT_ROUTE_TOOL_IDS
+);
+
+/**
+ * Assert every assembled chat tool id is in the inventory.
+ * Call after free + paid + locked tool sets are merged.
+ *
+ * Fails closed so unregistered tools cannot ship silently.
+ */
+export function assertChatToolsRegistered(
+  tools: Readonly<Record<string, unknown>>,
+  inventory: ReadonlySet<string> = CHAT_ROUTE_TOOL_ID_SET
+): void {
+  const unregistered = Object.keys(tools).filter(name => !inventory.has(name));
+  if (unregistered.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Chat tools missing from CHAT_ROUTE_TOOL_IDS: ${unregistered.sort().join(', ')}. ` +
+      'Add them to apps/web/lib/chat/chat-tool-inventory.ts. ' +
+      'Do not use PUBLIC_SKILL_REGISTRY/SKILL_REGISTRY as the chat tool inventory ' +
+      '(that catalog is productized skills only).'
+  );
+}

--- a/docs/SCHEMA_MAP.md
+++ b/docs/SCHEMA_MAP.md
@@ -14,6 +14,8 @@ All schema files live in `apps/web/lib/db/schema/`. Import tables and types from
 
 **Sync:** `skills_catalog` and `tools_catalog` are upserted from `PUBLIC_SKILL_REGISTRY` (`SKILL_REGISTRY` alias) at deploy time by `apps/web/scripts/sync-skills-catalog.ts` (wired into `postbuild`). Do not hand-edit these rows.
 
+**Live chat tools (JOV-3013):** inventoried in `apps/web/lib/chat/chat-tool-inventory.ts` (`CHAT_ROUTE_TOOL_IDS`); not the same set as this catalog.
+
 **Partial catalog (JOV-3013):** `PUBLIC_SKILL_REGISTRY` is intentionally **not** the exhaustive live chat tool list. Chat tools are assembled in `app/api/chat/route.ts` and gated by plan/entitlements (`lib/chat/tool-access.ts`). Treat `skills_catalog` as admin/playbook/lifecycle source of truth only — not "what the model can call."
 
 **Enums:** `skillKindEnum` (`vertical_agent`, `tool`, `style`); `retouchJobStatusEnum` (`queued`, `running`, `identity_check_failed`, `identity_check_retrying`, `completed`, `failed`, `rejected_by_user`, `accepted_by_user`).


### PR DESCRIPTION
## Summary

Completes the remaining JOV-3013 acceptance path after #15272 landed the `PUBLIC_SKILL_REGISTRY` rename + partial-catalog docs.

Live chat tools (~25–35 plan-gated ids) are now inventoried in `CHAT_ROUTE_TOOL_IDS` with:

- `assertChatToolsRegistered()` after free + paid + locked tool assembly in `app/api/chat/route.ts` (fails closed on unregistered tools)
- Unit tests that scan route factories and assert every live tool id is in the inventory
- Docs cross-links so `skills_catalog` / `PUBLIC_SKILL_REGISTRY` is never treated as the chat tool surface of truth

## Why not expand the skill catalog?

Cataloging every chat tool into `skills_catalog` would pollute admin/playbook/lifecycle surfaces. The productized registry stays partial by design; the chat inventory is the fail-closed source for live tools.

## Test plan / results

- [x] `pnpm --filter web exec vitest run lib/chat/chat-tool-inventory.test.ts lib/agents/registry.test.ts` — **45 passed**
- [x] Pre-commit typecheck/eslint on original commit; focused suite re-run after rebase

## Risk

Low. One `Object.keys` assert per chat turn. No catalog schema change. Adding a chat tool without updating `CHAT_ROUTE_TOOL_IDS` will fail tests/runtime until registered.

## Fixes

Fixes JOV-3013

<!-- linear-issue-id:JOV-3013 -->