### PR TITLE
feat(design-lab): route approved proposals to design-html builder (JOV-1939)

### DIFF
--- a/agentos/agents/README.md
+++ b/agentos/agents/README.md
@@ -7,7 +7,7 @@ See `.claude/skills/` for gstack skill examples of the general pattern. AgentOS 
 Planned roles (from the AgentOS architecture plan):
 
 - `design-lever-scout.md` — discovers design improvement opportunities across authenticated routes
-- `design-html-builder.md` — generates production-ready HTML design proposals from Figma/prompts
+- `design-html-builder.md` — D5 builder: `/design-html` job for approved Design Lab proposals (JOV-1939)
 - `visual-qa-agent.md` — screenshot-based visual regression and consistency audit
 
-Add new role files here when a new agent type is formally defined and approved.
+Defined roles live as `.md` files in this directory. Add new role files when a new agent type is formally approved.

--- a/agentos/agents/design-html-builder.md
+++ b/agentos/agents/design-html-builder.md
@@ -1,0 +1,49 @@
+# design-html-builder
+
+Role definition for the Design Lab D5 HTML builder job (JOV-1939).
+
+## Trigger
+
+Dispatched automatically when a Design Lab proposal is approved in the D2
+review flow (`yes` or `yes-with-notes`) via
+`apps/web/lib/agent-os/design-lab/dispatch.ts`.
+
+## Required skills
+
+- `design-html` — production-quality HTML/CSS from the approved direction
+- `autoplan` — bounded execution plan before mutation
+
+## Dispatch payload (contract)
+
+The Hermes client payload / on-disk manifest includes:
+
+| Field | Source |
+| --- | --- |
+| `surfaceId` / `surfaceName` | Approved proposal |
+| `proposalText` | Approved proposal body |
+| `amendmentNotes` | `yes-with-notes` review notes (else null) |
+| `tasteMemoryExcerpt` | Tail of `agentos/memory/design-taste.md` |
+| `linearIssueId` / `linearIssueUrl` | Originating Linear issue |
+| `dispatchId` | `design-lab-<uuid>` |
+
+## Outputs
+
+1. HTML under `agentos/runs/design-lab/artifacts/<dispatchId>/` (prefer `index.html`).
+2. Terminal marker **last**:
+   `agentos/runs/design-lab/artifacts/<dispatchId>/complete.json`
+   with `{"status":"completed","runId":"<dispatchId>"}`.
+3. Link the completed HTML back to the originating Linear issue (attachment or
+   comment with the artifact path). Dispatch already posts a start comment and
+   optional GitHub tree attachment when configured.
+
+## Allowed paths
+
+- `agentos`
+- `apps/web/components`
+- `apps/web/styles`
+
+## Do not
+
+- Write artifacts outside the owned `design-lab/artifacts/<dispatchId>/` tree
+- Skip `complete.json` or write it before other outputs
+- Mutate billing, auth, or unrelated product surfaces

--- a/apps/web/lib/agent-os/design-lab/dispatch.ts
+++ b/apps/web/lib/agent-os/design-lab/dispatch.ts
@@ -11,12 +11,14 @@ import {
   retainRegularFiles,
   writeTextFileAtomic,
 } from '@/lib/agent-os/run-retention';
+import { env } from '@/lib/env-server';
 import {
   dispatchHermesWorker,
   getHermesDispatchAvailability,
   HermesDispatchConfigurationError,
 } from '@/lib/hermes/dispatch';
 import { logger } from '@/lib/utils/logger';
+import { linkDesignLabDispatchToLinearIssue } from './linear';
 import {
   getDesignLabArtifactDirectory,
   getDesignLabDispatchDirectory,
@@ -30,6 +32,11 @@ const DESIGN_LAB_DISPATCH_LIMIT = 100;
 const DESIGN_LAB_DISPATCH_MAX_BYTES = 32 * 1024;
 const DESIGN_LAB_ARTIFACT_COMPLETED_LIMIT = 14;
 const DESIGN_LAB_ARTIFACT_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+/** Hermes dispatch prompt cap (see HermesDispatchRequestSchema). */
+const HERMES_PROMPT_MAX_CHARS = 4000;
+
+export const DESIGN_HTML_BUILDER_SKILLS = ['design-html', 'autoplan'] as const;
+
 async function enforceArtifactLifecycle(dispatchId: string): Promise<void> {
   const artifactRoot = getDesignLabArtifactDirectory();
   const runDirectory = resolveDesignLabArtifactRunDirectory(dispatchId);
@@ -60,28 +67,104 @@ async function enforceArtifactLifecycle(dispatchId: string): Promise<void> {
   }
 }
 
-function buildDispatchPrompt(payload: DesignLabDispatchPayload): string {
+function truncateForPrompt(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+/**
+ * Builds the Hermes /design-html worker prompt. Exported for unit tests of the
+ * JOV-1939 dispatch contract (surface, proposal, amendments, taste memory).
+ */
+export function buildDesignHtmlDispatchPrompt(
+  payload: DesignLabDispatchPayload
+): string {
   const notesBlock = payload.amendmentNotes
-    ? `\nAmendment notes:\n${payload.amendmentNotes.trim()}`
+    ? `Amendment notes:\n${truncateForPrompt(payload.amendmentNotes, 600)}`
     : '';
 
   const tasteBlock = payload.tasteMemoryExcerpt
-    ? `\nTaste memory excerpt:\n${payload.tasteMemoryExcerpt.trim()}`
+    ? `Taste memory context:\n${truncateForPrompt(payload.tasteMemoryExcerpt, 900)}`
     : '';
 
-  return [
-    'Design Lab D5 dispatch: build an HTML artifact for the approved proposal.',
-    `Surface: ${payload.surfaceName} (${payload.surfaceId})`,
+  const proposalBlock = `Approved proposal:\n${truncateForPrompt(payload.proposalText, 1400)}`;
+
+  const parts = [
+    'Design Lab D5: run /design-html for the approved proposal and produce an HTML artifact.',
+    `Surface ID: ${payload.surfaceId}`,
+    `Surface name: ${payload.surfaceName}`,
     `Linear issue: ${payload.linearIssueId}`,
-    `Proposal:\n${payload.proposalText.trim()}`,
+    proposalBlock,
     notesBlock,
     tasteBlock,
     `Store every binary or built output under agentos/runs/design-lab/artifacts/${payload.dispatchId}/ and nowhere else.`,
+    `Write the primary HTML as agentos/runs/design-lab/artifacts/${payload.dispatchId}/index.html (or a single .html file in that directory).`,
     `After every output is durably written, write agentos/runs/design-lab/artifacts/${payload.dispatchId}/complete.json LAST with exactly {"status":"completed","runId":"${payload.dispatchId}"}.`,
-    'Link the completed artifact back to the Linear issue.',
-  ]
-    .filter(part => part.length > 0)
-    .join('\n\n');
+    'Link the completed HTML artifact back to the originating Linear issue as an attachment (attachmentLinkURL or issue comment with the artifact path).',
+  ].filter(part => part.length > 0);
+
+  let prompt = parts.join('\n\n');
+  if (prompt.length > HERMES_PROMPT_MAX_CHARS) {
+    prompt = `${prompt.slice(0, HERMES_PROMPT_MAX_CHARS - 1).trimEnd()}…`;
+  }
+  return prompt;
+}
+
+function resolveDesignLabArtifactRelativePath(dispatchId: string): string {
+  return `agentos/runs/design-lab/artifacts/${dispatchId}/`;
+}
+
+function resolveDesignLabDispatchRelativePath(dispatchId: string): string {
+  return `agentos/runs/design-lab/dispatches/${dispatchId}.json`;
+}
+
+/**
+ * Best-effort public URL for Linear attachment unfurl. Prefers an explicit
+ * proposal Linear URL host context is not enough; when GitHub owner/repo env
+ * is present, point at the design-lab artifacts tree for operator discovery.
+ */
+function resolveDesignLabArtifactPublicUrl(dispatchId: string): string | null {
+  const owner = env.HUD_GITHUB_OWNER ?? env.VERCEL_GIT_REPO_OWNER;
+  const repo = env.HUD_GITHUB_REPO ?? env.VERCEL_GIT_REPO_SLUG;
+  if (!owner || !repo) {
+    return null;
+  }
+  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tree/HEAD/agentos/runs/design-lab/artifacts/${encodeURIComponent(dispatchId)}`;
+}
+
+async function linkDispatchToLinear(
+  payload: DesignLabDispatchPayload
+): Promise<void> {
+  try {
+    await linkDesignLabDispatchToLinearIssue({
+      issueIdentifier: payload.linearIssueId,
+      dispatchId: payload.dispatchId,
+      surfaceId: payload.surfaceId,
+      surfaceName: payload.surfaceName,
+      proposalId: payload.proposalId,
+      proposalText: payload.proposalText,
+      amendmentNotes: payload.amendmentNotes,
+      artifactRelativePath: resolveDesignLabArtifactRelativePath(
+        payload.dispatchId
+      ),
+      dispatchRelativePath: resolveDesignLabDispatchRelativePath(
+        payload.dispatchId
+      ),
+      artifactUrl: resolveDesignLabArtifactPublicUrl(payload.dispatchId),
+    });
+  } catch (error) {
+    // Fail open: Linear linking must never block the design-html dispatch.
+    logger.error(
+      '[design-lab/dispatch] Linear link failed after manifest write',
+      {
+        dispatchId: payload.dispatchId,
+        error,
+      }
+    );
+  }
 }
 
 export async function triggerDesignLabDispatch(params: {
@@ -123,6 +206,10 @@ export async function triggerDesignLabDispatch(params: {
     root: dispatchDirectory,
   });
 
+  // Persist the Linear trail before worker dispatch so operators can find the
+  // run even when Hermes is unavailable.
+  await linkDispatchToLinear(payload);
+
   const availability = getHermesDispatchAvailability();
   if (!availability.available) {
     logger.info(
@@ -143,13 +230,13 @@ export async function triggerDesignLabDispatch(params: {
       kind: 'investigation',
       runtime: 'codex-cli',
       priority: 70,
-      skills: ['design-html', 'autoplan'],
+      skills: [...DESIGN_HTML_BUILDER_SKILLS],
       allowedPaths: ['agentos', 'apps/web/components', 'apps/web/styles'],
       verification: [
         'pnpm --filter @jovie/web run typecheck -- --pretty false',
       ],
       dryRun: false,
-      prompt: buildDispatchPrompt(payload),
+      prompt: buildDesignHtmlDispatchPrompt(payload),
       owner: params.requestedBy,
     });
   } catch (error) {

--- a/apps/web/lib/agent-os/design-lab/linear.ts
+++ b/apps/web/lib/agent-os/design-lab/linear.ts
@@ -200,3 +200,154 @@ export async function updateDesignLabLinearIssueStatus(
     return false;
   }
 }
+
+export interface DesignLabLinearArtifactLink {
+  readonly issueIdentifier: string;
+  readonly dispatchId: string;
+  readonly surfaceId: string;
+  readonly surfaceName: string;
+  readonly proposalId: string;
+  readonly proposalText: string;
+  readonly amendmentNotes: string | null;
+  readonly artifactRelativePath: string;
+  readonly dispatchRelativePath: string;
+  /**
+   * Optional HTTPS URL for Linear attachment unfurl (e.g. GitHub blob/tree URL
+   * once the artifact is committed, or an operator UI deep link). When omitted,
+   * only a durable comment is written.
+   */
+  readonly artifactUrl: string | null;
+}
+
+function buildDispatchLinkCommentBody(
+  params: DesignLabLinearArtifactLink
+): string {
+  const notesLine = params.amendmentNotes?.trim()
+    ? `- Amendment notes: ${params.amendmentNotes.trim()}`
+    : null;
+  const proposalPreview = params.proposalText.trim().slice(0, 500);
+  const proposalEllipsis = params.proposalText.trim().length > 500 ? '…' : '';
+
+  return [
+    '## Design HTML builder dispatched',
+    '',
+    'Approved Design Lab proposal routed to `/design-html`.',
+    '',
+    `- Surface: **${params.surfaceName}** (\`${params.surfaceId}\`)`,
+    `- Proposal: \`${params.proposalId}\``,
+    `- Dispatch: \`${params.dispatchId}\``,
+    `- Dispatch manifest: \`${params.dispatchRelativePath}\``,
+    `- Artifact directory: \`${params.artifactRelativePath}\``,
+    notesLine,
+    '',
+    '### Approved proposal',
+    '',
+    proposalPreview + proposalEllipsis,
+    '',
+    'The HTML artifact will be written under the artifact directory. When complete, attach the resulting HTML file path back to this issue.',
+  ]
+    .filter((part): part is string => part !== null)
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Links a design-html builder dispatch (and optional public artifact URL) back
+ * to the originating Linear issue. Always best-effort: returns false on any
+ * failure so dispatch success is not blocked by Linear availability.
+ */
+export async function linkDesignLabDispatchToLinearIssue(
+  params: DesignLabLinearArtifactLink
+): Promise<boolean> {
+  if (!env.LINEAR_API_KEY) {
+    logger.warn('[design-lab/linear] LINEAR_API_KEY not configured');
+    return false;
+  }
+
+  try {
+    const issue = await resolveLinearIssue(params.issueIdentifier);
+    if (!issue) {
+      logger.warn('[design-lab/linear] Issue not found for artifact link', {
+        issueIdentifier: params.issueIdentifier,
+        dispatchId: params.dispatchId,
+      });
+      return false;
+    }
+
+    const commentMutation = `
+      mutation CreateDesignLabComment($issueId: String!, $body: String!) {
+        commentCreate(input: { issueId: $issueId, body: $body }) {
+          success
+        }
+      }
+    `;
+
+    const commentResult = await linearGraphql<{
+      commentCreate: { success: boolean };
+    }>(commentMutation, {
+      issueId: issue.id,
+      body: buildDispatchLinkCommentBody(params),
+    });
+
+    if (!commentResult.commentCreate.success) {
+      logger.warn('[design-lab/linear] Comment create returned success=false', {
+        issueIdentifier: params.issueIdentifier,
+        dispatchId: params.dispatchId,
+      });
+      return false;
+    }
+
+    const artifactUrl = params.artifactUrl?.trim() ?? '';
+    if (artifactUrl.length === 0) {
+      return true;
+    }
+
+    const attachmentMutation = `
+      mutation LinkDesignLabArtifact(
+        $issueId: String!
+        $url: String!
+        $title: String!
+        $subtitle: String
+      ) {
+        attachmentLinkURL(
+          issueId: $issueId
+          url: $url
+          title: $title
+          subtitle: $subtitle
+        ) {
+          success
+        }
+      }
+    `;
+
+    const attachmentResult = await linearGraphql<{
+      attachmentLinkURL: { success: boolean };
+    }>(attachmentMutation, {
+      issueId: issue.id,
+      url: artifactUrl,
+      title: `Design HTML: ${params.surfaceName}`,
+      subtitle: `dispatch ${params.dispatchId}`,
+    });
+
+    if (!attachmentResult.attachmentLinkURL.success) {
+      logger.warn(
+        '[design-lab/linear] attachmentLinkURL returned success=false',
+        {
+          issueIdentifier: params.issueIdentifier,
+          dispatchId: params.dispatchId,
+        }
+      );
+      // Comment already persisted; treat partial success as true for operators.
+      return true;
+    }
+
+    return true;
+  } catch (error) {
+    logger.error('[design-lab/linear] Failed to link design-html dispatch', {
+      issueIdentifier: params.issueIdentifier,
+      dispatchId: params.dispatchId,
+      error,
+    });
+    return false;
+  }
+}

--- a/apps/web/tests/unit/agent-os/design-lab/dispatch.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/dispatch.test.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   mkdtemp,
   readdir,
+  readFile,
   realpath,
   rm,
   symlink,
@@ -16,6 +17,8 @@ vi.mock('server-only', () => ({}));
 
 const mocks = vi.hoisted(() => ({
   dispatchHermesWorker: vi.fn(),
+  linkDesignLabDispatchToLinearIssue: vi.fn(),
+  readDesignTasteMemoryExcerpt: vi.fn(),
 }));
 
 vi.mock('@/lib/hermes/dispatch', () => ({
@@ -28,8 +31,19 @@ vi.mock('@/lib/utils/logger', () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
+vi.mock('@/lib/env-server', () => ({
+  env: {
+    HUD_GITHUB_OWNER: 'JovieInc',
+    HUD_GITHUB_REPO: 'Jovie',
+  },
+}));
+
 vi.mock('@/lib/agent-os/design-lab/taste-memory', () => ({
-  readDesignTasteMemoryExcerpt: () => Promise.resolve(''),
+  readDesignTasteMemoryExcerpt: () => mocks.readDesignTasteMemoryExcerpt(),
+}));
+
+vi.mock('@/lib/agent-os/design-lab/linear', () => ({
+  linkDesignLabDispatchToLinearIssue: mocks.linkDesignLabDispatchToLinearIssue,
 }));
 
 let tempRoot = '';
@@ -68,6 +82,14 @@ describe('triggerDesignLabDispatch artifact lifecycle', () => {
       await mkdtemp(path.join(os.tmpdir(), 'design-lab-dispatch-'))
     );
     mocks.dispatchHermesWorker.mockReset().mockResolvedValue(undefined);
+    mocks.linkDesignLabDispatchToLinearIssue
+      .mockReset()
+      .mockResolvedValue(true);
+    mocks.readDesignTasteMemoryExcerpt
+      .mockReset()
+      .mockResolvedValue(
+        '## prior — profile — accepted\nDirection: Quiet surfaces only.'
+      );
   });
 
   afterEach(async () => {
@@ -101,6 +123,77 @@ describe('triggerDesignLabDispatch artifact lifecycle', () => {
     ).toBeTruthy();
   });
 
+  it('routes approval to /design-html with full D2→D5 payload and Linear link', async () => {
+    const { triggerDesignLabDispatch, DESIGN_HTML_BUILDER_SKILLS } =
+      await import('@/lib/agent-os/design-lab/dispatch');
+
+    const result = await triggerDesignLabDispatch({
+      amendmentNotes: 'Keep the underline but reduce accent saturation.',
+      proposal,
+      requestedBy: 'tim@jovie.com',
+    });
+
+    expect(result.triggered).toBe(true);
+    expect(result.dispatchId).toMatch(/^design-lab-/);
+
+    const hermesCall = mocks.dispatchHermesWorker.mock.calls[0]?.[0] as {
+      readonly skills: readonly string[];
+      readonly prompt: string;
+      readonly source: string;
+      readonly sourceId: string;
+    };
+    expect(hermesCall.skills).toEqual([...DESIGN_HTML_BUILDER_SKILLS]);
+    expect(hermesCall.skills).toContain('design-html');
+    expect(hermesCall.source).toBe('linear');
+    expect(hermesCall.sourceId).toBe('JOV-4264');
+    expect(hermesCall.prompt).toContain('Surface ID: profile');
+    expect(hermesCall.prompt).toContain(
+      'Build the approved profile direction.'
+    );
+    expect(hermesCall.prompt).toContain(
+      'Keep the underline but reduce accent saturation.'
+    );
+    expect(hermesCall.prompt).toContain('Taste memory context:');
+    expect(hermesCall.prompt).toContain('Quiet surfaces only.');
+    expect(hermesCall.prompt).toContain('/design-html');
+    expect(hermesCall.prompt.length).toBeLessThanOrEqual(4000);
+
+    const manifestRaw = await readFile(
+      path.join(tempRoot, 'dispatches', `${result.dispatchId}.json`),
+      'utf8'
+    );
+    const manifest = JSON.parse(manifestRaw) as {
+      surfaceId: string;
+      proposalText: string;
+      amendmentNotes: string | null;
+      tasteMemoryExcerpt: string;
+      linearIssueId: string;
+    };
+    expect(manifest.surfaceId).toBe('profile');
+    expect(manifest.proposalText).toBe('Build the approved profile direction.');
+    expect(manifest.amendmentNotes).toBe(
+      'Keep the underline but reduce accent saturation.'
+    );
+    expect(manifest.tasteMemoryExcerpt).toContain('Quiet surfaces only.');
+    expect(manifest.linearIssueId).toBe('JOV-4264');
+
+    expect(mocks.linkDesignLabDispatchToLinearIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueIdentifier: 'JOV-4264',
+        dispatchId: result.dispatchId,
+        surfaceId: 'profile',
+        surfaceName: 'Profile',
+        proposalId: 'proposal-1',
+        amendmentNotes: 'Keep the underline but reduce accent saturation.',
+        artifactRelativePath: `agentos/runs/design-lab/artifacts/${result.dispatchId}/`,
+        dispatchRelativePath: `agentos/runs/design-lab/dispatches/${result.dispatchId}.json`,
+        artifactUrl: expect.stringContaining(
+          `agentos/runs/design-lab/artifacts/${result.dispatchId}`
+        ),
+      })
+    );
+  });
+
   it('rejects a new dispatch when unknown symlinked output makes usage unknowable', async () => {
     const outside = await realpath(
       await mkdtemp(path.join(os.tmpdir(), 'design-lab-outside-'))
@@ -119,6 +212,7 @@ describe('triggerDesignLabDispatch artifact lifecycle', () => {
       })
     ).rejects.toThrow(/symlinked artifact path/);
     expect(mocks.dispatchHermesWorker).not.toHaveBeenCalled();
+    expect(mocks.linkDesignLabDispatchToLinearIssue).not.toHaveBeenCalled();
     expect(await readdir(path.join(tempRoot, 'artifacts'))).toEqual([
       'unknown-output',
     ]);
@@ -149,5 +243,35 @@ describe('triggerDesignLabDispatch artifact lifecycle', () => {
       expect(await readdir(artifactRoot)).toHaveLength(100);
     }
     expect(mocks.dispatchHermesWorker).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildDesignHtmlDispatchPrompt', () => {
+  it('includes surface, proposal, amendments, and taste memory', async () => {
+    const { buildDesignHtmlDispatchPrompt } = await import(
+      '@/lib/agent-os/design-lab/dispatch'
+    );
+
+    const prompt = buildDesignHtmlDispatchPrompt({
+      dispatchId: 'design-lab-00000000-0000-4000-8000-000000000099',
+      proposalId: 'proposal-1',
+      surfaceId: 'dashboard-sidebar',
+      surfaceName: 'Dashboard sidebar',
+      proposalText: 'Collapse unused nav groups by default.',
+      amendmentNotes: 'Keep icons monochrome.',
+      linearIssueId: 'JOV-1939',
+      linearIssueUrl: 'https://linear.app/jovie/issue/JOV-1939',
+      tasteMemoryExcerpt: 'Reject loud accent squares on chrome.',
+      requestedAt: '2026-07-31T00:00:00.000Z',
+      requestedBy: 'tim@jovie.com',
+    });
+
+    expect(prompt).toContain('Surface ID: dashboard-sidebar');
+    expect(prompt).toContain('Collapse unused nav groups by default.');
+    expect(prompt).toContain('Keep icons monochrome.');
+    expect(prompt).toContain('Taste memory context:');
+    expect(prompt).toContain('Reject loud accent squares on chrome.');
+    expect(prompt).toContain('/design-html');
+    expect(prompt.length).toBeLessThanOrEqual(4000);
   });
 });

--- a/apps/web/tests/unit/agent-os/design-lab/linear-link.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/linear-link.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  env: {
+    LINEAR_API_KEY: 'lin_api_test' as string | undefined,
+  },
+}));
+
+vi.mock('@/lib/env-server', () => ({
+  env: mocks.env,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: mocks.logger,
+}));
+
+describe('linkDesignLabDispatchToLinearIssue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.fetch.mockReset();
+    mocks.logger.error.mockReset();
+    mocks.logger.warn.mockReset();
+    mocks.env.LINEAR_API_KEY = 'lin_api_test';
+    vi.stubGlobal('fetch', mocks.fetch);
+  });
+
+  it('posts a dispatch comment and optional attachment URL on the Linear issue', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { issue: { id: 'issue-uuid', identifier: 'JOV-1951' } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { commentCreate: { success: true } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { attachmentLinkURL: { success: true } },
+        }),
+      });
+
+    const { linkDesignLabDispatchToLinearIssue } = await import(
+      '@/lib/agent-os/design-lab/linear'
+    );
+
+    const ok = await linkDesignLabDispatchToLinearIssue({
+      issueIdentifier: 'JOV-1951',
+      dispatchId: 'design-lab-00000000-0000-4000-8000-000000000001',
+      surfaceId: 'profile-page',
+      surfaceName: 'Public profile page',
+      proposalId: 'profile-page-quiet-hero',
+      proposalText: 'Use a restrained surface-1 header band.',
+      amendmentNotes: 'Keep underline, reduce accent.',
+      artifactRelativePath:
+        'agentos/runs/design-lab/artifacts/design-lab-00000000-0000-4000-8000-000000000001/',
+      dispatchRelativePath:
+        'agentos/runs/design-lab/dispatches/design-lab-00000000-0000-4000-8000-000000000001.json',
+      artifactUrl:
+        'https://github.com/JovieInc/Jovie/tree/HEAD/agentos/runs/design-lab/artifacts/design-lab-00000000-0000-4000-8000-000000000001',
+    });
+
+    expect(ok).toBe(true);
+    expect(mocks.fetch).toHaveBeenCalledTimes(3);
+
+    const commentBody = JSON.parse(
+      String(mocks.fetch.mock.calls[1]?.[1]?.body ?? '{}')
+    ) as {
+      variables: { body: string; issueId: string };
+    };
+    expect(commentBody.variables.issueId).toBe('issue-uuid');
+    expect(commentBody.variables.body).toContain(
+      'Design HTML builder dispatched'
+    );
+    expect(commentBody.variables.body).toContain('profile-page');
+    expect(commentBody.variables.body).toContain(
+      'agentos/runs/design-lab/artifacts/design-lab-00000000-0000-4000-8000-000000000001/'
+    );
+    expect(commentBody.variables.body).toContain(
+      'Keep underline, reduce accent.'
+    );
+
+    const attachmentBody = JSON.parse(
+      String(mocks.fetch.mock.calls[2]?.[1]?.body ?? '{}')
+    ) as {
+      variables: { url: string; title: string; issueId: string };
+    };
+    expect(attachmentBody.variables.issueId).toBe('issue-uuid');
+    expect(attachmentBody.variables.url).toContain(
+      'agentos/runs/design-lab/artifacts/'
+    );
+    expect(attachmentBody.variables.title).toContain('Public profile page');
+  });
+
+  it('skips attachment mutation when no public artifact URL is provided', async () => {
+    mocks.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { issue: { id: 'issue-uuid', identifier: 'JOV-1951' } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { commentCreate: { success: true } },
+        }),
+      });
+
+    const { linkDesignLabDispatchToLinearIssue } = await import(
+      '@/lib/agent-os/design-lab/linear'
+    );
+
+    const ok = await linkDesignLabDispatchToLinearIssue({
+      issueIdentifier: 'JOV-1951',
+      dispatchId: 'design-lab-test',
+      surfaceId: 'profile-page',
+      surfaceName: 'Public profile page',
+      proposalId: 'proposal-1',
+      proposalText: 'Quiet hero.',
+      amendmentNotes: null,
+      artifactRelativePath:
+        'agentos/runs/design-lab/artifacts/design-lab-test/',
+      dispatchRelativePath:
+        'agentos/runs/design-lab/dispatches/design-lab-test.json',
+      artifactUrl: null,
+    });
+
+    expect(ok).toBe(true);
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns false when LINEAR_API_KEY is missing', async () => {
+    mocks.env.LINEAR_API_KEY = undefined;
+
+    const { linkDesignLabDispatchToLinearIssue } = await import(
+      '@/lib/agent-os/design-lab/linear'
+    );
+
+    const ok = await linkDesignLabDispatchToLinearIssue({
+      issueIdentifier: 'JOV-1951',
+      dispatchId: 'design-lab-test',
+      surfaceId: 'profile-page',
+      surfaceName: 'Public profile page',
+      proposalId: 'proposal-1',
+      proposalText: 'Quiet hero.',
+      amendmentNotes: null,
+      artifactRelativePath:
+        'agentos/runs/design-lab/artifacts/design-lab-test/',
+      dispatchRelativePath:
+        'agentos/runs/design-lab/dispatches/design-lab-test.json',
+      artifactUrl: null,
+    });
+
+    expect(ok).toBe(false);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Completes **JOV-1939**: on Design Lab D2 approval (`yes` / `yes-with-notes`), route the approved proposal into a `/design-html` Hermes builder job with the full dispatch contract, persist under `agentos/runs/design-lab/`, and link the run back to the originating Linear issue.

### What changed

- **Dispatch contract** (`dispatch.ts`): Hermes skills fixed to `design-html` + `autoplan`; prompt includes surface ID, approved proposal text, yes-with-notes amendments, and taste memory excerpt (Hermes 4k prompt cap).
- **Linear linkage** (`linear.ts`): best-effort `commentCreate` on the originating issue plus optional `attachmentLinkURL` when GitHub owner/repo env is available; never blocks dispatch success.
- **Role doc**: `agentos/agents/design-html-builder.md` documents the D5 builder inputs/outputs.
- **Tests**: payload + Linear link coverage for the D2→D5 path.

### Flow

1. Admin approves proposal in Design Lab D2 panel.
2. `reviewDesignProposal` → `triggerDesignLabDispatch`.
3. Manifest + artifact dir reserved under `agentos/runs/design-lab/`.
4. Linear issue gets a dispatch comment (+ optional attachment URL).
5. Hermes worker runs `/design-html` with the approved payload.

## Test plan / results

- [x] `pnpm biome check --write` on touched files
- [x] `pnpm --filter web exec vitest run tests/unit/agent-os/design-lab` — **17 passed**
- [x] Pre-commit typecheck + eslint on staged files
- [x] Pre-push typecheck + affected verify suite (passed)

## Fixes JOV-1939

<!-- linear-issue-id:JOV-1939 -->