### PR TITLE
fix(tasks): retain populated pane during warm loads [JOV-4649]

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -1542,9 +1542,19 @@ export function TasksPageClient() {
     statusFilter !== 'all' ||
     priorityFilter !== 'all' ||
     assigneeFilter !== 'human';
-  const isResolvingProfile = !profileId || !isTaskLayoutReady;
-  const isActiveBoardLoading = isResolvingProfile || isBoardLoading;
-  const isActiveListLoading = isResolvingProfile || isLoading;
+  const isResolvingProfile = !profileId;
+  const hasActiveTaskData = isBoardMode
+    ? boardData !== undefined
+    : data !== undefined;
+  const isResolvingTaskLayout = !isTaskLayoutReady && !hasActiveTaskData;
+  const isActiveBoardLoading =
+    isResolvingProfile ||
+    isResolvingTaskLayout ||
+    (isBoardLoading && boardData === undefined);
+  const isActiveListLoading =
+    isResolvingProfile ||
+    isResolvingTaskLayout ||
+    (isLoading && data === undefined);
   const showTaskListPane =
     isBoardMode ||
     isDesktopTaskLayout ||

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -954,15 +954,44 @@ describe('TasksPageClient', () => {
 
     renderPage();
 
+    expect(screen.getByTestId('tasks-board')).toBeInTheDocument();
     expect(
-      screen.getByTestId('task-workspace-loading-rows')
-    ).toBeInTheDocument();
+      screen.queryByTestId('task-workspace-loading-rows')
+    ).not.toBeInTheDocument();
     expect(mockUseTasksQuery.mock.calls.at(-1)?.[2]).toEqual({
       enabled: false,
     });
     expect(mockUseTaskBoardQuery.mock.calls.at(-1)?.[2]).toEqual({
       enabled: false,
     });
+  });
+
+  it('retains cached list content through saved view mode hydration', () => {
+    mockViewModeHydrated = false;
+
+    renderPage();
+
+    expect(screen.getByTestId('tasks-table')).toHaveAttribute(
+      'data-loading',
+      'false'
+    );
+    expect(
+      screen.queryByTestId('task-workspace-loading-rows')
+    ).not.toBeInTheDocument();
+  });
+
+  it('retains populated list content during a warm refetch', () => {
+    mockListQueryIsLoading = true;
+
+    renderPage();
+
+    expect(screen.getByTestId('tasks-table')).toHaveAttribute(
+      'data-loading',
+      'false'
+    );
+    expect(
+      screen.queryByTestId('task-workspace-loading-rows')
+    ).not.toBeInTheDocument();
   });
 
   it('shows shell loading rows on mobile instead of flashing the empty state', () => {


### PR DESCRIPTION
## Summary\n- keep cached Tasks list or board content mounted while responsive layout and saved view mode hydrate\n- keep populated rows visible through warm query transitions instead of swapping to skeletons\n- preserve the bounded task-pane loading state for genuinely cold loads with no data\n\n## Linear\nJOV-4649\n\n## Verification\n- Node 22.23.1 / pnpm 9.15.4\n- focused TasksPageClient suite: 55/55 passed\n- affected pre-push suite: 57/57 passed\n- Biome, Tailwind guard, proxy guard, typecheck, lint, CI harness, and diff-check passed\n- normal hooked force-with-lease push; no bypass\n\nTaste review is advisory and non-blocking per current shipping policy.