### PR TITLE
fix(start): separate flow and composer status [JOV-4532]

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -476,23 +476,23 @@ function getDisplayMessages(
   ];
 }
 
-interface ComposerStatusBannerProps {
+interface OnboardingFlowStatusProps {
   readonly reserveTurnstileSpace?: boolean;
   readonly shouldShowTurnstileBanner: boolean;
   readonly turnstilePanel: ReactNode;
 }
 
-function ComposerStatusBanner({
+function OnboardingFlowStatus({
   reserveTurnstileSpace = false,
   shouldShowTurnstileBanner,
   turnstilePanel,
-}: ComposerStatusBannerProps) {
+}: OnboardingFlowStatusProps) {
   if (!shouldShowTurnstileBanner) return null;
 
   return (
     <div
       className={reserveTurnstileSpace ? 'min-h-[10rem]' : undefined}
-      data-testid='onboarding-turnstile-slot'
+      data-testid='onboarding-flow-status'
     >
       {turnstilePanel}
     </div>
@@ -962,8 +962,8 @@ export function OnboardingChat({
     (isAwaitingFirstToken ||
       shouldReserveStarterVerification ||
       verificationRequested);
-  const composerStatusBanner = shouldShowTurnstileBanner ? (
-    <ComposerStatusBanner
+  const flowStatus = shouldShowTurnstileBanner ? (
+    <OnboardingFlowStatus
       reserveTurnstileSpace={shouldReserveStarterVerification}
       shouldShowTurnstileBanner={shouldShowTurnstileBanner}
       turnstilePanel={turnstilePanel}
@@ -995,25 +995,26 @@ export function OnboardingChat({
     isSubmitting: isSubmitted,
     isStreaming,
     onStop: stop,
-    // Raw "Securing chat..." text is replaced in follow-up pass with
-    // statusBanner skeleton treatment. Handle step gets a confirm-oriented
-    // placeholder so incomplete free-text is less tempting.
     placeholder: handleDraft
       ? 'Confirm handle or type a different one…'
-      : 'Artist, release, or link...',
+      : hasConversationStarted
+        ? 'Reply to Jovie…'
+        : 'Artist, release, or link...',
+    dictationEnabled: false,
     onPickerOpenChange: setComposerPickerOpen,
     chips: chipTray.chips,
     onRemoveChipAt: chipTray.removeAt,
     onRemoveLastChip: chipTray.removeLast,
     onAddSkill: chipTray.addSkill,
     onAddEntity: chipTray.addEntity,
-    statusBanner: composerStatusBanner,
   } as const;
+  const sendLocalError =
+    chatError?.errorCode === 'TURNSTILE_REQUIRED' ? null : chatError;
   const onboardingComposerSurface = (
     <div className='mx-auto w-full max-w-[45rem]'>
-      {chatError ? (
+      {sendLocalError ? (
         <OnboardingMessageRecoveryRow
-          chatError={chatError}
+          chatError={sendLocalError}
           handleRetry={handleRetry}
           isBusy={isBusy}
           isSubmitted={isSubmitted}
@@ -1047,6 +1048,7 @@ export function OnboardingChat({
             !shouldDockComposer && 'justify-center'
           )}
         >
+          {flowStatus}
           <OnboardingMessageRegion
             composerPickerOpen={composerPickerOpen}
             displayMessages={displayMessages}

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -97,6 +97,8 @@ export interface ChatInputProps {
   readonly profileId?: string;
   /** Optional compact status content rendered inside the composer surface. */
   readonly statusBanner?: ReactNode;
+  /** Enables the shared dictation affordance when the surrounding flow supports it. */
+  readonly dictationEnabled?: boolean;
 }
 
 type SurfaceMode = 'empty' | 'typing' | 'root' | 'entity';
@@ -238,6 +240,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       onPickerOpenChange,
       profileId,
       statusBanner,
+      dictationEnabled = true,
     },
     ref
   ) {
@@ -812,7 +815,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                   ) : null}
                   {/* Grid accordion reserves height while animating dictation
                       banner in/out — avoids the ~64px jump (JOV-11948). */}
-                  {isDictationSupported ? (
+                  {dictationEnabled && isDictationSupported ? (
                     <div
                       className={cn(
                         'grid transition-[grid-template-rows] duration-subtle ease-in-out',
@@ -851,7 +854,10 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                       plusMenuOpen={plusMenuOpen}
                       setPlusMenuOpen={setPlusMenuOpen}
                       handlePreserveFocus={handlePreserveFocus}
-                      isDictationSupported={isDictationSupported}
+                      dictationEnabled={dictationEnabled}
+                      isDictationSupported={
+                        dictationEnabled && isDictationSupported
+                      }
                       isListening={isListening}
                       handleMicPushStart={handleMicPushStart}
                       handleMicPushEnd={handleMicPushEnd}
@@ -909,7 +915,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
 
                 {/* Grid accordion reserves height while animating dictation
                     banner in/out — avoids the ~64px jump (JOV-11948). */}
-                {isDictationSupported ? (
+                {dictationEnabled && isDictationSupported ? (
                   <div
                     className={cn(
                       'grid transition-[grid-template-rows] duration-subtle ease-in-out',
@@ -948,7 +954,10 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                   plusMenuOpen={plusMenuOpen}
                   setPlusMenuOpen={setPlusMenuOpen}
                   handlePreserveFocus={handlePreserveFocus}
-                  isDictationSupported={isDictationSupported}
+                  dictationEnabled={dictationEnabled}
+                  isDictationSupported={
+                    dictationEnabled && isDictationSupported
+                  }
                   isListening={isListening}
                   handleMicPushStart={handleMicPushStart}
                   handleMicPushEnd={handleMicPushEnd}
@@ -1023,6 +1032,7 @@ interface InputRowProps {
   readonly handlePreserveFocus: (
     event: React.MouseEvent<HTMLButtonElement>
   ) => void;
+  readonly dictationEnabled: boolean;
   readonly isDictationSupported: boolean;
   readonly isListening: boolean;
   readonly handleMicPushStart: () => void;
@@ -1072,6 +1082,7 @@ function InputRow({
   plusMenuOpen,
   setPlusMenuOpen,
   handlePreserveFocus,
+  dictationEnabled,
   isDictationSupported,
   isListening,
   handleMicPushStart,
@@ -1221,16 +1232,18 @@ function InputRow({
           </div>
 
           <div className='flex shrink-0 items-center gap-2'>
-            <ComposerMicButton
-              isListening={isListening}
-              isLoading={isLoading}
-              isSubmitting={isSubmitting}
-              isSupported={isDictationSupported}
-              onPreserveFocus={handlePreserveFocus}
-              onPushStart={handleMicPushStart}
-              onPushEnd={handleMicPushEnd}
-              onToggle={handleMicToggle}
-            />
+            {dictationEnabled ? (
+              <ComposerMicButton
+                isListening={isListening}
+                isLoading={isLoading}
+                isSubmitting={isSubmitting}
+                isSupported={isDictationSupported}
+                onPreserveFocus={handlePreserveFocus}
+                onPushStart={handleMicPushStart}
+                onPushEnd={handleMicPushEnd}
+                onToggle={handleMicToggle}
+              />
+            ) : null}
 
             <ComposerSendButton
               canSend={canSend}

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -472,6 +472,19 @@ describe('ChatInput', () => {
     expect(screen.getByRole('button', { name: /send message/i })).toBeEnabled();
   });
 
+  it('removes dictation chrome when the surrounding flow disables it', () => {
+    installMockSpeechRecognition();
+
+    fastRender(
+      withProviders(<ChatInput {...baseProps} dictationEnabled={false} />)
+    );
+
+    expect(screen.queryByTestId('dictation-toggle')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /dictation|microphone/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('starts push-to-talk dictation on pointer down and stops on release', async () => {
     installMockSpeechRecognition();
 

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -98,20 +98,35 @@ vi.mock('@/components/jovie/components', () => ({
     HTMLTextAreaElement,
     {
       readonly isSubmitting: boolean;
+      readonly dictationEnabled?: boolean;
       readonly onChange: (value: string) => void;
       readonly onSubmit: (event?: FormEvent) => void;
+      readonly placeholder?: string;
       readonly statusBanner?: ReactNode;
       readonly value: string;
     }
   >(function MockChatInput(
-    { isSubmitting, onChange, onSubmit, statusBanner, value },
+    {
+      dictationEnabled,
+      isSubmitting,
+      onChange,
+      onSubmit,
+      placeholder,
+      statusBanner,
+      value,
+    },
     ref
   ) {
     return (
-      <form onSubmit={onSubmit}>
+      <form
+        onSubmit={onSubmit}
+        data-dictation-enabled={dictationEnabled ? 'true' : 'false'}
+        data-has-status-banner={statusBanner ? 'true' : 'false'}
+      >
         <textarea
           ref={ref}
           aria-label='Chat Message Input'
+          placeholder={placeholder}
           value={value}
           onChange={event => onChange(event.currentTarget.value)}
         />
@@ -267,6 +282,10 @@ describe('OnboardingChat Turnstile gating', () => {
 
     expect(screen.getByTestId('onboarding-centered-composer')).toBeVisible();
     expect(screen.queryByTestId('onboarding-composer-dock')).toBeNull();
+    expect(screen.getByLabelText('Chat Message Input')).toHaveAttribute(
+      'placeholder',
+      'Artist, release, or link...'
+    );
 
     chatMocks.messages = [
       {
@@ -279,6 +298,10 @@ describe('OnboardingChat Turnstile gating', () => {
 
     expect(screen.getByTestId('onboarding-centered-composer')).toBeVisible();
     expect(screen.queryByTestId('onboarding-composer-dock')).toBeNull();
+    expect(screen.getByLabelText('Chat Message Input')).toHaveAttribute(
+      'placeholder',
+      'Reply to Jovie…'
+    );
 
     chatMocks.messages = [
       ...chatMocks.messages,
@@ -316,7 +339,7 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(screen.getByLabelText('Chat Message Input')).toHaveValue(
       'Hey, I want to get access to Jovie.'
     );
-    expect(screen.getByTestId('onboarding-turnstile-slot')).toHaveClass(
+    expect(screen.getByTestId('onboarding-flow-status')).toHaveClass(
       'min-h-[10rem]'
     );
     expect(screen.getByTestId('test-turnstile-panel')).toBeInTheDocument();
@@ -344,8 +367,14 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(onTurnstileRequired).toHaveBeenCalledWith(
       'Verify you are human to send'
     );
-    expect(screen.getByTestId('onboarding-turnstile-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-flow-status')).toBeInTheDocument();
     expect(screen.getByTestId('test-turnstile-panel')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Chat Message Input').closest('form')
+    ).toHaveAttribute('data-has-status-banner', 'false');
+    expect(
+      screen.getByLabelText('Chat Message Input').closest('form')
+    ).toHaveAttribute('data-dictation-enabled', 'false');
   });
 
   it('auto-submits a starter prompt once when verification is ready', async () => {
@@ -559,12 +588,11 @@ describe('OnboardingChat Turnstile gating', () => {
     );
 
     errorMocks.metadata = {
-      errorCode: 'TURNSTILE_REQUIRED',
-      message: 'Bot challenge failed',
+      message: 'Network interrupted',
       requestId: 'req-1',
     };
     act(() => {
-      chatMocks.onError?.(new Error('Bot challenge failed'));
+      chatMocks.onError?.(new Error('Network interrupted'));
     });
 
     chatMocks.sendMessage.mockClear();
@@ -610,12 +638,12 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(chatMocks.setMessages).toHaveBeenCalled();
     expect(chatMocks.messages).toEqual([]);
     expect(onTurnstileRejected).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('onboarding-message-recovery')).toHaveTextContent(
-      'Complete the security check to send your message.'
-    );
     expect(
-      screen.getByTestId('onboarding-message-recovery')
-    ).not.toHaveTextContent('Bot challenge failed');
+      screen.queryByTestId('onboarding-message-recovery')
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-flow-status')).toHaveTextContent(
+      'Verify you are human to send'
+    );
     expect(screen.getByLabelText('Chat Message Input')).toHaveValue(
       'I am Test Artist'
     );
@@ -722,7 +750,7 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(screen.getByText('Verify you are human to send')).toBeVisible();
 
     chatMocks.sendMessage.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: 'Retry message' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
 
     expect(chatMocks.sendMessage).not.toHaveBeenCalled();
     expect(screen.getByLabelText('Chat Message Input')).toHaveValue(


### PR DESCRIPTION
## Summary
- separate composer-local send failures from transcript pending state and flow-wide onboarding errors
- make onboarding replies use reply-specific status copy while suppressing duplicate recovery messaging
- opt onboarding out of microphone and dictation controls without changing shared chat defaults

## Verification
- 47/47 focused chat and onboarding tests passed
- Biome passed on all four changed files
- @jovie/web typecheck passed
- git diff --check passed

Closes #15057
Linear: JOV-4532