### PR TITLE
fix(admin): relocate campaign and waitlist defaults

### DIFF
--- a/apps/web/app/app/(shell)/admin/people/page.tsx
+++ b/apps/web/app/app/(shell)/admin/people/page.tsx
@@ -7,6 +7,7 @@ import { AdminUsersTableUnified } from '@/components/features/admin/admin-users-
 import { AdminFeedbackTable } from '@/components/features/admin/feedback-table/AdminFeedbackTable';
 import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { WaitlistMetrics } from '@/components/features/admin/WaitlistMetrics';
+import { WaitlistSettingsPanel } from '@/components/features/admin/WaitlistSettingsPanel';
 import { AdminWaitlistTableWithViews } from '@/components/features/admin/waitlist-table/AdminWaitlistTableWithViews';
 import {
   type AdminPeopleView,
@@ -97,6 +98,7 @@ async function renderPeopleView(
       return (
         <div className='space-y-4'>
           <WaitlistMetrics metrics={metrics} />
+          <WaitlistSettingsPanel />
           <AdminWaitlistTableWithViews
             entries={entries}
             page={1}

--- a/apps/web/components/features/admin/OperationalControlPanel.tsx
+++ b/apps/web/components/features/admin/OperationalControlPanel.tsx
@@ -2,8 +2,6 @@
 
 import { Terminal } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { CampaignSettingsPanel } from '@/components/features/admin/campaigns/CampaignSettingsPanel';
-import { WaitlistSettingsPanel } from '@/components/features/admin/WaitlistSettingsPanel';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { SettingsPanel } from '@/components/molecules/settings/SettingsPanel';
@@ -45,7 +43,7 @@ export function OperationalControlPanel() {
     >
       <ContentSectionHeader
         title='Operational controls'
-        subtitle='Environment, people intake, and growth defaults in one place.'
+        subtitle='Local environment helpers for operator sessions.'
       />
       <div className='space-y-6 p-4 sm:p-5'>
         <SettingsPanel
@@ -63,9 +61,6 @@ export function OperationalControlPanel() {
             />
           </div>
         </SettingsPanel>
-
-        <WaitlistSettingsPanel />
-        <CampaignSettingsPanel />
       </div>
     </ContentSurfaceCard>
   );

--- a/apps/web/components/features/admin/leads/GtmCollapsibles.tsx
+++ b/apps/web/components/features/admin/leads/GtmCollapsibles.tsx
@@ -50,6 +50,14 @@ const LeadPipelineControls = dynamic(
   { ssr: false }
 );
 
+const CampaignSettingsPanel = dynamic(
+  () =>
+    import('@/components/features/admin/campaigns/CampaignSettingsPanel').then(
+      m => m.CampaignSettingsPanel
+    ),
+  { ssr: false }
+);
+
 interface AccordionSectionProps {
   readonly title: string;
   readonly isOpen: boolean;
@@ -177,8 +185,9 @@ export function GtmCollapsibles({ initialOpen }: GtmCollapsiblesProps) {
         onToggle={() => toggle(1)}
       >
         {everOpened.has(1) && (
-          <div className='px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)'>
+          <div className='space-y-4 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)'>
             <LeadPipelineControls hideMainSwitch embedded />
+            <CampaignSettingsPanel />
           </div>
         )}
       </AccordionSection>

--- a/apps/web/tests/unit/app/admin-ops-controls-moved.test.ts
+++ b/apps/web/tests/unit/app/admin-ops-controls-moved.test.ts
@@ -3,9 +3,8 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * JOV-2103 — operational on/off controls must not live under Settings.
- * They belong on the Ops OperationalControlPanel; Settings keeps only a
- * redirect/discovery pointer for admins.
+ * JOV-4639 — environment controls belong on Ops, campaign defaults belong
+ * with Growth, and people intake defaults belong with the waitlist.
  */
 
 function findSourceFile(...candidates: string[]): string {
@@ -62,6 +61,19 @@ const OPS_PAGE = findSourceFile(
   resolve(process.cwd(), 'apps/web/app/app/(shell)/admin/ops/page.tsx')
 );
 
+const GROWTH_COLLAPSIBLES = findSourceFile(
+  resolve(process.cwd(), 'components/features/admin/leads/GtmCollapsibles.tsx'),
+  resolve(
+    process.cwd(),
+    'apps/web/components/features/admin/leads/GtmCollapsibles.tsx'
+  )
+);
+
+const PEOPLE_PAGE = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/admin/people/page.tsx'),
+  resolve(process.cwd(), 'apps/web/app/app/(shell)/admin/people/page.tsx')
+);
+
 const SETTINGS_ROUTE_DIR = findSourceFile(
   resolve(process.cwd(), 'app/app/(shell)/settings'),
   resolve(process.cwd(), 'apps/web/app/app/(shell)/settings')
@@ -70,14 +82,13 @@ const SETTINGS_ROUTE_DIR = findSourceFile(
 const OPERATIONAL_PANEL_MARKERS = [
   'WaitlistSettingsPanel',
   'CampaignSettingsPanel',
-  'OperationalControlPanel',
   'Toggle waitlist gate',
   'Toggle auto-accept',
   'Toggle dev toolbar',
   'Manual approval gate',
 ] as const;
 
-describe('JOV-2103 operational controls moved to Ops', () => {
+describe('JOV-4639 admin settings are owned by their workspace', () => {
   it('keeps /settings/admin as a redirect-only pointer to Ops', () => {
     const source = readFileSync(SETTINGS_ADMIN_PAGE, 'utf8');
 
@@ -89,16 +100,26 @@ describe('JOV-2103 operational controls moved to Ops', () => {
     expect(source).not.toContain('SettingsToggleRow');
   });
 
-  it('mounts the consolidated operational control panel on Ops', () => {
+  it('keeps only environment controls on Ops', () => {
     const opsPage = readFileSync(OPS_PAGE, 'utf8');
     const panel = readFileSync(OPERATIONAL_CONTROL_PANEL, 'utf8');
 
     expect(opsPage).toContain('OperationalControlPanel');
     expect(opsPage).toContain('<OperationalControlPanel');
     expect(panel).toContain("data-testid='operational-control-panel'");
-    expect(panel).toContain('WaitlistSettingsPanel');
-    expect(panel).toContain('CampaignSettingsPanel');
     expect(panel).toContain('Dev toolbar');
+    expect(panel).not.toContain('WaitlistSettingsPanel');
+    expect(panel).not.toContain('CampaignSettingsPanel');
+  });
+
+  it('mounts campaign defaults in Growth advanced settings and waitlist defaults in People', () => {
+    const growthCollapsibles = readFileSync(GROWTH_COLLAPSIBLES, 'utf8');
+    const peoplePage = readFileSync(PEOPLE_PAGE, 'utf8');
+
+    expect(growthCollapsibles).toContain('CampaignSettingsPanel');
+    expect(growthCollapsibles).toContain("title='Advanced Settings'");
+    expect(peoplePage).toContain('WaitlistSettingsPanel');
+    expect(peoplePage).toContain('<WaitlistSettingsPanel');
   });
 
   it('does not reintroduce operational control panels under Settings routes', () => {

--- a/apps/web/tests/unit/app/admin-settings-heading-typography.test.ts
+++ b/apps/web/tests/unit/app/admin-settings-heading-typography.test.ts
@@ -134,7 +134,8 @@ describe('admin settings heading typography', () => {
 
     expect(operationalControls).toContain('import { SettingsPanel }');
     expect(operationalControls).toContain('<SettingsPanel');
-    expect(operationalControls).toContain('WaitlistSettingsPanel');
-    expect(operationalControls).toContain('CampaignSettingsPanel');
+    // Waitlist/campaign defaults moved to People/Growth (JOV-4639)
+    expect(operationalControls).not.toContain('WaitlistSettingsPanel');
+    expect(operationalControls).not.toContain('CampaignSettingsPanel');
   });
 });

--- a/apps/web/tests/unit/components/admin/OperationalControlPanel.test.tsx
+++ b/apps/web/tests/unit/components/admin/OperationalControlPanel.test.tsx
@@ -1,23 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { OperationalControlPanel } from '@/features/admin/OperationalControlPanel';
 
-vi.mock('@/components/features/admin/WaitlistSettingsPanel', () => ({
-  WaitlistSettingsPanel: () => <div>Waitlist settings</div>,
-}));
-
-vi.mock('@/components/features/admin/campaigns/CampaignSettingsPanel', () => ({
-  CampaignSettingsPanel: () => <div>Campaign settings</div>,
-}));
-
 describe('OperationalControlPanel', () => {
-  it('renders the consolidated operational controls card', () => {
+  it('renders only the operational environment controls', () => {
     render(<OperationalControlPanel />);
 
     expect(screen.getByTestId('operational-control-panel')).toBeInTheDocument();
     expect(screen.getByText('Operational controls')).toBeInTheDocument();
     expect(screen.getByText('Dev toolbar')).toBeInTheDocument();
-    expect(screen.getByText('Waitlist settings')).toBeInTheDocument();
-    expect(screen.getByText('Campaign settings')).toBeInTheDocument();
+    expect(screen.queryByText('Waitlist settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Campaign settings')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4639 -->

## Summary
- keep Ops focused on local environment controls
- mount existing campaign defaults in Growth > Advanced Settings
- mount existing waitlist defaults in People > Waitlist

## Verification
- `pnpm biome check --write` on changed files
- focused admin relocation contracts: 5 passed
- reused settings panel suites: 6 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

No routes, APIs, permissions, loading, or error handling changed.