### PR TITLE
fix(profile): public artist polish + regression coverage (JOV-4436)

### DIFF
--- a/apps/web/components/features/profile/ProfileHeroCard.tsx
+++ b/apps/web/components/features/profile/ProfileHeroCard.tsx
@@ -123,7 +123,7 @@ export function ArtistHero({
       <div className='absolute inset-0'>
         <ImageWithFallback
           src={resolvedHeroImageUrl}
-          alt={artist.name}
+          alt=''
           fill
           priority={true}
           sizes='(max-width: 767px) 100vw, 620px'

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.test.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.test.tsx
@@ -250,13 +250,11 @@ describe('ProfileDesktopSurface', () => {
       />
     );
 
-    expect(screen.getByRole('link', { name: 'instagram' })).toHaveAttribute(
-      'href',
-      'https://instagram.com/timwhite'
-    );
-    expect(screen.getByRole('link', { name: 'twitter' })).toHaveAttribute(
-      'href',
-      'https://x.com/timwhite'
-    );
+    expect(
+      screen.getByRole('link', { name: 'Follow Tim White on Instagram' })
+    ).toHaveAttribute('href', 'https://instagram.com/timwhite');
+    expect(
+      screen.getByRole('link', { name: 'Follow Tim White on Twitter' })
+    ).toHaveAttribute('href', 'https://x.com/timwhite');
   });
 });

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
@@ -40,6 +40,10 @@ import { buildProfileShareContext } from '@/lib/share/context';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import { cn } from '@/lib/utils';
 import type { AvatarSize } from '@/lib/utils/avatar-sizes';
+import {
+  publicLinkAriaLabel,
+  sanitizePublicHref,
+} from '@/lib/utils/public-url';
 import type { PublicContact } from '@/types/contacts';
 import type { Artist, LegacySocialLink } from '@/types/db';
 import type { NotificationContentType } from '@/types/notifications';
@@ -393,7 +397,7 @@ export function ProfileDesktopSurface({
             {heroImageUrl ? (
               <ImageWithFallback
                 src={heroImageUrl}
-                alt={artist.name}
+                alt=''
                 fill
                 priority
                 sizes='(max-width: 1536px) 60vw, 900px'
@@ -445,23 +449,38 @@ export function ProfileDesktopSurface({
 
               {visibleSocialLinks.length > 0 ? (
                 <div className='flex items-center gap-3'>
-                  {visibleSocialLinks.map(link =>
-                    link.platform && link.url ? (
+                  {visibleSocialLinks.map(link => {
+                    if (!link.platform) return null;
+                    const href = sanitizePublicHref(link.url);
+                    if (!href) return null;
+                    const platformLabel =
+                      link.platform.charAt(0).toUpperCase() +
+                      link.platform.slice(1);
+                    return (
                       <a
                         key={link.id}
-                        href={link.url}
+                        href={href}
                         target='_blank'
                         rel='noopener noreferrer'
-                        className='inline-flex h-10 w-10 items-center justify-center text-white/78 drop-shadow-[0_2px_10px_rgba(0,0,0,0.45)] transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
-                        aria-label={link.platform}
+                        className='inline-flex h-11 w-11 items-center justify-center text-white/78 drop-shadow-[0_2px_10px_rgba(0,0,0,0.45)] transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+                        aria-label={publicLinkAriaLabel(
+                          artist.name,
+                          link.platform,
+                          platformLabel
+                        )}
+                        title={publicLinkAriaLabel(
+                          artist.name,
+                          link.platform,
+                          platformLabel
+                        )}
                       >
                         <SocialIcon
                           platform={link.platform}
-                          className='h-4 w-4'
+                          className='h-5 w-5'
                         />
                       </a>
-                    ) : null
-                  )}
+                    );
+                  })}
                 </div>
               ) : null}
             </div>

--- a/apps/web/components/molecules/SocialLink.tsx
+++ b/apps/web/components/molecules/SocialLink.tsx
@@ -6,6 +6,10 @@ import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { track } from '@/lib/analytics';
 import { getSocialDeepLinkConfig, openDeepLink } from '@/lib/deep-links';
 import { useTrackingMutation } from '@/lib/queries';
+import {
+  publicLinkAriaLabel,
+  sanitizePublicHref,
+} from '@/lib/utils/public-url';
 import type { LegacySocialLink as SocialLinkType } from '@/types/db';
 
 interface SocialLinkProps {
@@ -19,10 +23,18 @@ function SocialLinkComponent({ link, handle, artistName }: SocialLinkProps) {
     endpoint: '/api/track',
   });
 
-  // Guard against incomplete link data
-  if (!link.platform || !link.url) {
+  const href = sanitizePublicHref(link.url);
+  // Guard against incomplete or malformed link data
+  if (!link.platform || !href) {
     return null;
   }
+  const platformLabel =
+    link.platform.charAt(0).toUpperCase() + link.platform.slice(1);
+  const accessibleName = publicLinkAriaLabel(
+    artistName,
+    link.platform,
+    platformLabel
+  );
   const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault();
     // Track analytics first
@@ -30,7 +42,7 @@ function SocialLinkComponent({ link, handle, artistName }: SocialLinkProps) {
       handle,
       artist: artistName,
       platform: link.platform,
-      url: link.url,
+      url: href,
     });
 
     // Fire-and-forget server tracking
@@ -46,7 +58,7 @@ function SocialLinkComponent({ link, handle, artistName }: SocialLinkProps) {
 
     if (deepLinkConfig) {
       try {
-        await openDeepLink(link.url, deepLinkConfig, {
+        await openDeepLink(href, deepLinkConfig, {
           onNativeAttempt: () => {
             // Optional: could add loading state here
           },
@@ -56,11 +68,11 @@ function SocialLinkComponent({ link, handle, artistName }: SocialLinkProps) {
         });
       } catch (error) {
         console.debug('Deep link failed, using fallback:', error);
-        globalThis.open(link.url, '_blank', 'noopener,noreferrer');
+        globalThis.open(href, '_blank', 'noopener,noreferrer');
       }
     } else {
       // No deep link config, use original URL
-      globalThis.open(link.url, '_blank', 'noopener,noreferrer');
+      globalThis.open(href, '_blank', 'noopener,noreferrer');
     }
   };
 
@@ -69,15 +81,15 @@ function SocialLinkComponent({ link, handle, artistName }: SocialLinkProps) {
       asChild
       size='md'
       variant='pearl'
-      ariaLabel={`Follow ${artistName} on ${link.platform}`}
+      ariaLabel={accessibleName}
       className='text-primary-token/72 shadow-none hover:text-primary-token'
     >
       <a
-        href={link.url}
+        href={href}
         target='_blank'
         rel='noopener noreferrer'
         onClick={handleClick}
-        title={`Follow on ${link.platform}`}
+        title={accessibleName}
       >
         <SocialIcon platform={link.platform} className='h-4 w-4' />
       </a>

--- a/apps/web/tests/unit/SocialBar.test.tsx
+++ b/apps/web/tests/unit/SocialBar.test.tsx
@@ -88,15 +88,18 @@ describe('SocialBar', () => {
     );
 
     const links = screen.getAllByRole('link');
-    expect(links[0]).toHaveAttribute('title', 'Follow on instagram');
+    expect(links[0]).toHaveAttribute(
+      'title',
+      'Follow Test Artist on Instagram'
+    );
     expect(links[0]).toHaveAttribute(
       'aria-label',
-      'Follow Test Artist on instagram'
+      'Follow Test Artist on Instagram'
     );
-    expect(links[1]).toHaveAttribute('title', 'Follow on twitter');
+    expect(links[1]).toHaveAttribute('title', 'Follow Test Artist on Twitter');
     expect(links[1]).toHaveAttribute(
       'aria-label',
-      'Follow Test Artist on twitter'
+      'Follow Test Artist on Twitter'
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes public artist profile polish regressions from the staging `/tim` audit (JOV-4436). Desktop remains the Linktree-style centered mobile shell.

### Workstream 1 — Data / content / link hygiene
- Suppress malformed public website/social URLs (e.g. `https://itstimwhite/` without a TLD) via `sanitizePublicHref` / `isRenderablePublicUrl`
- Website aria names use **Visit … website**; payment platforms are excluded from Follow (support/tip path)
- FAQ source links for same-site paths are **relative** so staging no longer hard-links to production `jov.ie`
- Copy: “known for” instead of “working in”; drop awkward generated handle filler when a bio exists
- Location facts: **Based In** vs **Hometown** when both differ
- Omit empty touring/merch FAQs instead of publishing “no dates / no merch”
- Latest Release PAC meta matches catalog cards (`Single · 2024`)
- Slug collisions prefer **year** disambiguation before `-2`/`-3`

### Workstream 2 — UI / a11y / shell
- Profile-landscape carousel gap avoids mid-CTA peek clipping
- Hero/desktop social controls: proper touch targets + accessible names
- Verified badge: clearer treatment + **Verified Artist** label/tooltip
- Decorative cover/hero alts (empty) so the name is not duplicated as image alt
- QR floating control clarified (**Open On Phone** / scan copy) instead of “View on mobile”
- Bottom tab `aria-current` retained; labels remain icon + `sr-only` per surface spec

## Test plan / results
- Unit: `public-url`, AEO content, DesktopQrOverlay, SocialBar, ProfileDesktopSurface, slug disambiguation
- Pre-push affected verify (typecheck/lint + unit shards) — pass
- Pre-commit biome/eslint/a11y/typecheck — pass

## Notes
- Existing catalog slugs with `-2` suffixes are not rewritten; new imports prefer year-based disambiguation.

Fixes JOV-4436
<!-- linear-issue-id:JOV-4436 -->