### PR TITLE
feat(merch): streamline editorial design selection

### DIFF
--- a/apps/web/app/api/chat/confirm-merch-action/route.ts
+++ b/apps/web/app/api/chat/confirm-merch-action/route.ts
@@ -8,17 +8,35 @@ import { db } from '@/lib/db';
 import { chatAuditLog } from '@/lib/db/schema/chat';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { NO_CACHE_HEADERS } from '@/lib/http/headers';
-import { publishMerchCard, updateMerchCardStatus } from '@/lib/merch/service';
+import {
+  publishMerchCard,
+  selectMerchDesign,
+  updateMerchCardStatus,
+} from '@/lib/merch/service';
 import { getClientIP } from '@/lib/rate-limit';
 import { logger } from '@/lib/utils/logger';
 
-const confirmMerchActionSchema = chatToolSchema({
+const confirmMerchStatusActionSchema = chatToolSchema({
   profileId: z.string().uuid(),
   merchCardId: z.string().uuid(),
   action: z.enum(['publish', 'archive', 'unpause', 'pause']),
 });
 
+const confirmMerchSelectSchema = chatToolSchema({
+  profileId: z.string().uuid(),
+  generationId: z.string().uuid(),
+  optionId: z.string().uuid(),
+  optionNumber: z.number().int().min(1).max(4),
+  action: z.literal('select'),
+});
+
+const confirmMerchActionSchema = z.union([
+  confirmMerchSelectSchema,
+  confirmMerchStatusActionSchema,
+]);
+
 const AUDIT_ACTION_BY_CONFIRM = {
+  select: 'select_merch',
   publish: 'publish_merch',
   archive: 'archive_merch',
   unpause: 'unpause_merch',
@@ -52,7 +70,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const { profileId, merchCardId, action } = parseResult.data;
+  const { profileId, action } = parseResult.data;
 
   try {
     const profile = await db.query.creatorProfiles.findFirst({
@@ -74,6 +92,42 @@ export async function POST(req: Request) {
       );
     }
 
+    if (action === 'select') {
+      const result = await selectMerchDesign({
+        generationId: parseResult.data.generationId,
+        clerkUserId: userId,
+        profileId,
+        optionId: parseResult.data.optionId,
+        optionNumber: parseResult.data.optionNumber,
+        publish: false,
+      });
+
+      if (!result.product) {
+        throw new Error('Selected merch product state unavailable');
+      }
+
+      const ipAddress = getClientIP(req);
+      const userAgent = req.headers.get('user-agent');
+
+      await db.insert(chatAuditLog).values({
+        userId,
+        creatorProfileId: profileId,
+        action: AUDIT_ACTION_BY_CONFIRM[action],
+        field: 'merch_selection',
+        previousValue: null,
+        newValue: JSON.stringify({
+          merchCardId: result.merchCardId,
+          selectedOptionId: result.selectedOptionId,
+          status: result.status,
+        }),
+        ipAddress: ipAddress ?? null,
+        userAgent: userAgent ?? null,
+      });
+
+      return NextResponse.json(result, { headers: NO_CACHE_HEADERS });
+    }
+
+    const { merchCardId } = parseResult.data;
     const card =
       action === 'publish'
         ? await publishMerchCard({
@@ -124,7 +178,19 @@ export async function POST(req: Request) {
     logger.error('[confirm-merch-action] Error applying merch action:', error);
     Sentry.captureException(error, {
       tags: { feature: 'ai-chat', operation: 'confirm-merch-action' },
-      extra: { userId, profileId, merchCardId, action },
+      extra: {
+        userId,
+        profileId,
+        action,
+        merchCardId:
+          'merchCardId' in parseResult.data
+            ? parseResult.data.merchCardId
+            : undefined,
+        generationId:
+          'generationId' in parseResult.data
+            ? parseResult.data.generationId
+            : undefined,
+      },
     });
     return NextResponse.json(
       { error: 'Failed to apply merch action' },

--- a/apps/web/app/api/chat/confirm-merch-action/route.ts
+++ b/apps/web/app/api/chat/confirm-merch-action/route.ts
@@ -9,6 +9,7 @@ import { chatAuditLog } from '@/lib/db/schema/chat';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { NO_CACHE_HEADERS } from '@/lib/http/headers';
 import {
+  getMerchProductOptions,
   publishMerchCard,
   selectMerchDesign,
   updateMerchCardStatus,
@@ -27,11 +28,21 @@ const confirmMerchSelectSchema = chatToolSchema({
   generationId: z.string().uuid(),
   optionId: z.string().uuid(),
   optionNumber: z.number().int().min(1).max(4),
+  catalogProductId: z.number().int().positive(),
   action: z.literal('select'),
+});
+
+const confirmMerchProductsSchema = chatToolSchema({
+  profileId: z.string().uuid(),
+  generationId: z.string().uuid(),
+  optionId: z.string().uuid(),
+  optionNumber: z.number().int().min(1).max(4),
+  action: z.literal('products'),
 });
 
 const confirmMerchActionSchema = z.union([
   confirmMerchSelectSchema,
+  confirmMerchProductsSchema,
   confirmMerchStatusActionSchema,
 ]);
 
@@ -92,6 +103,20 @@ export async function POST(req: Request) {
       );
     }
 
+    if (action === 'products') {
+      const products = await getMerchProductOptions({
+        generationId: parseResult.data.generationId,
+        clerkUserId: userId,
+        profileId,
+        optionId: parseResult.data.optionId,
+        optionNumber: parseResult.data.optionNumber,
+      });
+      return NextResponse.json(
+        { success: true, products },
+        { headers: NO_CACHE_HEADERS }
+      );
+    }
+
     if (action === 'select') {
       const result = await selectMerchDesign({
         generationId: parseResult.data.generationId,
@@ -99,6 +124,7 @@ export async function POST(req: Request) {
         profileId,
         optionId: parseResult.data.optionId,
         optionNumber: parseResult.data.optionNumber,
+        catalogProductId: parseResult.data.catalogProductId,
         publish: false,
       });
 
@@ -118,6 +144,7 @@ export async function POST(req: Request) {
         newValue: JSON.stringify({
           merchCardId: result.merchCardId,
           selectedOptionId: result.selectedOptionId,
+          catalogProductId: parseResult.data.catalogProductId,
           status: result.status,
         }),
         ipAddress: ipAddress ?? null,

--- a/apps/web/components/jovie/components/ChatMerchCard.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.test.tsx
@@ -154,8 +154,7 @@ describe('ChatMerchCard', () => {
       expect.objectContaining({
         type: 'jovie-chat-submit-prompt',
         detail: {
-          prompt:
-            'Select and publish merch option 1 from generation 00000000-0000-4000-8000-000000000100.',
+          prompt: 'Select and publish merch option 1.',
         },
       })
     );
@@ -212,7 +211,7 @@ describe('ChatMerchCard', () => {
         type: 'jovie-chat-submit-prompt',
         detail: {
           prompt:
-            'Create a hoodie version of merch card 00000000-0000-4000-8000-000000000201 with the same design.',
+            'Create a hoodie version of this merch item with the same design.',
         },
       })
     );

--- a/apps/web/components/jovie/components/ChatMerchCard.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.tsx
@@ -130,17 +130,13 @@ function submitMerchPrompt(prompt: string): void {
   );
 }
 
-function optionPrompt(
-  generationId: string,
-  option: MerchGenerationOption,
-  publish: boolean
-): string {
+function optionPrompt(option: MerchGenerationOption, publish: boolean): string {
   const action = publish ? 'Select and publish' : 'Select';
-  return `${action} merch option ${option.option_number} from generation ${generationId}.`;
+  return `${action} merch option ${option.option_number}.`;
 }
 
-function alternativeItemPrompt(merchCardId: string, itemType: string): string {
-  return `Create a ${itemType} version of merch card ${merchCardId} with the same design.`;
+function alternativeItemPrompt(itemType: string): string {
+  return `Create a ${itemType} version of this merch item with the same design.`;
 }
 
 function MerchOptionPricing({
@@ -207,9 +203,9 @@ export function ChatMerchOptionsCard({
 }) {
   const handleSelect = useCallback(
     (option: MerchGenerationOption, publish: boolean) => {
-      submitMerchPrompt(optionPrompt(result.generationId, option, publish));
+      submitMerchPrompt(optionPrompt(option, publish));
     },
-    [result.generationId]
+    []
   );
 
   return (
@@ -340,21 +336,15 @@ export function ChatMerchSelectionCard({
   const statusLabel =
     result.status.slice(0, 1).toUpperCase() + result.status.slice(1);
   const blockedReasons = result.publishBlockedReasons ?? [];
-  const handleAlternativeItem = useCallback(
-    (itemType: string) => {
-      submitMerchPrompt(alternativeItemPrompt(result.merchCardId, itemType));
-    },
-    [result.merchCardId]
-  );
+  const handleAlternativeItem = useCallback((itemType: string) => {
+    submitMerchPrompt(alternativeItemPrompt(itemType));
+  }, []);
 
   return (
-    <ChatGenerationArtifactSurface
-      title={result.title}
-      subtitle='Saved to Library'
-    >
+    <section className='max-w-2xl'>
       <div
         data-testid='chat-merch-selection-card'
-        className='flex items-start gap-3 rounded-lg border border-subtle bg-surface-0 p-3'
+        className='flex items-start gap-3 py-2'
       >
         <span className='grid h-9 w-9 shrink-0 place-items-center rounded-md bg-success-subtle text-success'>
           <CheckCircle2 className='h-4 w-4' strokeWidth={2.25} />
@@ -421,7 +411,7 @@ export function ChatMerchSelectionCard({
         </div>
       </div>
       {profileId && result.publishProposal?.success ? (
-        <div className='mt-3'>
+        <div className='mt-2'>
           <ChatMerchActionCard
             profileId={profileId}
             merchCardId={result.publishProposal.merchCardId}
@@ -433,6 +423,6 @@ export function ChatMerchSelectionCard({
           />
         </div>
       ) : null}
-    </ChatGenerationArtifactSurface>
+    </section>
   );
 }

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MerchDesignCarouselResult } from '@/lib/merch/types';
+import { ChatMerchDesignCarousel } from './ChatMerchDesignCarousel';
+
+const mutateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/queries', () => ({
+  useConfirmChatMerchActionMutation: () => ({ mutate: mutateMock }),
+}));
+
+vi.mock('@/components/shell/ThreadImageCard', () => ({
+  ThreadImageCard: ({ prompt, status }: { prompt: string; status: string }) => (
+    <div data-testid='concept-art'>{`${prompt}:${status}`}</div>
+  ),
+}));
+
+const result: MerchDesignCarouselResult = {
+  success: true,
+  generationId: '00000000-0000-4000-8000-000000000010',
+  designs: [
+    {
+      id: '00000000-0000-4000-8000-000000000011',
+      option_number: 1,
+      design_name: 'Signal Vintage',
+      concept: 'Distressed type and a one-color emblem.',
+      status: 'ready',
+      preview_url: 'https://blob.example.com/one.png',
+      slots: { artist_name: 'Signal' },
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000012',
+      option_number: 2,
+      design_name: 'Signal Mono',
+      concept: 'Editorial type with open space.',
+      status: 'ready',
+      preview_url: 'https://blob.example.com/two.png',
+      slots: { artist_name: 'Signal' },
+    },
+  ],
+};
+
+describe('ChatMerchDesignCarousel', () => {
+  beforeEach(() => {
+    mutateMock.mockReset();
+  });
+
+  it('moves one concept at a time with arrows, keyboard, and stable dots', async () => {
+    const user = userEvent.setup();
+    render(<ChatMerchDesignCarousel result={result} />);
+
+    expect(
+      screen.queryByTestId('chat-generation-artifact-surface')
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Signal Vintage')).toBeInTheDocument();
+    expect(screen.queryByText('Signal Mono')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next concept' }));
+    expect(screen.getByText('Signal Mono')).toBeInTheDocument();
+
+    const dots = screen.getAllByRole('button', { name: /Go to concept/ });
+    expect(dots).toHaveLength(2);
+    expect(dots[0]).toHaveClass('h-8', 'w-8');
+    fireEvent.keyDown(dots[1], { key: 'ArrowLeft' });
+    expect(screen.getByText('Signal Vintage')).toBeInTheDocument();
+    expect(dots[0]).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('selects in place and labels pending mockups truthfully', async () => {
+    const user = userEvent.setup();
+    mutateMock.mockImplementation(
+      (
+        input: { action: string },
+        callbacks: {
+          onSuccess: (response: Record<string, unknown>) => void;
+        }
+      ) => {
+        if (input.action === 'select') {
+          callbacks.onSuccess({
+            success: true,
+            merchCardId: '00000000-0000-4000-8000-000000000020',
+            status: 'draft',
+            selectedOptionId: '00000000-0000-4000-8000-000000000011',
+            title: 'Signal Vintage',
+            publicUrl: null,
+            product: {
+              productType: 't-shirt',
+              productName: 'Unisex Staple T-Shirt',
+              colorway: 'Black',
+              artworkUrl: 'https://blob.example.com/one.png',
+              mockupUrl: null,
+              mockupStatus: 'pending',
+              retailPrice: '$30.00',
+              artistProfit: '$10.00',
+              publishEligible: true,
+            },
+          });
+          return;
+        }
+        callbacks.onSuccess({
+          success: true,
+          merchCardId: '00000000-0000-4000-8000-000000000020',
+          status: 'live',
+          title: 'Signal Vintage',
+        });
+      }
+    );
+
+    render(
+      <ChatMerchDesignCarousel
+        result={result}
+        profileId='00000000-0000-4000-8000-000000000001'
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Use this design' }));
+
+    expect(mutateMock).toHaveBeenNthCalledWith(
+      1,
+      {
+        profileId: '00000000-0000-4000-8000-000000000001',
+        generationId: '00000000-0000-4000-8000-000000000010',
+        optionId: '00000000-0000-4000-8000-000000000011',
+        optionNumber: 1,
+        action: 'select',
+      },
+      expect.any(Object)
+    );
+    expect(
+      screen.getByText('Product mockup is still rendering. Artwork shown.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('$30.00 · $10.00 artist profit')
+    ).toBeInTheDocument();
+    expect(screen.queryByAltText(/product mockup/i)).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Publish to profile' })
+    );
+    expect(mutateMock).toHaveBeenNthCalledWith(
+      2,
+      {
+        profileId: '00000000-0000-4000-8000-000000000001',
+        merchCardId: '00000000-0000-4000-8000-000000000020',
+        action: 'publish',
+      },
+      expect.any(Object)
+    );
+    expect(
+      screen.getByRole('button', { name: 'Live on profile' })
+    ).toBeDisabled();
+  });
+
+  it('falls back to a concise prompt without exposing generation IDs', async () => {
+    const dispatch = vi.spyOn(globalThis, 'dispatchEvent');
+    const user = userEvent.setup();
+    render(<ChatMerchDesignCarousel result={result} />);
+
+    await user.click(screen.getByRole('button', { name: 'Use this design' }));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'jovie-chat-submit-prompt',
+        detail: { prompt: 'Use concept 1.' },
+      })
+    );
+    expect(JSON.stringify(dispatch.mock.calls)).not.toContain(
+      result.generationId
+    );
+    dispatch.mockRestore();
+  });
+});

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
@@ -76,6 +76,26 @@ describe('ChatMerchDesignCarousel', () => {
           onSuccess: (response: Record<string, unknown>) => void;
         }
       ) => {
+        if (input.action === 'products') {
+          callbacks.onSuccess({
+            success: true,
+            products: [
+              {
+                catalogProductId: 71,
+                productName: 'Unisex Staple T-Shirt',
+                productType: 't-shirt',
+                colorway: 'Black',
+              },
+              {
+                catalogProductId: 91,
+                productName: 'Unisex Heavy Hoodie',
+                productType: 'hoodie',
+                colorway: 'Black',
+              },
+            ],
+          });
+          return;
+        }
         if (input.action === 'select') {
           callbacks.onSuccess({
             success: true,
@@ -123,6 +143,24 @@ describe('ChatMerchDesignCarousel', () => {
         generationId: '00000000-0000-4000-8000-000000000010',
         optionId: '00000000-0000-4000-8000-000000000011',
         optionNumber: 1,
+        action: 'products',
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByText('Choose a product')).toBeInTheDocument();
+    expect(screen.queryByText(/artist profit/)).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /Unisex Staple T-Shirt/ })
+    );
+    expect(mutateMock).toHaveBeenNthCalledWith(
+      2,
+      {
+        profileId: '00000000-0000-4000-8000-000000000001',
+        generationId: '00000000-0000-4000-8000-000000000010',
+        optionId: '00000000-0000-4000-8000-000000000011',
+        optionNumber: 1,
+        catalogProductId: 71,
         action: 'select',
       },
       expect.any(Object)
@@ -139,7 +177,7 @@ describe('ChatMerchDesignCarousel', () => {
       screen.getByRole('button', { name: 'Publish to profile' })
     );
     expect(mutateMock).toHaveBeenNthCalledWith(
-      2,
+      3,
       {
         profileId: '00000000-0000-4000-8000-000000000001',
         merchCardId: '00000000-0000-4000-8000-000000000020',

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -190,6 +190,10 @@ export function ChatMerchDesignCarousel({
       {
         onSuccess: response => {
           setPendingAction(null);
+          if (!('status' in response)) {
+            setErrorMessage('Unable to publish this item. Try again.');
+            return;
+          }
           setSelected(previous =>
             previous
               ? {
@@ -233,7 +237,7 @@ export function ChatMerchDesignCarousel({
           <div className='relative aspect-square bg-surface-2'>
             <Image
               src={product.mockupUrl}
-              alt={`${selected.title} product mockup`}
+              alt={`${current.design_name} product mockup`}
               fill
               sizes='(max-width: 768px) 100vw, 640px'
               className='object-cover'

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -10,6 +10,7 @@ import type {
   MerchDesignPreview,
 } from '@/lib/merch/types';
 import {
+  type ConfirmChatMerchProductsResponse,
   type ConfirmChatMerchSelectResponse,
   useConfirmChatMerchActionMutation,
 } from '@/lib/queries';
@@ -49,6 +50,31 @@ function isSelectionResponse(
   );
 }
 
+function isProductsResponse(
+  value: unknown
+): value is ConfirmChatMerchProductsResponse {
+  const products =
+    typeof value === 'object' && value !== null
+      ? (value as { products?: unknown }).products
+      : null;
+  return (
+    Array.isArray(products) &&
+    products.every(
+      product =>
+        typeof product === 'object' &&
+        product !== null &&
+        typeof (product as { catalogProductId?: unknown }).catalogProductId ===
+          'number' &&
+        (product as { catalogProductId: number }).catalogProductId > 0 &&
+        typeof (product as { productName?: unknown }).productName ===
+          'string' &&
+        typeof (product as { productType?: unknown }).productType ===
+          'string' &&
+        typeof (product as { colorway?: unknown }).colorway === 'string'
+    )
+  );
+}
+
 export function ChatMerchDesignCarousel({
   result,
   profileId,
@@ -60,8 +86,14 @@ export function ChatMerchDesignCarousel({
   const [active, setActive] = useState(0);
   const [selected, setSelected] =
     useState<ConfirmChatMerchSelectResponse | null>(null);
+  const [productOptions, setProductOptions] = useState<
+    ConfirmChatMerchProductsResponse['products']
+  >([]);
+  const [pendingCatalogProductId, setPendingCatalogProductId] = useState<
+    number | null
+  >(null);
   const [pendingAction, setPendingAction] = useState<
-    'select' | 'publish' | null
+    'products' | 'select' | 'publish' | null
   >(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const confirmAction = useConfirmChatMerchActionMutation();
@@ -77,34 +109,68 @@ export function ChatMerchDesignCarousel({
 
   if (count === 0 || !current) return null;
 
-  const handleSelect = () => {
+  const handleLoadProducts = () => {
     setErrorMessage(null);
     if (!profileId) {
       submitMerchPrompt(usePrompt(current));
       return;
     }
 
-    setPendingAction('select');
+    setPendingAction('products');
     confirmAction.mutate(
       {
         profileId,
         generationId: result.generationId,
         optionId: current.id,
         optionNumber: current.option_number,
+        action: 'products',
+      },
+      {
+        onSuccess: response => {
+          setPendingAction(null);
+          if (isProductsResponse(response) && response.products.length > 0) {
+            setProductOptions(response.products);
+            return;
+          }
+          setErrorMessage('No products are available right now.');
+        },
+        onError: () => {
+          setPendingAction(null);
+          setErrorMessage('Unable to load products. Try again.');
+        },
+      }
+    );
+  };
+
+  const handleSelectProduct = (catalogProductId: number) => {
+    if (!profileId) return;
+    setErrorMessage(null);
+    setPendingAction('select');
+    setPendingCatalogProductId(catalogProductId);
+    confirmAction.mutate(
+      {
+        profileId,
+        generationId: result.generationId,
+        optionId: current.id,
+        optionNumber: current.option_number,
+        catalogProductId,
         action: 'select',
       },
       {
         onSuccess: response => {
           setPendingAction(null);
+          setPendingCatalogProductId(null);
           if (isSelectionResponse(response)) {
             setSelected(response);
+            setProductOptions([]);
             return;
           }
           setErrorMessage('Product details are not ready yet.');
         },
         onError: () => {
           setPendingAction(null);
-          setErrorMessage('Unable to use this design. Try again.');
+          setPendingCatalogProductId(null);
+          setErrorMessage('Unable to create this product. Try again.');
         },
       }
     );
@@ -142,7 +208,7 @@ export function ChatMerchDesignCarousel({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-    if (selected || count < 2) return;
+    if (selected || productOptions.length > 0 || count < 2) return;
     if (event.key === 'ArrowLeft') {
       event.preventDefault();
       go(-1);
@@ -184,7 +250,7 @@ export function ChatMerchDesignCarousel({
           <ThreadImageCard status='generating' prompt={current.design_name} />
         )}
 
-        {!selected && count > 1 ? (
+        {!selected && productOptions.length === 0 && count > 1 ? (
           <>
             <CarouselArrow side='left' onClick={() => go(-1)} />
             <CarouselArrow side='right' onClick={() => go(1)} />
@@ -256,25 +322,60 @@ export function ChatMerchDesignCarousel({
               ? 'Live on profile'
               : 'Publish to profile'}
           </Button>
-        ) : (
+        ) : productOptions.length === 0 ? (
           <Button
             type='button'
             size='sm'
             className='shrink-0 whitespace-nowrap'
-            onClick={handleSelect}
+            onClick={handleLoadProducts}
             disabled={current.status !== 'ready' || pendingAction !== null}
           >
-            {pendingAction === 'select' ? (
+            {pendingAction === 'products' ? (
               <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden />
             ) : null}
-            {pendingAction === 'select'
-              ? 'Preparing product'
+            {pendingAction === 'products'
+              ? 'Loading products'
               : 'Use this design'}
           </Button>
-        )}
+        ) : null}
       </div>
 
-      {!selected && count > 1 ? (
+      {!selected && productOptions.length > 0 ? (
+        <fieldset className='m-0 border-0 p-0 pb-2'>
+          <legend className='mb-2 text-2xs font-medium uppercase tracking-wide text-tertiary-token'>
+            Choose a product
+          </legend>
+          <div className='grid grid-cols-1 gap-2 sm:grid-cols-3'>
+            {productOptions.map(option => (
+              <Button
+                key={option.catalogProductId}
+                type='button'
+                variant='secondary'
+                className='h-auto min-w-0 justify-start px-3 py-2 text-left'
+                onClick={() => handleSelectProduct(option.catalogProductId)}
+                disabled={pendingAction !== null}
+              >
+                {pendingCatalogProductId === option.catalogProductId ? (
+                  <Loader2
+                    className='h-3.5 w-3.5 shrink-0 animate-spin'
+                    aria-hidden
+                  />
+                ) : null}
+                <span className='min-w-0'>
+                  <span className='block truncate text-xs font-medium'>
+                    {option.productName}
+                  </span>
+                  <span className='block truncate text-2xs text-secondary-token'>
+                    {option.colorway}
+                  </span>
+                </span>
+              </Button>
+            ))}
+          </div>
+        </fieldset>
+      ) : null}
+
+      {!selected && productOptions.length === 0 && count > 1 ? (
         <nav className='flex items-center justify-center' aria-label='Concepts'>
           {designs.map((design, index) => (
             <Button

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
+import Image from 'next/image';
+import { type KeyboardEvent, useCallback, useState } from 'react';
 import { ThreadImageCard } from '@/components/shell/ThreadImageCard';
 import type {
   MerchDesignCarouselResult,
   MerchDesignPreview,
 } from '@/lib/merch/types';
+import {
+  type ConfirmChatMerchSelectResponse,
+  useConfirmChatMerchActionMutation,
+} from '@/lib/queries';
 import { cn } from '@/lib/utils';
-import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
 
 export function isChatMerchDesignCarouselResult(
   value: unknown
@@ -29,17 +33,38 @@ function submitMerchPrompt(prompt: string): void {
   );
 }
 
-function usePrompt(generationId: string, design: MerchDesignPreview): string {
-  return `Use design ${design.option_number} from generation ${generationId}.`;
+function usePrompt(design: MerchDesignPreview): string {
+  return `Use concept ${design.option_number}.`;
+}
+
+function isSelectionResponse(
+  value: unknown
+): value is ConfirmChatMerchSelectResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { selectedOptionId?: unknown }).selectedOptionId ===
+      'string' &&
+    typeof (value as { product?: unknown }).product === 'object'
+  );
 }
 
 export function ChatMerchDesignCarousel({
   result,
+  profileId,
 }: {
   readonly result: MerchDesignCarouselResult;
+  readonly profileId?: string;
 }) {
   const designs = result.designs;
   const [active, setActive] = useState(0);
+  const [selected, setSelected] =
+    useState<ConfirmChatMerchSelectResponse | null>(null);
+  const [pendingAction, setPendingAction] = useState<
+    'select' | 'publish' | null
+  >(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const confirmAction = useConfirmChatMerchActionMutation();
   const count = designs.length;
   const current = designs[Math.min(active, Math.max(0, count - 1))];
 
@@ -52,85 +77,229 @@ export function ChatMerchDesignCarousel({
 
   if (count === 0 || !current) return null;
 
-  const useThis = () =>
-    submitMerchPrompt(usePrompt(result.generationId, current));
+  const handleSelect = () => {
+    setErrorMessage(null);
+    if (!profileId) {
+      submitMerchPrompt(usePrompt(current));
+      return;
+    }
+
+    setPendingAction('select');
+    confirmAction.mutate(
+      {
+        profileId,
+        generationId: result.generationId,
+        optionId: current.id,
+        optionNumber: current.option_number,
+        action: 'select',
+      },
+      {
+        onSuccess: response => {
+          setPendingAction(null);
+          if (isSelectionResponse(response)) {
+            setSelected(response);
+            return;
+          }
+          setErrorMessage('Product details are not ready yet.');
+        },
+        onError: () => {
+          setPendingAction(null);
+          setErrorMessage('Unable to use this design. Try again.');
+        },
+      }
+    );
+  };
+
+  const handlePublish = () => {
+    if (!profileId || !selected) return;
+
+    setErrorMessage(null);
+    setPendingAction('publish');
+    confirmAction.mutate(
+      {
+        profileId,
+        merchCardId: selected.merchCardId,
+        action: 'publish',
+      },
+      {
+        onSuccess: response => {
+          setPendingAction(null);
+          setSelected(previous =>
+            previous
+              ? {
+                  ...previous,
+                  status: response.status,
+                }
+              : previous
+          );
+        },
+        onError: () => {
+          setPendingAction(null);
+          setErrorMessage('Unable to publish this item. Try again.');
+        },
+      }
+    );
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (selected || count < 2) return;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      go(-1);
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      go(1);
+    }
+  };
+
+  const product = selected?.product;
+  const showProductMockup =
+    product?.mockupStatus === 'ready' && Boolean(product.mockupUrl);
 
   return (
-    <ChatGenerationArtifactSurface
-      title='Merch Designs'
-      subtitle={result.nextStep ?? 'Pick one and I’ll put it on products'}
+    <section
+      aria-label='Merch design concepts'
+      aria-roledescription='carousel'
       className='max-w-2xl'
     >
-      <div className='flex flex-col gap-3'>
-        <div className='relative'>
-          {/* Fixed-aspect media so generating -> ready never shifts layout. */}
-          <div className='overflow-hidden rounded-xl'>
-            {current.status === 'ready' && current.preview_url ? (
-              <ThreadImageCard
-                status='ready'
-                prompt={current.design_name}
-                previewUrl={current.preview_url}
-              />
-            ) : (
-              <ThreadImageCard
-                status='generating'
-                prompt={current.design_name}
-              />
-            )}
+      <div className='relative overflow-hidden rounded-xl'>
+        {showProductMockup && product?.mockupUrl ? (
+          <div className='relative aspect-square bg-surface-2'>
+            <Image
+              src={product.mockupUrl}
+              alt={`${selected.title} product mockup`}
+              fill
+              sizes='(max-width: 768px) 100vw, 640px'
+              className='object-cover'
+              unoptimized
+            />
           </div>
+        ) : current.status === 'ready' && current.preview_url ? (
+          <ThreadImageCard
+            status='ready'
+            prompt={current.design_name}
+            previewUrl={current.preview_url}
+          />
+        ) : (
+          <ThreadImageCard status='generating' prompt={current.design_name} />
+        )}
 
-          {count > 1 ? (
+        {!selected && count > 1 ? (
+          <>
+            <CarouselArrow side='left' onClick={() => go(-1)} />
+            <CarouselArrow side='right' onClick={() => go(1)} />
+          </>
+        ) : null}
+      </div>
+
+      <div className='flex min-h-20 items-start justify-between gap-4 pt-3'>
+        <div className='min-w-0 flex-1'>
+          <p className='text-3xs font-medium uppercase tracking-wide text-tertiary-token'>
+            {selected
+              ? product?.mockupStatus === 'ready'
+                ? 'Product mockup'
+                : 'Artwork preview'
+              : `Concept ${active + 1} of ${count}`}
+          </p>
+          <h3 className='mt-0.5 truncate text-app font-semibold text-primary-token'>
+            {selected?.title ?? current.design_name}
+          </h3>
+          {selected && product ? (
             <>
-              <CarouselArrow side='left' onClick={() => go(-1)} />
-              <CarouselArrow side='right' onClick={() => go(1)} />
+              <p className='mt-0.5 truncate text-xs text-secondary-token'>
+                {product.productName} · {product.colorway}
+              </p>
+              <p className='mt-1 text-2xs text-tertiary-token'>
+                {product.retailPrice} · {product.artistProfit} artist profit
+              </p>
+              {product.mockupStatus === 'pending' ? (
+                <p className='mt-1 text-2xs text-tertiary-token'>
+                  Product mockup is still rendering. Artwork shown.
+                </p>
+              ) : null}
+              {selected.publishBlockedReasons?.length ? (
+                <p className='mt-1 line-clamp-2 text-2xs text-tertiary-token'>
+                  {selected.publishBlockedReasons.join(' ')}
+                </p>
+              ) : null}
             </>
+          ) : current.concept ? (
+            <p className='mt-0.5 line-clamp-2 text-xs text-secondary-token'>
+              {current.concept}
+            </p>
+          ) : null}
+          {errorMessage ? (
+            <output className='mt-1 block text-2xs text-error'>
+              {errorMessage}
+            </output>
           ) : null}
         </div>
 
-        <div className='flex min-h-9 items-start justify-between gap-3'>
-          <div className='min-w-0'>
-            <h3 className='truncate text-app font-semibold text-primary-token'>
-              {current.design_name}
-            </h3>
-            {current.concept ? (
-              <p className='mt-0.5 line-clamp-1 text-2xs text-tertiary-token'>
-                {current.concept}
-              </p>
-            ) : null}
-          </div>
+        {selected && product ? (
           <Button
             type='button'
             size='sm'
-            onClick={useThis}
-            disabled={current.status !== 'ready'}
+            className='shrink-0 whitespace-nowrap'
+            onClick={handlePublish}
+            disabled={
+              selected.status === 'live' ||
+              !product.publishEligible ||
+              pendingAction !== null
+            }
           >
-            Use This One
+            {pendingAction === 'publish' ? (
+              <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden />
+            ) : selected.status === 'live' ? (
+              <Check className='h-3.5 w-3.5' aria-hidden />
+            ) : null}
+            {selected.status === 'live'
+              ? 'Live on profile'
+              : 'Publish to profile'}
           </Button>
-        </div>
+        ) : (
+          <Button
+            type='button'
+            size='sm'
+            className='shrink-0 whitespace-nowrap'
+            onClick={handleSelect}
+            disabled={current.status !== 'ready' || pendingAction !== null}
+          >
+            {pendingAction === 'select' ? (
+              <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden />
+            ) : null}
+            {pendingAction === 'select'
+              ? 'Preparing product'
+              : 'Use this design'}
+          </Button>
+        )}
+      </div>
 
-        {count > 1 ? (
-          <div className='flex items-center justify-center gap-1.5'>
-            {designs.map((design, index) => (
-              <Button
-                key={design.id}
-                type='button'
-                variant='ghost'
-                aria-label={`Go to design ${index + 1}`}
-                aria-current={index === active}
-                onClick={() => setActive(index)}
+      {!selected && count > 1 ? (
+        <nav className='flex items-center justify-center' aria-label='Concepts'>
+          {designs.map((design, index) => (
+            <Button
+              key={design.id}
+              type='button'
+              variant='ghost'
+              aria-label={`Go to concept ${index + 1}`}
+              aria-pressed={index === active}
+              onClick={() => setActive(index)}
+              onKeyDown={handleKeyDown}
+              className='h-8 w-8 min-w-0 p-0 before:content-none'
+            >
+              <span
                 className={cn(
-                  'h-1.5 min-w-0 p-0 before:content-none',
-                  'rounded-full transition-[width,background-color] duration-subtle',
+                  'h-1.5 rounded-full transition-[width,background-color] duration-subtle',
                   index === active
-                    ? 'w-5 bg-primary-token hover:bg-primary-token'
-                    : 'w-1.5 bg-surface-2 hover:bg-surface-2'
+                    ? 'w-5 bg-primary-token'
+                    : 'w-1.5 bg-surface-2'
                 )}
               />
-            ))}
-          </div>
-        ) : null}
-      </div>
-    </ChatGenerationArtifactSurface>
+            </Button>
+          ))}
+        </nav>
+      ) : null}
+    </section>
   );
 }
 
@@ -147,7 +316,7 @@ function CarouselArrow({
       type='button'
       variant='frosted'
       size='icon'
-      aria-label={side === 'left' ? 'Previous design' : 'Next design'}
+      aria-label={side === 'left' ? 'Previous concept' : 'Next concept'}
       onClick={onClick}
       className={cn(
         'absolute top-1/2 h-8 w-8 -translate-y-1/2',

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -546,9 +546,14 @@ function renderReleasePitchArtifact(event: PersistedToolEvent): ReactNode {
   );
 }
 
-function renderMerchGenerationArtifact(event: PersistedToolEvent): ReactNode {
+function renderMerchGenerationArtifact(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
   if (isChatMerchDesignCarouselResult(event.output)) {
-    return <ChatMerchDesignCarousel result={event.output} />;
+    return (
+      <ChatMerchDesignCarousel result={event.output} profileId={profileId} />
+    );
   }
   if (!isChatMerchGenerationResult(event.output)) {
     return null;
@@ -662,8 +667,10 @@ const ARTIFACT_RENDERERS: Partial<Record<string, ArtifactRenderer>> = {
   generateAlbumArt: (event, profileId) =>
     renderAlbumArtArtifact(event, profileId),
   generateReleasePitch: event => renderReleasePitchArtifact(event),
-  createMerch: event => renderMerchGenerationArtifact(event),
-  previewMerchOptions: event => renderMerchGenerationArtifact(event),
+  createMerch: (event, profileId) =>
+    renderMerchGenerationArtifact(event, profileId),
+  previewMerchOptions: (event, profileId) =>
+    renderMerchGenerationArtifact(event, profileId),
   selectMerchDesign: (event, profileId) =>
     renderMerchSelectionArtifact(event, profileId),
   createMerchAlternativeItem: (event, profileId) =>

--- a/apps/web/lib/merch/catalog.test.ts
+++ b/apps/web/lib/merch/catalog.test.ts
@@ -11,7 +11,11 @@ const printful = vi.hoisted(() => ({
 
 vi.mock('@/lib/printful/client', () => printful);
 
-import { resolveMerchCatalogSelection } from './catalog';
+import {
+  listMerchCatalogProductOptions,
+  resolveLiveMerchCatalogProduct,
+  resolveMerchCatalogSelection,
+} from './catalog';
 
 describe('resolveMerchCatalogSelection', () => {
   beforeEach(() => {
@@ -222,5 +226,136 @@ describe('resolveMerchCatalogSelection', () => {
     expect(selection.providerWarnings).toEqual([
       'Printful catalog pricing unavailable: catalog timeout',
     ]);
+  });
+
+  it('lists only live products with confirmed variants and pricing', async () => {
+    printful.isPrintfulConfigured.mockReturnValue(true);
+    printful.listCatalogProducts.mockResolvedValue([
+      {
+        id: 71,
+        name: 'Unisex Staple T-Shirt',
+        type: 't-shirt',
+        is_discontinued: false,
+      },
+      {
+        id: 91,
+        name: 'Unisex Heavy Hoodie',
+        type: 'hoodie',
+        is_discontinued: false,
+      },
+      {
+        id: 222,
+        name: 'Structured Cap',
+        type: 'hat',
+        is_discontinued: false,
+      },
+      {
+        id: 999,
+        name: 'Discontinued Tee',
+        type: 't-shirt',
+        is_discontinued: true,
+      },
+    ]);
+    printful.listCatalogVariants.mockImplementation(
+      async (catalogProductId: number) => [
+        {
+          id: catalogProductId * 10,
+          catalog_product_id: catalogProductId,
+          name: 'M / Black',
+          size: 'M',
+          color: 'Black',
+        },
+      ]
+    );
+    printful.getCatalogVariantPrices.mockResolvedValue({
+      currency: 'USD',
+      product: {
+        id: 71,
+        placements: [{ id: 'front', price: '15.00' }],
+      },
+      variant: {
+        id: 710,
+        techniques: [{ technique_key: 'dtg', price: '2.00' }],
+      },
+    });
+    printful.getCatalogProductAvailability.mockImplementation(
+      async (catalogProductId: number) => [
+        {
+          catalog_variant_id: catalogProductId * 10,
+          techniques: [
+            {
+              technique: 'dtg',
+              selling_regions: [
+                { name: 'north_america', availability: 'available' },
+              ],
+            },
+          ],
+        },
+      ]
+    );
+
+    await expect(listMerchCatalogProductOptions()).resolves.toEqual([
+      {
+        catalogProductId: 71,
+        productName: 'Unisex Staple T-Shirt',
+        productType: 't-shirt',
+        colorway: 'Black',
+      },
+      {
+        catalogProductId: 91,
+        productName: 'Unisex Heavy Hoodie',
+        productType: 'hoodie',
+        colorway: 'Black',
+      },
+      {
+        catalogProductId: 222,
+        productName: 'Structured Cap',
+        productType: 'hat',
+        colorway: 'Black',
+      },
+    ]);
+  });
+
+  it('never exposes draft defaults as selectable products', async () => {
+    printful.isPrintfulConfigured.mockReturnValue(false);
+
+    await expect(listMerchCatalogProductOptions()).resolves.toEqual([]);
+    expect(printful.listCatalogProducts).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicitly selected product without confirmed availability', async () => {
+    printful.isPrintfulConfigured.mockReturnValue(true);
+    printful.getCatalogProduct.mockResolvedValue({
+      id: 333,
+      name: 'Heavyweight Tank',
+      type: 'tank',
+      is_discontinued: false,
+    });
+    printful.listCatalogVariants.mockResolvedValue([
+      {
+        id: 3301,
+        catalog_product_id: 333,
+        name: 'M / Black',
+        size: 'M',
+        color: 'Black',
+      },
+    ]);
+    printful.getCatalogProductAvailability.mockResolvedValue([
+      {
+        catalog_variant_id: 3301,
+        techniques: [
+          {
+            technique: 'embroidery',
+            selling_regions: [
+              { name: 'north_america', availability: 'available' },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    await expect(resolveLiveMerchCatalogProduct(333)).rejects.toThrow(
+      'no confirmed North America variants'
+    );
   });
 });

--- a/apps/web/lib/merch/catalog.ts
+++ b/apps/web/lib/merch/catalog.ts
@@ -50,6 +50,13 @@ export interface MerchCatalogSelection {
   readonly providerWarnings: string[];
 }
 
+export interface MerchCatalogProductOption {
+  readonly catalogProductId: number;
+  readonly productName: string;
+  readonly productType: string;
+  readonly colorway: string;
+}
+
 function defaultSelection(
   providerWarnings: string[] = []
 ): MerchCatalogSelection {
@@ -231,6 +238,184 @@ function selectVariants(
   return source.slice(0, 4);
 }
 
+function isVariantAvailable(
+  availability: Awaited<ReturnType<typeof getCatalogProductAvailability>>,
+  variantId: number
+): boolean {
+  const row = availability.find(item => item.catalog_variant_id === variantId);
+  return (
+    row?.techniques?.some(
+      technique =>
+        technique.technique === MERCH_DEFAULT_PRINTFUL_PRODUCT.technique &&
+        technique.selling_regions?.some(
+          region =>
+            region.name === 'north_america' &&
+            region.availability.toLowerCase() === 'available'
+        )
+    ) === true
+  );
+}
+
+async function buildCatalogSelection(
+  product: PrintfulCatalogProduct,
+  options: { readonly requireConfirmedAvailability?: boolean } = {}
+): Promise<MerchCatalogSelection> {
+  const selectedVariants = selectVariants(
+    await listCatalogVariants(product.id)
+  );
+  if (selectedVariants.length === 0) {
+    throw new Error('Printful catalog product has no eligible variants');
+  }
+
+  const availability = await getCatalogProductAvailability(
+    product.id,
+    'north_america'
+  );
+  const variants = options.requireConfirmedAvailability
+    ? selectedVariants.filter(variant =>
+        isVariantAvailable(availability, variant.id)
+      )
+    : selectedVariants;
+  if (variants.length === 0) {
+    throw new Error(
+      'Printful catalog product has no confirmed North America variants'
+    );
+  }
+
+  const variantMap = variants.reduce<MerchVariantMap>((map, variant, index) => {
+    map[variantKey(variant, index)] = variant.id;
+    return map;
+  }, {});
+  const prices = await getCatalogVariantPrices(variants[0].id, {
+    currency: 'USD',
+    sellingRegionName: 'north_america',
+  });
+  const productCostCents = parsePrintfulPriceCents(
+    prices,
+    MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
+    MERCH_DEFAULT_PRINTFUL_PRODUCT.technique
+  );
+  if (!productCostCents) {
+    throw new Error('Printful did not return a usable product cost');
+  }
+
+  const availabilityWarnings =
+    availability.length > 0
+      ? variants.flatMap(variant =>
+          isVariantAvailable(availability, variant.id)
+            ? []
+            : [`Printful variant ${variant.id} is not available.`]
+        )
+      : [];
+  const printfulCostUpdatedAt = new Date().toISOString();
+
+  return {
+    catalogProductId: product.id,
+    productName: product.name,
+    productType: product.type ?? product.model ?? 'Printful product',
+    colorway: variants[0].color ?? MERCH_DEFAULT_PRINTFUL_PRODUCT.colorway,
+    variantMap,
+    catalogVariantIds: variants.map(variant => variant.id),
+    sizes: variants.map(variant => variant.size ?? variant.name),
+    placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
+    technique: MERCH_DEFAULT_PRINTFUL_PRODUCT.technique,
+    availabilityRegion: MERCH_DEFAULT_PRINTFUL_PRODUCT.availabilityRegion,
+    shippingProfile: MERCH_DEFAULT_PRINTFUL_PRODUCT.shippingProfile,
+    pricing: buildMerchPricingSnapshot({
+      retailPriceCents: calculateRecommendedSalePriceCents(
+        productCostCents,
+        MERCH_DEFAULT_MARGIN_PRESET,
+        {
+          printfulCostSource: 'printful',
+          printfulCostUpdatedAt,
+        }
+      ),
+      printfulProductCostCents: productCostCents,
+      printfulCostSource: 'printful',
+      printfulCostUpdatedAt,
+    }),
+    providerWarnings: availabilityWarnings,
+  };
+}
+
+function catalogProductRank(product: PrintfulCatalogProduct): number {
+  const value = normalize(
+    [product.type, product.name].filter(Boolean).join(' ')
+  );
+  if (value.includes('t shirt') || value.includes('tee')) return 0;
+  if (value.includes('hoodie') || value.includes('sweatshirt')) return 1;
+  if (value.includes('hat') || value.includes('cap')) return 2;
+  return 3;
+}
+
+/**
+ * Return only live, priced, North America-available Printful products.
+ * No draft/default catalog records are exposed as selectable options.
+ */
+export async function listMerchCatalogProductOptions(
+  limit = 3
+): Promise<MerchCatalogProductOption[]> {
+  if (!isPrintfulConfigured() || limit <= 0) return [];
+
+  try {
+    const products = (await listCatalogProductsForSelection())
+      .filter(product => !product.is_discontinued)
+      .sort(
+        (left, right) => catalogProductRank(left) - catalogProductRank(right)
+      );
+    const seenTypes = new Set<string>();
+    const candidates = products.filter(product => {
+      const typeKey = normalize(product.type ?? product.model ?? product.name);
+      if (seenTypes.has(typeKey)) return false;
+      seenTypes.add(typeKey);
+      return true;
+    });
+    const verified = await Promise.all(
+      candidates.slice(0, Math.max(limit * 2, limit)).map(async product => {
+        try {
+          return await buildCatalogSelection(product, {
+            requireConfirmedAvailability: true,
+          });
+        } catch {
+          // A product is not offered until live variants and pricing verify.
+          return null;
+        }
+      })
+    );
+
+    return verified
+      .filter((selection): selection is MerchCatalogSelection =>
+        Boolean(selection)
+      )
+      .slice(0, limit)
+      .map(selection => ({
+        catalogProductId: selection.catalogProductId,
+        productName: selection.productName,
+        productType: selection.productType,
+        colorway: selection.colorway,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+export async function resolveLiveMerchCatalogProduct(
+  catalogProductId: number
+): Promise<MerchCatalogSelection> {
+  if (!isPrintfulConfigured()) {
+    throw new Error('Printful catalog is not configured');
+  }
+  const product = await getCatalogProduct(catalogProductId);
+  if (product.is_discontinued) {
+    throw new Error(
+      `Printful catalog product ${catalogProductId} is discontinued`
+    );
+  }
+  return buildCatalogSelection(product, {
+    requireConfirmedAvailability: true,
+  });
+}
+
 export async function resolveMerchCatalogSelection(
   itemRequest: string | null | undefined
 ): Promise<MerchCatalogSelection> {
@@ -258,81 +443,7 @@ export async function resolveMerchCatalogSelection(
       throw new Error('Printful catalog did not return an eligible product');
     }
 
-    const variants = selectVariants(await listCatalogVariants(product.id));
-    if (variants.length === 0) {
-      throw new Error('Printful catalog product has no eligible variants');
-    }
-
-    const variantMap = variants.reduce<MerchVariantMap>(
-      (map, variant, index) => {
-        map[variantKey(variant, index)] = variant.id;
-        return map;
-      },
-      {}
-    );
-    const prices = await getCatalogVariantPrices(variants[0].id, {
-      currency: 'USD',
-      sellingRegionName: 'north_america',
-    });
-    const productCostCents = parsePrintfulPriceCents(
-      prices,
-      MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
-      MERCH_DEFAULT_PRINTFUL_PRODUCT.technique
-    );
-    if (!productCostCents) {
-      throw new Error('Printful did not return a usable product cost');
-    }
-
-    const availability = await getCatalogProductAvailability(
-      product.id,
-      'north_america'
-    );
-    const availabilityWarnings =
-      availability.length > 0
-        ? variants.flatMap(variant => {
-            const row = availability.find(
-              item => item.catalog_variant_id === variant.id
-            );
-            const available = row?.techniques?.some(technique =>
-              technique.selling_regions?.some(
-                region =>
-                  region.name === 'north_america' &&
-                  region.availability.toLowerCase() === 'available'
-              )
-            );
-            return available === false
-              ? [`Printful variant ${variant.id} is not available.`]
-              : [];
-          })
-        : [];
-
-    return {
-      catalogProductId: product.id,
-      productName: product.name,
-      productType: product.type ?? product.model ?? 'Printful product',
-      colorway: variants[0].color ?? MERCH_DEFAULT_PRINTFUL_PRODUCT.colorway,
-      variantMap,
-      catalogVariantIds: variants.map(variant => variant.id),
-      sizes: variants.map(variant => variant.size ?? variant.name),
-      placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
-      technique: MERCH_DEFAULT_PRINTFUL_PRODUCT.technique,
-      availabilityRegion: MERCH_DEFAULT_PRINTFUL_PRODUCT.availabilityRegion,
-      shippingProfile: MERCH_DEFAULT_PRINTFUL_PRODUCT.shippingProfile,
-      pricing: buildMerchPricingSnapshot({
-        retailPriceCents: calculateRecommendedSalePriceCents(
-          productCostCents,
-          MERCH_DEFAULT_MARGIN_PRESET,
-          {
-            printfulCostSource: 'printful',
-            printfulCostUpdatedAt: new Date().toISOString(),
-          }
-        ),
-        printfulProductCostCents: productCostCents,
-        printfulCostSource: 'printful',
-        printfulCostUpdatedAt: new Date().toISOString(),
-      }),
-      providerWarnings: availabilityWarnings,
-    };
+    return buildCatalogSelection(product);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return defaultSelection([

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -34,7 +34,11 @@ import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { publicEnv } from '@/lib/env-public';
 import { logger } from '@/lib/utils/logger';
 import { createMerchArtwork } from './artwork';
-import { resolveMerchCatalogSelection } from './catalog';
+import {
+  listMerchCatalogProductOptions,
+  resolveLiveMerchCatalogProduct,
+  resolveMerchCatalogSelection,
+} from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
 import { resolveArchivedMerchRestoreStatus } from './merch-lifecycle-policy';
 import { isPrintfulMockupUrl, selectPreferredMockupUrl } from './mockup-urls';
@@ -800,6 +804,77 @@ async function hydrateOptionPrintfulEconomics(
   return updated ?? option;
 }
 
+async function applyCatalogProductToOption(
+  option: MerchDesignOption,
+  catalogProductId: number
+): Promise<MerchDesignOption> {
+  if (
+    option.printfulCatalogProductId === catalogProductId &&
+    option.pricing.printfulCostSource === 'printful'
+  ) {
+    return option;
+  }
+
+  const catalog = await resolveLiveMerchCatalogProduct(catalogProductId);
+  const pricing = catalog.pricing;
+  const grossMargin =
+    pricing.retailPriceCents -
+    pricing.estimatedPrintfulProductCostCents -
+    pricing.stripeFeeEstimateCents -
+    pricing.refundReserveCents;
+  const retainedArtwork = option.mockupUrls.filter(
+    url => !isPrintfulMockupUrl(url)
+  );
+
+  const [updated] = await db
+    .update(merchDesignOptions)
+    .set({
+      productType: catalog.productType,
+      printfulProductName: catalog.productName,
+      printfulCatalogProductId: catalog.catalogProductId,
+      printfulCatalogVariantIds: catalog.catalogVariantIds,
+      variantMap: catalog.variantMap,
+      colorway: catalog.colorway,
+      availableSizes: catalog.sizes,
+      placements: catalog.placements,
+      technique: catalog.technique,
+      retailPriceCents: pricing.retailPriceCents,
+      estimatedPrintfulProductCostCents:
+        pricing.estimatedPrintfulProductCostCents,
+      estimatedShippingCostCents: pricing.estimatedShippingCostCents,
+      estimatedGrossMarginCents: grossMargin,
+      artistShareCents: pricing.artistPayoutPerUnitEstimateCents,
+      jovieShareCents: pricing.jovieMarginPerUnitEstimateCents,
+      pricing,
+      mockupUrls: retainedArtwork,
+      productionWarnings: catalog.providerWarnings,
+      updatedAt: new Date(),
+    })
+    .where(eq(merchDesignOptions.id, option.id))
+    .returning();
+
+  if (!updated) {
+    throw new Error('Unable to persist selected Printful product');
+  }
+  return updated;
+}
+
+export async function getMerchProductOptions(params: {
+  readonly generationId: string;
+  readonly clerkUserId: string;
+  readonly profileId: string;
+  readonly optionId: string;
+  readonly optionNumber: number;
+}) {
+  const option = await getOptionForSelection(params);
+  if (option.creatorProfileId !== params.profileId) {
+    throw new Error('Merch design option not found');
+  }
+  await assertCanManageMerchProfile(params.profileId, params.clerkUserId);
+
+  return listMerchCatalogProductOptions(3);
+}
+
 /**
  * Refresh merch card economics from Printful when still on jovie_default so
  * publish / checkout sellability can pass (JOV-3393).
@@ -866,6 +941,7 @@ export async function selectMerchDesign(params: {
   readonly profileId?: string | null;
   readonly optionId?: string | null;
   readonly optionNumber?: number | null;
+  readonly catalogProductId?: number | null;
   readonly publish?: boolean;
 }): Promise<MerchSelectionResult> {
   const rawSelected = await getOptionForSelection(params);
@@ -876,18 +952,28 @@ export async function selectMerchDesign(params: {
     rawSelected.creatorProfileId,
     params.clerkUserId
   );
-  const selected = await hydrateOptionPrintfulEconomics(rawSelected);
+  const existing = await db
+    .select()
+    .from(merchCards)
+    .where(eq(merchCards.selectedDesignOptionId, rawSelected.id))
+    .limit(1);
+  const existingCard = existing[0] ?? null;
+  if (
+    existingCard &&
+    params.catalogProductId &&
+    existingCard.printful.catalogProductId !== params.catalogProductId
+  ) {
+    throw new Error('A product is already selected for this merch design');
+  }
+
+  const selected = params.catalogProductId
+    ? await applyCatalogProductToOption(rawSelected, params.catalogProductId)
+    : await hydrateOptionPrintfulEconomics(rawSelected);
   const profile = await getCreatorProfileForMerch(selected.creatorProfileId);
   const publishSellability = getDesignOptionSellability(selected);
   const shouldPublish = params.publish === true && publishSellability.sellable;
 
-  const existing = await db
-    .select()
-    .from(merchCards)
-    .where(eq(merchCards.selectedDesignOptionId, selected.id))
-    .limit(1);
-
-  let card = existing[0] ?? null;
+  let card = existingCard;
   if (card) {
     card = await hydrateMerchCardPrintfulEconomics(card);
 
@@ -963,6 +1049,9 @@ export async function selectMerchDesign(params: {
       })
       .returning();
     card = inserted;
+    if (params.catalogProductId) {
+      attachPrintfulMockupsAsync([selected]);
+    }
   } else if (shouldPublish && card.status !== 'live') {
     validateMerchCardForPublishing(card);
     [card] = await db

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -37,7 +37,7 @@ import { createMerchArtwork } from './artwork';
 import { resolveMerchCatalogSelection } from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
 import { resolveArchivedMerchRestoreStatus } from './merch-lifecycle-policy';
-import { selectPreferredMockupUrl } from './mockup-urls';
+import { isPrintfulMockupUrl, selectPreferredMockupUrl } from './mockup-urls';
 import { attachMockupsToDesignOption, generateProductMockups } from './mockups'; // HOT ZONE pipeline (gh-9803)
 import {
   buildMerchPresetPriceQuotes,
@@ -863,11 +863,15 @@ async function hydrateMerchCardPrintfulEconomics(
 export async function selectMerchDesign(params: {
   readonly generationId: string;
   readonly clerkUserId: string;
+  readonly profileId?: string | null;
   readonly optionId?: string | null;
   readonly optionNumber?: number | null;
   readonly publish?: boolean;
 }): Promise<MerchSelectionResult> {
   const rawSelected = await getOptionForSelection(params);
+  if (params.profileId && rawSelected.creatorProfileId !== params.profileId) {
+    throw new Error('Merch design option not found');
+  }
   await assertCanManageMerchProfile(
     rawSelected.creatorProfileId,
     params.clerkUserId
@@ -884,6 +888,24 @@ export async function selectMerchDesign(params: {
     .limit(1);
 
   let card = existing[0] ?? null;
+  if (card) {
+    card = await hydrateMerchCardPrintfulEconomics(card);
+
+    const printfulMockupUrl = selected.mockupUrls.find(isPrintfulMockupUrl);
+    if (printfulMockupUrl && !card.mockupUrls.includes(printfulMockupUrl)) {
+      const [updatedCard] = await db
+        .update(merchCards)
+        .set({
+          primaryImageUrl: printfulMockupUrl,
+          mockupUrls: selected.mockupUrls,
+          updatedAt: new Date(),
+        })
+        .where(eq(merchCards.id, card.id))
+        .returning();
+      card = updatedCard ?? card;
+    }
+  }
+
   if (!card) {
     const rejected = await db
       .select({ id: merchDesignOptions.id })
@@ -977,6 +999,12 @@ export async function selectMerchDesign(params: {
     revalidatePublicProfile(profile.usernameNormalized);
   }
 
+  const cardSellability = getMerchCardSellability(card);
+  const printfulMockupUrl =
+    card.mockupUrls.find(isPrintfulMockupUrl) ??
+    selected.mockupUrls.find(isPrintfulMockupUrl) ??
+    null;
+
   return {
     success: true,
     merchCardId: card.id,
@@ -987,10 +1015,21 @@ export async function selectMerchDesign(params: {
       card.status === 'live'
         ? publicMerchUrl(profile.usernameNormalized, card.id)
         : null,
-    publishBlockedReasons:
-      params.publish === true && !publishSellability.sellable
-        ? publishSellability.reasons
-        : undefined,
+    publishBlockedReasons: cardSellability.sellable
+      ? undefined
+      : cardSellability.reasons,
+    product: {
+      productType: card.productType,
+      productName:
+        card.printful.catalogProductName ?? selected.printfulProductName,
+      colorway: selected.colorway,
+      artworkUrl: selected.printFileUrls[0] ?? null,
+      mockupUrl: printfulMockupUrl,
+      mockupStatus: printfulMockupUrl ? 'ready' : 'pending',
+      retailPrice: formatMerchMoney(card.retailPriceCents),
+      artistProfit: formatMerchMoney(card.artistPayoutPerUnitEstimateCents),
+      publishEligible: cardSellability.sellable,
+    },
   };
 }
 

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -81,6 +81,21 @@ export interface MerchSelectionResult {
   readonly title: string;
   readonly publicUrl: string | null;
   readonly publishBlockedReasons?: readonly string[];
+  /**
+   * Truthful, persisted product state for in-place chat selection. A Printful
+   * mockup is only exposed after the async provider job has attached one.
+   */
+  readonly product?: {
+    readonly productType: string;
+    readonly productName: string;
+    readonly colorway: string;
+    readonly artworkUrl: string | null;
+    readonly mockupUrl: string | null;
+    readonly mockupStatus: 'ready' | 'pending';
+    readonly retailPrice: string;
+    readonly artistProfit: string;
+    readonly publishEligible: boolean;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/queries/index.ts
+++ b/apps/web/lib/queries/index.ts
@@ -260,7 +260,9 @@ export {
 // Confirm chat merch action mutation
 export {
   type ConfirmChatMerchActionInput,
+  type ConfirmChatMerchActionResponse,
   type ConfirmChatMerchActionType,
+  type ConfirmChatMerchSelectResponse,
   useConfirmChatMerchActionMutation,
 } from './useConfirmChatMerchActionMutation';
 // Confirm chat remove link mutation

--- a/apps/web/lib/queries/index.ts
+++ b/apps/web/lib/queries/index.ts
@@ -262,6 +262,7 @@ export {
   type ConfirmChatMerchActionInput,
   type ConfirmChatMerchActionResponse,
   type ConfirmChatMerchActionType,
+  type ConfirmChatMerchProductsResponse,
   type ConfirmChatMerchSelectResponse,
   useConfirmChatMerchActionMutation,
 } from './useConfirmChatMerchActionMutation';

--- a/apps/web/lib/queries/useConfirmChatMerchActionMutation.ts
+++ b/apps/web/lib/queries/useConfirmChatMerchActionMutation.ts
@@ -11,18 +11,52 @@ export type ConfirmChatMerchActionType =
   | 'unpause'
   | 'pause';
 
-export interface ConfirmChatMerchActionInput {
+export interface ConfirmChatMerchStatusActionInput {
   readonly profileId: string;
   readonly merchCardId: string;
   readonly action: ConfirmChatMerchActionType;
 }
 
-interface ConfirmChatMerchActionResponse {
-  readonly success: boolean;
+export interface ConfirmChatMerchSelectInput {
+  readonly profileId: string;
+  readonly generationId: string;
+  readonly optionId: string;
+  readonly optionNumber: number;
+  readonly action: 'select';
+}
+
+export type ConfirmChatMerchActionInput =
+  | ConfirmChatMerchStatusActionInput
+  | ConfirmChatMerchSelectInput;
+
+export interface ConfirmChatMerchStatusActionResponse {
+  readonly success: true;
   readonly merchCardId: string;
   readonly status: string;
   readonly title: string;
 }
+
+export interface ConfirmChatMerchSelectResponse
+  extends ConfirmChatMerchStatusActionResponse {
+  readonly selectedOptionId: string;
+  readonly publicUrl: string | null;
+  readonly publishBlockedReasons?: readonly string[];
+  readonly product: {
+    readonly productType: string;
+    readonly productName: string;
+    readonly colorway: string;
+    readonly artworkUrl: string | null;
+    readonly mockupUrl: string | null;
+    readonly mockupStatus: 'ready' | 'pending';
+    readonly retailPrice: string;
+    readonly artistProfit: string;
+    readonly publishEligible: boolean;
+  };
+}
+
+export type ConfirmChatMerchActionResponse =
+  | ConfirmChatMerchStatusActionResponse
+  | ConfirmChatMerchSelectResponse;
 
 export function useConfirmChatMerchActionMutation() {
   const queryClient = useQueryClient();

--- a/apps/web/lib/queries/useConfirmChatMerchActionMutation.ts
+++ b/apps/web/lib/queries/useConfirmChatMerchActionMutation.ts
@@ -22,11 +22,21 @@ export interface ConfirmChatMerchSelectInput {
   readonly generationId: string;
   readonly optionId: string;
   readonly optionNumber: number;
+  readonly catalogProductId: number;
   readonly action: 'select';
+}
+
+export interface ConfirmChatMerchProductsInput {
+  readonly profileId: string;
+  readonly generationId: string;
+  readonly optionId: string;
+  readonly optionNumber: number;
+  readonly action: 'products';
 }
 
 export type ConfirmChatMerchActionInput =
   | ConfirmChatMerchStatusActionInput
+  | ConfirmChatMerchProductsInput
   | ConfirmChatMerchSelectInput;
 
 export interface ConfirmChatMerchStatusActionResponse {
@@ -54,8 +64,19 @@ export interface ConfirmChatMerchSelectResponse
   };
 }
 
+export interface ConfirmChatMerchProductsResponse {
+  readonly success: true;
+  readonly products: readonly {
+    readonly catalogProductId: number;
+    readonly productName: string;
+    readonly productType: string;
+    readonly colorway: string;
+  }[];
+}
+
 export type ConfirmChatMerchActionResponse =
   | ConfirmChatMerchStatusActionResponse
+  | ConfirmChatMerchProductsResponse
   | ConfirmChatMerchSelectResponse;
 
 export function useConfirmChatMerchActionMutation() {

--- a/apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts
+++ b/apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => ({
   authMock: vi.fn(),
   findFirstMock: vi.fn(),
+  getMerchProductOptionsMock: vi.fn(),
   publishMerchCardMock: vi.fn(),
   selectMerchDesignMock: vi.fn(),
   updateMerchCardStatusMock: vi.fn(),
@@ -38,6 +39,7 @@ vi.mock('@/lib/db/schema/chat', () => ({
 vi.mock('drizzle-orm', () => ({ eq: vi.fn() }));
 
 vi.mock('@/lib/merch/service', () => ({
+  getMerchProductOptions: hoisted.getMerchProductOptionsMock,
   publishMerchCard: hoisted.publishMerchCardMock,
   selectMerchDesign: hoisted.selectMerchDesignMock,
   updateMerchCardStatus: hoisted.updateMerchCardStatusMock,
@@ -65,6 +67,14 @@ describe('POST /api/chat/confirm-merch-action', () => {
       status: 'live',
       title: 'Tour Tee',
     });
+    hoisted.getMerchProductOptionsMock.mockResolvedValue([
+      {
+        catalogProductId: 71,
+        productName: 'Unisex Staple T-Shirt',
+        productType: 't-shirt',
+        colorway: 'Black',
+      },
+    ]);
     hoisted.selectMerchDesignMock.mockResolvedValue({
       success: true,
       merchCardId: '00000000-0000-4000-8000-000000000004',
@@ -130,6 +140,7 @@ describe('POST /api/chat/confirm-merch-action', () => {
           generationId: '00000000-0000-4000-8000-000000000002',
           optionId: '00000000-0000-4000-8000-000000000003',
           optionNumber: 1,
+          catalogProductId: 71,
           action: 'select',
         }),
       })
@@ -142,6 +153,7 @@ describe('POST /api/chat/confirm-merch-action', () => {
       profileId: '00000000-0000-4000-8000-000000000001',
       optionId: '00000000-0000-4000-8000-000000000003',
       optionNumber: 1,
+      catalogProductId: 71,
       publish: false,
     });
     const body = await response.json();
@@ -151,5 +163,42 @@ describe('POST /api/chat/confirm-merch-action', () => {
       retailPrice: '$30.00',
       artistProfit: '$10.00',
     });
+  });
+
+  it('returns live product choices before creating the merch card', async () => {
+    const { POST } = await import('@/app/api/chat/confirm-merch-action/route');
+    const response = await POST(
+      new Request('http://localhost/api/chat/confirm-merch-action', {
+        method: 'POST',
+        body: JSON.stringify({
+          profileId: '00000000-0000-4000-8000-000000000001',
+          generationId: '00000000-0000-4000-8000-000000000002',
+          optionId: '00000000-0000-4000-8000-000000000003',
+          optionNumber: 1,
+          action: 'products',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.getMerchProductOptionsMock).toHaveBeenCalledWith({
+      generationId: '00000000-0000-4000-8000-000000000002',
+      clerkUserId: 'user-1',
+      profileId: '00000000-0000-4000-8000-000000000001',
+      optionId: '00000000-0000-4000-8000-000000000003',
+      optionNumber: 1,
+    });
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      products: [
+        {
+          catalogProductId: 71,
+          productName: 'Unisex Staple T-Shirt',
+          productType: 't-shirt',
+          colorway: 'Black',
+        },
+      ],
+    });
+    expect(hoisted.selectMerchDesignMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts
+++ b/apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts
@@ -4,6 +4,7 @@ const hoisted = vi.hoisted(() => ({
   authMock: vi.fn(),
   findFirstMock: vi.fn(),
   publishMerchCardMock: vi.fn(),
+  selectMerchDesignMock: vi.fn(),
   updateMerchCardStatusMock: vi.fn(),
   insertValuesMock: vi.fn().mockResolvedValue(undefined),
   insertMock: vi
@@ -38,6 +39,7 @@ vi.mock('drizzle-orm', () => ({ eq: vi.fn() }));
 
 vi.mock('@/lib/merch/service', () => ({
   publishMerchCard: hoisted.publishMerchCardMock,
+  selectMerchDesign: hoisted.selectMerchDesignMock,
   updateMerchCardStatus: hoisted.updateMerchCardStatusMock,
 }));
 
@@ -62,6 +64,25 @@ describe('POST /api/chat/confirm-merch-action', () => {
       id: 'card-1',
       status: 'live',
       title: 'Tour Tee',
+    });
+    hoisted.selectMerchDesignMock.mockResolvedValue({
+      success: true,
+      merchCardId: '00000000-0000-4000-8000-000000000004',
+      status: 'draft',
+      selectedOptionId: '00000000-0000-4000-8000-000000000003',
+      title: 'Tour Tee',
+      publicUrl: null,
+      product: {
+        productType: 't-shirt',
+        productName: 'Unisex Staple T-Shirt',
+        colorway: 'Black',
+        artworkUrl: 'https://blob.example.com/art.png',
+        mockupUrl: null,
+        mockupStatus: 'pending',
+        retailPrice: '$30.00',
+        artistProfit: '$10.00',
+        publishEligible: true,
+      },
     });
   });
 
@@ -97,5 +118,38 @@ describe('POST /api/chat/confirm-merch-action', () => {
     expect(hoisted.publishMerchCardMock).toHaveBeenCalledOnce();
     const body = await response.json();
     expect(body.status).toBe('live');
+  });
+
+  it('selects merch through the existing confirmation contract', async () => {
+    const { POST } = await import('@/app/api/chat/confirm-merch-action/route');
+    const response = await POST(
+      new Request('http://localhost/api/chat/confirm-merch-action', {
+        method: 'POST',
+        body: JSON.stringify({
+          profileId: '00000000-0000-4000-8000-000000000001',
+          generationId: '00000000-0000-4000-8000-000000000002',
+          optionId: '00000000-0000-4000-8000-000000000003',
+          optionNumber: 1,
+          action: 'select',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.selectMerchDesignMock).toHaveBeenCalledWith({
+      generationId: '00000000-0000-4000-8000-000000000002',
+      clerkUserId: 'user-1',
+      profileId: '00000000-0000-4000-8000-000000000001',
+      optionId: '00000000-0000-4000-8000-000000000003',
+      optionNumber: 1,
+      publish: false,
+    });
+    const body = await response.json();
+    expect(body.product).toMatchObject({
+      mockupStatus: 'pending',
+      mockupUrl: null,
+      retailPrice: '$30.00',
+      artistProfit: '$10.00',
+    });
   });
 });

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -430,7 +430,7 @@ describe('ChatMessage', () => {
       expect(submitListener).toHaveBeenCalledTimes(1);
       expect(submitListener.mock.calls[0]?.[0]).toMatchObject({
         detail: {
-          prompt: 'Select merch option 1 from generation generation-1.',
+          prompt: 'Select merch option 1.',
         },
       });
     } finally {


### PR DESCRIPTION
## Summary
- present the three generated merch directions as a chrome-free editorial carousel
- persist product selection with truthful price, profit, mockup, and publish state
- preserve Library archive/profile-visibility lifecycle contracts after composing on main

## Verification
- `pnpm biome check --write <14 changed files>`
- `pnpm --filter web exec vitest run components/jovie/components/ChatMerchCard.test.tsx components/jovie/components/ChatMerchDesignCarousel.test.tsx tests/unit/api/chat/confirm-merch-action-route.test.ts tests/unit/chat/ChatMessage.test.tsx tests/unit/library/library-entity-actions.test.ts --maxWorkers 1` (38/38)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

No browser or taste gate used; UI review remains advisory per shipping policy.