### PR TITLE
fix(ui): remove residual press compression

### DIFF
--- a/.claude/rules/motion.md
+++ b/.claude/rules/motion.md
@@ -77,7 +77,11 @@ Rules:
 
 ### Press feedback
 
-Every pressable element scales down on `:active`. Jovie's canonical press scale is **`var(--scale-press)` (0.96)** — per ui.md, not the source's 0.97.
+Press feedback is opt-in, not a default. Do not compress controls when the
+action already supplies immediate state feedback: play/pause, toggles,
+accordions, menus, navigation, and submitting controls remain static. When a
+standalone action has no other immediate cue and tactile compression materially
+helps, use the shared **`var(--scale-press)` (0.98)** token.
 
 ```css
 .button {
@@ -88,7 +92,9 @@ Every pressable element scales down on `:active`. Jovie's canonical press scale 
 }
 ```
 
-Press feedback must be tactile and interruptible; provide a static opt-out when motion would distract (ui.md).
+Press feedback must be tactile and interruptible; the shared Button defaults to
+`pressFeedback={false}`. Use that default for self-evident controls, and never
+hardcode a scale value or apply press scale to every pressable element.
 
 ### Never animate from `scale(0)`
 
@@ -147,6 +153,7 @@ When reviewing animation code, output a single markdown table with `| Before | A
 | UI duration > 300ms outside CINEMATIC intent | `--duration-subtle`/`--duration-slow` |
 | Hover animation without media query | `@media (hover: hover) and (pointer: fine)` |
 | Keyframes on rapidly-triggered element | CSS transitions |
-| No `:active` press feedback on pressable | `scale(var(--scale-press))` |
+| Press scale on a self-evident state change | Remove it; state change is the feedback |
+| Tactile press feedback needed without another cue | Opt in with `scale(var(--scale-press))` |
 | Same enter/exit speed on hold patterns | Exit faster than enter |
 | List items all appear at once | 30–80ms stagger |

--- a/apps/web/components/features/release/SmartLinkAudioPreview.tsx
+++ b/apps/web/components/features/release/SmartLinkAudioPreview.tsx
@@ -102,7 +102,7 @@ export function SmartLinkAudioPreview({
           aria-pressed={isPlaying}
           aria-busy={isLoading || undefined}
           disabled={isLoading}
-          className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/90 text-black dark:text-black transition-colors duration-fast hover:bg-white active:scale-[var(--scale-press)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:opacity-70 motion-reduce:active:scale-100'
+          className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/90 text-black dark:text-black transition-colors duration-fast hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:opacity-70'
         >
           {isLoading ? (
             <Loader2

--- a/apps/web/components/homepage/HomepagePosterHero.tsx
+++ b/apps/web/components/homepage/HomepagePosterHero.tsx
@@ -3,9 +3,6 @@ import Link from 'next/link';
 import type { ElementType, ReactNode } from 'react';
 import { HomepageCtaPendingLabel } from './HomepageCtaPendingLabel';
 
-const CTA_PRESS_CLASS =
-  'active:scale-[0.98] motion-reduce:active:scale-100 motion-reduce:transition-none';
-
 export interface HomepagePosterHeroCta {
   readonly label: ReactNode;
   readonly href: string;
@@ -60,13 +57,7 @@ export function HomepagePosterHero({
         <p className='homepage-poster-hero__subtitle'>{subtitle}</p>
         {lede ? <p className='homepage-poster-hero__lede'>{lede}</p> : null}
         <div className='homepage-poster-hero__actions'>
-          <Button
-            asChild
-            static
-            size='md'
-            variant='primary'
-            className={CTA_PRESS_CLASS}
-          >
+          <Button asChild static size='md' variant='primary'>
             <LinkComponent
               href={primaryCta.href}
               prefetch={primaryCta.prefetch}
@@ -80,13 +71,7 @@ export function HomepagePosterHero({
             </LinkComponent>
           </Button>
           {secondaryCta ? (
-            <Button
-              asChild
-              static
-              size='md'
-              variant='ghost'
-              className={CTA_PRESS_CLASS}
-            >
+            <Button asChild static size='md' variant='ghost'>
               <LinkComponent
                 href={secondaryCta.href}
                 prefetch={secondaryCta.prefetch}

--- a/apps/web/components/marketing/artist-profile/captureShared.tsx
+++ b/apps/web/components/marketing/artist-profile/captureShared.tsx
@@ -113,9 +113,9 @@ export function CaptureActionPill({
 
             <span
               className={cn(
-                'ap-capture-tracking rounded-full px-4 py-2.5 text-xs font-semibold transition-[background-color,color,transform] duration-subtle',
+                'ap-capture-tracking rounded-full px-4 py-2.5 text-xs font-semibold transition-[background-color,color] duration-subtle',
                 isSubmitting
-                  ? 'ap-capture-action__cta--submitting scale-[0.96] text-primary-token'
+                  ? 'ap-capture-action__cta--submitting text-primary-token'
                   : 'bg-surface-1 text-primary-token'
               )}
             >

--- a/apps/web/components/shell/JovieOverlay.tsx
+++ b/apps/web/components/shell/JovieOverlay.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { Mic } from 'lucide-react';
+import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 
 const MOTION_CINEMATIC =
@@ -31,6 +34,8 @@ export function JovieOverlay({
   listening: boolean;
   className?: string;
 }) {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
     <>
       {/* Backdrop dim — fades the entire shell when dictating so
@@ -55,9 +60,13 @@ export function JovieOverlay({
         style={{
           opacity: listening ? 1 : 0,
           transform: listening
-            ? 'translateY(0) scale(1)'
-            : 'translateY(16px) scale(0.96)',
-          transition: `opacity ${MOTION_CINEMATIC}, transform ${MOTION_CINEMATIC}`,
+            ? 'translateY(0)'
+            : prefersReducedMotion
+              ? 'translateY(0)'
+              : 'translateY(16px)',
+          transition: prefersReducedMotion
+            ? `opacity ${MOTION_CINEMATIC}`
+            : `opacity ${MOTION_CINEMATIC}, transform ${MOTION_CINEMATIC}`,
         }}
       >
         <div

--- a/apps/web/tests/unit/design-system/press-motion-contract.test.ts
+++ b/apps/web/tests/unit/design-system/press-motion-contract.test.ts
@@ -47,11 +47,32 @@ describe('shared press-motion contract', () => {
     const entityCard = readWeb(
       'components/organisms/entity-card/EntityCard.tsx'
     );
+    const smartLinkAudioPreview = readWeb(
+      'components/features/release/SmartLinkAudioPreview.tsx'
+    );
+    const homepagePosterHero = readWeb(
+      'components/homepage/HomepagePosterHero.tsx'
+    );
+    const captureShared = readWeb(
+      'components/marketing/artist-profile/captureShared.tsx'
+    );
+    const jovieOverlay = readWeb('components/shell/JovieOverlay.tsx');
 
     expect(bottomTabs).not.toContain('active:scale');
     expect(bottomTabs).not.toContain('transition-[color,transform]');
     expect(entityCard).toContain('group-active:scale-[var(--scale-press)]');
     expect(entityCard).not.toContain('group-active:scale-[0.96]');
+    expect(smartLinkAudioPreview).not.toContain('active:scale');
+    expect(homepagePosterHero).not.toContain('active:scale');
+    expect(captureShared).not.toContain('scale-[0.96]');
+    expect(captureShared).not.toContain(
+      'transition-[background-color,color,transform]'
+    );
+    expect(jovieOverlay).not.toContain('scale(0.96)');
+    expect(jovieOverlay).toContain('useReducedMotion');
+    expect(jovieOverlay).toMatch(
+      /prefersReducedMotion\s*\?\s*'translateY\(0\)'/
+    );
   });
 
   it.each([

--- a/apps/web/tests/unit/home/HomepagePosterHero.test.tsx
+++ b/apps/web/tests/unit/home/HomepagePosterHero.test.tsx
@@ -56,13 +56,12 @@ describe('HomepagePosterHero', () => {
     expect(primaryLink).toHaveAttribute('href', '/signup');
     expect(primaryLink).toHaveAttribute('data-size', 'md');
     expect(primaryLink).toHaveAttribute('data-variant', 'primary');
-    expect(primaryLink).toHaveClass('active:scale-[0.98]');
-    expect(primaryLink).toHaveClass('motion-reduce:active:scale-100');
+    expect(primaryLink).not.toHaveClass('active:scale-[0.98]');
 
     const secondaryLink = screen.getByRole('link', { name: 'See proof' });
     expect(secondaryLink).toHaveAttribute('href', '/artist-profiles');
     expect(secondaryLink).toHaveAttribute('data-variant', 'ghost');
-    expect(secondaryLink).toHaveClass('active:scale-[0.98]');
+    expect(secondaryLink).not.toHaveClass('active:scale-[0.98]');
     // Secondary must stay quieter than the primary conversion control.
     expect(secondaryLink.getAttribute('data-variant')).not.toBe('primary');
   });

--- a/apps/web/tests/unit/home/homepage-hero-next-move-contract.test.ts
+++ b/apps/web/tests/unit/home/homepage-hero-next-move-contract.test.ts
@@ -38,8 +38,7 @@ describe('homepage hero next-move contract (JOV-4475)', () => {
     expect(heroSource).not.toMatch(
       /secondaryCta[\s\S]*?variant=['"]tertiary['"]/
     );
-    expect(heroSource).toContain('active:scale-[0.98]');
-    expect(heroSource).toContain('motion-reduce:active:scale-100');
+    expect(heroSource).not.toContain('active:scale');
   });
 
   it('uses a 100ms opacity-only ready reveal with reduced-motion parity', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4637 -->

## Summary
- remove press scaling from controls whose state change is already immediate
- keep the dictation overlay spatial with opacity/translate, respecting reduced motion
- align the written motion rule and source guard to the opt-in 0.98 contract

## Verification
- `pnpm --filter web exec vitest run tests/unit/design-system/press-motion-contract.test.ts tests/unit/home/HomepagePosterHero.test.tsx tests/unit/home/homepage-hero-next-move-contract.test.ts tests/components/features/release/SmartLinkAudioPreview.test.tsx components/shell/__tests__/JovieOverlay.test.tsx --maxWorkers 1` — 29/29 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- targeted Biome + `git diff --check` — passed
- `pnpm --filter @jovie/web run test:bug-to-test` — not applicable (not classified as a bug fix PR)

No Kimi/Grok review: taste is advisory under the current nonblocking policy.