### PR TITLE
fix(ui): neutralize routine shell states

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6413,25 +6413,25 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
    ============================================ */
 
 [data-app-shell-frame="true"] {
-  /* Surfaces — stepped Noir Ion elevation via semantic aliases */
-  --app-shell-content-surface: #0a0d16; /* panel canvas */
-  --app-shell-frame-seam: rgba(168, 176, 195, 0.1);
-  --app-shell-border: rgba(168, 176, 195, 0.16);
+  /* Surfaces — neutral graphite elevation; Ion stays reserved for intent. */
+  --app-shell-content-surface: #101114; /* panel canvas */
+  --app-shell-frame-seam: rgba(255, 255, 255, 0.07);
+  --app-shell-border: rgba(255, 255, 255, 0.12);
   --system-b-app-content-surface: var(--app-shell-content-surface);
   --system-b-app-frame-seam: var(--app-shell-frame-seam);
   --system-b-app-shell-border: var(--app-shell-border);
 
-  --color-bg-surface-0: #0a0d16; /* panel / recessed wells */
-  --color-bg-surface-1: #0f1420; /* card */
-  --color-bg-surface-2: #151b2a; /* elevated */
-  --color-bg-surface-3: #1b2436; /* floating */
-  --color-bg-elevated: #151b2a;
-  --color-bg-tooltip: #1b2436;
-  --color-bg-hover: rgba(17, 175, 255, 0.06);
-  --color-bg-active: rgba(17, 175, 255, 0.1);
-  --color-bg-input: #0f1420;
-  --color-row-hover: rgba(17, 175, 255, 0.06);
-  --color-row-selected: rgba(17, 175, 255, 0.1);
+  --color-bg-surface-0: #0b0c0f; /* recessed wells */
+  --color-bg-surface-1: #14161a; /* card */
+  --color-bg-surface-2: #1b1d22; /* elevated */
+  --color-bg-surface-3: #24272d; /* floating */
+  --color-bg-elevated: #1b1d22;
+  --color-bg-tooltip: #24272d;
+  --color-bg-hover: rgba(255, 255, 255, 0.055);
+  --color-bg-active: rgba(255, 255, 255, 0.085);
+  --color-bg-input: #14161a;
+  --color-row-hover: rgba(255, 255, 255, 0.055);
+  --color-row-selected: rgba(255, 255, 255, 0.085);
   --system-b-bg-surface-0: var(--color-bg-surface-0);
   --system-b-bg-surface-1: var(--color-bg-surface-1);
   --system-b-bg-surface-2: var(--color-bg-surface-2);
@@ -6446,19 +6446,19 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
   --color-surface-active: var(--color-bg-active);
 
   /* Borders / focus — electric ion */
-  --color-border-subtle: rgba(168, 176, 195, 0.1);
-  --color-border-default: rgba(168, 176, 195, 0.16);
-  --color-border-strong: rgba(199, 237, 255, 0.26);
+  --color-border-subtle: rgba(255, 255, 255, 0.07);
+  --color-border-default: rgba(255, 255, 255, 0.12);
+  --color-border-strong: rgba(255, 255, 255, 0.22);
   --color-border-focus: rgba(17, 175, 255, 0.72);
   --color-focus-ring: rgba(17, 175, 255, 0.72);
 
   /* Overlay elevation (popovers / tooltips / drawers) */
   --shadow-popover:
-    0 0 0 1px rgba(168, 176, 195, 0.16), 0 12px 32px rgba(0, 0, 0, 0.5);
+    0 0 0 1px rgba(255, 255, 255, 0.12), 0 12px 32px rgba(0, 0, 0, 0.52);
 
   /* Skeleton / loading — reserved geometry; color only */
-  --color-skeleton-base: #151b2a;
-  --color-skeleton-shimmer: rgba(168, 176, 195, 0.14);
+  --color-skeleton-base: #1b1d22;
+  --color-skeleton-shimmer: rgba(255, 255, 255, 0.11);
 }
 
 :where(.system-b-table-row-height) {

--- a/apps/web/tests/unit/design-system/noir-ion-workspace-states.test.tsx
+++ b/apps/web/tests/unit/design-system/noir-ion-workspace-states.test.tsx
@@ -53,19 +53,30 @@ function extractShellWorkspaceBlock(css: string): string {
 describe('Noir Ion D — workspace state surfaces (JOV-4648)', () => {
   const shellBlock = extractShellWorkspaceBlock(DESIGN_SYSTEM_CSS);
 
-  it('contains shell-scoped Noir Ion anchors without writing them on :root', () => {
-    expect(shellBlock).toContain('--color-row-hover: rgba(17, 175, 255, 0.06)');
+  it('keeps routine workspace state and depth graphite, reserving Ion for focus', () => {
     expect(shellBlock).toContain(
-      '--color-row-selected: rgba(17, 175, 255, 0.1)'
+      '--color-row-hover: rgba(255, 255, 255, 0.055)'
+    );
+    expect(shellBlock).toContain(
+      '--color-row-selected: rgba(255, 255, 255, 0.085)'
     );
     expect(shellBlock).toContain(
       '--color-focus-ring: rgba(17, 175, 255, 0.72)'
     );
-    expect(shellBlock).toContain('--color-bg-elevated: #151b2a');
-    expect(shellBlock).toContain('--color-bg-tooltip: #1b2436');
-    expect(shellBlock).toContain('--color-skeleton-base: #151b2a');
-    expect(shellBlock).toContain('--app-shell-content-surface: #0a0d16');
-    expect(shellBlock).toContain('--color-bg-surface-1: #0f1420');
+    expect(shellBlock).toContain('--color-bg-elevated: #1b1d22');
+    expect(shellBlock).toContain('--color-bg-tooltip: #24272d');
+    expect(shellBlock).toContain('--color-skeleton-base: #1b1d22');
+    expect(shellBlock).toContain('--app-shell-content-surface: #101114');
+    expect(shellBlock).toContain('--color-bg-surface-1: #14161a');
+    expect(shellBlock).toContain(
+      '--color-bg-hover: rgba(255, 255, 255, 0.055)'
+    );
+    expect(shellBlock).toContain(
+      '--color-bg-active: rgba(255, 255, 255, 0.085)'
+    );
+    expect(shellBlock).toContain(
+      '--color-border-default: rgba(255, 255, 255, 0.12)'
+    );
     // Shrink-only: shell block must not introduce new --linear-* call sites.
     expect(shellBlock).not.toMatch(/--linear-[a-z0-9-]+/);
 
@@ -75,9 +86,11 @@ describe('Noir Ion D — workspace state surfaces (JOV-4648)', () => {
     );
     expect(rootBlocks?.length).toBeGreaterThan(0);
     for (const block of rootBlocks ?? []) {
-      expect(block).not.toContain('--color-row-selected: rgba(17, 175, 255');
-      expect(block).not.toContain('--color-bg-elevated: #151b2a');
-      expect(block).not.toContain('--color-bg-tooltip: #1b2436');
+      expect(block).not.toContain(
+        '--color-row-selected: rgba(255, 255, 255, 0.085)'
+      );
+      expect(block).not.toContain('--color-bg-elevated: #1b1d22');
+      expect(block).not.toContain('--color-bg-tooltip: #24272d');
     }
   });
 


### PR DESCRIPTION
Closes JOV-4691

## Summary
- rebinds only the authenticated `[data-app-shell-frame="true"]` semantic surface ladder to neutral charcoal/graphite
- replaces routine hover, selection, and active blue fills with restrained neutral states
- preserves Ion blue for keyboard focus and primary intent, preserving status/accent semantics

Design-read: Reading this as: an authenticated creator-workspace shell for operators, with a dense cinematic language, leaning toward the established System B semantic token system.
Dials: DESIGN_VARIANCE=low, MOTION_INTENSITY=none, VISUAL_DENSITY=high

Before/after evidence: token contract isolates the change to the authenticated shell; no public, marketing, auth, or layout selector changed.
Checklist: contrast pass, states pass, layout pass (token-only, stable geometry), motion pass, icons pass, anti-slop pass, evidence pass.
Verification:
- `pnpm --filter web exec vitest run tests/unit/design-system/noir-ion-workspace-states.test.tsx tests/unit/design-system/noir-ion-tokens.test.ts --maxWorkers 1` (11/11)
- `pnpm biome check --write apps/web/styles/design-system.css apps/web/tests/unit/design-system/noir-ion-workspace-states.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run test:bug-to-test`