### PR TITLE
refactor(start): clear status ownership quality gate [JOV-4532]

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -482,6 +482,20 @@ interface OnboardingFlowStatusProps {
   readonly turnstilePanel: ReactNode;
 }
 
+function getOnboardingComposerPlaceholder(
+  handleDraft: string | null,
+  hasConversationStarted: boolean
+) {
+  if (handleDraft) return 'Confirm handle or type a different one…';
+  return hasConversationStarted
+    ? 'Reply to Jovie…'
+    : 'Artist, release, or link...';
+}
+
+function getSendLocalError(chatError: ChatError | null) {
+  return chatError?.errorCode === 'TURNSTILE_REQUIRED' ? null : chatError;
+}
+
 function OnboardingFlowStatus({
   reserveTurnstileSpace = false,
   shouldShowTurnstileBanner,
@@ -995,11 +1009,10 @@ export function OnboardingChat({
     isSubmitting: isSubmitted,
     isStreaming,
     onStop: stop,
-    placeholder: handleDraft
-      ? 'Confirm handle or type a different one…'
-      : hasConversationStarted
-        ? 'Reply to Jovie…'
-        : 'Artist, release, or link...',
+    placeholder: getOnboardingComposerPlaceholder(
+      handleDraft,
+      hasConversationStarted
+    ),
     dictationEnabled: false,
     onPickerOpenChange: setComposerPickerOpen,
     chips: chipTray.chips,
@@ -1008,8 +1021,7 @@ export function OnboardingChat({
     onAddSkill: chipTray.addSkill,
     onAddEntity: chipTray.addEntity,
   } as const;
-  const sendLocalError =
-    chatError?.errorCode === 'TURNSTILE_REQUIRED' ? null : chatError;
+  const sendLocalError = getSendLocalError(chatError);
   const onboardingComposerSurface = (
     <div className='mx-auto w-full max-w-[45rem]'>
       {sendLocalError ? (

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -710,6 +710,48 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       />
     );
     const showDictationBanner = isListening || Boolean(dictationError);
+    const inputRowProps = {
+      containerRef,
+      hiddenDivRef,
+      internalTextareaRef,
+      value,
+      onChange: handleChange,
+      handleKeyDown,
+      onPaste: handlePaste,
+      placeholder,
+      isAtMaxHeight,
+      measuredHeight,
+      reducedMotion,
+      isNearLimit,
+      hasAttachButton,
+      onFileAttach,
+      isFileProcessing,
+      isLoading,
+      isSubmitting,
+      plusMenuOpen,
+      setPlusMenuOpen,
+      handlePreserveFocus,
+      dictationEnabled,
+      isDictationSupported: dictationEnabled && isDictationSupported,
+      isListening,
+      handleMicPushStart,
+      handleMicPushEnd,
+      handleMicToggle,
+      canSend,
+      isStreaming,
+      onSend: handleSendClick,
+      onStop,
+      setIsFocused,
+      setComposerFocused,
+      chips,
+      onRemoveChipAt,
+      isPickerOpen,
+      isRootPickerOpen,
+      pickerListId,
+      pickerActiveRowId,
+      attachDisabledForPicker: isPickerOpen,
+      isHero,
+    } satisfies Omit<InputRowProps, 'hasBorderTop'>;
 
     return (
       <form
@@ -833,50 +875,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                     </div>
                   ) : null}
                   <div className='system-b-chat-composer-seam border-t'>
-                    <InputRow
-                      containerRef={containerRef}
-                      hiddenDivRef={hiddenDivRef}
-                      internalTextareaRef={internalTextareaRef}
-                      value={value}
-                      onChange={handleChange}
-                      handleKeyDown={handleKeyDown}
-                      onPaste={handlePaste}
-                      placeholder={placeholder}
-                      isAtMaxHeight={isAtMaxHeight}
-                      measuredHeight={measuredHeight}
-                      reducedMotion={reducedMotion}
-                      isNearLimit={isNearLimit}
-                      hasAttachButton={hasAttachButton}
-                      onFileAttach={onFileAttach}
-                      isFileProcessing={isFileProcessing}
-                      isLoading={isLoading}
-                      isSubmitting={isSubmitting}
-                      plusMenuOpen={plusMenuOpen}
-                      setPlusMenuOpen={setPlusMenuOpen}
-                      handlePreserveFocus={handlePreserveFocus}
-                      dictationEnabled={dictationEnabled}
-                      isDictationSupported={
-                        dictationEnabled && isDictationSupported
-                      }
-                      isListening={isListening}
-                      handleMicPushStart={handleMicPushStart}
-                      handleMicPushEnd={handleMicPushEnd}
-                      handleMicToggle={handleMicToggle}
-                      canSend={canSend}
-                      isStreaming={isStreaming}
-                      onSend={handleSendClick}
-                      onStop={onStop}
-                      setIsFocused={setIsFocused}
-                      setComposerFocused={setComposerFocused}
-                      chips={chips}
-                      onRemoveChipAt={onRemoveChipAt}
-                      isPickerOpen={isPickerOpen}
-                      isRootPickerOpen={isRootPickerOpen}
-                      pickerListId={pickerListId}
-                      pickerActiveRowId={pickerActiveRowId}
-                      attachDisabledForPicker={isPickerOpen}
-                      isHero={isHero}
-                    />
+                    <InputRow {...inputRowProps} />
                   </div>
                 </div>
               </div>
@@ -934,42 +933,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                 ) : null}
 
                 <InputRow
-                  containerRef={containerRef}
-                  hiddenDivRef={hiddenDivRef}
-                  internalTextareaRef={internalTextareaRef}
-                  value={value}
-                  onChange={handleChange}
-                  handleKeyDown={handleKeyDown}
-                  onPaste={handlePaste}
-                  placeholder={placeholder}
-                  isAtMaxHeight={isAtMaxHeight}
-                  measuredHeight={measuredHeight}
-                  reducedMotion={reducedMotion}
-                  isNearLimit={isNearLimit}
-                  hasAttachButton={hasAttachButton}
-                  onFileAttach={onFileAttach}
-                  isFileProcessing={isFileProcessing}
-                  isLoading={isLoading}
-                  isSubmitting={isSubmitting}
-                  plusMenuOpen={plusMenuOpen}
-                  setPlusMenuOpen={setPlusMenuOpen}
-                  handlePreserveFocus={handlePreserveFocus}
-                  dictationEnabled={dictationEnabled}
-                  isDictationSupported={
-                    dictationEnabled && isDictationSupported
-                  }
-                  isListening={isListening}
-                  handleMicPushStart={handleMicPushStart}
-                  handleMicPushEnd={handleMicPushEnd}
-                  handleMicToggle={handleMicToggle}
-                  canSend={canSend}
-                  isStreaming={isStreaming}
-                  onSend={handleSendClick}
-                  onStop={onStop}
-                  setIsFocused={setIsFocused}
-                  setComposerFocused={setComposerFocused}
-                  chips={chips}
-                  onRemoveChipAt={onRemoveChipAt}
+                  {...inputRowProps}
                   hasBorderTop={
                     // Add a top separator only when there is surface content
                     // *inside* the surface above the InputRow (entity mode).
@@ -978,12 +942,6 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                     // composer vertically.
                     showEntitySurface
                   }
-                  isPickerOpen={isPickerOpen}
-                  isRootPickerOpen={isRootPickerOpen}
-                  pickerListId={pickerListId}
-                  pickerActiveRowId={pickerActiveRowId}
-                  attachDisabledForPicker={isPickerOpen}
-                  isHero={isHero}
                 />
               </>
             )}


### PR DESCRIPTION
## Summary
- extract onboarding placeholder and send-error classification from the main chat component
- share the typed ChatInput row contract across stacked and split render paths
- clear the cognitive-complexity, nested-ternary, and duplicate-lines findings reported on #15289

## Verification
- 47/47 focused chat and onboarding tests passed on this exact tree
- Biome passed on all touched files
- @jovie/web typecheck passed
- git diff --check passed

Follow-up to #15289.
Linear: JOV-4532