### PR TITLE
fix(health): prevent stale production build-info after promote (JOV-1958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- [internal] **OAuth provider enablement is a code allowlist, not env flags (JOV-2131):** Documented why `NEXT_PUBLIC_CLERK_OAUTH_*` gating emptied production sign-in (PRs #8458/#8497), confirmed Turbo still hashes `NEXT_PUBLIC_*` and Next still collects them for inlining, and locked the hardcoded apple/google allowlist with source + static-env regression tests.
+- [internal] **Production build-info cannot cache a stale commit after promote (JOV-1958):** `/api/health/*` identity headers now force browser and Vercel CDN no-store after the general API cache rule, and promote still proves the public `jov.ie` alias before release success.
 - [internal] **Profile redesign proposal loop (JOV-1951):** Design Lab can generate pending mockup proposals for owned profiles and selected competitor handles; output stays gated by D2 approval before any production or design-system rollout.
 - [internal] **Shared organisms layer is server-import-free (JOV-3506):** ProfileSwitcher switches active profiles via `POST /api/dashboard/profile/switch` instead of importing a dashboard server action, driving the server-imports ratchet baseline to 0.
 - **Authenticated shell adopts Jovie Noir Ion dark color system (JOV-4635):** stepped near-black surfaces, cool graphite borders, and electric-blue (Ion) focus/selection replace the prior carbon dark palette; agent, creative, system, and status accents keep their approved meanings.

--- a/apps/web/app/api/health/build-info/route.ts
+++ b/apps/web/app/api/health/build-info/route.ts
@@ -10,6 +10,20 @@ import releaseInfo from '../../../../../../version.json';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+/**
+ * Build-info is the public production identity receipt (JOV-1958). It must
+ * never be edge- or browser-cached: a stale commitSha after promote is a
+ * false production proof. Keep CDN + browser directives aligned with
+ * next.config.js `/api/health/*` headers.
+ */
+export const BUILD_INFO_CACHE_HEADERS = {
+  'cache-control': 'private, no-cache, no-store, must-revalidate',
+  'cdn-cache-control': 'no-store',
+  'vercel-cdn-cache-control': 'no-store',
+  pragma: 'no-cache',
+  expires: '0',
+} as const;
+
 let _cachedBuildId: string | undefined;
 
 function resolveAppVersion(): string {
@@ -27,12 +41,18 @@ function resolveAppVersion(): string {
   return '0.0.0';
 }
 
+function resolveCommitSha(): string | undefined {
+  const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim().slice(0, 7);
+  const runtimeCommitSha = env.VERCEL_GIT_COMMIT_SHA?.trim().slice(0, 7);
+  // Prefer build-time SHA when present (inlined for prebuilt artifacts). Fall
+  // back to the runtime Vercel deployment SHA so CLI deploys still identify.
+  return buildSha || runtimeCommitSha || undefined;
+}
+
 export function GET() {
   const version = resolveAppVersion();
   const environment = env.VERCEL_ENV;
   const isDevelopment = env.NODE_ENV !== 'production';
-  const buildSha = env.NEXT_PUBLIC_BUILD_SHA?.trim().slice(0, 7);
-  const runtimeCommitSha = env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7);
 
   if (_cachedBuildId === undefined) {
     try {
@@ -55,13 +75,11 @@ export function GET() {
       buildId: _cachedBuildId,
       version,
       deployedAt: env.VERCEL_DEPLOYMENT_TIME || Date.now(),
-      commitSha: buildSha || runtimeCommitSha,
+      commitSha: resolveCommitSha(),
       environment,
     },
     {
-      headers: {
-        'cache-control': 'no-store',
-      },
+      headers: { ...BUILD_INFO_CACHE_HEADERS },
     }
   );
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -182,16 +182,21 @@ const nextConfig = {
       },
     };
 
-    return [
+    // Cache-Control merges when multiple sources match. Keep health identity
+    // routes AFTER the general /api rule so no-store wins over s-maxage=300
+    // (JOV-1958: stale public build-info after promote).
+    const healthNoStoreHeaders = [
       {
-        source: '/api/health/build-info',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-store, no-cache, must-revalidate',
-          },
-        ],
+        key: 'Cache-Control',
+        value: 'private, no-cache, no-store, must-revalidate',
       },
+      { key: 'CDN-Cache-Control', value: 'no-store' },
+      { key: 'Vercel-CDN-Cache-Control', value: 'no-store' },
+      { key: 'Pragma', value: 'no-cache' },
+      { key: 'Expires', value: '0' },
+    ];
+
+    return [
       {
         source: '/api/(.*)',
         headers: [
@@ -201,6 +206,11 @@ const nextConfig = {
             value: 'public, max-age=300, s-maxage=300', // 5 minutes
           },
         ],
+      },
+      {
+        // Public deployment identity receipt — must never inherit API s-maxage.
+        source: '/api/health/:path*',
+        headers: healthNoStoreHeaders,
       },
       // Marketing pages (pre-rendered at build) - long-lived cache
       {

--- a/apps/web/tests/unit/api/health/build-info-cache-headers.test.ts
+++ b/apps/web/tests/unit/api/health/build-info-cache-headers.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * JOV-1958: public production build-info must never inherit the general
+ * `/api/*` s-maxage=300 rule. Health identity routes are declared after the
+ * general API header block so no-store wins when sources merge.
+ */
+describe('build-info cache headers (JOV-1958)', () => {
+  const nextConfigSource = readFileSync(
+    resolve(process.cwd(), 'next.config.js'),
+    'utf8'
+  );
+
+  it('declares health no-store headers after the general API cache rule', () => {
+    const noStoreConstIndex = nextConfigSource.indexOf(
+      'const healthNoStoreHeaders'
+    );
+    const apiCacheIndex = nextConfigSource.indexOf("source: '/api/(.*)'");
+    const healthIndex = nextConfigSource.indexOf(
+      "source: '/api/health/:path*'"
+    );
+
+    expect(noStoreConstIndex).toBeGreaterThanOrEqual(0);
+    expect(apiCacheIndex).toBeGreaterThan(noStoreConstIndex);
+    expect(healthIndex).toBeGreaterThan(apiCacheIndex);
+
+    const noStoreBlock = nextConfigSource.slice(
+      noStoreConstIndex,
+      apiCacheIndex
+    );
+    expect(noStoreBlock).toContain('no-store');
+    expect(noStoreBlock).toContain('CDN-Cache-Control');
+    expect(noStoreBlock).toContain('Vercel-CDN-Cache-Control');
+    expect(noStoreBlock).not.toMatch(/s-maxage=\d+/);
+
+    const healthRuleBlock = nextConfigSource.slice(
+      healthIndex,
+      healthIndex + 200
+    );
+    expect(healthRuleBlock).toContain('headers: healthNoStoreHeaders');
+  });
+
+  it('does not pin build-info alone before the general API rule', () => {
+    // Pre-fix order put /api/health/build-info first, so a merge/last-wins
+    // Cache-Control could reintroduce public s-maxage on the identity receipt.
+    const buildInfoOnlyIndex = nextConfigSource.indexOf(
+      "source: '/api/health/build-info'"
+    );
+    expect(buildInfoOnlyIndex).toBe(-1);
+  });
+});

--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -56,14 +56,25 @@ describe('@critical GET /api/health/build-info', () => {
     expect(body.commitSha).toBe('abcdef1');
   });
 
-  it('marks build info as no-store so desktop reload polling sees fresh deploys', async () => {
+  it('marks build info as no-store at browser and CDN layers (JOV-1958)', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_BUILD_SHA', 'abcdef1');
 
-    const { GET } = await import('@/app/api/health/build-info/route');
+    const { BUILD_INFO_CACHE_HEADERS, GET } = await import(
+      '@/app/api/health/build-info/route'
+    );
     const response = GET();
 
-    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('cache-control')).toBe(
+      BUILD_INFO_CACHE_HEADERS['cache-control']
+    );
+    expect(response.headers.get('cdn-cache-control')).toBe('no-store');
+    expect(response.headers.get('vercel-cdn-cache-control')).toBe('no-store');
+    expect(response.headers.get('pragma')).toBe('no-cache');
+    expect(response.headers.get('expires')).toBe('0');
+    // Must never advertise a positive shared cache lifetime.
+    expect(response.headers.get('cache-control')).not.toMatch(/s-maxage=\d+/);
+    expect(response.headers.get('cache-control')).not.toMatch(/max-age=[1-9]/);
   });
 
   it('returns development build id without warning in development', async () => {

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1659,8 +1659,11 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     }
   });
 
-  it('verifies production promotion through the canonical public alias', () => {
+  it('verifies production promotion through the canonical public alias (JOV-1958)', () => {
+    // Regression: verifying only the immutable deployment URL can green while
+    // jov.ie still serves a prior commit. Promote must prove the public alias.
     const workflow = readFileSync(productionReleaseWorkflowPath, 'utf8');
+    const verifier = readFileSync(productionAliasVerifierPath, 'utf8');
     const promoteJob = getJobBlock(workflow, 'promote-production');
     const domainGuardStep = getStepBlock(
       promoteJob,
@@ -1695,6 +1698,10 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     expect(stageIndex).toBeGreaterThan(domainGuardIndex);
     expect(promoteIndex).toBeGreaterThan(stageIndex);
     expect(verifyIndex).toBeGreaterThan(promoteIndex);
+    expect(verifier).toContain('https://jov.ie/api/health/build-info');
+    expect(verifier).toContain('production_alias_not_updated');
+    expect(verifier).toContain('vcrrForceStable=true');
+    expect(verifier).toContain('vcrrForceCanary=true');
     expect(promoteJob).toContain(
       'steps.stage-production.outputs.failure_subtype || steps.performance-gate.outputs.failure_subtype || steps.promote.outputs.failure_subtype || steps.verify-production.outputs.failure_subtype'
     );


### PR DESCRIPTION
## Summary

Production `jov.ie/api/health/build-info` could report a stale `commitSha` after a successful promote when the public identity path was treated as a cacheable API response or when release verification only trusted the immutable deployment URL.

This change:
- Forces browser + Vercel CDN **no-store** headers on `/api/health/*` **after** the general `/api/*` `s-maxage=300` rule so health identity cannot inherit a shared cache lifetime
- Aligns the build-info route response headers with the same contract
- Locks the promote → public `jov.ie` alias verification invariant as the release identity receipt (JOV-1958 regression)

### Diagnosis
- Live production currently serves the correct main SHA with `cache-control: no-store` / `x-vercel-cache: MISS`
- CI already verifies promote via `verify-production-alias.sh` against `https://jov.ie/api/health/build-info` (plain/stable/canary) after the May 2026 incident
- Residual app-side risk: next.config declared build-info no-store **before** the general API rule that sets `public, max-age=300, s-maxage=300`, so merged/last-wins header application could reintroduce CDN caching of the identity receipt

## Test plan / results

- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/api/health/build-info.critical.test.ts tests/unit/api/health/build-info-cache-headers.test.ts` — 9 passed
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts -t "canonical public alias"` — 1 passed
- [x] Pre-push affected gate (biome, typecheck, affected vitest shards) — passed
- [x] Live check (pre-change baseline): `curl https://jov.ie/api/health/build-info` → `commitSha` matched `origin/main` head

## Fixes JOV-1958

<!-- linear-issue-id:JOV-1958 -->