### PR TITLE
feat(agentos): /roadmap Linear ops CLI (JOV-1932)

### DIFF
--- a/.claude/commands/roadmap.md
+++ b/.claude/commands/roadmap.md
@@ -1,0 +1,12 @@
+# /roadmap
+
+Run Linear AgentOS roadmap ops via the repo CLI.
+
+```bash
+pnpm roadmap <command> [args] [flags]
+```
+
+Commands: `add`, `expand`, `sync`, `today`, `approved`, `agent-brief`.
+
+Full skill: `.claude/skills/roadmap/SKILL.md`
+Contract: `agentos/roadmap/SYNC_MODEL.md`

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: roadmap
+description: |
+  Linear AgentOS roadmap ops. Use when creating issues from briefs, expanding
+  epics into sub-issues, syncing Linear into agentos/roadmap/backlog.json,
+  listing today's active work, listing human-approval-cleared issues, or
+  emitting a structured agent-brief for a Linear issue. Invoked as /roadmap.
+version: 2026-07-31
+scope: JovieInc/Jovie
+---
+
+# /roadmap
+
+CLI + skill wrapper around Linear GraphQL for AgentOS roadmap operations.
+Linear remains the source of truth; `agentos/roadmap/backlog.json` is a
+regenerated mirror (see `agentos/roadmap/SYNC_MODEL.md`).
+
+## Invocation
+
+```bash
+pnpm roadmap <command> [args] [flags]
+# or
+node scripts/roadmap/roadmap.mjs <command> [args] [flags]
+```
+
+Requires `LINEAR_API_KEY` for network commands (`add`, `expand`, `sync`, live
+`agent-brief`). Prefer Doppler:
+
+```bash
+doppler run --project jovie-web --config dev -- pnpm roadmap <command> ...
+```
+
+## Subcommands
+
+| Command | Purpose |
+|---|---|
+| `add <title>` | Create a Linear issue from a brief (always labels `agentos`) |
+| `expand <issueId>` | Generate sub-issues from epic description bullets or `--from` file |
+| `sync` | Pull Linear state into `agentos/roadmap/backlog.json` |
+| `today` | List/emit today's active issues (Todo / In Progress / In Review) |
+| `approved` | List agent-owned issues with `human-review-required` cleared |
+| `agent-brief <issueId>` | Emit structured agent brief JSON for an issue |
+
+### Examples
+
+```bash
+# Create
+pnpm roadmap add "Define sync cadence" --description "..." --priority 2 --dry-run
+
+# Expand epic from its acceptance-criteria bullets
+pnpm roadmap expand JOV-1900 --dry-run
+pnpm roadmap expand JOV-1900 --from /tmp/subissues.txt
+
+# Sync mirror (write) / drift check (read-only)
+pnpm roadmap sync --force
+pnpm roadmap sync --check
+
+# Today's work + approved agent issues
+pnpm roadmap today --json
+pnpm roadmap approved --json
+
+# Structured brief for an agent run
+pnpm roadmap agent-brief JOV-1932
+```
+
+### Flags
+
+- `--dry-run` — plan writes without Linear mutations (`add`, `expand`)
+- `--check` / `--force` / `--out <path>` — `sync` modes
+- `--json` — machine-readable output (default for most commands)
+- `--from <file>` — title list for `expand`
+- `--description`, `--project`, `--priority`, `--parent`, `--labels` — `add`
+- `--limit <n>` — cap list size
+- `--backlog <path>` — override backlog.json path for offline commands
+
+## Contract
+
+- Schema: `agentos/roadmap/backlog.types.ts` + `SYNC_MODEL.md` §3
+- Agent ownership: label `agentos` + no `human-review-required` (+ delegate when JOV-1934 provisions AgentOS app user)
+- Drift: Linear always wins; `sync --check` exits non-zero on tracked field drift
+- Brief schemaVersion `1` aligns with JOV-1933; this skill emits a usable brief now
+
+## Tests
+
+```bash
+pnpm roadmap:test
+```
+
+Each subcommand module is unit-tested in isolation under `scripts/roadmap/__tests__/`.

--- a/.gitignore
+++ b/.gitignore
@@ -180,10 +180,9 @@ ruvector.db
 .no-mistakes/evidence/**
 !.no-mistakes/evidence/.gitkeep
 
-# AgentOS run artifacts (binary outputs not source-controlled)
+# AgentOS: source + Linear mirror are tracked; run binary outputs are not
 agentos/runs/**/artifacts/
 .hermes/
-agentos/
 docs/leads/
 *.bak
 *.bak2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,4 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
-
-## [Unreleased]
+- [internal] **`/roadmap` Linear ops CLI (JOV-1932):** skill + `pnpm roadmap` parser for `add`, `expand`, `sync`, `today`, `approved`, and `agent-brief`, with isolated unit tests and `agentos/roadmap/backlog.types.ts`.
 - [internal] **Grok sidecar admission is one source of truth (JOV-4802):** reconcile no longer launches an issue that will fail grok-ship-one's check — `blocked` was added to the shared blocked-label gate, grok-ship-one now delegates its admission decision to the controller's `check-admission` predicate (exactly what reconcile uses), and reconcile re-verifies each issue immediately before launching so a `blocked`/`needs-human` guard landing after the list query can never be dispatched. Default `SYMPHONY_GROK_MAX` raised 2→4 with a live-concurrency cap so total grok ships never exceed the limit (Gem 16c/62GB).
 - [internal] **Desktop System-B token contract aligns with web app-shell canon (JOV-4803):** the desktop tokens contract test now reads Noir Ion dark-mode anchors from `design-system.css` and the authenticated app-shell frame overrides from `system-b-app.css` instead of removed `--linear-*` tokens; no DMG publish in this PR.
 - [internal] **Production public-profile alias perf gate is warning-only (#15586 / JOV-4854):** post-promote `jov.ie` usable-result budgets still measure and emit `::warning::` / `performance_status=warn` on cold-cache noise, but no longer fail Production Verified; the immutable staged public-profile budget gate remains hard.

--- a/agentos/roadmap/README.md
+++ b/agentos/roadmap/README.md
@@ -4,10 +4,21 @@ This directory is a structured mirror of Linear's AgentOS initiative. Linear rem
 
 | File | Purpose |
 |------|---------|
-| `SYNC_MODEL.md` | Sync protocol spec — how issues move from Linear into this directory. Defined in JOV-1930. |
-| `backlog.json` | Machine-readable mirror of active AgentOS issues (schema defined in `SYNC_MODEL.md §3`) |
+| `SYNC_MODEL.md` | Sync protocol spec — how issues move from Linear into this directory (JOV-1930). |
+| `backlog.types.ts` | TypeScript shape for `backlog.json` (SYNC_MODEL §3; JOV-1932). |
+| `backlog.json` | Machine-readable mirror of active AgentOS issues (schema: `backlog.types.ts` / `SYNC_MODEL.md` §3). Do not hand-edit. |
 | `<project-slug>.md` | Per-project spec detail, one file per Linear project under the AgentOS initiative |
 
-<!-- TODO(JOV-1930): SYNC_MODEL.md is being defined in the parallel R1 task. Once that PR lands, update this README to link directly to SYNC_MODEL.md §3 for the backlog.json schema. -->
+## Sync + ops
 
-Sync operations are handled by the `/roadmap` command (JOV-1932).
+```bash
+pnpm roadmap sync              # regenerate backlog.json from Linear
+pnpm roadmap sync --check      # exit 1 if mirror drifts
+pnpm roadmap today --json      # active issues (Todo / In Progress / In Review)
+pnpm roadmap approved --json   # agent-owned, human-review gate cleared
+pnpm roadmap agent-brief JOV-N # structured agent brief
+pnpm roadmap add "Title" --dry-run
+pnpm roadmap expand JOV-N --dry-run
+```
+
+Skill: `.claude/skills/roadmap/SKILL.md` · CLI: `scripts/roadmap/roadmap.mjs` · Tests: `pnpm roadmap:test`

--- a/agentos/roadmap/backlog.types.ts
+++ b/agentos/roadmap/backlog.types.ts
@@ -1,0 +1,89 @@
+/**
+ * Machine-readable Linear → repo mirror types for AgentOS roadmap.
+ * Canonical contract: agentos/roadmap/SYNC_MODEL.md §3 (JOV-1930).
+ * Written by `/roadmap sync` (JOV-1932). Do not hand-edit backlog.json.
+ */
+
+export type RoadmapProjectStatus =
+  | 'planned'
+  | 'started'
+  | 'paused'
+  | 'completed'
+  | 'canceled';
+
+export type RoadmapStateType =
+  | 'triage'
+  | 'backlog'
+  | 'unstarted'
+  | 'started'
+  | 'completed'
+  | 'canceled';
+
+/** Linear priority: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low */
+export type RoadmapPriority = 0 | 1 | 2 | 3 | 4;
+
+export interface RoadmapBacklog {
+  /** ISO datetime of the last successful Linear → repo sync */
+  readonly syncedAt: string;
+  /** SHA of the Linear MCP/GraphQL revision used to build this snapshot, if available */
+  readonly sourceRevision: string | null;
+  /** AgentOS initiative-level metadata */
+  readonly initiative: {
+    readonly id: string;
+    readonly name: string;
+    readonly url: string;
+  };
+  readonly projects: readonly RoadmapProject[];
+  readonly issues: readonly RoadmapIssue[];
+}
+
+export interface RoadmapProject {
+  readonly id: string;
+  readonly name: string;
+  /** kebab-case used for repo file matching */
+  readonly slug: string;
+  readonly status: RoadmapProjectStatus;
+  readonly url: string;
+  /** Path (relative to repo root) of the spec mirror, if one exists */
+  readonly specPath: string | null;
+}
+
+export interface RoadmapIssue {
+  /** Linear short ID, e.g. "JOV-1930" */
+  readonly id: string;
+  /** Linear UUID (for MCP write calls) */
+  readonly uuid: string;
+  readonly title: string;
+  readonly url: string;
+
+  readonly state: {
+    readonly name: string;
+    readonly type: RoadmapStateType;
+  };
+  readonly priority: RoadmapPriority;
+  readonly assignee: { readonly id: string; readonly name: string } | null;
+  readonly delegate: { readonly id: string; readonly name: string } | null;
+  readonly labels: readonly string[];
+
+  readonly projectId: string | null;
+  /** Linear parent issue short ID (sub-issue link) */
+  readonly parentId: string | null;
+  /** Linear short IDs */
+  readonly blockedBy: readonly string[];
+  readonly blocks: readonly string[];
+
+  /** Computed by the sync job from SYNC_MODEL §2.3 */
+  readonly agentOwned: boolean;
+  readonly humanReviewRequired: boolean;
+
+  /** Repo paths referenced in the issue description */
+  readonly repoFileRefs: readonly string[];
+
+  /** Derived: matches an attached PR via `<!-- linear-issue-id:JOV-XXXX -->` */
+  readonly pullRequestUrl: string | null;
+
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  /** ISO datetime this row was last refreshed from Linear */
+  readonly lastSyncedAt: string;
+}

--- a/package.json
+++ b/package.json
@@ -237,7 +237,9 @@
     "backlog:gate-next": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs gate-next",
     "backlog:approve-plan": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs approve-plan",
     "backlog:report": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs report",
-    "backlog:test": "node --test scripts/backlog-orchestrator/__tests__/*.test.mjs"
+    "backlog:test": "node --test scripts/backlog-orchestrator/__tests__/*.test.mjs",
+    "roadmap": "node scripts/roadmap/roadmap.mjs",
+    "roadmap:test": "node --test scripts/roadmap/__tests__/*.test.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.100.1",

--- a/scripts/roadmap/__tests__/commands.test.mjs
+++ b/scripts/roadmap/__tests__/commands.test.mjs
@@ -1,0 +1,528 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { runAdd } from '../commands/add.mjs';
+import {
+  buildAgentBriefFromIssue,
+  runAgentBrief,
+} from '../commands/agent-brief.mjs';
+import { runApproved } from '../commands/approved.mjs';
+import { runExpand } from '../commands/expand.mjs';
+import { buildBacklogSnapshot, runSync } from '../commands/sync.mjs';
+import { runToday } from '../commands/today.mjs';
+import { runRoadmap } from '../roadmap.mjs';
+
+function makeMockClient(overrides = {}) {
+  const created = [];
+  return {
+    created,
+    fetchInitiative: async () =>
+      overrides.initiative ?? {
+        id: 'init-1',
+        name: 'AgentOS',
+        url: 'https://linear.app/jovie/initiative/agentos',
+        projects: {
+          nodes: [
+            {
+              id: 'proj-1',
+              name: 'Roadmap System',
+              url: 'https://linear.app/jovie/project/roadmap',
+              status: { name: 'started' },
+            },
+          ],
+        },
+      },
+    fetchAgentOsIssues: async () =>
+      overrides.issues ?? [
+        {
+          id: 'uuid-1930',
+          identifier: 'JOV-1930',
+          title: 'Define sync model',
+          description: 'See agentos/roadmap/SYNC_MODEL.md',
+          url: 'https://linear.app/jovie/issue/JOV-1930',
+          priority: 2,
+          assignee: { id: 'u1', name: 'Tim' },
+          labels: { nodes: [{ name: 'agentos' }] },
+          parent: null,
+          project: { id: 'proj-1', name: 'Roadmap System' },
+          state: { name: 'In Progress', type: 'started' },
+          relations: { nodes: [] },
+          createdAt: '2026-05-08T00:00:00.000Z',
+          updatedAt: '2026-05-08T01:00:00.000Z',
+        },
+        {
+          id: 'uuid-1932',
+          identifier: 'JOV-1932',
+          title: 'Build roadmap parser',
+          description: '## Acceptance criteria\n- [ ] CLI\n- [ ] Tests',
+          url: 'https://linear.app/jovie/issue/JOV-1932',
+          priority: 2,
+          assignee: null,
+          labels: {
+            nodes: [{ name: 'agentos' }, { name: 'human-review-required' }],
+          },
+          parent: null,
+          project: { id: 'proj-1' },
+          state: { name: 'Todo', type: 'unstarted' },
+          relations: { nodes: [] },
+          createdAt: '2026-05-08T00:00:00.000Z',
+          updatedAt: '2026-05-08T01:00:00.000Z',
+        },
+        {
+          id: 'uuid-1933',
+          identifier: 'JOV-1933',
+          title: 'Brief generator',
+          description: '',
+          url: 'https://linear.app/jovie/issue/JOV-1933',
+          priority: 3,
+          assignee: null,
+          labels: { nodes: [{ name: 'agentos' }] },
+          parent: null,
+          project: { id: 'proj-1' },
+          state: { name: 'Todo', type: 'unstarted' },
+          relations: { nodes: [] },
+          createdAt: '2026-05-08T00:00:00.000Z',
+          updatedAt: '2026-05-08T01:00:00.000Z',
+        },
+      ],
+    fetchIssueByIdentifier: async id => {
+      if (overrides.fetchIssueByIdentifier) {
+        return overrides.fetchIssueByIdentifier(id);
+      }
+      const issues = await makeMockClient(overrides).fetchAgentOsIssues();
+      const want = String(id).toUpperCase().replace(/^JOV-/, 'JOV-');
+      return (
+        issues.find(
+          i =>
+            i.identifier.toUpperCase() === want.toUpperCase() ||
+            i.identifier === `JOV-${String(id).replace(/^JOV-/i, '')}`
+        ) ?? null
+      );
+    },
+    resolveProjectId: async ref =>
+      overrides.resolveProjectId
+        ? overrides.resolveProjectId(ref)
+        : ref
+          ? 'proj-1'
+          : null,
+    createIssue: async input => {
+      const issue = {
+        id: `uuid-new-${created.length + 1}`,
+        identifier: `JOV-${9000 + created.length}`,
+        title: input.title,
+        url: `https://linear.app/jovie/issue/JOV-${9000 + created.length}`,
+      };
+      created.push({ input, issue });
+      return issue;
+    },
+  };
+}
+
+const sampleBacklog = {
+  syncedAt: '2026-05-08T12:00:00.000Z',
+  sourceRevision: null,
+  initiative: {
+    id: 'init-1',
+    name: 'AgentOS',
+    url: 'https://linear.app/jovie/initiative/agentos',
+  },
+  projects: [
+    {
+      id: 'proj-1',
+      name: 'Roadmap System',
+      slug: 'roadmap-system',
+      status: 'started',
+      url: 'https://linear.app/jovie/project/roadmap',
+      specPath: 'agentos/roadmap/roadmap-system.md',
+    },
+  ],
+  issues: [
+    {
+      id: 'JOV-1930',
+      uuid: 'uuid-1930',
+      title: 'Define sync model',
+      url: 'https://linear.app/jovie/issue/JOV-1930',
+      state: { name: 'In Progress', type: 'started' },
+      priority: 2,
+      assignee: { id: 'u1', name: 'Tim' },
+      delegate: null,
+      labels: ['agentos'],
+      projectId: 'proj-1',
+      parentId: null,
+      blockedBy: [],
+      blocks: ['JOV-1932'],
+      agentOwned: true,
+      humanReviewRequired: false,
+      repoFileRefs: ['agentos/roadmap/SYNC_MODEL.md'],
+      pullRequestUrl: null,
+      createdAt: '2026-05-08T00:00:00.000Z',
+      updatedAt: '2026-05-08T01:00:00.000Z',
+      lastSyncedAt: '2026-05-08T12:00:00.000Z',
+    },
+    {
+      id: 'JOV-1932',
+      uuid: 'uuid-1932',
+      title: 'Build roadmap parser',
+      url: 'https://linear.app/jovie/issue/JOV-1932',
+      state: { name: 'Todo', type: 'unstarted' },
+      priority: 2,
+      assignee: null,
+      delegate: null,
+      labels: ['agentos', 'human-review-required'],
+      projectId: 'proj-1',
+      parentId: null,
+      blockedBy: ['JOV-1930'],
+      blocks: [],
+      agentOwned: false,
+      humanReviewRequired: true,
+      repoFileRefs: [],
+      pullRequestUrl: null,
+      createdAt: '2026-05-08T00:00:00.000Z',
+      updatedAt: '2026-05-08T01:00:00.000Z',
+      lastSyncedAt: '2026-05-08T12:00:00.000Z',
+    },
+    {
+      id: 'JOV-1933',
+      uuid: 'uuid-1933',
+      title: 'Brief generator',
+      url: 'https://linear.app/jovie/issue/JOV-1933',
+      state: { name: 'Todo', type: 'unstarted' },
+      priority: 3,
+      assignee: null,
+      delegate: null,
+      labels: ['agentos'],
+      projectId: 'proj-1',
+      parentId: null,
+      blockedBy: [],
+      blocks: [],
+      agentOwned: true,
+      humanReviewRequired: false,
+      repoFileRefs: [],
+      pullRequestUrl: null,
+      createdAt: '2026-05-08T00:00:00.000Z',
+      updatedAt: '2026-05-08T01:00:00.000Z',
+      lastSyncedAt: '2026-05-08T12:00:00.000Z',
+    },
+  ],
+};
+
+describe('runAdd', () => {
+  it('dry-runs without calling createIssue', async () => {
+    const client = makeMockClient();
+    const result = await runAdd({
+      client,
+      positionals: ['Ship', 'roadmap', 'parser'],
+      flags: { 'dry-run': true, description: 'body', priority: '1' },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.dryRun, true);
+    assert.equal(result.planned.title, 'Ship roadmap parser');
+    assert.equal(client.created.length, 0);
+  });
+
+  it('creates an issue with agentos label path', async () => {
+    const client = makeMockClient();
+    const result = await runAdd({
+      client,
+      positionals: ['New issue'],
+      flags: { description: 'hi' },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.issue.id, 'JOV-9000');
+    assert.equal(client.created.length, 1);
+    assert.equal(client.created[0].input.title, 'New issue');
+  });
+
+  it('errors without a title', async () => {
+    const result = await runAdd({
+      client: makeMockClient(),
+      positionals: [],
+      flags: {},
+    });
+    assert.equal(result.ok, false);
+  });
+});
+
+describe('runExpand', () => {
+  it('parses epic bullets and dry-runs sub-issues', async () => {
+    const client = makeMockClient({
+      fetchIssueByIdentifier: async () => ({
+        id: 'uuid-epic',
+        identifier: 'JOV-1000',
+        title: 'Epic',
+        description: '## Sub-issues\n- [ ] First child\n- [ ] Second child',
+        url: 'https://linear.app/jovie/issue/JOV-1000',
+        project: { id: 'proj-1' },
+      }),
+    });
+    const result = await runExpand({
+      client,
+      positionals: ['JOV-1000'],
+      flags: { 'dry-run': true },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.count, 2);
+    assert.deepEqual(
+      result.planned.map(p => p.title),
+      ['First child', 'Second child']
+    );
+    assert.equal(client.created.length, 0);
+  });
+
+  it('creates sub-issues when not dry-run', async () => {
+    const client = makeMockClient({
+      fetchIssueByIdentifier: async () => ({
+        id: 'uuid-epic',
+        identifier: 'JOV-1000',
+        title: 'Epic',
+        description: '## Acceptance criteria\n- [ ] Only one',
+        url: 'https://linear.app/jovie/issue/JOV-1000',
+        project: { id: 'proj-1' },
+      }),
+    });
+    const result = await runExpand({
+      client,
+      positionals: ['JOV-1000'],
+      flags: {},
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.created.length, 1);
+    assert.equal(client.created[0].input.parentId, 'uuid-epic');
+  });
+
+  it('reads titles from --from file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'roadmap-expand-'));
+    const file = join(dir, 'titles.txt');
+    await writeFile(file, 'Alpha\nBeta\n', 'utf8');
+    const client = makeMockClient({
+      fetchIssueByIdentifier: async () => ({
+        id: 'uuid-epic',
+        identifier: 'JOV-1000',
+        title: 'Epic',
+        description: '',
+        url: 'https://linear.app/jovie/issue/JOV-1000',
+        project: { id: 'proj-1' },
+      }),
+    });
+    const result = await runExpand({
+      client,
+      positionals: ['JOV-1000'],
+      flags: { from: file, 'dry-run': true },
+      cwd: dir,
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(
+      result.planned.map(p => p.title),
+      ['Alpha', 'Beta']
+    );
+  });
+});
+
+describe('runSync', () => {
+  it('builds a backlog snapshot from Linear nodes', () => {
+    const snap = buildBacklogSnapshot({
+      initiative: {
+        id: 'init-1',
+        name: 'AgentOS',
+        url: 'https://example',
+        projects: {
+          nodes: [
+            {
+              id: 'p1',
+              name: 'Roadmap System',
+              url: 'https://p',
+              status: { name: 'started' },
+            },
+          ],
+        },
+      },
+      issues: [
+        {
+          id: 'u1',
+          identifier: 'JOV-1',
+          title: 'T',
+          url: 'https://i',
+          priority: 0,
+          labels: { nodes: [{ name: 'agentos' }] },
+          state: { name: 'Todo', type: 'unstarted' },
+          relations: { nodes: [] },
+        },
+      ],
+      syncedAt: '2026-01-01T00:00:00.000Z',
+    });
+    assert.equal(snap.issues.length, 1);
+    assert.equal(snap.projects[0].slug, 'roadmap-system');
+    assert.equal(snap.syncedAt, '2026-01-01T00:00:00.000Z');
+  });
+
+  it('writes backlog.json and supports --check drift', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'roadmap-sync-'));
+    const out = join(dir, 'backlog.json');
+    const client = makeMockClient();
+
+    const wrote = await runSync({
+      client,
+      flags: { force: true, out },
+      cwd: dir,
+      now: () => '2026-05-08T12:00:00.000Z',
+    });
+    assert.equal(wrote.ok, true);
+    assert.equal(wrote.mode, 'wrote');
+    const onDisk = JSON.parse(await readFile(out, 'utf8'));
+    assert.ok(onDisk.issues.length >= 1);
+
+    const checkClean = await runSync({
+      client,
+      flags: { check: true, out },
+      cwd: dir,
+      now: () => '2026-05-08T12:00:00.000Z',
+    });
+    assert.equal(checkClean.ok, true);
+    assert.equal(checkClean.drifted, false);
+
+    // Mutate disk to force drift
+    onDisk.issues[0].state = { name: 'Done', type: 'completed' };
+    await writeFile(out, JSON.stringify(onDisk), 'utf8');
+    const checkDrift = await runSync({
+      client,
+      flags: { check: true, out },
+      cwd: dir,
+      now: () => '2026-05-08T12:00:00.000Z',
+    });
+    assert.equal(checkDrift.ok, false);
+    assert.equal(checkDrift.drifted, true);
+  });
+});
+
+describe('runToday', () => {
+  it('lists active non-gated issues from backlog', async () => {
+    const result = await runToday({ backlog: sampleBacklog, flags: {} });
+    assert.equal(result.ok, true);
+    const ids = result.issues.map(i => i.id);
+    assert.ok(ids.includes('JOV-1930'));
+    assert.ok(ids.includes('JOV-1933'));
+    assert.ok(!ids.includes('JOV-1932')); // human-review-required
+  });
+
+  it('emits briefs when --json', async () => {
+    const result = await runToday({
+      backlog: sampleBacklog,
+      flags: { json: true },
+    });
+    assert.equal(result.ok, true);
+    assert.ok(result.briefs.length >= 1);
+    assert.equal(result.briefs[0].schemaVersion, 1);
+  });
+});
+
+describe('runApproved', () => {
+  it('returns only agent-owned cleared issues', async () => {
+    const result = await runApproved({ backlog: sampleBacklog, flags: {} });
+    assert.equal(result.ok, true);
+    const ids = result.issues.map(i => i.id);
+    assert.deepEqual(ids.sort(), ['JOV-1930', 'JOV-1933']);
+  });
+});
+
+describe('runAgentBrief / buildAgentBriefFromIssue', () => {
+  it('builds a structured brief with forbidden actions', () => {
+    const brief = buildAgentBriefFromIssue({
+      issue: sampleBacklog.issues[0],
+      backlog: sampleBacklog,
+      description: '## Acceptance criteria\n- [ ] Spec lands\n',
+      generatedAt: '2026-05-08T12:00:00.000Z',
+    });
+    assert.equal(brief.schemaVersion, 1);
+    assert.equal(brief.currentIssue.id, 'JOV-1930');
+    assert.ok(brief.forbiddenActions.includes('change_billing'));
+    assert.deepEqual(brief.successCriteria, ['Spec lands']);
+    assert.equal(brief.humanApprovalRequired, false);
+    assert.ok(brief.dependencies.blocks.some(b => b.id === 'JOV-1932'));
+  });
+
+  it('clears forbidden minimums when human review required', () => {
+    const brief = buildAgentBriefFromIssue({
+      issue: sampleBacklog.issues[1],
+      backlog: sampleBacklog,
+      description: '',
+    });
+    assert.equal(brief.humanApprovalRequired, true);
+    assert.deepEqual(brief.forbiddenActions, []);
+  });
+
+  it('loads from backlog offline without client', async () => {
+    const result = await runAgentBrief({
+      positionals: ['JOV-1930'],
+      backlog: sampleBacklog,
+      flags: {},
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.brief.currentIssue.id, 'JOV-1930');
+  });
+
+  it('prefers live Linear description when client present', async () => {
+    const client = makeMockClient({
+      fetchIssueByIdentifier: async () => ({
+        id: 'uuid-1930',
+        identifier: 'JOV-1930',
+        title: 'Define sync model',
+        description: '## Acceptance criteria\n- [ ] Live criterion\n',
+        url: 'https://linear.app/jovie/issue/JOV-1930',
+        priority: 2,
+        labels: { nodes: [{ name: 'agentos' }] },
+        state: { name: 'In Progress', type: 'started' },
+        project: { id: 'proj-1', name: 'Roadmap System' },
+        relations: { nodes: [] },
+      }),
+    });
+    const result = await runAgentBrief({
+      client,
+      positionals: ['JOV-1930'],
+      backlog: sampleBacklog,
+      flags: {},
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.brief.successCriteria, ['Live criterion']);
+  });
+});
+
+describe('runRoadmap CLI wiring', () => {
+  it('help exits 0', async () => {
+    const lines = [];
+    const { exitCode } = await runRoadmap(['--help'], {
+      stdout: s => lines.push(s),
+      stderr: () => {},
+    });
+    assert.equal(exitCode, 0);
+    assert.ok(lines.join('\n').includes('agent-brief'));
+  });
+
+  it('unknown command exits 2', async () => {
+    const { exitCode } = await runRoadmap(['wat'], {
+      stdout: () => {},
+      stderr: () => {},
+    });
+    assert.equal(exitCode, 2);
+  });
+
+  it('today works offline via injected backlog path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'roadmap-cli-'));
+    const path = join(dir, 'backlog.json');
+    await writeFile(path, JSON.stringify(sampleBacklog), 'utf8');
+    const out = [];
+    const { exitCode, result } = await runRoadmap(
+      ['today', '--backlog', path, '--json'],
+      {
+        cwd: dir,
+        client: makeMockClient(),
+        stdout: s => out.push(s),
+        stderr: () => {},
+      }
+    );
+    assert.equal(exitCode, 0);
+    assert.equal(result.ok, true);
+  });
+});

--- a/scripts/roadmap/__tests__/map-issue.test.mjs
+++ b/scripts/roadmap/__tests__/map-issue.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeAgentOwned,
+  detectBacklogDrift,
+  extractRepoFileRefs,
+  mapLinearIssueToRoadmap,
+  parseSubIssueTitles,
+  selectApprovedIssues,
+  selectTodayIssues,
+  toSlug,
+} from '../map-issue.mjs';
+
+describe('map-issue pure helpers', () => {
+  it('toSlug kebab-cases names', () => {
+    assert.equal(toSlug('Roadmap System'), 'roadmap-system');
+  });
+
+  it('extractRepoFileRefs finds paths', () => {
+    const refs = extractRepoFileRefs(
+      'See `agentos/roadmap/SYNC_MODEL.md` and apps/web/lib/agent-os/artifact.ts'
+    );
+    assert.ok(refs.includes('agentos/roadmap/SYNC_MODEL.md'));
+    assert.ok(refs.includes('apps/web/lib/agent-os/artifact.ts'));
+  });
+
+  it('computeAgentOwned requires agentos and no human-review', () => {
+    assert.equal(
+      computeAgentOwned({ labels: ['agentos'], delegate: null }),
+      true
+    );
+    assert.equal(
+      computeAgentOwned({
+        labels: ['agentos', 'human-review-required'],
+        delegate: { id: '1', name: 'AgentOS' },
+      }),
+      false
+    );
+    assert.equal(computeAgentOwned({ labels: [], delegate: null }), false);
+  });
+
+  it('mapLinearIssueToRoadmap maps fields', () => {
+    const mapped = mapLinearIssueToRoadmap(
+      {
+        id: 'uuid-1',
+        identifier: 'JOV-1930',
+        title: 'Define sync model',
+        url: 'https://linear.app/jovie/issue/JOV-1930',
+        description: 'Touch agentos/roadmap/SYNC_MODEL.md',
+        priority: 2,
+        assignee: { id: 'u1', name: 'Tim' },
+        labels: { nodes: [{ name: 'agentos' }, { name: 'type:doc' }] },
+        parent: null,
+        project: { id: 'p1' },
+        state: { name: 'In Progress', type: 'started' },
+        relations: {
+          nodes: [
+            {
+              type: 'blocks',
+              relatedIssue: { identifier: 'JOV-1932', title: 'parser' },
+            },
+          ],
+        },
+        createdAt: '2026-05-08T00:00:00.000Z',
+        updatedAt: '2026-05-08T01:00:00.000Z',
+      },
+      '2026-05-08T02:00:00.000Z'
+    );
+    assert.equal(mapped.id, 'JOV-1930');
+    assert.equal(mapped.uuid, 'uuid-1');
+    assert.equal(mapped.agentOwned, true);
+    assert.equal(mapped.humanReviewRequired, false);
+    assert.deepEqual(mapped.blocks, ['JOV-1932']);
+    assert.ok(mapped.repoFileRefs.includes('agentos/roadmap/SYNC_MODEL.md'));
+    assert.equal(mapped.priority, 2);
+  });
+
+  it('parseSubIssueTitles reads acceptance criteria bullets', () => {
+    const text = `
+## Summary
+Epic for roadmap.
+
+## Acceptance criteria
+- [ ] Build parser
+- [ ] Add tests
+1. Document skill
+
+## Other
+- ignore this after heading switch
+`;
+    const titles = parseSubIssueTitles(text);
+    assert.deepEqual(titles, ['Build parser', 'Add tests', 'Document skill']);
+  });
+
+  it('selectTodayIssues filters human-review and sorts by priority', () => {
+    const issues = [
+      {
+        id: 'JOV-2',
+        title: 'Low',
+        priority: 4,
+        humanReviewRequired: false,
+        state: { name: 'Todo' },
+      },
+      {
+        id: 'JOV-1',
+        title: 'Urgent',
+        priority: 1,
+        humanReviewRequired: false,
+        state: { name: 'In Progress' },
+      },
+      {
+        id: 'JOV-3',
+        title: 'Blocked',
+        priority: 1,
+        humanReviewRequired: true,
+        state: { name: 'Todo' },
+      },
+      {
+        id: 'JOV-4',
+        title: 'Done',
+        priority: 1,
+        humanReviewRequired: false,
+        state: { name: 'Done' },
+      },
+    ];
+    const today = selectTodayIssues(issues, { limit: 10 });
+    assert.deepEqual(
+      today.map(i => i.id),
+      ['JOV-1', 'JOV-2']
+    );
+  });
+
+  it('selectApprovedIssues requires agentOwned and cleared gate', () => {
+    const issues = [
+      {
+        id: 'A',
+        priority: 2,
+        agentOwned: true,
+        humanReviewRequired: false,
+        title: 'ok',
+      },
+      {
+        id: 'B',
+        priority: 1,
+        agentOwned: true,
+        humanReviewRequired: true,
+        title: 'gate',
+      },
+      {
+        id: 'C',
+        priority: 1,
+        agentOwned: false,
+        humanReviewRequired: false,
+        title: 'human',
+      },
+    ];
+    const approved = selectApprovedIssues(issues);
+    assert.deepEqual(
+      approved.map(i => i.id),
+      ['A']
+    );
+  });
+
+  it('detectBacklogDrift reports tracked field changes', () => {
+    const disk = {
+      issues: [
+        {
+          id: 'JOV-1',
+          state: { name: 'Todo' },
+          priority: 2,
+          assignee: null,
+          delegate: null,
+          labels: ['agentos'],
+          projectId: null,
+          parentId: null,
+          blockedBy: [],
+          blocks: [],
+        },
+      ],
+    };
+    const next = {
+      issues: [
+        {
+          id: 'JOV-1',
+          state: { name: 'In Progress' },
+          priority: 2,
+          assignee: null,
+          delegate: null,
+          labels: ['agentos'],
+          projectId: null,
+          parentId: null,
+          blockedBy: [],
+          blocks: [],
+        },
+      ],
+    };
+    const drift = detectBacklogDrift(disk, next);
+    assert.equal(drift.drifted, true);
+    assert.ok(drift.details.some(d => d.includes('JOV-1.state')));
+  });
+});

--- a/scripts/roadmap/__tests__/parse-args.test.mjs
+++ b/scripts/roadmap/__tests__/parse-args.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { formatHelp, parseRoadmapArgs } from '../parse-args.mjs';
+
+describe('parseRoadmapArgs', () => {
+  it('returns help for empty argv', () => {
+    const r = parseRoadmapArgs([]);
+    assert.equal(r.ok, true);
+    assert.equal(r.command, 'help');
+  });
+
+  it('parses each known command', () => {
+    for (const cmd of [
+      'add',
+      'expand',
+      'sync',
+      'today',
+      'approved',
+      'agent-brief',
+    ]) {
+      const r = parseRoadmapArgs([cmd]);
+      assert.equal(r.ok, true);
+      assert.equal(r.command, cmd);
+    }
+  });
+
+  it('rejects unknown commands', () => {
+    const r = parseRoadmapArgs(['nope']);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Unknown command/);
+  });
+
+  it('parses positionals and boolean/value flags', () => {
+    const r = parseRoadmapArgs([
+      'add',
+      'Ship',
+      'parser',
+      '--description',
+      'body',
+      '--dry-run',
+      '--priority',
+      '2',
+      '--labels=a,b',
+    ]);
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.positionals, ['Ship', 'parser']);
+    assert.equal(r.flags.description, 'body');
+    assert.equal(r.flags['dry-run'], true);
+    assert.equal(r.flags.priority, '2');
+    assert.equal(r.flags.labels, 'a,b');
+  });
+
+  it('formatHelp mentions all subcommands', () => {
+    const help = formatHelp();
+    for (const cmd of [
+      'add',
+      'expand',
+      'sync',
+      'today',
+      'approved',
+      'agent-brief',
+    ]) {
+      assert.match(help, new RegExp(cmd));
+    }
+  });
+});

--- a/scripts/roadmap/commands/add.mjs
+++ b/scripts/roadmap/commands/add.mjs
@@ -1,0 +1,98 @@
+/**
+ * `roadmap add <title>` — create a Linear issue from a brief.
+ */
+
+import { LABEL_AGENTOS } from '../config.mjs';
+import { normalizePriority } from '../map-issue.mjs';
+
+/**
+ * @param {{
+ *   client: import('../linear-client.mjs').LinearClient,
+ *   positionals: string[],
+ *   flags?: Record<string, string|boolean>,
+ * }} opts
+ */
+export async function runAdd(opts) {
+  const flags = opts.flags ?? {};
+  const title =
+    opts.positionals.join(' ').trim() ||
+    (typeof flags.title === 'string' ? flags.title.trim() : '');
+
+  if (!title) {
+    return {
+      ok: false,
+      error: 'add requires a title: roadmap add <title> [--description ...]',
+    };
+  }
+
+  const description =
+    typeof flags.description === 'string' ? flags.description : '';
+  const priority = normalizePriority(
+    typeof flags.priority === 'string' || typeof flags.priority === 'number'
+      ? Number(flags.priority)
+      : 0
+  );
+
+  /** @type {string[]} */
+  const extraLabels = [];
+  if (typeof flags.labels === 'string' && flags.labels.trim()) {
+    extraLabels.push(
+      ...flags.labels
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+    );
+  }
+
+  let parentId = null;
+  if (typeof flags.parent === 'string' && flags.parent.trim()) {
+    const parent = await opts.client.fetchIssueByIdentifier(flags.parent.trim());
+    if (!parent) {
+      return { ok: false, error: `Parent issue not found: ${flags.parent}` };
+    }
+    parentId = parent.id;
+  }
+
+  let projectId = null;
+  if (typeof flags.project === 'string' && flags.project.trim()) {
+    projectId = await opts.client.resolveProjectId(flags.project.trim());
+    if (!projectId) {
+      return {
+        ok: false,
+        error: `Project not found: ${flags.project}`,
+      };
+    }
+  }
+
+  const payload = {
+    title,
+    description,
+    priority,
+    parentId,
+    projectId,
+    labelNames: extraLabels,
+  };
+
+  if (flags['dry-run'] === true) {
+    return {
+      ok: true,
+      dryRun: true,
+      planned: {
+        ...payload,
+        labels: [LABEL_AGENTOS, ...extraLabels],
+      },
+    };
+  }
+
+  const issue = await opts.client.createIssue(payload);
+  return {
+    ok: true,
+    dryRun: false,
+    issue: {
+      id: issue.identifier,
+      uuid: issue.id,
+      title: issue.title,
+      url: issue.url,
+    },
+  };
+}

--- a/scripts/roadmap/commands/add.mjs
+++ b/scripts/roadmap/commands/add.mjs
@@ -46,7 +46,9 @@ export async function runAdd(opts) {
 
   let parentId = null;
   if (typeof flags.parent === 'string' && flags.parent.trim()) {
-    const parent = await opts.client.fetchIssueByIdentifier(flags.parent.trim());
+    const parent = await opts.client.fetchIssueByIdentifier(
+      flags.parent.trim()
+    );
     if (!parent) {
       return { ok: false, error: `Parent issue not found: ${flags.parent}` };
     }

--- a/scripts/roadmap/commands/agent-brief.mjs
+++ b/scripts/roadmap/commands/agent-brief.mjs
@@ -1,0 +1,301 @@
+/**
+ * `roadmap agent-brief <issueId>` — emit a structured agent brief.
+ *
+ * Full AgentBrief schema is owned by JOV-1933 (SYNC_MODEL §4). This command
+ * emits a compatible v1 structured brief so agents can start work now; JOV-1933
+ * may deepen tasteRules / verificationGates selection.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  DEFAULT_ALLOWED_ACTIONS,
+  DEFAULT_BACKLOG_PATH,
+  DEFAULT_FORBIDDEN_ACTIONS,
+} from '../config.mjs';
+import { mapLinearIssueToRoadmap } from '../map-issue.mjs';
+
+/**
+ * Pure brief builder from a RoadmapIssue (+ optional live description).
+ * @param {{
+ *   issue: object,
+ *   backlog?: object|null,
+ *   description?: string,
+ *   generatedAt?: string,
+ * }} input
+ */
+export function buildAgentBriefFromIssue(input) {
+  const issue = input.issue;
+  const backlog = input.backlog ?? null;
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const project =
+    backlog?.projects?.find(
+      /** @param {{id:string}} p */ p => p.id === issue.projectId
+    ) ?? null;
+
+  const humanApprovalRequired = Boolean(issue.humanReviewRequired);
+  const forbiddenActions = humanApprovalRequired
+    ? []
+    : [...DEFAULT_FORBIDDEN_ACTIONS];
+
+  const blockedBy = (issue.blockedBy ?? []).map(
+    /** @param {string} id */ id => ({
+      id,
+      title: findTitle(backlog, id),
+      state: findState(backlog, id),
+    })
+  );
+  const blocks = (issue.blocks ?? []).map(
+    /** @param {string} id */ id => ({
+      id,
+      title: findTitle(backlog, id),
+      state: findState(backlog, id),
+    })
+  );
+
+  const siblings = (backlog?.issues ?? [])
+    .filter(
+      /** @param {{id:string,projectId?:string|null}} i */
+      i =>
+        i.projectId &&
+        i.projectId === issue.projectId &&
+        i.id !== issue.id
+    )
+    .slice(0, 20)
+    .map(
+      /** @param {{id:string,title:string,state?:{name?:string}}} i */ i => ({
+        id: i.id,
+        title: i.title,
+        state: i.state?.name ?? 'Unknown',
+      })
+    );
+
+  const idSlug = String(issue.id ?? 'unknown').toLowerCase();
+  const briefId = `brief-${idSlug}-${generatedAt}`;
+
+  return {
+    id: briefId,
+    schemaVersion: 1,
+    linearProject: project
+      ? { id: project.id, name: project.name, slug: project.slug }
+      : {
+          id: issue.projectId ?? 'unknown',
+          name: 'Unknown',
+          slug: 'unknown',
+        },
+    currentIssue: {
+      id: issue.id,
+      title: issue.title,
+      url: issue.url,
+      description: input.description ?? '',
+      priority: issue.priority ?? 0,
+      state: issue.state?.name ?? 'Unknown',
+      labels: issue.labels ?? [],
+    },
+    dependencies: {
+      blockedBy,
+      blocks,
+      siblings,
+    },
+    repoSpecs: issue.repoFileRefs ?? [],
+    tasteRules: inferTasteRules(issue),
+    gstackSkills: inferGstackSkills(issue),
+    kind: inferKind(issue),
+    modelRoute: 'claude-code',
+    allowedActions: [...DEFAULT_ALLOWED_ACTIONS],
+    forbiddenActions,
+    humanApprovalRequired,
+    humanApprovalReason: humanApprovalRequired
+      ? 'Issue carries human-review-required label'
+      : null,
+    successCriteria: extractSuccessCriteria(input.description ?? ''),
+    verificationGates: [
+      'gstack.qa.exhaustive',
+      'gstack.review',
+      'gstack.ship',
+      'github.ci',
+    ],
+    generatedAt,
+    generatedBy: 'agentos-app-user',
+    backlogSyncedAt: backlog?.syncedAt ?? null,
+  };
+}
+
+/**
+ * @param {{
+ *   client?: import('../linear-client.mjs').LinearClient|null,
+ *   positionals: string[],
+ *   flags?: Record<string, string|boolean>,
+ *   cwd?: string,
+ *   readFileImpl?: typeof readFile,
+ *   backlog?: object|null,
+ * }} opts
+ */
+export async function runAgentBrief(opts) {
+  const flags = opts.flags ?? {};
+  const issueId = opts.positionals[0];
+  if (!issueId) {
+    return {
+      ok: false,
+      error: 'agent-brief requires an issue id: roadmap agent-brief JOV-1234',
+    };
+  }
+
+  const backlog =
+    opts.backlog ??
+    (await loadBacklog({
+      cwd: opts.cwd ?? process.cwd(),
+      readFileImpl: opts.readFileImpl ?? readFile,
+      path: typeof flags.backlog === 'string' ? flags.backlog : DEFAULT_BACKLOG_PATH,
+    }));
+
+  /** @type {object|null} */
+  let issue = backlog?.issues?.find(
+    /** @param {{id:string}} i */ i =>
+      i.id.toUpperCase() === String(issueId).toUpperCase()
+  );
+
+  let description = '';
+  if (opts.client) {
+    const live = await opts.client.fetchIssueByIdentifier(issueId);
+    if (live) {
+      description = live.description ?? '';
+      const mapped = mapLinearIssueToRoadmap(
+        live,
+        backlog?.syncedAt ?? new Date().toISOString()
+      );
+      issue = { ...mapped, ...(issue ?? {}) };
+      // Prefer live fields for correctness
+      issue = mapped;
+    }
+  }
+
+  if (!issue) {
+    return {
+      ok: false,
+      error: `Issue ${issueId} not found in backlog.json${opts.client ? ' or Linear' : ''}. Run roadmap sync, or pass a live Linear client.`,
+    };
+  }
+
+  const brief = buildAgentBriefFromIssue({
+    issue,
+    backlog,
+    description,
+  });
+
+  return { ok: true, brief };
+}
+
+/**
+ * @param {object|null} backlog
+ * @param {string} id
+ */
+function findTitle(backlog, id) {
+  const hit = backlog?.issues?.find(
+    /** @param {{id:string}} i */ i => i.id === id
+  );
+  return hit?.title ?? '';
+}
+
+/**
+ * @param {object|null} backlog
+ * @param {string} id
+ */
+function findState(backlog, id) {
+  const hit = backlog?.issues?.find(
+    /** @param {{id:string}} i */ i => i.id === id
+  );
+  return hit?.state?.name ?? 'Unknown';
+}
+
+/**
+ * @param {object} issue
+ * @returns {string[]}
+ */
+function inferTasteRules(issue) {
+  const labels = (issue.labels ?? []).map(
+    /** @param {string} l */ l => l.toLowerCase()
+  );
+  const rules = ['.claude/rules/code-style.md', '.claude/rules/testing.md'];
+  if (labels.some(l => l.includes('ui') || l.includes('design'))) {
+    rules.push('.claude/rules/ui.md', 'DESIGN.md');
+  }
+  if (labels.some(l => l.includes('auth'))) {
+    rules.push('.claude/rules/auth.md', '.claude/rules/security.md');
+  }
+  if (labels.some(l => l.includes('db') || l.includes('migration'))) {
+    rules.push('.claude/rules/db.md');
+  }
+  if (labels.some(l => l.includes('billing') || l.includes('stripe'))) {
+    rules.push('.claude/rules/security.md');
+  }
+  return [...new Set(rules)];
+}
+
+/**
+ * @param {object} issue
+ * @returns {string[]}
+ */
+function inferGstackSkills(issue) {
+  const labels = (issue.labels ?? []).map(
+    /** @param {string} l */ l => l.toLowerCase()
+  );
+  if (labels.some(l => l.includes('ui') || l.includes('design'))) {
+    return ['/qa --exhaustive', '/design-review', '/review', '/ship'];
+  }
+  return ['/qa --exhaustive', '/review', '/ship'];
+}
+
+/**
+ * @param {object} issue
+ * @returns {string}
+ */
+function inferKind(issue) {
+  const labels = (issue.labels ?? []).map(
+    /** @param {string} l */ l => l.toLowerCase()
+  );
+  const title = String(issue.title ?? '').toLowerCase();
+  if (labels.some(l => l.includes('qa')) || title.includes('qa')) return 'qa';
+  if (labels.some(l => l.includes('design')) || title.includes('design'))
+    return 'design_review';
+  if (labels.some(l => l.includes('review'))) return 'code_review';
+  if (labels.some(l => l.includes('triage'))) return 'triage';
+  return 'workflow';
+}
+
+/**
+ * @param {string} description
+ * @returns {string[]}
+ */
+function extractSuccessCriteria(description) {
+  if (!description) return [];
+  const lines = description.split(/\r?\n/);
+  /** @type {string[]} */
+  const out = [];
+  let inSection = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (/^#{1,3}\s*(acceptance criteria|success criteria|done when)\b/i.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^#{1,3}\s+\S/.test(line)) break;
+    if (!inSection) continue;
+    const m = line.match(/^[-*]\s+(?:\[[ xX]\]\s+)?(.+)$/) || line.match(/^\d+[.)]\s+(.+)$/);
+    if (m?.[1]) out.push(m[1].trim());
+  }
+  return out;
+}
+
+/**
+ * @param {{ cwd: string, readFileImpl: typeof readFile, path: string }} opts
+ */
+async function loadBacklog(opts) {
+  try {
+    const raw = await opts.readFileImpl(resolve(opts.cwd, opts.path), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/roadmap/commands/agent-brief.mjs
+++ b/scripts/roadmap/commands/agent-brief.mjs
@@ -57,10 +57,7 @@ export function buildAgentBriefFromIssue(input) {
   const siblings = (backlog?.issues ?? [])
     .filter(
       /** @param {{id:string,projectId?:string|null}} i */
-      i =>
-        i.projectId &&
-        i.projectId === issue.projectId &&
-        i.id !== issue.id
+      i => i.projectId && i.projectId === issue.projectId && i.id !== issue.id
     )
     .slice(0, 20)
     .map(
@@ -147,7 +144,10 @@ export async function runAgentBrief(opts) {
     (await loadBacklog({
       cwd: opts.cwd ?? process.cwd(),
       readFileImpl: opts.readFileImpl ?? readFile,
-      path: typeof flags.backlog === 'string' ? flags.backlog : DEFAULT_BACKLOG_PATH,
+      path:
+        typeof flags.backlog === 'string'
+          ? flags.backlog
+          : DEFAULT_BACKLOG_PATH,
     }));
 
   /** @type {object|null} */
@@ -276,13 +276,17 @@ function extractSuccessCriteria(description) {
   let inSection = false;
   for (const raw of lines) {
     const line = raw.trim();
-    if (/^#{1,3}\s*(acceptance criteria|success criteria|done when)\b/i.test(line)) {
+    if (
+      /^#{1,3}\s*(acceptance criteria|success criteria|done when)\b/i.test(line)
+    ) {
       inSection = true;
       continue;
     }
     if (inSection && /^#{1,3}\s+\S/.test(line)) break;
     if (!inSection) continue;
-    const m = line.match(/^[-*]\s+(?:\[[ xX]\]\s+)?(.+)$/) || line.match(/^\d+[.)]\s+(.+)$/);
+    const m =
+      line.match(/^[-*]\s+(?:\[[ xX]\]\s+)?(.+)$/) ||
+      line.match(/^\d+[.)]\s+(.+)$/);
     if (m?.[1]) out.push(m[1].trim());
   }
   return out;

--- a/scripts/roadmap/commands/approved.mjs
+++ b/scripts/roadmap/commands/approved.mjs
@@ -1,0 +1,72 @@
+/**
+ * `roadmap approved` — list issues with human-approval gate cleared
+ * (agentOwned && !humanReviewRequired).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { DEFAULT_BACKLOG_PATH } from '../config.mjs';
+import { selectApprovedIssues } from '../map-issue.mjs';
+
+/**
+ * @param {{
+ *   flags?: Record<string, string|boolean>,
+ *   cwd?: string,
+ *   readFileImpl?: typeof readFile,
+ *   backlog?: object|null,
+ * }} opts
+ */
+export async function runApproved(opts) {
+  const flags = opts.flags ?? {};
+  const limit =
+    typeof flags.limit === 'string' || typeof flags.limit === 'number'
+      ? Math.max(1, Number(flags.limit) || 50)
+      : 50;
+
+  const backlog =
+    opts.backlog ??
+    (await loadBacklog({
+      cwd: opts.cwd ?? process.cwd(),
+      readFileImpl: opts.readFileImpl ?? readFile,
+      path: typeof flags.backlog === 'string' ? flags.backlog : DEFAULT_BACKLOG_PATH,
+    }));
+
+  if (!backlog?.issues) {
+    return {
+      ok: false,
+      error:
+        'No backlog.json found. Run `roadmap sync` first, or pass a valid --backlog path.',
+    };
+  }
+
+  const selected = selectApprovedIssues(backlog.issues, { limit });
+
+  return {
+    ok: true,
+    count: selected.length,
+    backlogSyncedAt: backlog.syncedAt ?? null,
+    issues: selected.map(i => ({
+      id: i.id,
+      title: i.title,
+      state: i.state?.name,
+      priority: i.priority,
+      labels: i.labels,
+      agentOwned: i.agentOwned,
+      humanReviewRequired: i.humanReviewRequired,
+      url: i.url,
+    })),
+  };
+}
+
+/**
+ * @param {{ cwd: string, readFileImpl: typeof readFile, path: string }} opts
+ */
+async function loadBacklog(opts) {
+  try {
+    const raw = await opts.readFileImpl(resolve(opts.cwd, opts.path), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/roadmap/commands/approved.mjs
+++ b/scripts/roadmap/commands/approved.mjs
@@ -29,7 +29,10 @@ export async function runApproved(opts) {
     (await loadBacklog({
       cwd: opts.cwd ?? process.cwd(),
       readFileImpl: opts.readFileImpl ?? readFile,
-      path: typeof flags.backlog === 'string' ? flags.backlog : DEFAULT_BACKLOG_PATH,
+      path:
+        typeof flags.backlog === 'string'
+          ? flags.backlog
+          : DEFAULT_BACKLOG_PATH,
     }));
 
   if (!backlog?.issues) {

--- a/scripts/roadmap/commands/expand.mjs
+++ b/scripts/roadmap/commands/expand.mjs
@@ -1,0 +1,108 @@
+/**
+ * `roadmap expand <issueId>` — generate sub-issues from an epic.
+ * Titles come from --from file lines or parsed epic description bullets.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { LABEL_AGENTOS } from '../config.mjs';
+import { parseSubIssueTitles } from '../map-issue.mjs';
+
+/**
+ * @param {{
+ *   client: import('../linear-client.mjs').LinearClient,
+ *   positionals: string[],
+ *   flags?: Record<string, string|boolean>,
+ *   cwd?: string,
+ *   readFileImpl?: typeof readFile,
+ * }} opts
+ */
+export async function runExpand(opts) {
+  const flags = opts.flags ?? {};
+  const issueId = opts.positionals[0];
+  if (!issueId) {
+    return {
+      ok: false,
+      error: 'expand requires an issue id: roadmap expand JOV-1234',
+    };
+  }
+
+  const parent = await opts.client.fetchIssueByIdentifier(issueId);
+  if (!parent) {
+    return { ok: false, error: `Issue not found: ${issueId}` };
+  }
+
+  /** @type {string[]} */
+  let titles = [];
+  if (typeof flags.from === 'string' && flags.from.trim()) {
+    const cwd = opts.cwd ?? process.cwd();
+    const readFileImpl = opts.readFileImpl ?? readFile;
+    const raw = await readFileImpl(resolve(cwd, flags.from), 'utf8');
+    titles = raw
+      .split(/\r?\n/)
+      .map(l => l.replace(/^[-*]\s+/, '').trim())
+      .filter(l => l && !l.startsWith('#'));
+  } else {
+    titles = parseSubIssueTitles(parent.description ?? '');
+  }
+
+  const limit =
+    typeof flags.limit === 'string' || typeof flags.limit === 'number'
+      ? Math.max(1, Number(flags.limit) || 20)
+      : 20;
+  titles = titles.slice(0, limit);
+
+  if (titles.length === 0) {
+    return {
+      ok: false,
+      error:
+        'No sub-issue titles found. Add checklist/bullets under "Acceptance criteria" / "Sub-issues", or pass --from <file>.',
+      parent: {
+        id: parent.identifier,
+        title: parent.title,
+        url: parent.url,
+      },
+    };
+  }
+
+  const projectId = parent.project?.id ?? null;
+  /** @type {object[]} */
+  const created = [];
+  /** @type {object[]} */
+  const planned = [];
+
+  for (const title of titles) {
+    const payload = {
+      title,
+      description: `Sub-issue of ${parent.identifier}: ${parent.title}\n\nParent: ${parent.url}`,
+      parentId: parent.id,
+      projectId,
+      labelNames: [LABEL_AGENTOS],
+    };
+    planned.push({ title, parentId: parent.identifier, projectId });
+
+    if (flags['dry-run'] !== true) {
+      const issue = await opts.client.createIssue(payload);
+      created.push({
+        id: issue.identifier,
+        uuid: issue.id,
+        title: issue.title,
+        url: issue.url,
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    dryRun: flags['dry-run'] === true,
+    parent: {
+      id: parent.identifier,
+      title: parent.title,
+      url: parent.url,
+    },
+    planned,
+    created,
+    count: flags['dry-run'] === true ? planned.length : created.length,
+  };
+}

--- a/scripts/roadmap/commands/sync.mjs
+++ b/scripts/roadmap/commands/sync.mjs
@@ -1,0 +1,118 @@
+/**
+ * `roadmap sync` — Linear → agentos/roadmap/backlog.json
+ * Supports --check (drift) and --force (always write).
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import {
+  AGENTOS_INITIATIVE_NAME,
+  DEFAULT_BACKLOG_PATH,
+} from '../config.mjs';
+import {
+  detectBacklogDrift,
+  mapLinearIssueToRoadmap,
+  mapLinearProjectToRoadmap,
+} from '../map-issue.mjs';
+
+/**
+ * Build a RoadmapBacklog object from Linear data (pure given client results).
+ * @param {{
+ *   initiative: object,
+ *   issues: object[],
+ *   syncedAt?: string,
+ *   sourceRevision?: string|null,
+ * }} input
+ */
+export function buildBacklogSnapshot(input) {
+  const syncedAt = input.syncedAt ?? new Date().toISOString();
+  const projects = (input.initiative.projects?.nodes ?? input.initiative.projects ?? []).map(
+    /** @param {object} p */ p => mapLinearProjectToRoadmap(p)
+  );
+  const issues = input.issues.map(
+    /** @param {object} n */ n => mapLinearIssueToRoadmap(n, syncedAt)
+  );
+
+  return {
+    syncedAt,
+    sourceRevision: input.sourceRevision ?? null,
+    initiative: {
+      id: input.initiative.id,
+      name: input.initiative.name ?? AGENTOS_INITIATIVE_NAME,
+      url: input.initiative.url ?? '',
+    },
+    projects,
+    issues,
+  };
+}
+
+/**
+ * @param {{
+ *   client: import('../linear-client.mjs').LinearClient,
+ *   flags?: Record<string, string|boolean>,
+ *   cwd?: string,
+ *   readFileImpl?: typeof readFile,
+ *   writeFileImpl?: typeof writeFile,
+ *   mkdirImpl?: typeof mkdir,
+ *   now?: () => string,
+ * }} opts
+ */
+export async function runSync(opts) {
+  const flags = opts.flags ?? {};
+  const cwd = opts.cwd ?? process.cwd();
+  const outRel =
+    typeof flags.out === 'string' ? flags.out : DEFAULT_BACKLOG_PATH;
+  const outPath = resolve(cwd, outRel);
+  const checkOnly = flags.check === true;
+  const force = flags.force === true;
+  const readFileImpl = opts.readFileImpl ?? readFile;
+  const writeFileImpl = opts.writeFileImpl ?? writeFile;
+  const mkdirImpl = opts.mkdirImpl ?? mkdir;
+  const syncedAt = opts.now?.() ?? new Date().toISOString();
+
+  const initiative = await opts.client.fetchInitiative(AGENTOS_INITIATIVE_NAME);
+  const issues = await opts.client.fetchAgentOsIssues();
+  const next = buildBacklogSnapshot({ initiative, issues, syncedAt });
+
+  /** @type {object|null} */
+  let disk = null;
+  try {
+    const raw = await readFileImpl(outPath, 'utf8');
+    disk = JSON.parse(raw);
+  } catch {
+    disk = null;
+  }
+
+  const drift = detectBacklogDrift(disk, next);
+
+  if (checkOnly) {
+    return {
+      ok: !drift.drifted,
+      mode: 'check',
+      path: outPath,
+      drifted: drift.drifted,
+      details: drift.details,
+      issueCount: next.issues.length,
+      projectCount: next.projects.length,
+      syncedAt: next.syncedAt,
+    };
+  }
+
+  const shouldWrite = force || drift.drifted || !disk;
+  if (shouldWrite) {
+    await mkdirImpl(dirname(outPath), { recursive: true });
+    await writeFileImpl(`${outPath}`, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+  }
+
+  return {
+    ok: true,
+    mode: shouldWrite ? 'wrote' : 'unchanged',
+    path: outPath,
+    drifted: drift.drifted,
+    details: drift.details.slice(0, 20),
+    issueCount: next.issues.length,
+    projectCount: next.projects.length,
+    syncedAt: next.syncedAt,
+  };
+}

--- a/scripts/roadmap/commands/sync.mjs
+++ b/scripts/roadmap/commands/sync.mjs
@@ -6,10 +6,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import {
-  AGENTOS_INITIATIVE_NAME,
-  DEFAULT_BACKLOG_PATH,
-} from '../config.mjs';
+import { AGENTOS_INITIATIVE_NAME, DEFAULT_BACKLOG_PATH } from '../config.mjs';
 import {
   detectBacklogDrift,
   mapLinearIssueToRoadmap,
@@ -27,9 +24,11 @@ import {
  */
 export function buildBacklogSnapshot(input) {
   const syncedAt = input.syncedAt ?? new Date().toISOString();
-  const projects = (input.initiative.projects?.nodes ?? input.initiative.projects ?? []).map(
-    /** @param {object} p */ p => mapLinearProjectToRoadmap(p)
-  );
+  const projects = (
+    input.initiative.projects?.nodes ??
+    input.initiative.projects ??
+    []
+  ).map(/** @param {object} p */ p => mapLinearProjectToRoadmap(p));
   const issues = input.issues.map(
     /** @param {object} n */ n => mapLinearIssueToRoadmap(n, syncedAt)
   );
@@ -102,7 +101,11 @@ export async function runSync(opts) {
   const shouldWrite = force || drift.drifted || !disk;
   if (shouldWrite) {
     await mkdirImpl(dirname(outPath), { recursive: true });
-    await writeFileImpl(`${outPath}`, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+    await writeFileImpl(
+      `${outPath}`,
+      `${JSON.stringify(next, null, 2)}\n`,
+      'utf8'
+    );
   }
 
   return {

--- a/scripts/roadmap/commands/today.mjs
+++ b/scripts/roadmap/commands/today.mjs
@@ -1,0 +1,89 @@
+/**
+ * `roadmap today` — emit today's active issues (optionally as agent-briefs).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { DEFAULT_BACKLOG_PATH } from '../config.mjs';
+import { selectTodayIssues } from '../map-issue.mjs';
+import { buildAgentBriefFromIssue } from './agent-brief.mjs';
+
+/**
+ * @param {{
+ *   flags?: Record<string, string|boolean>,
+ *   cwd?: string,
+ *   readFileImpl?: typeof readFile,
+ *   backlog?: object|null,
+ *   client?: import('../linear-client.mjs').LinearClient|null,
+ * }} opts
+ */
+export async function runToday(opts) {
+  const flags = opts.flags ?? {};
+  const limit =
+    typeof flags.limit === 'string' || typeof flags.limit === 'number'
+      ? Math.max(1, Number(flags.limit) || 50)
+      : 50;
+
+  const backlog =
+    opts.backlog ??
+    (await loadBacklog({
+      cwd: opts.cwd ?? process.cwd(),
+      readFileImpl: opts.readFileImpl ?? readFile,
+      path: typeof flags.backlog === 'string' ? flags.backlog : DEFAULT_BACKLOG_PATH,
+    }));
+
+  if (!backlog?.issues) {
+    return {
+      ok: false,
+      error:
+        'No backlog.json found. Run `roadmap sync` first, or pass a valid --backlog path.',
+    };
+  }
+
+  const selected = selectTodayIssues(backlog.issues, { limit });
+  const asBriefs = flags.briefs === true || flags.json === true;
+
+  if (asBriefs) {
+    const briefs = selected.map(issue =>
+      buildAgentBriefFromIssue({
+        issue,
+        backlog,
+        description: '', // mirror-only; live description requires Linear
+      })
+    );
+    return {
+      ok: true,
+      count: briefs.length,
+      backlogSyncedAt: backlog.syncedAt ?? null,
+      issues: selected.map(i => ({ id: i.id, title: i.title, state: i.state?.name })),
+      briefs,
+    };
+  }
+
+  return {
+    ok: true,
+    count: selected.length,
+    backlogSyncedAt: backlog.syncedAt ?? null,
+    issues: selected.map(i => ({
+      id: i.id,
+      title: i.title,
+      state: i.state?.name,
+      priority: i.priority,
+      agentOwned: i.agentOwned,
+      url: i.url,
+    })),
+  };
+}
+
+/**
+ * @param {{ cwd: string, readFileImpl: typeof readFile, path: string }} opts
+ */
+async function loadBacklog(opts) {
+  try {
+    const raw = await opts.readFileImpl(resolve(opts.cwd, opts.path), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/roadmap/commands/today.mjs
+++ b/scripts/roadmap/commands/today.mjs
@@ -30,7 +30,10 @@ export async function runToday(opts) {
     (await loadBacklog({
       cwd: opts.cwd ?? process.cwd(),
       readFileImpl: opts.readFileImpl ?? readFile,
-      path: typeof flags.backlog === 'string' ? flags.backlog : DEFAULT_BACKLOG_PATH,
+      path:
+        typeof flags.backlog === 'string'
+          ? flags.backlog
+          : DEFAULT_BACKLOG_PATH,
     }));
 
   if (!backlog?.issues) {
@@ -56,7 +59,11 @@ export async function runToday(opts) {
       ok: true,
       count: briefs.length,
       backlogSyncedAt: backlog.syncedAt ?? null,
-      issues: selected.map(i => ({ id: i.id, title: i.title, state: i.state?.name })),
+      issues: selected.map(i => ({
+        id: i.id,
+        title: i.title,
+        state: i.state?.name,
+      })),
       briefs,
     };
   }

--- a/scripts/roadmap/config.mjs
+++ b/scripts/roadmap/config.mjs
@@ -1,0 +1,50 @@
+/**
+ * Shared constants for the /roadmap CLI.
+ * Team ID matches scripts/backlog-orchestrator/config.json.
+ */
+
+export const TEAM_KEY = 'JOV';
+export const TEAM_ID = 'bdc09edc-f91c-4a06-b308-74b4fcf093f8';
+
+/** Default AgentOS initiative name used when resolving projects/issues. */
+export const AGENTOS_INITIATIVE_NAME = 'AgentOS';
+
+export const LABEL_AGENTOS = 'agentos';
+export const LABEL_HUMAN_REVIEW = 'human-review-required';
+
+export const DEFAULT_BACKLOG_PATH = 'agentos/roadmap/backlog.json';
+
+/** Active work states surfaced by `today`. */
+export const TODAY_STATE_NAMES = Object.freeze([
+  'Todo',
+  'In Progress',
+  'In Review',
+]);
+
+/** Linear state types considered "active" for agent scheduling. */
+export const ACTIVE_STATE_TYPES = Object.freeze([
+  'unstarted',
+  'started',
+  'triage',
+]);
+
+/**
+ * Minimum forbidden actions for agent-briefs (SYNC_MODEL §4.3)
+ * unless human approval is required and cleared.
+ */
+export const DEFAULT_FORBIDDEN_ACTIONS = Object.freeze([
+  'mutate_production_data',
+  'change_auth',
+  'change_billing',
+  'change_security',
+]);
+
+export const DEFAULT_ALLOWED_ACTIONS = Object.freeze([
+  'read',
+  'classify',
+  'rank',
+  'summarize',
+  'draft',
+  'write_code',
+  'open_pr',
+]);

--- a/scripts/roadmap/linear-client.mjs
+++ b/scripts/roadmap/linear-client.mjs
@@ -243,7 +243,10 @@ export function createLinearClient(opts = {}) {
     );
     const byName = new Map(
       (data?.team?.labels?.nodes ?? []).map(
-        /** @param {{id:string,name:string}} n */ n => [n.name.toLowerCase(), n.id]
+        /** @param {{id:string,name:string}} n */ n => [
+          n.name.toLowerCase(),
+          n.id,
+        ]
       )
     );
     /** @type {string[]} */

--- a/scripts/roadmap/linear-client.mjs
+++ b/scripts/roadmap/linear-client.mjs
@@ -1,0 +1,336 @@
+/**
+ * Linear GraphQL client for /roadmap.
+ * Accepts an optional `fetch` for tests; production uses global fetch + LINEAR_API_KEY.
+ */
+
+import {
+  AGENTOS_INITIATIVE_NAME,
+  LABEL_AGENTOS,
+  TEAM_ID,
+  TEAM_KEY,
+} from './config.mjs';
+
+export const LINEAR_API_KEY_ENV = 'LINEAR_API_KEY';
+const API_URL = 'https://api.linear.app/graphql';
+
+/**
+ * @param {{ apiKey?: string, fetchImpl?: typeof fetch }} [opts]
+ */
+export function createLinearClient(opts = {}) {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const apiKey = opts.apiKey ?? process.env[LINEAR_API_KEY_ENV];
+
+  /**
+   * @param {string} query
+   * @param {Record<string, unknown>} [variables]
+   */
+  async function graphql(query, variables = {}) {
+    if (!apiKey) {
+      throw new Error(`${LINEAR_API_KEY_ENV} not set`);
+    }
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('fetch is not available');
+    }
+    const resp = await fetchImpl(API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      throw new Error(
+        `Linear API request failed (${resp.status} ${resp.statusText}): ${body}`
+      );
+    }
+    const data = await resp.json();
+    if (data.errors?.length) {
+      throw new Error(
+        `Linear API error: ${data.errors.map(/** @param {{message:string}} e */ e => e.message).join('; ')}`
+      );
+    }
+    return data.data;
+  }
+
+  /**
+   * Fetch AgentOS initiative (by name) with projects.
+   */
+  async function fetchInitiative(name = AGENTOS_INITIATIVE_NAME) {
+    // Linear GraphQL: initiatives connection may require org-level access.
+    // Fall back to team projects filtered by name if initiatives are unavailable.
+    try {
+      const data = await graphql(
+        `query($name: String!) {
+          initiatives(filter: { name: { eq: $name } }, first: 1) {
+            nodes {
+              id
+              name
+              url
+              projects {
+                nodes {
+                  id
+                  name
+                  url
+                  status { name type }
+                }
+              }
+            }
+          }
+        }`,
+        { name }
+      );
+      const node = data?.initiatives?.nodes?.[0] ?? null;
+      if (node) return node;
+    } catch {
+      // fall through
+    }
+
+    // Fallback: invent a synthetic initiative envelope from team projects
+    // whose name or description references AgentOS, plus all team projects
+    // labeled under agentos work.
+    const projects = await fetchTeamProjects();
+    return {
+      id: 'synthetic-agentos',
+      name: AGENTOS_INITIATIVE_NAME,
+      url: 'https://linear.app/jovie/initiative/agentos-1838d0d6b914',
+      projects: { nodes: projects },
+      _synthetic: true,
+    };
+  }
+
+  async function fetchTeamProjects() {
+    const data = await graphql(
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          projects(first: 100) {
+            nodes {
+              id
+              name
+              url
+              status { name type }
+            }
+          }
+        }
+      }`,
+      { teamId: TEAM_ID }
+    );
+    return data?.team?.projects?.nodes ?? [];
+  }
+
+  /**
+   * Active + recently completed agentos-labeled issues for the team.
+   * @param {{ maxResults?: number, label?: string }} [opts]
+   */
+  async function fetchAgentOsIssues(opts = {}) {
+    const maxResults = opts.maxResults ?? 500;
+    const label = opts.label ?? LABEL_AGENTOS;
+    /** @type {object[]} */
+    const issues = [];
+    let cursor = null;
+    while (issues.length < maxResults) {
+      const data = await graphql(
+        `query($teamId: String!, $cursor: String, $label: String!) {
+          team(id: $teamId) {
+            issues(
+              first: 50
+              after: $cursor
+              filter: {
+                labels: { name: { eq: $label } }
+                state: {
+                  type: { nin: ["canceled"] }
+                }
+              }
+            ) {
+              nodes {
+                id
+                identifier
+                title
+                description
+                url
+                createdAt
+                updatedAt
+                priority
+                assignee { id name }
+                labels { nodes { id name } }
+                parent { id identifier }
+                project { id name }
+                state { id name type }
+                relations {
+                  nodes {
+                    type
+                    relatedIssue { id identifier title }
+                  }
+                }
+                attachments { nodes { url } }
+              }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }`,
+        { teamId: TEAM_ID, cursor, label }
+      );
+      const edge = data?.team?.issues;
+      if (!edge) break;
+      issues.push(...edge.nodes);
+      if (!edge.pageInfo.hasNextPage) break;
+      cursor = edge.pageInfo.endCursor;
+    }
+    return issues;
+  }
+
+  /**
+   * @param {string} identifier  e.g. JOV-1932
+   */
+  async function fetchIssueByIdentifier(identifier) {
+    const m = String(identifier).match(/^(?:JOV-)?(\d+)$/i);
+    if (!m) {
+      throw new Error(`Invalid issue identifier: ${identifier}`);
+    }
+    const number = Number.parseInt(m[1], 10);
+    const data = await graphql(
+      `query($n: Float!) {
+        issues(
+          filter: { team: { key: { eq: "JOV" } }, number: { eq: $n } }
+          first: 1
+        ) {
+          nodes {
+            id
+            identifier
+            title
+            description
+            url
+            createdAt
+            updatedAt
+            priority
+            assignee { id name }
+            labels { nodes { id name } }
+            parent { id identifier }
+            project { id name url }
+            state { id name type }
+            children { nodes { id identifier title state { name type } } }
+            relations {
+              nodes {
+                type
+                relatedIssue { id identifier title state { name type } }
+              }
+            }
+            attachments { nodes { url } }
+            team { id key }
+          }
+        }
+      }`,
+      { n: number }
+    );
+    return data?.issues?.nodes?.[0] ?? null;
+  }
+
+  /**
+   * Resolve label IDs by name on the JOV team.
+   * @param {readonly string[]} names
+   */
+  async function resolveLabelIds(names) {
+    if (names.length === 0) return [];
+    const data = await graphql(
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          labels(first: 250) { nodes { id name } }
+        }
+      }`,
+      { teamId: TEAM_ID }
+    );
+    const byName = new Map(
+      (data?.team?.labels?.nodes ?? []).map(
+        /** @param {{id:string,name:string}} n */ n => [n.name.toLowerCase(), n.id]
+      )
+    );
+    /** @type {string[]} */
+    const ids = [];
+    for (const name of names) {
+      const id = byName.get(name.toLowerCase());
+      if (id) ids.push(id);
+    }
+    return ids;
+  }
+
+  /**
+   * @param {string} projectRef  slug or id
+   */
+  async function resolveProjectId(projectRef) {
+    if (!projectRef) return null;
+    // UUID-ish
+    if (/^[0-9a-f-]{20,}$/i.test(projectRef)) return projectRef;
+    const projects = await fetchTeamProjects();
+    const slug = projectRef.toLowerCase();
+    const hit = projects.find(p => {
+      const nameSlug = String(p.name)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      return nameSlug === slug || p.name.toLowerCase() === slug;
+    });
+    return hit?.id ?? null;
+  }
+
+  /**
+   * @param {{
+   *   title: string,
+   *   description?: string,
+   *   priority?: number,
+   *   parentId?: string|null,
+   *   projectId?: string|null,
+   *   labelNames?: string[],
+   * }} input
+   */
+  async function createIssue(input) {
+    const labelNames = [
+      LABEL_AGENTOS,
+      ...(input.labelNames ?? []).filter(n => n && n !== LABEL_AGENTOS),
+    ];
+    const labelIds = await resolveLabelIds(labelNames);
+    const data = await graphql(
+      `mutation($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue { id identifier url title }
+        }
+      }`,
+      {
+        input: {
+          teamId: TEAM_ID,
+          title: input.title,
+          description: input.description ?? '',
+          ...(typeof input.priority === 'number'
+            ? { priority: input.priority }
+            : {}),
+          ...(input.parentId ? { parentId: input.parentId } : {}),
+          ...(input.projectId ? { projectId: input.projectId } : {}),
+          ...(labelIds.length ? { labelIds } : {}),
+        },
+      }
+    );
+    if (!data?.issueCreate?.success) {
+      throw new Error('issueCreate returned success=false');
+    }
+    return data.issueCreate.issue;
+  }
+
+  return {
+    graphql,
+    fetchInitiative,
+    fetchTeamProjects,
+    fetchAgentOsIssues,
+    fetchIssueByIdentifier,
+    resolveLabelIds,
+    resolveProjectId,
+    createIssue,
+    teamId: TEAM_ID,
+    teamKey: TEAM_KEY,
+  };
+}
+
+/**
+ * @typedef {ReturnType<typeof createLinearClient>} LinearClient
+ */

--- a/scripts/roadmap/linear-client.mjs
+++ b/scripts/roadmap/linear-client.mjs
@@ -46,6 +46,7 @@ export function createLinearClient(opts = {}) {
         `Linear API request failed (${resp.status} ${resp.statusText}): ${body}`
       );
     }
+    /** @type {{ data?: any, errors?: Array<{ message: string }> }} */
     const data = await resp.json();
     if (data.errors?.length) {
       throw new Error(

--- a/scripts/roadmap/map-issue.mjs
+++ b/scripts/roadmap/map-issue.mjs
@@ -3,10 +3,7 @@
  * No network, no fs — unit-testable in isolation.
  */
 
-import {
-  LABEL_AGENTOS,
-  LABEL_HUMAN_REVIEW,
-} from './config.mjs';
+import { LABEL_AGENTOS, LABEL_HUMAN_REVIEW } from './config.mjs';
 
 /**
  * @param {string} name
@@ -133,13 +130,19 @@ export function normalizePriority(priority) {
  * @param {object} node  Linear issue GraphQL node
  * @param {string} [syncedAt]
  */
-export function mapLinearIssueToRoadmap(node, syncedAt = new Date().toISOString()) {
+export function mapLinearIssueToRoadmap(
+  node,
+  syncedAt = new Date().toISOString()
+) {
   const labels = (node.labels?.nodes ?? node.labels ?? []).map(
     /** @param {{name?: string}|string} l */ l =>
       typeof l === 'string' ? l : String(l?.name ?? '')
   );
   const assignee = node.assignee
-    ? { id: node.assignee.id, name: node.assignee.name ?? node.assignee.displayName ?? '' }
+    ? {
+        id: node.assignee.id,
+        name: node.assignee.name ?? node.assignee.displayName ?? '',
+      }
     : null;
   // Linear GraphQL does not always expose "delegate"; accept optional field
   // or agentOS metadata when present.
@@ -219,7 +222,10 @@ function extractPullRequestUrl(node) {
  * @param {object} node  Linear project node
  * @param {string} [repoRootRelativePrefix]
  */
-export function mapLinearProjectToRoadmap(node, repoRootRelativePrefix = 'agentos/roadmap') {
+export function mapLinearProjectToRoadmap(
+  node,
+  repoRootRelativePrefix = 'agentos/roadmap'
+) {
   const slug = toSlug(node.name ?? node.slug ?? node.id);
   return {
     id: node.id,
@@ -296,11 +302,18 @@ export function detectBacklogDrift(disk, next) {
   /** @type {string[]} */
   const details = [];
   if (!disk || !Array.isArray(disk.issues)) {
-    return { drifted: true, details: ['on-disk backlog missing or has no issues array'] };
+    return {
+      drifted: true,
+      details: ['on-disk backlog missing or has no issues array'],
+    };
   }
 
-  const diskById = new Map(disk.issues.map(/** @param {{id:string}} i */ i => [i.id, i]));
-  const nextById = new Map(next.issues.map(/** @param {{id:string}} i */ i => [i.id, i]));
+  const diskById = new Map(
+    disk.issues.map(/** @param {{id:string}} i */ i => [i.id, i])
+  );
+  const nextById = new Map(
+    next.issues.map(/** @param {{id:string}} i */ i => [i.id, i])
+  );
 
   for (const id of new Set([...diskById.keys(), ...nextById.keys()])) {
     const a = diskById.get(id);
@@ -318,15 +331,29 @@ export function detectBacklogDrift(disk, next) {
       ['priority', a.priority, b.priority],
       ['assignee', a.assignee?.id ?? null, b.assignee?.id ?? null],
       ['delegate', a.delegate?.id ?? null, b.delegate?.id ?? null],
-      ['labels', (a.labels ?? []).slice().sort().join(','), (b.labels ?? []).slice().sort().join(',')],
+      [
+        'labels',
+        (a.labels ?? []).slice().sort().join(','),
+        (b.labels ?? []).slice().sort().join(','),
+      ],
       ['projectId', a.projectId, b.projectId],
       ['parentId', a.parentId, b.parentId],
-      ['blockedBy', (a.blockedBy ?? []).slice().sort().join(','), (b.blockedBy ?? []).slice().sort().join(',')],
-      ['blocks', (a.blocks ?? []).slice().sort().join(','), (b.blocks ?? []).slice().sort().join(',')],
+      [
+        'blockedBy',
+        (a.blockedBy ?? []).slice().sort().join(','),
+        (b.blockedBy ?? []).slice().sort().join(','),
+      ],
+      [
+        'blocks',
+        (a.blocks ?? []).slice().sort().join(','),
+        (b.blocks ?? []).slice().sort().join(','),
+      ],
     ];
     for (const [name, av, bv] of fields) {
       if (av !== bv) {
-        details.push(`${id}.${name}: ${JSON.stringify(av)} → ${JSON.stringify(bv)}`);
+        details.push(
+          `${id}.${name}: ${JSON.stringify(av)} → ${JSON.stringify(bv)}`
+        );
       }
     }
   }

--- a/scripts/roadmap/map-issue.mjs
+++ b/scripts/roadmap/map-issue.mjs
@@ -1,0 +1,382 @@
+/**
+ * Pure Linear → RoadmapIssue / RoadmapProject mappers (SYNC_MODEL §3).
+ * No network, no fs — unit-testable in isolation.
+ */
+
+import {
+  LABEL_AGENTOS,
+  LABEL_HUMAN_REVIEW,
+} from './config.mjs';
+
+/**
+ * @param {string} name
+ * @returns {string}
+ */
+export function toSlug(name) {
+  return String(name ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Extract repo-relative path refs from markdown/description text.
+ * @param {string|null|undefined} text
+ * @returns {string[]}
+ */
+export function extractRepoFileRefs(text) {
+  if (!text) return [];
+  const refs = new Set();
+  // backtick paths and bare paths with common prefixes
+  const re =
+    /(?:`|\b)((?:apps|packages|agentos|scripts|docs|\.claude|canon)\/[A-Za-z0-9_./@-]+\.[A-Za-z0-9]+)(?:`|\b)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    refs.add(m[1]);
+  }
+  return [...refs].sort();
+}
+
+/**
+ * Agent-owned when all three are true (SYNC_MODEL §2.3):
+ * 1. label `agentos`
+ * 2. delegate is set (AgentOS app user when provisioned)
+ * 3. no `human-review-required` label
+ *
+ * Until JOV-1934 provisions the app user, delegate may be null.
+ * We treat label agentos + !human-review-required as agent-eligible when
+ * delegate is absent, and require all three when delegate is present.
+ *
+ * @param {{ labels: string[], delegate: { id: string; name: string } | null }} input
+ * @returns {boolean}
+ */
+export function computeAgentOwned(input) {
+  const labels = input.labels.map(l => l.toLowerCase());
+  const hasAgentos = labels.includes(LABEL_AGENTOS);
+  const humanReview = labels.includes(LABEL_HUMAN_REVIEW);
+  if (!hasAgentos || humanReview) return false;
+  // If a delegate is recorded, require it (full §2.3). If not yet provisioned,
+  // agentos label alone is sufficient for mirror eligibility.
+  if (input.delegate) return true;
+  return true;
+}
+
+/**
+ * @param {{ labels: string[] }} input
+ */
+export function computeHumanReviewRequired(input) {
+  return input.labels.map(l => l.toLowerCase()).includes(LABEL_HUMAN_REVIEW);
+}
+
+/**
+ * Normalize Linear state type to RoadmapStateType.
+ * @param {string|null|undefined} type
+ * @param {string|null|undefined} name
+ */
+export function normalizeStateType(type, name) {
+  const t = String(type ?? '').toLowerCase();
+  if (
+    t === 'triage' ||
+    t === 'backlog' ||
+    t === 'unstarted' ||
+    t === 'started' ||
+    t === 'completed' ||
+    t === 'canceled'
+  ) {
+    return t;
+  }
+  const n = String(name ?? '').toLowerCase();
+  if (n.includes('triage')) return 'triage';
+  if (n.includes('backlog')) return 'backlog';
+  if (n.includes('todo') || n.includes('unstarted')) return 'unstarted';
+  if (n.includes('progress') || n.includes('review') || n.includes('started'))
+    return 'started';
+  if (n.includes('done') || n.includes('complete')) return 'completed';
+  if (n.includes('cancel') || n.includes('duplicate')) return 'canceled';
+  return 'unstarted';
+}
+
+/**
+ * Map Linear project status string to RoadmapProjectStatus.
+ * @param {string|null|undefined} status
+ */
+export function normalizeProjectStatus(status) {
+  const s = String(status ?? '').toLowerCase();
+  if (
+    s === 'planned' ||
+    s === 'started' ||
+    s === 'paused' ||
+    s === 'completed' ||
+    s === 'canceled'
+  ) {
+    return s;
+  }
+  if (s.includes('progress') || s === 'in progress') return 'started';
+  if (s.includes('complete') || s === 'done') return 'completed';
+  if (s.includes('cancel')) return 'canceled';
+  if (s.includes('pause')) return 'paused';
+  return 'planned';
+}
+
+/**
+ * @param {number|null|undefined} priority
+ * @returns {0|1|2|3|4}
+ */
+export function normalizePriority(priority) {
+  const p = Number(priority);
+  if (p === 1 || p === 2 || p === 3 || p === 4) return p;
+  return 0;
+}
+
+/**
+ * @param {object} node  Linear issue GraphQL node
+ * @param {string} [syncedAt]
+ */
+export function mapLinearIssueToRoadmap(node, syncedAt = new Date().toISOString()) {
+  const labels = (node.labels?.nodes ?? node.labels ?? []).map(
+    /** @param {{name?: string}|string} l */ l =>
+      typeof l === 'string' ? l : String(l?.name ?? '')
+  );
+  const assignee = node.assignee
+    ? { id: node.assignee.id, name: node.assignee.name ?? node.assignee.displayName ?? '' }
+    : null;
+  // Linear GraphQL does not always expose "delegate"; accept optional field
+  // or agentOS metadata when present.
+  const delegate = node.delegate
+    ? { id: node.delegate.id, name: node.delegate.name ?? '' }
+    : null;
+
+  const blockedBy = [];
+  const blocks = [];
+  for (const rel of node.relations?.nodes ?? []) {
+    const related = rel.relatedIssue;
+    if (!related?.identifier) continue;
+    if (rel.type === 'blocks') {
+      // "this issue blocks related" — related is blocked by us
+      blocks.push(related.identifier);
+    } else if (rel.type === 'blocked_by' || rel.type === 'blockedBy') {
+      blockedBy.push(related.identifier);
+    }
+  }
+  // Inverse: if relation type is "blocks" on the other side, Linear may only
+  // surface one direction. Also scan inverse relations when provided.
+  for (const rel of node.inverseRelations?.nodes ?? []) {
+    const related = rel.relatedIssue;
+    if (!related?.identifier) continue;
+    if (rel.type === 'blocks') {
+      blockedBy.push(related.identifier);
+    }
+  }
+
+  const humanReviewRequired = computeHumanReviewRequired({ labels });
+  const agentOwned = computeAgentOwned({ labels, delegate });
+
+  return {
+    id: node.identifier,
+    uuid: node.id,
+    title: node.title ?? '',
+    url: node.url ?? '',
+    state: {
+      name: node.state?.name ?? 'Unknown',
+      type: normalizeStateType(node.state?.type, node.state?.name),
+    },
+    priority: normalizePriority(node.priority),
+    assignee,
+    delegate,
+    labels,
+    projectId: node.project?.id ?? node.projectId ?? null,
+    parentId: node.parent?.identifier ?? null,
+    blockedBy: [...new Set(blockedBy)],
+    blocks: [...new Set(blocks)],
+    agentOwned,
+    humanReviewRequired,
+    repoFileRefs: extractRepoFileRefs(node.description),
+    pullRequestUrl: extractPullRequestUrl(node),
+    createdAt: node.createdAt ?? syncedAt,
+    updatedAt: node.updatedAt ?? syncedAt,
+    lastSyncedAt: syncedAt,
+  };
+}
+
+/**
+ * @param {object} node
+ * @returns {string|null}
+ */
+function extractPullRequestUrl(node) {
+  if (node.pullRequestUrl) return node.pullRequestUrl;
+  const attachments = node.attachments?.nodes ?? [];
+  for (const a of attachments) {
+    const url = a.url ?? a.href ?? '';
+    if (/github\.com\/.+\/pull\/\d+/i.test(url)) return url;
+  }
+  const desc = node.description ?? '';
+  const m = desc.match(/https:\/\/github\.com\/[^\s)]+\/pull\/\d+/);
+  return m ? m[0] : null;
+}
+
+/**
+ * @param {object} node  Linear project node
+ * @param {string} [repoRootRelativePrefix]
+ */
+export function mapLinearProjectToRoadmap(node, repoRootRelativePrefix = 'agentos/roadmap') {
+  const slug = toSlug(node.name ?? node.slug ?? node.id);
+  return {
+    id: node.id,
+    name: node.name ?? '',
+    slug,
+    status: normalizeProjectStatus(
+      typeof node.status === 'string' ? node.status : node.status?.name
+    ),
+    url: node.url ?? '',
+    specPath: `${repoRootRelativePrefix}/${slug}.md`,
+  };
+}
+
+/**
+ * Parse sub-issue titles from an epic description or freeform brief.
+ * Prefers checklist items, then numbered/bulleted lines under common headings.
+ *
+ * @param {string|null|undefined} text
+ * @returns {string[]}
+ */
+export function parseSubIssueTitles(text) {
+  if (!text) return [];
+  const lines = text.split(/\r?\n/);
+  /** @type {string[]} */
+  const titles = [];
+  let inSection = false;
+  const sectionRe =
+    /^(#{1,3}\s*)?(acceptance criteria|sub-?issues|tasks|breakdown|children|work items)\b/i;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (sectionRe.test(line)) {
+      inSection = true;
+      continue;
+    }
+    // Leaving a section when another heading appears
+    if (inSection && /^#{1,3}\s+\S/.test(line) && !sectionRe.test(line)) {
+      inSection = false;
+    }
+
+    const checklist = line.match(/^[-*]\s+\[[ xX]\]\s+(.+)$/);
+    const bullet = line.match(/^[-*]\s+(.+)$/);
+    const numbered = line.match(/^\d+[.)]\s+(.+)$/);
+    const candidate = checklist?.[1] ?? bullet?.[1] ?? numbered?.[1] ?? null;
+    if (!candidate) continue;
+
+    // Prefer section-scoped items; also accept top-level checklists anywhere
+    if (inSection || checklist) {
+      const cleaned = candidate.replace(/\s+$/, '').trim();
+      if (cleaned.length >= 3 && cleaned.length <= 200) {
+        titles.push(cleaned);
+      }
+    }
+  }
+
+  // Dedupe preserving order
+  const seen = new Set();
+  return titles.filter(t => {
+    const key = t.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Compare two backlog snapshots on tracked drift fields (SYNC_MODEL §5.1).
+ * @param {object|null} disk
+ * @param {object} next
+ * @returns {{ drifted: boolean, details: string[] }}
+ */
+export function detectBacklogDrift(disk, next) {
+  /** @type {string[]} */
+  const details = [];
+  if (!disk || !Array.isArray(disk.issues)) {
+    return { drifted: true, details: ['on-disk backlog missing or has no issues array'] };
+  }
+
+  const diskById = new Map(disk.issues.map(/** @param {{id:string}} i */ i => [i.id, i]));
+  const nextById = new Map(next.issues.map(/** @param {{id:string}} i */ i => [i.id, i]));
+
+  for (const id of new Set([...diskById.keys(), ...nextById.keys()])) {
+    const a = diskById.get(id);
+    const b = nextById.get(id);
+    if (!a) {
+      details.push(`${id}: added in Linear`);
+      continue;
+    }
+    if (!b) {
+      details.push(`${id}: removed from Linear active set`);
+      continue;
+    }
+    const fields = [
+      ['state', a.state?.name, b.state?.name],
+      ['priority', a.priority, b.priority],
+      ['assignee', a.assignee?.id ?? null, b.assignee?.id ?? null],
+      ['delegate', a.delegate?.id ?? null, b.delegate?.id ?? null],
+      ['labels', (a.labels ?? []).slice().sort().join(','), (b.labels ?? []).slice().sort().join(',')],
+      ['projectId', a.projectId, b.projectId],
+      ['parentId', a.parentId, b.parentId],
+      ['blockedBy', (a.blockedBy ?? []).slice().sort().join(','), (b.blockedBy ?? []).slice().sort().join(',')],
+      ['blocks', (a.blocks ?? []).slice().sort().join(','), (b.blocks ?? []).slice().sort().join(',')],
+    ];
+    for (const [name, av, bv] of fields) {
+      if (av !== bv) {
+        details.push(`${id}.${name}: ${JSON.stringify(av)} → ${JSON.stringify(bv)}`);
+      }
+    }
+  }
+
+  return { drifted: details.length > 0, details };
+}
+
+/**
+ * Filter issues for `today` (active, not human-review-required).
+ * @param {readonly object[]} issues
+ * @param {{ limit?: number, stateNames?: readonly string[] }} [opts]
+ */
+export function selectTodayIssues(issues, opts = {}) {
+  const limit = opts.limit ?? 50;
+  const stateNames = new Set(
+    (opts.stateNames ?? ['Todo', 'In Progress', 'In Review']).map(s =>
+      s.toLowerCase()
+    )
+  );
+  return issues
+    .filter(i => {
+      if (i.humanReviewRequired) return false;
+      const name = String(i.state?.name ?? '').toLowerCase();
+      return stateNames.has(name);
+    })
+    .sort((a, b) => {
+      // priority: lower number first, but 0 (None) last
+      const pa = a.priority === 0 ? 99 : a.priority;
+      const pb = b.priority === 0 ? 99 : b.priority;
+      if (pa !== pb) return pa - pb;
+      return String(a.id).localeCompare(String(b.id));
+    })
+    .slice(0, limit);
+}
+
+/**
+ * Filter issues that are agent-eligible and do NOT require human review
+ * (human-approval gate cleared).
+ * @param {readonly object[]} issues
+ * @param {{ limit?: number }} [opts]
+ */
+export function selectApprovedIssues(issues, opts = {}) {
+  const limit = opts.limit ?? 50;
+  return issues
+    .filter(i => i.agentOwned === true && i.humanReviewRequired === false)
+    .sort((a, b) => {
+      const pa = a.priority === 0 ? 99 : a.priority;
+      const pb = b.priority === 0 ? 99 : b.priority;
+      if (pa !== pb) return pa - pb;
+      return String(a.id).localeCompare(String(b.id));
+    })
+    .slice(0, limit);
+}

--- a/scripts/roadmap/parse-args.mjs
+++ b/scripts/roadmap/parse-args.mjs
@@ -1,0 +1,129 @@
+/**
+ * Pure argv parser for `/roadmap`. No I/O — fully unit-testable.
+ *
+ * Usage shapes:
+ *   roadmap <command> [args...] [--flag value] [--bool]
+ *   roadmap --help
+ */
+
+/** @typedef {'add'|'expand'|'sync'|'today'|'approved'|'agent-brief'|'help'} RoadmapCommand */
+
+const COMMANDS = new Set([
+  'add',
+  'expand',
+  'sync',
+  'today',
+  'approved',
+  'agent-brief',
+  'help',
+]);
+
+/**
+ * @param {readonly string[]} argv  process.argv slice after node + script
+ * @returns {{
+ *   ok: true,
+ *   command: RoadmapCommand,
+ *   positionals: string[],
+ *   flags: Record<string, string|boolean>,
+ * } | {
+ *   ok: false,
+ *   error: string,
+ *   command?: string,
+ * }}
+ */
+export function parseRoadmapArgs(argv) {
+  const args = [...argv];
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    return { ok: true, command: 'help', positionals: [], flags: {} };
+  }
+
+  const command = args[0];
+  if (!COMMANDS.has(command)) {
+    return {
+      ok: false,
+      error: `Unknown command "${command}". Expected one of: ${[...COMMANDS].filter(c => c !== 'help').join(', ')}.`,
+      command,
+    };
+  }
+
+  /** @type {string[]} */
+  const positionals = [];
+  /** @type {Record<string, string|boolean>} */
+  const flags = {};
+
+  for (let i = 1; i < args.length; i++) {
+    const token = args[i];
+    if (token === '--help' || token === '-h') {
+      flags.help = true;
+      continue;
+    }
+    if (token.startsWith('--')) {
+      const eq = token.indexOf('=');
+      if (eq !== -1) {
+        const key = token.slice(2, eq);
+        const value = token.slice(eq + 1);
+        flags[key] = value;
+        continue;
+      }
+      const key = token.slice(2);
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        flags[key] = true;
+      } else {
+        flags[key] = next;
+        i++;
+      }
+      continue;
+    }
+    positionals.push(token);
+  }
+
+  return {
+    ok: true,
+    command: /** @type {RoadmapCommand} */ (command),
+    positionals,
+    flags,
+  };
+}
+
+export function formatHelp() {
+  return `Usage: roadmap <command> [args] [flags]
+
+Commands:
+  add <title>              Create a Linear issue from a brief title/description
+  expand <issueId>         Generate sub-issues from an epic (description bullets)
+  sync                     Pull Linear state into agentos/roadmap/backlog.json
+  today                    Emit today's active issues as agent-briefs (or list)
+  approved                 List issues with human-approval gate cleared
+  agent-brief <issueId>    Emit structured agent brief for a given issue
+
+Flags (common):
+  --json                   Machine-readable JSON output (default for agent-brief)
+  --dry-run                Print planned writes without calling Linear mutations
+  --help, -h               Show this help
+
+sync:
+  --check                  Diff in-memory sync vs on-disk backlog; exit 1 on drift
+  --force                  Always rewrite backlog.json
+  --out <path>             Output path (default: agentos/roadmap/backlog.json)
+
+add:
+  --description <text>     Issue description body
+  --project <slug|id>      Linear project slug or id
+  --priority <0-4>         Linear priority (0=None … 1=Urgent … 4=Low)
+  --parent <JOV-N>         Parent issue identifier
+  --labels <a,b,c>         Extra labels (agentos is always applied)
+
+expand:
+  --from <file>            Read sub-issue titles from a file (one per line)
+  --limit <n>              Cap number of sub-issues created (default: 20)
+
+today / approved:
+  --limit <n>              Cap results (default: 50)
+
+agent-brief / today:
+  --json                   Emit JSON (default true for agent-brief)
+`;
+}
+
+export { COMMANDS };

--- a/scripts/roadmap/roadmap.mjs
+++ b/scripts/roadmap/roadmap.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * /roadmap CLI — Linear ops for AgentOS (JOV-1932).
  *
@@ -8,14 +9,14 @@
  * Each subcommand is an isolated pure-ish module under commands/.
  */
 
-import { createLinearClient } from './linear-client.mjs';
-import { formatHelp, parseRoadmapArgs } from './parse-args.mjs';
 import { runAdd } from './commands/add.mjs';
 import { runAgentBrief } from './commands/agent-brief.mjs';
 import { runApproved } from './commands/approved.mjs';
 import { runExpand } from './commands/expand.mjs';
 import { runSync } from './commands/sync.mjs';
 import { runToday } from './commands/today.mjs';
+import { createLinearClient } from './linear-client.mjs';
+import { formatHelp, parseRoadmapArgs } from './parse-args.mjs';
 
 /**
  * Programmatic entry for tests.
@@ -112,7 +113,11 @@ export async function runRoadmap(argv, deps = {}) {
       return { exitCode: 1, result };
     }
 
-    if (parsed.command === 'sync' && parsed.flags.check === true && result?.drifted) {
+    if (
+      parsed.command === 'sync' &&
+      parsed.flags.check === true &&
+      result?.drifted
+    ) {
       stdout(JSON.stringify(result, null, 2));
       return { exitCode: 1, result };
     }

--- a/scripts/roadmap/roadmap.mjs
+++ b/scripts/roadmap/roadmap.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * /roadmap CLI — Linear ops for AgentOS (JOV-1932).
+ *
+ *   pnpm roadmap <command> [args] [flags]
+ *   node scripts/roadmap/roadmap.mjs <command> ...
+ *
+ * Each subcommand is an isolated pure-ish module under commands/.
+ */
+
+import { createLinearClient } from './linear-client.mjs';
+import { formatHelp, parseRoadmapArgs } from './parse-args.mjs';
+import { runAdd } from './commands/add.mjs';
+import { runAgentBrief } from './commands/agent-brief.mjs';
+import { runApproved } from './commands/approved.mjs';
+import { runExpand } from './commands/expand.mjs';
+import { runSync } from './commands/sync.mjs';
+import { runToday } from './commands/today.mjs';
+
+/**
+ * Programmatic entry for tests.
+ * @param {readonly string[]} argv
+ * @param {{
+ *   client?: ReturnType<typeof createLinearClient>,
+ *   cwd?: string,
+ *   stdout?: (s: string) => void,
+ *   stderr?: (s: string) => void,
+ * }} [deps]
+ * @returns {Promise<{ exitCode: number, result?: unknown }>}
+ */
+export async function runRoadmap(argv, deps = {}) {
+  const stdout = deps.stdout ?? (s => process.stdout.write(`${s}\n`));
+  const stderr = deps.stderr ?? (s => process.stderr.write(`${s}\n`));
+
+  const parsed = parseRoadmapArgs(argv);
+  if (!parsed.ok) {
+    stderr(parsed.error);
+    stderr(formatHelp());
+    return { exitCode: 2 };
+  }
+
+  if (parsed.command === 'help' || parsed.flags.help === true) {
+    stdout(formatHelp());
+    return { exitCode: 0 };
+  }
+
+  const needsLinear = new Set(['add', 'expand', 'sync', 'agent-brief']);
+  // today/approved work offline from backlog.json; agent-brief prefers live
+  // Linear when available but can run offline.
+  let client = deps.client ?? null;
+  if (!client && needsLinear.has(parsed.command)) {
+    try {
+      client = createLinearClient();
+    } catch (err) {
+      // agent-brief can degrade to backlog-only
+      if (parsed.command !== 'agent-brief') {
+        stderr(err instanceof Error ? err.message : String(err));
+        return { exitCode: 1 };
+      }
+    }
+  }
+
+  const common = {
+    client,
+    positionals: parsed.positionals,
+    flags: parsed.flags,
+    cwd: deps.cwd ?? process.cwd(),
+  };
+
+  try {
+    let result;
+    switch (parsed.command) {
+      case 'add':
+        result = await runAdd(common);
+        break;
+      case 'expand':
+        result = await runExpand(common);
+        break;
+      case 'sync':
+        result = await runSync(common);
+        break;
+      case 'today':
+        result = await runToday(common);
+        break;
+      case 'approved':
+        result = await runApproved(common);
+        break;
+      case 'agent-brief':
+        result = await runAgentBrief(common);
+        break;
+      default:
+        stderr(`Unhandled command: ${parsed.command}`);
+        return { exitCode: 2 };
+    }
+
+    const asJson =
+      parsed.flags.json === true ||
+      parsed.command === 'agent-brief' ||
+      parsed.command === 'sync' ||
+      parsed.command === 'add' ||
+      parsed.command === 'expand' ||
+      parsed.command === 'today' ||
+      parsed.command === 'approved';
+
+    if (result?.ok === false) {
+      if (asJson) {
+        stdout(JSON.stringify(result, null, 2));
+      } else {
+        stderr(result.error ?? 'Command failed');
+      }
+      // sync --check with drift uses ok:false path below via exit code
+      return { exitCode: 1, result };
+    }
+
+    if (parsed.command === 'sync' && parsed.flags.check === true && result?.drifted) {
+      stdout(JSON.stringify(result, null, 2));
+      return { exitCode: 1, result };
+    }
+
+    if (asJson) {
+      stdout(JSON.stringify(result, null, 2));
+    } else if (parsed.command === 'today' || parsed.command === 'approved') {
+      for (const issue of result.issues ?? []) {
+        stdout(
+          [
+            issue.id,
+            issue.state ?? '',
+            `p${issue.priority ?? 0}`,
+            issue.title,
+          ].join('\t')
+        );
+      }
+    } else {
+      stdout(JSON.stringify(result, null, 2));
+    }
+
+    return { exitCode: 0, result };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderr(message);
+    return { exitCode: 1, result: { ok: false, error: message } };
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  (process.argv[1].endsWith('/roadmap.mjs') ||
+    process.argv[1].endsWith('\\roadmap.mjs') ||
+    process.argv[1].endsWith('/roadmap') ||
+    process.argv[1].includes('scripts/roadmap/roadmap'));
+
+if (isMain) {
+  const { exitCode } = await runRoadmap(process.argv.slice(2));
+  process.exit(exitCode);
+}

--- a/scripts/roadmap/roadmap.mjs
+++ b/scripts/roadmap/roadmap.mjs
@@ -27,14 +27,14 @@ import { formatHelp, parseRoadmapArgs } from './parse-args.mjs';
  *   stdout?: (s: string) => void,
  *   stderr?: (s: string) => void,
  * }} [deps]
- * @returns {Promise<{ exitCode: number, result?: unknown }>}
+ * @returns {Promise<{ exitCode: number, result?: any }>}
  */
 export async function runRoadmap(argv, deps = {}) {
   const stdout = deps.stdout ?? (s => process.stdout.write(`${s}\n`));
   const stderr = deps.stderr ?? (s => process.stderr.write(`${s}\n`));
 
   const parsed = parseRoadmapArgs(argv);
-  if (!parsed.ok) {
+  if (parsed.ok === false) {
     stderr(parsed.error);
     stderr(formatHelp());
     return { exitCode: 2 };
@@ -69,6 +69,7 @@ export async function runRoadmap(argv, deps = {}) {
   };
 
   try {
+    /** @type {any} */
     let result;
     switch (parsed.command) {
       case 'add':

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -60,6 +60,7 @@
     "qa-design-review",
     "qa-only",
     "qa-swarm",
+    "roadmap",
     "retro",
     "review",
     "scrape",


### PR DESCRIPTION
## Summary

Implements the `/roadmap` command for AgentOS Linear ops (JOV-1932).

- **CLI:** `pnpm roadmap` / `scripts/roadmap/roadmap.mjs` with subcommands:
  - `add` — create issue from brief (always labels `agentos`; supports `--dry-run`)
  - `expand` — generate sub-issues from epic description bullets or `--from` file
  - `sync` — Linear → `agentos/roadmap/backlog.json` (`--check` drift / `--force` rewrite)
  - `today` — active issues (Todo / In Progress / In Review), optional briefs
  - `approved` — agent-owned issues with human-review gate cleared
  - `agent-brief` — structured schemaVersion-1 brief for a given issue ID
- **Types:** `agentos/roadmap/backlog.types.ts` (SYNC_MODEL §3)
- **Skill/command:** `.claude/skills/roadmap/SKILL.md`, `.claude/commands/roadmap.md`
- **Testability:** each subcommand is an injectable pure module; mock Linear client in tests
- **Gitignore:** stop blanket-ignoring `agentos/` source so the roadmap mirror can ship

Linear remains the source of truth; the repo mirror is regenerated only.

## Test plan / results

```bash
pnpm roadmap:test
# 31 tests, 9 suites, all pass

node scripts/roadmap/roadmap.mjs --help
node scripts/roadmap/roadmap.mjs add "Test" --dry-run
```

- [x] Unit tests for parse-args, map-issue, add, expand, sync, today, approved, agent-brief, CLI wiring
- [x] Help + dry-run smoke
- [ ] Live `pnpm roadmap sync` against Linear (requires `LINEAR_API_KEY`; optional for CI)

## Fixes JOV-1932

<!-- linear-issue-id:JOV-1932 -->