### PR TITLE
fix(ui): unify size-aware artwork framing

### DIFF
--- a/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react';
 import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
+import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
 import { cn } from '@/lib/utils';
 import { LibraryArtworkHoverZoom } from './LibraryArtworkHoverZoom';
 import { LibraryAudioWaveformThumbnail } from './LibraryAudioWaveformThumbnail';
@@ -78,6 +79,8 @@ export function LibraryMediaThumbnail({
     Boolean(asset.artworkUrl) &&
     (itemKind === 'image' || itemKind === 'merch') &&
     size !== 'row';
+  const artworkFrameSize =
+    size === 'row' ? 'thumbnail' : size === 'drawer' ? 'hero' : 'default';
 
   const updateScrub = useCallback((event: ReactMouseEvent<HTMLElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();
@@ -85,10 +88,10 @@ export function LibraryMediaThumbnail({
   }, []);
 
   return (
-    <div
+    <ArtworkFrame
+      size={artworkFrameSize}
       className={cn(
-        'system-b-library-media-thumbnail relative h-full w-full overflow-hidden',
-        size === 'row' && 'rounded-sm',
+        'system-b-library-media-thumbnail h-full w-full',
         className
       )}
       data-testid={`library-media-thumbnail-${asset.id}`}
@@ -151,6 +154,6 @@ export function LibraryMediaThumbnail({
           compact={compact}
         />
       ) : null}
-    </div>
+    </ArtworkFrame>
   );
 }

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -58,6 +58,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
 import { ProviderIcon } from '@/components/atoms/ProviderIcon';
 import { TableActionMenu } from '@/components/atoms/table-action-menu';
 import { NavigationDestinationReady } from '@/components/features/dashboard/NavigationDestinationReady';
@@ -481,7 +482,10 @@ const ReleaseCell = memo(function ReleaseCell({
 
   return (
     <div className='flex min-w-0 items-center gap-2.5'>
-      <span className='system-b-library-artwork-shell group/artwork relative h-10 w-10 shrink-0 overflow-hidden'>
+      <ArtworkFrame
+        size='thumbnail'
+        className='system-b-library-artwork-shell group/artwork h-10 w-10'
+      >
         <LibraryMediaThumbnail asset={asset} size='row' />
         {hasPreview ? (
           <button
@@ -509,7 +513,7 @@ const ReleaseCell = memo(function ReleaseCell({
             )}
           </button>
         ) : null}
-      </span>
+      </ArtworkFrame>
       <span className='min-w-0'>
         <span className='system-b-library-release-title block truncate'>
           {asset.title}
@@ -634,9 +638,12 @@ const CatalogArtworkCell = memo(function CatalogArtworkCell({
   readonly asset: LibraryReleaseAsset;
 }) {
   return (
-    <span className='system-b-library-artwork-shell relative block h-9 w-9 overflow-hidden'>
+    <ArtworkFrame
+      size='thumbnail'
+      className='system-b-library-artwork-shell block h-9 w-9'
+    >
       <LibraryMediaThumbnail asset={asset} size='row' />
-    </span>
+    </ArtworkFrame>
   );
 });
 

--- a/apps/web/components/atoms/ArtworkFrame.tsx
+++ b/apps/web/components/atoms/ArtworkFrame.tsx
@@ -1,0 +1,58 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type ArtworkFrameSize = number | 'thumbnail' | 'default' | 'hero';
+
+interface ArtworkFrameProps
+  extends Readonly<Omit<HTMLAttributes<HTMLDivElement>, 'children'>> {
+  readonly children?: ReactNode;
+  /**
+   * Artwork corners scale with the rendered media, not the surrounding card.
+   * Tiny table/search thumbnails stay nearly square so the frame does not
+   * visibly reshape the artwork.
+   */
+  readonly size: ArtworkFrameSize;
+}
+
+function resolveArtworkFrameScale(
+  size: ArtworkFrameSize
+): 'thumbnail' | 'default' | 'hero' {
+  if (typeof size !== 'number') return size;
+  if (size <= 48) return 'thumbnail';
+  if (size >= 160) return 'hero';
+  return 'default';
+}
+
+export function getArtworkRadiusClassName(size: ArtworkFrameSize): string {
+  const scale = resolveArtworkFrameScale(size);
+  if (scale === 'thumbnail') return 'rounded-xs';
+  if (scale === 'hero') return 'rounded-xl';
+  return 'rounded-lg';
+}
+
+/**
+ * Canonical square-media frame for album art, merch, and release thumbnails.
+ * It owns only clipping geometry: callers still own dimensions and imagery.
+ */
+export function ArtworkFrame({
+  children,
+  className,
+  size,
+  ...props
+}: ArtworkFrameProps) {
+  const scale = resolveArtworkFrameScale(size);
+
+  return (
+    <div
+      {...props}
+      className={cn(
+        className,
+        'relative shrink-0 overflow-hidden border-0 outline-none shadow-none',
+        getArtworkRadiusClassName(scale)
+      )}
+      data-artwork-frame={scale}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/atoms/ReleaseArtworkThumb.tsx
+++ b/apps/web/components/atoms/ReleaseArtworkThumb.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
+import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
 import { cn } from '@/lib/utils';
 
 interface ReleaseArtworkThumbProps {
@@ -14,10 +15,6 @@ interface ReleaseArtworkThumbProps {
   readonly className?: string;
   /** Icon size class for the fallback Disc3 icon */
   readonly fallbackIconClass?: string;
-}
-
-function getArtworkRadiusClassName(size: number): string {
-  return size >= 64 ? 'rounded-lg' : 'rounded-xs';
 }
 
 /**
@@ -40,12 +37,9 @@ export function ReleaseArtworkThumb({
   }, [src]);
 
   return (
-    <div
-      className={cn(
-        'relative shrink-0 overflow-hidden bg-surface-2 shadow-sm',
-        getArtworkRadiusClassName(size),
-        className
-      )}
+    <ArtworkFrame
+      size={size}
+      className={cn('bg-surface-2', className)}
       style={{ width: size, height: size }}
     >
       {src && !imgError ? (
@@ -64,6 +58,6 @@ export function ReleaseArtworkThumb({
           iconClassName={fallbackIconClass}
         />
       )}
-    </div>
+    </ArtworkFrame>
   );
 }

--- a/apps/web/components/atoms/index.ts
+++ b/apps/web/components/atoms/index.ts
@@ -5,6 +5,11 @@
 export { AmountSelector } from './AmountSelector';
 export { ArtistName } from './ArtistName';
 export { ArtworkFallbackTile } from './ArtworkFallbackTile';
+export {
+  ArtworkFrame,
+  type ArtworkFrameSize,
+  getArtworkRadiusClassName,
+} from './ArtworkFrame';
 export type { Assignee } from './AssigneeAvatar';
 export { AssigneeAvatar } from './AssigneeAvatar';
 export type {

--- a/apps/web/components/jovie/components/picker-rows.tsx
+++ b/apps/web/components/jovie/components/picker-rows.tsx
@@ -30,6 +30,7 @@ import {
 } from 'lucide-react';
 import Image from 'next/image';
 import { memo } from 'react';
+import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
 import type { EntityKind } from '@/lib/chat/tokens';
 import type { EntityRef } from '@/lib/commands/entities';
 import type { NavCommand, SkillCommand } from '@/lib/commands/registry';
@@ -106,7 +107,10 @@ export const ReleaseArt = memo(function ReleaseArt({
 }) {
   if (entity.thumbnail) {
     return (
-      <div className='system-b-picker-art system-b-picker-art-image'>
+      <ArtworkFrame
+        size='thumbnail'
+        className='system-b-picker-art system-b-picker-art-image'
+      >
         <Image
           src={entity.thumbnail}
           alt=''
@@ -115,11 +119,14 @@ export const ReleaseArt = memo(function ReleaseArt({
           className='object-cover'
           unoptimized
         />
-      </div>
+      </ArtworkFrame>
     );
   }
   return (
-    <div className='system-b-picker-art system-b-picker-art-release-fallback' />
+    <ArtworkFrame
+      size='thumbnail'
+      className='system-b-picker-art system-b-picker-art-release-fallback'
+    />
   );
 });
 

--- a/apps/web/components/shell/ArtworkThumb.test.tsx
+++ b/apps/web/components/shell/ArtworkThumb.test.tsx
@@ -31,5 +31,21 @@ describe('ArtworkThumb', () => {
     const tile = container.firstElementChild as HTMLElement;
     expect(tile.style.width).toBe('88px');
     expect(tile.style.height).toBe('88px');
+    expect(tile).toHaveClass('rounded-lg', 'border-0', 'shadow-none');
+  });
+
+  it('keeps tiny shell artwork nearly square without decoration', () => {
+    const { container } = render(
+      <ArtworkThumb src='' title='Tiny' size={28} />
+    );
+    const tile = container.firstElementChild as HTMLElement;
+
+    expect(tile).toHaveAttribute('data-artwork-frame', 'thumbnail');
+    expect(tile).toHaveClass(
+      'rounded-xs',
+      'border-0',
+      'outline-none',
+      'shadow-none'
+    );
   });
 });

--- a/apps/web/components/shell/ArtworkThumb.tsx
+++ b/apps/web/components/shell/ArtworkThumb.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
+import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
 import { cn } from '@/lib/utils';
 
 /**
@@ -56,11 +57,9 @@ export function ArtworkThumb({
   const isLoaded = loaded && !errored;
 
   return (
-    <div
-      className={cn(
-        'relative rounded-sm overflow-hidden shrink-0 bg-surface-1',
-        className
-      )}
+    <ArtworkFrame
+      size={size}
+      className={cn('bg-surface-1', className)}
       data-artwork-state={isLoaded ? 'image' : 'fallback'}
       style={{ height: size, width: size }}
     >
@@ -73,6 +72,6 @@ export function ArtworkThumb({
       ) : (
         <ArtworkFallbackTile seed={title} />
       )}
-    </div>
+    </ArtworkFrame>
   );
 }

--- a/apps/web/tests/unit/atoms/ArtworkFrame.test.tsx
+++ b/apps/web/tests/unit/atoms/ArtworkFrame.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  ArtworkFrame,
+  getArtworkRadiusClassName,
+} from '@/components/atoms/ArtworkFrame';
+
+describe('ArtworkFrame', () => {
+  it.each([
+    [28, 'rounded-xs'],
+    [48, 'rounded-xs'],
+    [49, 'rounded-lg'],
+    [96, 'rounded-lg'],
+    [160, 'rounded-xl'],
+    ['thumbnail', 'rounded-xs'],
+    ['default', 'rounded-lg'],
+    ['hero', 'rounded-xl'],
+  ] as const)('maps %s artwork to %s', (size, expectedClassName) => {
+    expect(getArtworkRadiusClassName(size)).toBe(expectedClassName);
+  });
+
+  it('removes decorative framing while preserving caller geometry', () => {
+    const { container } = render(
+      <ArtworkFrame size='thumbnail' className='h-10 w-10'>
+        Artwork
+      </ArtworkFrame>
+    );
+    const frame = container.firstElementChild as HTMLElement;
+
+    expect(frame).toHaveAttribute('data-artwork-frame', 'thumbnail');
+    expect(frame).toHaveClass(
+      'h-10',
+      'w-10',
+      'rounded-xs',
+      'border-0',
+      'outline-none',
+      'shadow-none'
+    );
+  });
+});

--- a/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
+++ b/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
@@ -88,6 +88,7 @@ describe('ReleaseArtworkThumb', () => {
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper).toHaveStyle({ width: '40px', height: '40px' });
     expect(wrapper).toHaveClass('rounded-xs');
+    expect(wrapper).toHaveClass('border-0', 'outline-none', 'shadow-none');
     expect(wrapper).not.toHaveClass('outline');
   });
 

--- a/apps/web/tests/unit/chat/picker-rows-artwork.test.tsx
+++ b/apps/web/tests/unit/chat/picker-rows-artwork.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ArtistArt,
+  ReleaseArt,
+} from '@/components/jovie/components/picker-rows';
+import type { EntityRef } from '@/lib/commands/entities';
+
+vi.mock('next/image', () => ({
+  default: (
+    props: ComponentProps<'img'> & {
+      readonly fill?: boolean;
+      readonly unoptimized?: boolean;
+    }
+  ) => {
+    const { fill: _fill, unoptimized: _unoptimized, ...imageProps } = props;
+    return <img alt='' {...imageProps} />;
+  },
+}));
+
+describe('picker row artwork', () => {
+  it('uses the undecorated thumbnail frame for release search results', () => {
+    const entity: EntityRef = {
+      id: 'release-1',
+      kind: 'release',
+      label: 'Take Me Over',
+      thumbnail: 'https://cdn.example.com/release.jpg',
+    };
+    const { container } = render(<ReleaseArt entity={entity} />);
+    const frame = container.firstElementChild as HTMLElement;
+
+    expect(frame).toHaveAttribute('data-artwork-frame', 'thumbnail');
+    expect(frame).toHaveClass(
+      'rounded-xs',
+      'border-0',
+      'outline-none',
+      'shadow-none'
+    );
+  });
+
+  it('preserves circular artist avatars', () => {
+    const entity: EntityRef = {
+      id: 'artist-1',
+      kind: 'artist',
+      label: 'Tim White',
+      thumbnail: 'https://cdn.example.com/artist.jpg',
+    };
+    const { container } = render(<ArtistArt entity={entity} />);
+    const frame = container.firstElementChild as HTMLElement;
+
+    expect(frame).not.toHaveAttribute('data-artwork-frame');
+    expect(frame).toHaveClass('system-b-picker-art-round');
+  });
+});

--- a/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
+++ b/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
@@ -85,6 +85,12 @@ describe('LibraryMediaThumbnail', () => {
     expect(
       container.querySelector('[data-artwork-fallback-sleeve="true"]')
     ).toHaveClass(expectedRadius);
+    expect(
+      screen.getByTestId('library-media-thumbnail-release-1')
+    ).toHaveAttribute(
+      'data-artwork-frame',
+      size === 'drawer' ? 'hero' : 'default'
+    );
   });
 
   it('uses a flat, subtly rounded fallback for row thumbnails', () => {
@@ -100,7 +106,13 @@ describe('LibraryMediaThumbnail', () => {
     );
 
     const thumbnail = screen.getByTestId('library-media-thumbnail-release-1');
-    expect(thumbnail).toHaveClass('rounded-sm');
+    expect(thumbnail).toHaveAttribute('data-artwork-frame', 'thumbnail');
+    expect(thumbnail).toHaveClass(
+      'rounded-xs',
+      'border-0',
+      'outline-none',
+      'shadow-none'
+    );
     expect(
       thumbnail.querySelector('[data-artwork-fallback="true"]')
     ).toHaveAttribute('data-artwork-fallback-compact', 'true');


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4527 -->

## Summary
- add one shared size-aware artwork frame for releases, album art, and merch imagery
- keep thumbnails at 48px and below barely softened with `rounded-xs` and no decorative border, outline, or shadow
- scale default and hero artwork to more generous radii while preserving circular artist/person avatars
- migrate Library rows, release artwork, shell artwork, and command/search release results to the shared contract

Closes JOV-4527 and delivers the linked JOV-4658 production follow-up.

## Bug-to-Test
bug-to-test: satisfied — shared radius thresholds, border-light framing, Library callers, release thumbnails, picker results, and circular artist avatars have focused tests.

## Test Coverage
- shared `ArtworkFrame` threshold and decoration contract
- Library row/default/hero framing
- release and shell artwork callers
- search/picker release artwork versus artist-avatar behavior

## Pre-Landing Review
No blocking source findings. The branch is a single focused commit rebased cleanly onto current main.

## Design Review
The production guardrail is encoded directly: tiny artwork is nearly square and undecorated; larger media may scale radius with size. Taste review remains advisory and does not block admission.

## Linear follow-ups
Linear follow-ups: none.

## Verification Results
- Node 22.23.1 / pnpm 9.15.4
- Biome: 12 changed files passed
- Vitest: 5 files, 32/32 tests passed
- @jovie/web typecheck: passed
- git diff --check: passed
- normal hooked push: passed, no bypass

## Test plan
- [x] Artwork frame, Library, release, shell, and picker focused suites pass
- [x] Typecheck and formatting pass
- [x] Branch rebased onto exact current `origin/main`