### PR TITLE
fix(ui): polish user menu spacing and truncation [JOV-4607]

### DIFF
--- a/apps/web/components/organisms/user-button/UsageMenuItem.tsx
+++ b/apps/web/components/organisms/user-button/UsageMenuItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { ChevronDown, ChevronRight, ExternalLink, Gauge } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
@@ -72,8 +72,11 @@ export function UsageMenuItem({
         variant='ghost'
         onClick={toggleExpanded}
         aria-expanded={expanded}
-        className='h-auto w-full justify-start gap-2 rounded-none px-2.5 py-2 text-left text-app font-normal text-secondary-token hover:text-secondary-token focus-visible:bg-interactive-hover'
+        className='min-h-8 w-full justify-start gap-2 rounded-none px-2.5 py-1.5 text-left text-app font-normal text-secondary-token hover:text-secondary-token focus-visible:bg-interactive-hover'
       >
+        <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token'>
+          <Gauge className='h-4 w-4' aria-hidden />
+        </span>
         <span className='min-w-0 flex-1'>Usage remaining</span>
         <span className='shrink-0 tabular-nums text-tertiary-token'>
           {isLoading ? (

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -73,6 +73,9 @@ interface BuildDropdownItemsParams {
   isElectronRuntime: boolean;
 }
 
+const USER_MENU_CONTENT_CLASS = 'w-80 max-w-[calc(100vw-1rem)]';
+const USER_MENU_GROUP_SPACER_CLASS = '-mx-1 my-0 h-2 border-0';
+
 function sanitizeInstallUrl(value: unknown): string | null {
   if (typeof value !== 'string') return null;
 
@@ -108,14 +111,15 @@ function buildDropdownItems({
     {
       type: 'action-row',
       id: 'profile-help',
-      className: 'grid w-full grid-cols-1 px-1',
+      className:
+        'grid min-h-12 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-1 px-1',
       items: [
         {
           type: 'action',
           id: 'profile-card',
           label: `Open profile for ${displayName}`,
           onClick: handleProfile,
-          className: 'min-w-0 min-h-12 gap-2.5 px-1.5 py-1.5',
+          className: 'min-h-12 min-w-0 gap-2.5 px-1.5 py-1.5',
           content: (
             <>
               <Avatar
@@ -159,11 +163,15 @@ function buildDropdownItems({
           label: 'Help',
           icon: HelpCircle,
           onClick: handleHelp,
-          className: 'min-h-8',
+          className: 'min-h-8 shrink-0 px-2',
         },
       ],
     },
-    { type: 'separator', id: 'sep-1' },
+    {
+      type: 'separator',
+      id: 'sep-1',
+      className: USER_MENU_GROUP_SPACER_CLASS,
+    },
     {
       type: 'action',
       id: 'settings',
@@ -320,7 +328,11 @@ function buildDropdownItems({
   // Add feedback, version info, and sign out.
   // Version is now shown to all users (moved from admin-only sidebar footer).
   items.push(
-    { type: 'separator', id: 'sep-support' },
+    {
+      type: 'separator',
+      id: 'sep-support',
+      className: USER_MENU_GROUP_SPACER_CLASS,
+    },
     {
       type: 'action',
       id: 'feedback',
@@ -328,12 +340,16 @@ function buildDropdownItems({
       icon: MessageSquare,
       onClick: () => setIsFeedbackOpen(true),
     },
-    { type: 'separator', id: 'sep-2' },
+    {
+      type: 'separator',
+      id: 'sep-2',
+      className: USER_MENU_GROUP_SPACER_CLASS,
+    },
     {
       type: 'custom',
       id: 'version',
       render: () => (
-        <div className='px-2.5 py-1.5 text-2xs leading-4 text-tertiary-token select-none'>
+        <div className='flex min-h-8 items-center px-2.5 py-1.5 text-2xs leading-4 text-tertiary-token select-none'>
           Version {process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0'}
           {process.env.NEXT_PUBLIC_BUILD_SHA
             ? ` (${process.env.NEXT_PUBLIC_BUILD_SHA})`
@@ -341,7 +357,11 @@ function buildDropdownItems({
         </div>
       ),
     },
-    { type: 'separator', id: 'sep-signout' },
+    {
+      type: 'separator',
+      id: 'sep-signout',
+      className: USER_MENU_GROUP_SPACER_CLASS,
+    },
     {
       type: 'action',
       id: 'sign-out',
@@ -480,7 +500,7 @@ export function UserButton({
             open={isMenuOpen}
             onOpenChange={setIsMenuOpen}
             disabled
-            contentClassName='w-72 max-w-[calc(100vw-1rem)]'
+            contentClassName={USER_MENU_CONTENT_CLASS}
           />
         </div>
       );
@@ -534,7 +554,7 @@ export function UserButton({
     (showUserInfo ? (
       <button
         type='button'
-        className='flex w-full items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-0'
+        className='flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-0'
       >
         <Avatar
           src={userImageUrl}
@@ -547,7 +567,10 @@ export function UserButton({
           data-user-button-display-name
           className='min-w-0 flex-1 group-data-[collapsible=icon]:hidden'
         >
-          <p className='text-app font-normal text-sidebar-item-foreground truncate'>
+          <p
+            title={displayName}
+            className='truncate text-app font-normal text-sidebar-item-foreground'
+          >
             {displayName}
           </p>
         </div>
@@ -584,7 +607,7 @@ export function UserButton({
         align={trigger || showUserInfo ? 'start' : 'end'}
         open={isMenuOpen}
         onOpenChange={setIsMenuOpen}
-        contentClassName='w-72 max-w-[calc(100vw-1rem)]'
+        contentClassName={USER_MENU_CONTENT_CLASS}
       />
       <DashboardFeedbackModal
         isOpen={isFeedbackOpen}

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -664,7 +664,7 @@ describe('UserButton billing actions', () => {
     expect(screen.queryByText('Usage Stats')).not.toBeInTheDocument();
   });
 
-  it('gives narrow identity content its own full-width row and preserves menu focus order', async () => {
+  it('gives identity and help enough width while preserving menu focus order', async () => {
     const longDisplayName =
       'Adele Adkins and the Very Long International Touring Ensemble';
     mockUseUserSafe.mockReturnValue({
@@ -696,10 +696,15 @@ describe('UserButton billing actions', () => {
     );
     expect(identityRow).not.toBeNull();
     expect(screen.getByRole('menu')).toHaveClass(
-      'w-72',
+      'w-80',
       'max-w-[calc(100vw-1rem)]'
     );
-    expect(identityRow).toHaveClass('grid', 'grid-cols-1', 'w-full');
+    expect(identityRow).toHaveClass(
+      'grid',
+      'grid-cols-[minmax(0,1fr)_auto]',
+      'min-h-12',
+      'w-full'
+    );
     expect(identityRow?.querySelectorAll('[role="menuitem"]')).toHaveLength(2);
     expect(identityRow?.querySelector('button, a')).toBeNull();
 
@@ -718,14 +723,14 @@ describe('UserButton billing actions', () => {
       longDisplayName
     );
 
-    // The dropdown's max width protects the full row contract on 390px
-    // screens, while the title keeps the complete identity discoverable.
+    // The responsive max width protects the row contract on 390px screens,
+    // while the wider default keeps ordinary names from clipping.
     expect(screen.getByRole('menu')).toHaveClass('max-w-[calc(100vw-1rem)]');
 
     const helpItem = within(identityRow as HTMLElement).getByRole('menuitem', {
       name: 'Help',
     });
-    expect(helpItem).toHaveClass('min-h-8');
+    expect(helpItem).toHaveClass('min-h-8', 'shrink-0');
     await user.keyboard('{ArrowDown}');
     expect(profileItem).toHaveFocus();
     await user.keyboard('{ArrowDown}');
@@ -741,6 +746,32 @@ describe('UserButton billing actions', () => {
       'noopener,noreferrer'
     );
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('uses spacing instead of visible rules to group account actions', async () => {
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: { isPro: true, plan: 'pro', hasStripeCustomer: true },
+      isLoading: false,
+      error: null,
+    } as any);
+    const user = userEvent.setup();
+
+    render(<UserButton showUserInfo />);
+    await user.click(screen.getByRole('button', { name: /Adele Adkins/i }));
+
+    const separators = screen.getAllByRole('separator');
+    expect(separators).toHaveLength(4);
+    for (const separator of separators) {
+      expect(separator).toHaveClass('h-2', 'border-0');
+    }
+
+    for (const menuItem of screen.getAllByRole('menuitem')) {
+      if (menuItem.getAttribute('aria-label')?.startsWith('Open profile for')) {
+        expect(menuItem).toHaveClass('min-h-12');
+      } else {
+        expect(menuItem).toHaveClass('min-h-8');
+      }
+    }
   });
 
   it('preserves trigger keyboard and escape-to-close menu semantics', async () => {

--- a/apps/web/tests/unit/user-button/UsageMenuItem.test.tsx
+++ b/apps/web/tests/unit/user-button/UsageMenuItem.test.tsx
@@ -41,6 +41,11 @@ describe('UsageMenuItem', () => {
       />
     );
 
+    const usageButton = screen.getByRole('button', {
+      name: /usage remaining/i,
+    });
+    expect(usageButton).toHaveClass('min-h-8');
+    expect(usageButton.querySelector('svg.lucide-gauge')).toBeInTheDocument();
     expect(screen.getByText('Usage remaining')).toBeInTheDocument();
     expect(screen.getByText('10%')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- widen the user menu so identity and action labels do not visibly truncate
- normalize row spacing, alignment, and usage presentation across the shared menu
- keep the existing menu behavior while removing inconsistent density between rows

## Verification
- exact branch rebased onto origin/main `92835d4966c57b1f37eb2955cffd281c257d0cd7` with zero conflicts
- focused user-menu suite: 25/25 passed on the semantic source state
- Biome and `git diff --check`: passed
- normal `git push` used; no hook or CI bypass

## Integration
- zero changed-file overlap with #15282, #15283, or #15284
