### PR TITLE
fix(tasks): polish workspace row rhythm and document readability

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
@@ -24,9 +24,9 @@ export function TaskDescriptionHelper({
         onClick={onBeginEditing}
         className='absolute inset-0 rounded-2xl bg-[color-mix(in_oklab,var(--linear-app-content-surface)_82%,var(--linear-app-shell-border)_18%)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
       />
-      <div className='pointer-events-none relative z-10 max-w-[40rem] space-y-3 px-5 py-5 text-left'>
-        <div className='space-y-1'>
-          <h3 className='text-app font-semibold text-primary-token'>
+      <div className='pointer-events-none relative z-10 max-w-xl space-y-4 px-5 py-5 text-left'>
+        <div className='space-y-2'>
+          <h3 className='text-app font-semibold leading-5 text-primary-token'>
             {helper.title}
           </h3>
           {helper.intro.map(paragraph => {
@@ -45,7 +45,7 @@ export function TaskDescriptionHelper({
         </div>
 
         {helper.bullets && helper.bullets.length > 0 ? (
-          <ul className='space-y-1.5 pl-4 text-app leading-6 text-secondary-token marker:text-tertiary-token'>
+          <ul className='space-y-2 pl-4 text-app leading-6 text-secondary-token marker:text-tertiary-token'>
             {helper.bullets.map(bullet => {
               const occurrence = bulletKeyCounts.get(bullet) ?? 0;
               bulletKeyCounts.set(bullet, occurrence + 1);
@@ -56,7 +56,7 @@ export function TaskDescriptionHelper({
         ) : null}
 
         {helper.links && helper.links.length > 0 ? (
-          <ul className='space-y-1.5 text-xs leading-5 text-secondary-token'>
+          <ul className='space-y-2 text-app leading-6 text-secondary-token'>
             {helper.links.map(link => {
               const linkKey = `${link.href}:${link.label}`;
               const occurrence = linkKeyCounts.get(linkKey) ?? 0;

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -175,7 +175,7 @@ export const TaskListRow = memo(function TaskListRow({
       isSelected={isSelected}
       interaction='task-row-group'
       className={cn(
-        'group/row flex h-full w-full items-center gap-2.5 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
+        'group/row flex h-full w-full items-center gap-2 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
         isDone && !isSelected && 'opacity-75',
         isCancelled && !isSelected && 'opacity-60'
       )}
@@ -203,7 +203,7 @@ export const TaskListRow = memo(function TaskListRow({
         <div
           data-testid={`task-list-row-meta-${task.id}`}
           className={cn(
-            'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 overflow-hidden text-3xs leading-none text-secondary-token',
+            'flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0 overflow-hidden text-3xs leading-4 text-secondary-token',
             !hideTitle && 'mt-px'
           )}
         >

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -854,7 +854,9 @@ function TaskDocumentPanel({
                 value={description}
                 onFocus={handleDescriptionFocus}
                 onChange={event => onDescriptionChange(event.target.value)}
-                placeholder='Start writing...'
+                placeholder={
+                  showDescriptionHelper ? undefined : 'Start writing...'
+                }
                 className='min-h-130 w-full resize-none rounded-md border-0 bg-transparent px-0 py-0 text-mid leading-[1.8] text-primary-token outline-none placeholder:text-[color-mix(in_oklab,var(--text-tertiary)_82%,transparent)] transition-colors duration-fast focus:outline-none! focus-visible:ring-0! focus:shadow-none! focus-visible:bg-[color-mix(in_oklab,var(--linear-border-focus)_16%,transparent)]'
                 style={{ boxShadow: 'none' }}
               />

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -699,7 +699,7 @@ function TaskDocumentPanel({
           className='min-h-0 flex-1 overflow-y-auto overscroll-contain'
           data-testid='task-document-scroll-region'
         >
-          <div className='mx-auto flex w-full max-w-[40rem] flex-col gap-3 px-4 pb-5 pt-4 sm:px-5 sm:pb-6 sm:pt-5'>
+          <div className='mx-auto flex w-full max-w-xl flex-col gap-4 px-4 pb-6 pt-5 sm:px-5 sm:pb-7 sm:pt-6'>
             <TaskTitleEditor value={title} onChange={onTitleChange} />
 
             <div

--- a/apps/web/components/molecules/filters/TableFilterDropdown.tsx
+++ b/apps/web/components/molecules/filters/TableFilterDropdown.tsx
@@ -86,7 +86,7 @@ function TableFilterSection<T extends string>({
   }, [category.options, search]);
 
   return (
-    <div className='flex max-h-80 min-h-55 min-w-65 flex-col overflow-hidden'>
+    <div className='flex max-h-80 min-w-65 flex-col overflow-hidden'>
       <div
         data-menu-header
         className='border-b border-[color-mix(in_oklab,var(--app-shell-frame-seam)_44%,transparent)]'

--- a/apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx
+++ b/apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx
@@ -19,7 +19,7 @@ export interface ShellListRowButtonProps
 
 function getTaskRowGroupState(isSelected: boolean): string {
   if (isSelected) {
-    return cn(rowState.selected, 'system-b-shell-list-task-row-selected');
+    return 'system-b-shell-list-task-row-selected';
   }
 
   return 'system-b-shell-list-task-row-hover';

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6741,7 +6741,10 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 }
 
 :where(.group\/task-row:focus-visible)
-  :where(.system-b-shell-list-task-row-hover, .system-b-shell-list-task-row-selected) {
+  :where(
+    .system-b-shell-list-task-row-hover,
+    .system-b-shell-list-task-row-selected
+  ) {
   box-shadow: inset 0 0 0 1px
     color-mix(in oklab, var(--color-focus-ring) 45%, transparent);
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6729,15 +6729,21 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.group\/task-row:hover, .group\/task-row:focus-visible)
   :where(.system-b-shell-list-task-row-hover) {
   background: var(--color-row-hover);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in oklab, var(--color-focus-ring) 45%, transparent);
 }
 
 :where(.group\/task-row:hover, .group\/task-row:focus-visible)
   :where(.system-b-shell-list-task-row-selected) {
   background: var(--color-row-selected);
+}
+
+:where(.system-b-shell-list-task-row-selected) {
+  background: var(--color-row-selected);
+}
+
+:where(.group\/task-row:focus-visible)
+  :where(.system-b-shell-list-task-row-hover, .system-b-shell-list-task-row-selected) {
   box-shadow: inset 0 0 0 1px
-    color-mix(in oklab, var(--color-focus-ring) 24%, transparent);
+    color-mix(in oklab, var(--color-focus-ring) 45%, transparent);
 }
 
 :where(.system-b-table-skeleton-release-title) {

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -53,8 +53,8 @@ describe('TaskListRow', () => {
     const meta = getByTestId('task-list-row-meta-task-1');
     expect(meta.className).toContain('flex-wrap');
     expect(meta.className).not.toContain('grid-cols-');
-    expect(meta.className).toContain('gap-x-2');
-    expect(meta.className).toContain('gap-y-0.5');
+    expect(meta).toHaveClass('gap-x-1.5');
+    expect(meta).toHaveClass('gap-y-0');
   });
 
   it('keeps row controls at the shared compact hit-area density', () => {

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -89,7 +89,7 @@ describe('TaskListRow', () => {
       'true'
     );
     expect(getByTestId('task-list-row-task-1').className).toContain(
-      'system-b-table-row-selected'
+      'system-b-shell-list-task-row-selected'
     );
     expect(getByText(mockTask.title)).toBeVisible();
   });

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -1117,6 +1117,9 @@ describe('TasksPageClient', () => {
     openTask(mockHelperTask);
 
     expect(screen.getByTestId('task-description-helper')).toBeInTheDocument();
+    expect(screen.getByLabelText('Task Description')).not.toHaveAttribute(
+      'placeholder'
+    );
     expect(screen.getByText('Press Release')).toBeInTheDocument();
     expect(
       screen.getByText(/tag @Jovie and ask her to draft a first pass/i)


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4653 -->

## Summary
- tighten Tasks list row and metadata spacing while preserving single-line status labels
- remove nested selected-row border emphasis and keep focus indication keyboard-only through the shared shell row primitive
- narrow and rebalance task document typography, padding, helper spacing, and placeholder behavior
- let short shared filter submenus fit their content without changing the canonical popover elevation, search, empty/loading, or keyboard behavior

Closes JOV-4653. Includes the bounded JOV-4655 shared filter sizing fix.

## Bug-to-Test
bug-to-test: satisfied — Tasks row state/rhythm, helper placeholder behavior, and filter submenu sizing are covered by focused component tests.

## Test Coverage
All changed behavior uses existing production components and focused component contracts.

## Pre-Landing Review
No blocking source findings. Rebase conflict preserved current semantic Noir Ion row tokens while applying the intended selected/hover/focus behavior.

## Design Review
Production screenshot requirements are preserved from the Linear issues: compact row rhythm, readable task-document measure and spacing, no two-line status labels, and canonical filter/popover styling. Per current policy, taste review is advisory and does not block admission.

## Linear follow-ups
Linear follow-ups: none.

## Verification Results
- Node 22.23.1 / pnpm 9.15.4
- Biome: 8 changed files passed
- Vitest: 3 files, 63/63 tests passed
- @jovie/web typecheck: passed
- git diff --check: passed
- normal hooked push: passed, no bypass

## Test plan
- [x] TasksPageClient, TaskListRow, and TableFilterDropdown focused suites pass
- [x] Typecheck and formatting pass
- [x] Branch rebased onto exact current `origin/main`