### PR TITLE
fix(tooling): never replace live typecheck singleflight owners by age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Typecheck singleflight no longer replaces live owners by age (JOV-4524):** locks are reclaimed only for dead owners, missing-pid age expiry, or bounded corrupt-lock recovery; live owners past the 30m window stay authoritative, with structured recovery logs and regression coverage.
 - [internal] **Machine-access revenue-share compliance package (JOV-3831):** draft decision set (70/30 artist-majority, opt-in default OFF, monthly $10 Connect fiat floor, platform stablecoin off-ramp), consent/ToS language, tax reporting path, and Pay Per Crawl public-docs verification — Tim sign-off still required before P1 build.
 - [internal] **Profile redesign proposal loop (JOV-1951):** Design Lab can generate pending mockup proposals for owned profiles and selected competitor handles; output stays gated by D2 approval before any production or design-system rollout.
 - [internal] **Shared organisms layer is server-import-free (JOV-3506):** ProfileSwitcher switches active profiles via `POST /api/dashboard/profile/switch` instead of importing a dashboard server action, driving the server-imports ratchet baseline to 0.

--- a/scripts/lib/__tests__/typecheck-singleflight.test.mjs
+++ b/scripts/lib/__tests__/typecheck-singleflight.test.mjs
@@ -1,55 +1,436 @@
 import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+  evaluateLockRecovery,
+  formatRecoveryLogLine,
+  normalizePid,
+} from '../typecheck-singleflight-lock.mjs';
 
 const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
 const wrapper = resolve(repoRoot, 'scripts/typecheck-singleflight.mjs');
 const temporaryDirectories = [];
+const childProcesses = [];
 
 afterEach(() => {
+  for (const child of childProcesses.splice(0)) {
+    if (!child.killed) {
+      child.kill('SIGKILL');
+    }
+  }
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
-function runWrapper(stateDir, marker) {
-  const script =
+function makeStateDir() {
+  const stateDir = mkdtempSync(resolve(tmpdir(), 'jovie-singleflight-'));
+  temporaryDirectories.push(stateDir);
+  return stateDir;
+}
+
+function wrapperEnv(stateDir, overrides = {}) {
+  return {
+    ...process.env,
+    TYPECHECK_SINGLEFLIGHT_DIR: stateDir,
+    TYPECHECK_SINGLEFLIGHT_POLL_MS: '25',
+    TYPECHECK_SINGLEFLIGHT_STALE_MS: '100',
+    TYPECHECK_SINGLEFLIGHT_REUSE_WINDOW_MS: '5000',
+    ...overrides,
+  };
+}
+
+function ownerScript(durationMs) {
+  // Track concurrent live owners so we can prove singleflight serialization
+  // independently of completed-result reuse (commands/fingerprints differ by
+  // argv paths across helper variants).
+  return (
     "const fs=require('node:fs');" +
-    "fs.appendFileSync(process.argv[1], 'owner\\n');" +
-    'setTimeout(() => process.exit(0), 700);';
+    'const marker=process.argv[1];' +
+    'const active=process.argv[2];' +
+    "const n=Number(fs.readFileSync(active,'utf8')||'0')+1;" +
+    'fs.writeFileSync(active,String(n));' +
+    "fs.appendFileSync(marker,'owner concurrent='+n+'\\n');" +
+    `setTimeout(()=>{` +
+    "const m=Number(fs.readFileSync(active,'utf8'))-1;" +
+    'fs.writeFileSync(active,String(m));' +
+    'process.exit(0);' +
+    `},${durationMs});`
+  );
+}
+
+function runWrapper(stateDir, marker, options = {}) {
+  const durationMs = options.durationMs ?? 700;
+  const active = resolve(stateDir, 'active.txt');
+  if (!existsSync(active)) {
+    writeFileSync(active, '0');
+  }
   return new Promise(resolveRun => {
     const child = spawn(
       process.execPath,
-      [wrapper, '--', process.execPath, '-e', script, marker],
+      [
+        wrapper,
+        '--',
+        process.execPath,
+        '-e',
+        ownerScript(durationMs),
+        marker,
+        active,
+      ],
       {
         cwd: repoRoot,
-        env: {
-          ...process.env,
-          TYPECHECK_SINGLEFLIGHT_DIR: stateDir,
-          TYPECHECK_SINGLEFLIGHT_POLL_MS: '25',
-          TYPECHECK_SINGLEFLIGHT_STALE_MS: '100',
-          TYPECHECK_SINGLEFLIGHT_REUSE_WINDOW_MS: '5000',
-        },
-        stdio: 'ignore',
+        env: wrapperEnv(stateDir, options.env),
+        stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'ignore',
       }
     );
-    child.once('exit', code => resolveRun(code));
+    childProcesses.push(child);
+    let stdout = '';
+    let stderr = '';
+    if (options.capture) {
+      child.stdout.on('data', chunk => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr.on('data', chunk => {
+        stderr += chunk.toString('utf8');
+      });
+    }
+    child.once('exit', code =>
+      resolveRun({ code, stdout, stderr, pid: child.pid })
+    );
   });
 }
 
-describe('typecheck singleflight', () => {
+function maxConcurrentOwners(markerPath) {
+  const lines = readFileSync(markerPath, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  return lines.reduce((max, line) => {
+    const match = /concurrent=(\d+)/.exec(line);
+    return match ? Math.max(max, Number(match[1])) : max;
+  }, 0);
+}
+
+function writeLock(stateDir, lock) {
+  writeFileSync(resolve(stateDir, 'lock.json'), JSON.stringify(lock, null, 2));
+}
+
+function holdLiveProcess(ms = 5_000) {
+  const child = spawn(process.execPath, ['-e', `setTimeout(() => {}, ${ms})`], {
+    stdio: 'ignore',
+  });
+  childProcesses.push(child);
+  return child;
+}
+
+describe('typecheck singleflight lock recovery', () => {
+  const staleMs = 30 * 60_000;
+  const nowMs = 1_700_000_000_000;
+
+  it('never marks a live owner recoverable solely because the lock is old', () => {
+    const recovery = evaluateLockRecovery(
+      {
+        pid: process.pid,
+        startedAtMs: nowMs - staleMs - 60_000,
+        cwd: 'apps/web',
+        command: ['tsc', '--noEmit'],
+      },
+      {
+        nowMs,
+        staleMs,
+        lockFileAgeMs: staleMs + 60_000,
+        isProcessAlive: () => true,
+      }
+    );
+
+    expect(recovery).toMatchObject({
+      recoverable: false,
+      reason: null,
+      pid: process.pid,
+    });
+  });
+
+  it('recovers a dead owner immediately, even when the lock is young', () => {
+    const recovery = evaluateLockRecovery(
+      {
+        pid: 2_147_483_646,
+        startedAtMs: nowMs - 1_000,
+        cwd: 'apps/web',
+        command: ['tsc', '--noEmit'],
+      },
+      {
+        nowMs,
+        staleMs,
+        lockFileAgeMs: 1_000,
+        isProcessAlive: () => false,
+      }
+    );
+
+    expect(recovery).toMatchObject({
+      recoverable: true,
+      reason: 'dead-owner',
+      pid: 2_147_483_646,
+      cwd: 'apps/web',
+      command: ['tsc', '--noEmit'],
+    });
+  });
+
+  it('recovers missing-pid locks only after the stale window', () => {
+    const young = evaluateLockRecovery(
+      {
+        startedAtMs: nowMs - 1_000,
+        cwd: '.',
+        command: ['tsc'],
+      },
+      {
+        nowMs,
+        staleMs,
+        lockFileAgeMs: 1_000,
+        isProcessAlive: () => true,
+      }
+    );
+    const old = evaluateLockRecovery(
+      {
+        startedAtMs: nowMs - staleMs - 1,
+        cwd: '.',
+        command: ['tsc'],
+      },
+      {
+        nowMs,
+        staleMs,
+        lockFileAgeMs: staleMs + 1,
+        isProcessAlive: () => true,
+      }
+    );
+
+    expect(young.recoverable).toBe(false);
+    expect(old).toMatchObject({
+      recoverable: true,
+      reason: 'missing-pid-stale-by-age',
+      pid: null,
+    });
+  });
+
+  it('recovers corrupt JSON only after the bounded file-age window', () => {
+    const fresh = evaluateLockRecovery(null, {
+      nowMs,
+      staleMs,
+      lockFileAgeMs: 1_000,
+      isProcessAlive: () => true,
+    });
+    const aged = evaluateLockRecovery(null, {
+      nowMs,
+      staleMs,
+      lockFileAgeMs: 5_001,
+      isProcessAlive: () => true,
+    });
+
+    expect(fresh.recoverable).toBe(false);
+    expect(aged).toMatchObject({
+      recoverable: true,
+      reason: 'corrupt-or-unreadable-lock',
+    });
+  });
+
+  it('normalizes string pids and keeps live string owners non-recoverable by age', () => {
+    expect(normalizePid('4242')).toBe(4242);
+    expect(normalizePid('nope')).toBeNull();
+
+    const recovery = evaluateLockRecovery(
+      {
+        pid: String(process.pid),
+        startedAtMs: nowMs - staleMs - 1,
+        cwd: '.',
+        command: ['tsc'],
+      },
+      {
+        nowMs,
+        staleMs,
+        lockFileAgeMs: staleMs + 1,
+        isProcessAlive: pid => pid === process.pid,
+      }
+    );
+
+    expect(recovery.recoverable).toBe(false);
+  });
+
+  it('logs owner cwd, command, age, and recovery reason without secrets', () => {
+    const line = formatRecoveryLogLine(
+      {
+        recoverable: true,
+        reason: 'dead-owner',
+        ageMs: 95_000,
+        pid: 99,
+        cwd: 'apps/web',
+        command: ['tsc', '-p', 'tsconfig.json'],
+      },
+      parts => parts.join(' ')
+    );
+
+    expect(line).toContain('pid 99');
+    expect(line).toContain('cwd=apps/web');
+    expect(line).toContain('command=tsc -p tsconfig.json');
+    expect(line).toContain('age=95s');
+    expect(line).toContain('reason=dead-owner');
+  });
+});
+
+describe('typecheck singleflight process integration', () => {
   it('never evicts a live owner solely because its lock is old', async () => {
-    const stateDir = mkdtempSync(resolve(tmpdir(), 'jovie-singleflight-'));
-    temporaryDirectories.push(stateDir);
+    const stateDir = makeStateDir();
     const marker = resolve(stateDir, 'owners.txt');
 
-    const first = runWrapper(stateDir, marker);
+    // STALE_MS=100 and second starts at 250ms: age-first recovery would spawn
+    // a concurrent second owner while the first is still live.
+    const first = runWrapper(stateDir, marker, { durationMs: 700 });
     await new Promise(resolveWait => setTimeout(resolveWait, 250));
-    const second = runWrapper(stateDir, marker);
+    const second = runWrapper(stateDir, marker, { durationMs: 700 });
 
-    expect(await Promise.all([first, second])).toEqual([0, 0]);
-    expect(readFileSync(marker, 'utf8').trim().split('\n')).toEqual(['owner']);
+    const results = await Promise.all([first, second]);
+    expect(results.map(result => result.code)).toEqual([0, 0]);
+    expect(maxConcurrentOwners(marker)).toBe(1);
+    // Waiter may re-run after the first completes (result fingerprint matches
+    // when commands are identical) — either reuse or a single serialized re-run
+    // is fine; concurrent owners are not.
+    const ownerLines = readFileSync(marker, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    expect(ownerLines.length).toBeGreaterThanOrEqual(1);
+    expect(ownerLines.length).toBeLessThanOrEqual(2);
+  });
+
+  it('reclaims a dead owner and becomes the sole live tsc owner', async () => {
+    const stateDir = makeStateDir();
+    const marker = resolve(stateDir, 'owners.txt');
+    writeLock(stateDir, {
+      pid: 2_147_483_646,
+      startedAtMs: Date.now() - 1_000,
+      cwd: '.',
+      command: ['tsc', '--noEmit'],
+      repoRoot,
+      fingerprint: 'dead-owner-fixture',
+    });
+
+    const result = await runWrapper(stateDir, marker, {
+      durationMs: 50,
+      capture: true,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toContain('reason=dead-owner');
+    expect(result.stderr).toContain('cwd=.');
+    expect(maxConcurrentOwners(marker)).toBe(1);
+    expect(existsSync(resolve(stateDir, 'lock.json'))).toBe(false);
+  });
+
+  it('does not reclaim a live seeded owner while it is still alive', async () => {
+    const stateDir = makeStateDir();
+    const marker = resolve(stateDir, 'owners.txt');
+    const active = resolve(stateDir, 'active.txt');
+    writeFileSync(active, '0');
+    const holder = holdLiveProcess(3_000);
+    writeLock(stateDir, {
+      pid: holder.pid,
+      startedAtMs: Date.now() - 60_000,
+      cwd: 'apps/web',
+      command: ['tsc', '--noEmit'],
+      repoRoot,
+      fingerprint: 'live-old-owner-fixture',
+    });
+
+    const waiter = spawn(
+      process.execPath,
+      [wrapper, '--', process.execPath, '-e', ownerScript(50), marker, active],
+      {
+        cwd: repoRoot,
+        env: wrapperEnv(stateDir),
+        stdio: 'ignore',
+      }
+    );
+    childProcesses.push(waiter);
+
+    await new Promise(resolveWait => setTimeout(resolveWait, 400));
+    expect(existsSync(marker)).toBe(false);
+    expect(existsSync(resolve(stateDir, 'lock.json'))).toBe(true);
+
+    holder.kill('SIGKILL');
+    const code = await new Promise(resolveExit =>
+      waiter.once('exit', resolveExit)
+    );
+    expect(code).toBe(0);
+    expect(maxConcurrentOwners(marker)).toBe(1);
+  });
+
+  it('reclaims missing-pid locks after the stale window', async () => {
+    const stateDir = makeStateDir();
+    const marker = resolve(stateDir, 'owners.txt');
+    writeLock(stateDir, {
+      startedAtMs: Date.now() - 5_000,
+      cwd: '.',
+      command: ['tsc'],
+      repoRoot,
+      fingerprint: 'missing-pid-fixture',
+    });
+
+    const result = await runWrapper(stateDir, marker, {
+      durationMs: 50,
+      capture: true,
+      env: { TYPECHECK_SINGLEFLIGHT_STALE_MS: '100' },
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toContain('reason=missing-pid-stale-by-age');
+    expect(maxConcurrentOwners(marker)).toBe(1);
+  });
+
+  it('reclaims corrupt lock JSON after the bounded file-age window', async () => {
+    const stateDir = makeStateDir();
+    const marker = resolve(stateDir, 'owners.txt');
+    const lockPath = resolve(stateDir, 'lock.json');
+    writeFileSync(lockPath, '{not-json');
+    const aged = (Date.now() - 10_000) / 1000;
+    utimesSync(lockPath, aged, aged);
+
+    const result = await runWrapper(stateDir, marker, {
+      durationMs: 50,
+      capture: true,
+      env: { TYPECHECK_SINGLEFLIGHT_STALE_MS: '30000' },
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toContain('reason=corrupt-or-unreadable-lock');
+    expect(maxConcurrentOwners(marker)).toBe(1);
+  });
+
+  it('reuses a completed result within the reuse window without a second owner', async () => {
+    const stateDir = makeStateDir();
+    const marker = resolve(stateDir, 'owners.txt');
+
+    const first = await runWrapper(stateDir, marker, {
+      durationMs: 50,
+      capture: true,
+    });
+    expect(first.code).toBe(0);
+
+    const second = await runWrapper(stateDir, marker, {
+      durationMs: 50,
+      capture: true,
+    });
+    expect(second.code).toBe(0);
+    expect(second.stderr).toContain('reused completed');
+    // Reuse must not re-execute the owner command.
+    expect(readFileSync(marker, 'utf8').trim().split('\n')).toEqual([
+      'owner concurrent=1',
+    ]);
   });
 });

--- a/scripts/lib/typecheck-singleflight-lock.mjs
+++ b/scripts/lib/typecheck-singleflight-lock.mjs
@@ -129,7 +129,7 @@ export function sanitizeLogValue(value) {
 
 /**
  * @param {LockRecovery} recovery
- * @param {(parts: unknown) => string} formatCommand
+ * @param {(parts: string[]) => string} formatCommand
  */
 export function formatRecoveryLogLine(recovery, formatCommand) {
   const owner = recovery.pid ? `pid ${recovery.pid}` : 'unknown pid';

--- a/scripts/lib/typecheck-singleflight-lock.mjs
+++ b/scripts/lib/typecheck-singleflight-lock.mjs
@@ -1,0 +1,142 @@
+/**
+ * Pure lock-recovery decisions for typecheck singleflight.
+ *
+ * Invariant: a live owner is never replaced solely because wall time exceeds
+ * the stale window. Age recovers only when owner liveness cannot be established
+ * (missing/invalid pid) or the lock payload is corrupt/unreadable. Dead owners
+ * are reclaimed immediately.
+ */
+
+/**
+ * @typedef {object} LockRecovery
+ * @property {boolean} recoverable
+ * @property {string | null} reason
+ * @property {number} ageMs
+ * @property {number | null} pid
+ * @property {string | null} cwd
+ * @property {string[] | null} command
+ */
+
+/**
+ * @param {unknown} lock
+ * @param {{
+ *   readonly nowMs?: number;
+ *   readonly staleMs: number;
+ *   readonly lockFileAgeMs: number;
+ *   readonly isProcessAlive: (pid: number) => boolean;
+ * }} options
+ * @returns {LockRecovery}
+ */
+export function evaluateLockRecovery(lock, options) {
+  const nowMs = options.nowMs ?? Date.now();
+  const staleMs = options.staleMs;
+
+  if (!lock || typeof lock !== 'object') {
+    const ageMs = Math.max(0, options.lockFileAgeMs);
+    // Bound corrupt/missing-payload recovery so a half-written lock cannot
+    // block the worktree forever, without waiting the full stale window.
+    const boundMs = Math.min(staleMs, 5000);
+    if (ageMs > boundMs) {
+      return {
+        recoverable: true,
+        reason: 'corrupt-or-unreadable-lock',
+        ageMs,
+        pid: null,
+        cwd: null,
+        command: null,
+      };
+    }
+    return {
+      recoverable: false,
+      reason: null,
+      ageMs,
+      pid: null,
+      cwd: null,
+      command: null,
+    };
+  }
+
+  const record = /** @type {Record<string, unknown>} */ (lock);
+  const pid = normalizePid(record.pid);
+  const ageMs = computeLockAgeMs(record, nowMs, options.lockFileAgeMs);
+  const meta = {
+    ageMs,
+    pid,
+    cwd: typeof record.cwd === 'string' ? record.cwd : null,
+    command: Array.isArray(record.command) ? record.command.map(String) : null,
+  };
+
+  if (pid !== null) {
+    // Live owner is authoritative. Long typechecks routinely exceed the stale
+    // threshold under host pressure; age alone must never permit a second owner.
+    if (options.isProcessAlive(pid)) {
+      return { recoverable: false, reason: null, ...meta };
+    }
+    return { recoverable: true, reason: 'dead-owner', ...meta };
+  }
+
+  // No usable pid → liveness cannot be established; only then may age recover.
+  if (ageMs > staleMs) {
+    return { recoverable: true, reason: 'missing-pid-stale-by-age', ...meta };
+  }
+  return { recoverable: false, reason: null, ...meta };
+}
+
+/**
+ * @param {Record<string, unknown>} lock
+ * @param {number} nowMs
+ * @param {number} lockFileAgeMs
+ */
+export function computeLockAgeMs(lock, nowMs, lockFileAgeMs) {
+  const startedAtMs = Number(lock.startedAtMs);
+  if (Number.isFinite(startedAtMs) && startedAtMs > 0) {
+    return Math.max(0, nowMs - startedAtMs);
+  }
+  // Missing/corrupt startedAtMs: fall back to lock file mtime so recovery
+  // stays bounded instead of treating age as NaN/never-stale.
+  return Math.max(0, lockFileAgeMs);
+}
+
+/**
+ * @param {unknown} pid
+ * @returns {number | null}
+ */
+export function normalizePid(pid) {
+  if (typeof pid === 'number' && Number.isInteger(pid) && pid > 0) {
+    return pid;
+  }
+  if (typeof pid === 'string' && /^\d+$/.test(pid)) {
+    const parsed = Number(pid);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+export function sanitizeLogValue(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+  // Strip control characters and cap length so lock logs cannot leak secrets
+  // or dump unbounded paths into CI logs.
+  return value.replaceAll(/[\u0000-\u001f\u007f]/g, '').slice(0, 200);
+}
+
+/**
+ * @param {LockRecovery} recovery
+ * @param {(parts: unknown) => string} formatCommand
+ */
+export function formatRecoveryLogLine(recovery, formatCommand) {
+  const owner = recovery.pid ? `pid ${recovery.pid}` : 'unknown pid';
+  const ownerCwd = sanitizeLogValue(recovery.cwd) ?? 'unknown-cwd';
+  const ownerCommand = recovery.command
+    ? formatCommand(recovery.command)
+    : 'unknown-command';
+  const ageSec = Math.max(0, Math.round((recovery.ageMs ?? 0) / 1000));
+  return `[typecheck-singleflight] removing stale typecheck lock held by ${owner} cwd=${ownerCwd} command=${ownerCommand} age=${ageSec}s reason=${recovery.reason}.`;
+}

--- a/scripts/typecheck-singleflight.mjs
+++ b/scripts/typecheck-singleflight.mjs
@@ -15,6 +15,10 @@ import {
 } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
+import {
+  evaluateLockRecovery as evaluateLockRecoveryDecision,
+  formatRecoveryLogLine,
+} from './lib/typecheck-singleflight-lock.mjs';
 
 const DEFAULT_POLL_MS = 500;
 const DEFAULT_REUSE_WINDOW_MS = 30_000;
@@ -84,15 +88,14 @@ async function main() {
     }
 
     const existingLock = readJson(lockPath);
-    if (isRecoverableLock(existingLock)) {
-      removeStaleLock(existingLock);
+    const recovery = evaluateLockRecovery(existingLock);
+    if (recovery.recoverable) {
+      removeStaleLock(recovery);
       continue;
     }
 
     if (!announcedWait) {
-      const owner = existingLock?.pid
-        ? `pid ${existingLock.pid}`
-        : 'another process';
+      const owner = recovery.pid ? `pid ${recovery.pid}` : 'another process';
       console.error(
         `[typecheck-singleflight] waiting for ${owner} to finish ${formatCommand(existingLock?.command ?? command)}.`
       );
@@ -239,11 +242,8 @@ function releaseLock() {
   rmSync(lockPath, { force: true });
 }
 
-function removeStaleLock(lock) {
-  const owner = lock?.pid ? `pid ${lock.pid}` : 'unknown pid';
-  console.error(
-    `[typecheck-singleflight] removing stale typecheck lock held by ${owner}.`
-  );
+function removeStaleLock(recovery) {
+  console.error(formatRecoveryLogLine(recovery, formatCommand));
   try {
     unlinkSync(lockPath);
   } catch (error) {
@@ -253,24 +253,18 @@ function removeStaleLock(lock) {
   }
 }
 
-function isRecoverableLock(lock) {
-  if (!lock) {
-    return lockFileAgeMs() > Math.min(staleMs, 5000);
-  }
-
-  // A live owner is authoritative. Long typechecks routinely exceed the stale
-  // threshold under host pressure; age alone must never permit a second owner.
-  if (typeof lock.pid === 'number') {
-    return !isProcessAlive(lock.pid);
-  }
-
-  const ageMs = Date.now() - Number(lock.startedAtMs ?? 0);
-  return Number.isFinite(ageMs) && ageMs > staleMs;
+function evaluateLockRecovery(lock, nowMs = Date.now()) {
+  return evaluateLockRecoveryDecision(lock, {
+    nowMs,
+    staleMs,
+    lockFileAgeMs: readLockFileAgeMs(nowMs),
+    isProcessAlive,
+  });
 }
 
-function lockFileAgeMs() {
+function readLockFileAgeMs(nowMs = Date.now()) {
   try {
-    return Date.now() - statSync(lockPath).mtimeMs;
+    return Math.max(0, nowMs - statSync(lockPath).mtimeMs);
   } catch {
     return 0;
   }
@@ -284,6 +278,8 @@ function isProcessAlive(pid) {
     process.kill(pid, 0);
     return true;
   } catch (error) {
+    // EPERM means the pid exists but we cannot signal it — treat as alive so
+    // we never spawn a duplicate owner for a protected live process.
     return error?.code === 'EPERM';
   }
 }


### PR DESCRIPTION
## Summary

Typecheck singleflight no longer reclaims a lock solely because wall time exceeds `TYPECHECK_SINGLEFLIGHT_STALE_MS` while the owner process is still alive. That path was spawning duplicate live `tsc` owners under long UI-drift typechecks.

**Recovery rules now:**
- **Live owner** → never recoverable by age (authoritative until exit)
- **Dead owner** → reclaim immediately (`reason=dead-owner`)
- **Missing/invalid pid** → reclaim only after the stale window (`reason=missing-pid-stale-by-age`)
- **Corrupt/unreadable lock JSON** → reclaim after a bounded file-age window (`min(staleMs, 5s)`, `reason=corrupt-or-unreadable-lock`)

Recovery logs include owner `cwd`, `command`, start age, and reason (sanitized, no secrets). Pure lock evaluation lives in `scripts/lib/typecheck-singleflight-lock.mjs` for deterministic unit coverage.

Rebased onto latest `main` and kept scripts-typecheck JSDoc fix (`formatCommand` parts typed as `string[]`).

## Test plan / results

```bash
pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/typecheck-singleflight.test.mjs
node scripts/ci-typecheck-gate-guard.mjs
pnpm run typecheck:scripts
pnpm biome check scripts/typecheck-singleflight.mjs scripts/lib/typecheck-singleflight-lock.mjs scripts/lib/__tests__/typecheck-singleflight.test.mjs
```

**Results:**
- [x] singleflight tests — **12/12 passed**
  - live old owner never recovered by age
  - dead owner reclaimed immediately
  - missing pid stale-by-age only
  - corrupt JSON bounded recovery
  - string pid normalization
  - recovery log shape (cwd/command/age/reason)
  - concurrent invocations: max concurrent owners = 1
  - live seeded lock not reclaimed while alive
  - completed result reuse without second owner
- [x] `ci-typecheck-gate-guard` — PASS (`--force` gate unchanged)
- [x] `typecheck:scripts` — PASS
- [x] Biome clean on touched files

## Risk

Developer tooling only. Does not weaken the CI typecheck gate (`--force` still required). Long typechecks may hold a worktree lock for >30m while the owner is live — intentional to prevent duplicate `tsc` contention.

## Cost Impact

None. No new cron, external API, or infra.

Fixes JOV-4524

<!-- linear-issue-id:JOV-4524 -->