### PR TITLE
docs(monetization): machine-access revenue share compliance (JOV-3831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- [internal] **Production build-info cannot cache a stale commit after promote (JOV-1958):** `/api/health/*` identity headers now force browser and Vercel CDN no-store after the general API cache rule, and promote still proves the public `jov.ie` alias before release success.
+- [internal] **Machine-access revenue-share compliance package (JOV-3831):** draft decision set (70/30 artist-majority, opt-in default OFF, monthly $10 Connect fiat floor, platform stablecoin off-ramp), consent/ToS language, tax reporting path, and Pay Per Crawl public-docs verification — Tim sign-off still required before P1 build.
 - [internal] **Profile redesign proposal loop (JOV-1951):** Design Lab can generate pending mockup proposals for owned profiles and selected competitor handles; output stays gated by D2 approval before any production or design-system rollout.
 - [internal] **Shared organisms layer is server-import-free (JOV-3506):** ProfileSwitcher switches active profiles via `POST /api/dashboard/profile/switch` instead of importing a dashboard server action, driving the server-imports ratchet baseline to 0.
 - **Authenticated shell adopts Jovie Noir Ion dark color system (JOV-4635):** stepped near-black surfaces, cool graphite borders, and electric-blue (Ion) focus/selection replace the prior carbon dark palette; agent, creative, system, and status accents keep their approved meanings.

--- a/apps/web/lib/monetization/machine-access-payout-policy.test.ts
+++ b/apps/web/lib/monetization/machine-access-payout-policy.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  exceedsUs1099Threshold,
+  isMachineAccessDecisionSetFullySignedOff,
+  MACHINE_ACCESS_ARTIST_SETTLEMENT,
+  MACHINE_ACCESS_ARTIST_SHARE_BPS,
+  MACHINE_ACCESS_CONSENT_COPY,
+  MACHINE_ACCESS_DECISIONS,
+  MACHINE_ACCESS_OPT_IN_DEFAULT,
+  MACHINE_ACCESS_PAYOUT_FLOOR_CENTS,
+  MACHINE_ACCESS_PLATFORM_SHARE_BPS,
+  MACHINE_ACCESS_SHARE_BPS_TOTAL,
+  MACHINE_ACCESS_STABLECOIN_POLICY,
+  meetsMachineAccessPayoutFloor,
+  splitMachineAccessNetCents,
+} from './machine-access-payout-policy';
+
+describe('machine-access payout policy', () => {
+  it('keeps artist-majority 70/30 basis points totaling 10000', () => {
+    expect(MACHINE_ACCESS_ARTIST_SHARE_BPS).toBe(7_000);
+    expect(MACHINE_ACCESS_PLATFORM_SHARE_BPS).toBe(3_000);
+    expect(
+      MACHINE_ACCESS_ARTIST_SHARE_BPS + MACHINE_ACCESS_PLATFORM_SHARE_BPS
+    ).toBe(MACHINE_ACCESS_SHARE_BPS_TOTAL);
+    expect(MACHINE_ACCESS_ARTIST_SHARE_BPS).toBeGreaterThan(
+      MACHINE_ACCESS_PLATFORM_SHARE_BPS
+    );
+  });
+
+  it('defaults opt-in to OFF', () => {
+    expect(MACHINE_ACCESS_OPT_IN_DEFAULT).toBe(false);
+  });
+
+  it('uses a $10 USD payout floor and monthly Connect fiat settlement', () => {
+    expect(MACHINE_ACCESS_PAYOUT_FLOOR_CENTS).toBe(1_000);
+    expect(MACHINE_ACCESS_ARTIST_SETTLEMENT).toBe('fiat_stripe_connect');
+    expect(MACHINE_ACCESS_STABLECOIN_POLICY).toBe('platform_redeems_to_fiat');
+  });
+
+  it('splits net cents with remainder to the platform', () => {
+    expect(splitMachineAccessNetCents(100)).toEqual({
+      artistShareCents: 70,
+      platformShareCents: 30,
+    });
+    // 1 cent: floor division → artist 0, platform 1
+    expect(splitMachineAccessNetCents(1)).toEqual({
+      artistShareCents: 0,
+      platformShareCents: 1,
+    });
+    expect(splitMachineAccessNetCents(0)).toEqual({
+      artistShareCents: 0,
+      platformShareCents: 0,
+    });
+  });
+
+  it('rejects invalid split inputs', () => {
+    expect(() => splitMachineAccessNetCents(-1)).toThrow(RangeError);
+    expect(() => splitMachineAccessNetCents(10.5)).toThrow(RangeError);
+    expect(() => splitMachineAccessNetCents(100, 10_001)).toThrow(RangeError);
+  });
+
+  it('enforces the payout floor', () => {
+    expect(meetsMachineAccessPayoutFloor(999)).toBe(false);
+    expect(meetsMachineAccessPayoutFloor(1_000)).toBe(true);
+    expect(meetsMachineAccessPayoutFloor(2_500)).toBe(true);
+  });
+
+  it('flags U.S. 1099 threshold at $600', () => {
+    expect(exceedsUs1099Threshold(59_999)).toBe(false);
+    expect(exceedsUs1099Threshold(60_000)).toBe(true);
+  });
+
+  it('records four pending Tim decisions and is not fully signed off yet', () => {
+    expect(MACHINE_ACCESS_DECISIONS.map(d => d.id)).toEqual([
+      'D1',
+      'D2',
+      'D3',
+      'D4',
+    ]);
+    expect(MACHINE_ACCESS_DECISIONS.every(d => d.state === 'pending_tim')).toBe(
+      true
+    );
+    expect(isMachineAccessDecisionSetFullySignedOff()).toBe(false);
+    expect(
+      isMachineAccessDecisionSetFullySignedOff(
+        MACHINE_ACCESS_DECISIONS.map(d => ({ ...d, state: 'approved' }))
+      )
+    ).toBe(true);
+  });
+
+  it('ships draft consent copy with version and non-empty UI strings', () => {
+    expect(MACHINE_ACCESS_CONSENT_COPY.version).toMatch(/draft/i);
+    expect(MACHINE_ACCESS_CONSENT_COPY.settingsTitle.length).toBeGreaterThan(0);
+    expect(
+      MACHINE_ACCESS_CONSENT_COPY.settingsDescription.toLowerCase()
+    ).toContain('opt');
+    expect(MACHINE_ACCESS_CONSENT_COPY.optInConfirm.toLowerCase()).toContain(
+      'authorize'
+    );
+  });
+});

--- a/apps/web/lib/monetization/machine-access-payout-policy.ts
+++ b/apps/web/lib/monetization/machine-access-payout-policy.ts
@@ -1,0 +1,172 @@
+/**
+ * Machine-access revenue share policy constants (Pay Per Crawl P1 + x402 P2).
+ *
+ * Decision package: docs/product/machine-access-revenue-share-compliance.md (JOV-3831).
+ * Exact artist share (D1) and final legal copy require Tim sign-off before production ToS.
+ *
+ * Do not invent parallel constants in UI or ledger code — import from here.
+ */
+
+/** Documented decision IDs from the compliance package. */
+export type MachineAccessDecisionId = 'D1' | 'D2' | 'D3' | 'D4';
+
+/**
+ * Sign-off state for JOV-3831 decisions.
+ * Flip to `approved` only after Tim records sign-off on the Linear issue.
+ */
+export type DecisionSignOffState = 'pending_tim' | 'approved' | 'revised';
+
+export interface MachineAccessDecisionRecord {
+  readonly id: MachineAccessDecisionId;
+  readonly title: string;
+  readonly state: DecisionSignOffState;
+  readonly summary: string;
+}
+
+/** D1 — proposed artist-majority split (basis points of net attributed revenue). */
+export const MACHINE_ACCESS_ARTIST_SHARE_BPS = 7_000; // 70%
+export const MACHINE_ACCESS_PLATFORM_SHARE_BPS = 3_000; // 30%
+export const MACHINE_ACCESS_SHARE_BPS_TOTAL = 10_000;
+
+/** D2 — charging requires explicit opt-in; default OFF. */
+export const MACHINE_ACCESS_OPT_IN_DEFAULT = false as const;
+
+/** D3 — monthly cadence + $10 USD floor (cents). */
+export const MACHINE_ACCESS_PAYOUT_CADENCE = 'monthly' as const;
+export const MACHINE_ACCESS_PAYOUT_FLOOR_CENTS = 1_000;
+export const MACHINE_ACCESS_PAYOUT_CURRENCY = 'usd' as const;
+
+/** D4 — artists always receive fiat via Connect; platform handles any crypto rails. */
+export const MACHINE_ACCESS_ARTIST_SETTLEMENT = 'fiat_stripe_connect' as const;
+export const MACHINE_ACCESS_STABLECOIN_POLICY =
+  'platform_redeems_to_fiat' as const;
+
+/** U.S. 1099-NEC-style reporting threshold (cents) for annual creator payouts. */
+export const MACHINE_ACCESS_US_1099_THRESHOLD_CENTS = 60_000;
+
+/** Consent copy version — bump when §5 language changes post sign-off. */
+export const MACHINE_ACCESS_CONSENT_COPY_VERSION = '2026-07-31-draft' as const;
+
+export const MACHINE_ACCESS_DECISIONS: readonly MachineAccessDecisionRecord[] =
+  [
+    {
+      id: 'D1',
+      title: 'Revenue-share split',
+      state: 'pending_tim',
+      summary:
+        'Artist 70% / platform 30% of net attributed machine-access revenue (artist-majority).',
+    },
+    {
+      id: 'D2',
+      title: 'Opt-in model',
+      state: 'pending_tim',
+      summary:
+        'Explicit opt-in required; default OFF; charging may reduce free AI crawler access.',
+    },
+    {
+      id: 'D3',
+      title: 'Payout floor and cadence',
+      state: 'pending_tim',
+      summary: 'Monthly Stripe Connect Express payouts; $10 USD minimum.',
+    },
+    {
+      id: 'D4',
+      title: 'Stablecoin policy (P2/x402)',
+      state: 'pending_tim',
+      summary:
+        'Platform redeems stablecoin to fiat; artists always paid fiat via Connect.',
+    },
+  ] as const;
+
+/**
+ * UI microcopy for the settings opt-in (draft until Tim + legal approve).
+ * Keep Title Case for labels per DESIGN.md; body is sentence case.
+ */
+export const MACHINE_ACCESS_CONSENT_COPY = {
+  version: MACHINE_ACCESS_CONSENT_COPY_VERSION,
+  settingsTitle: 'Share AI Access Revenue',
+  settingsDescription:
+    'Optional opt-in (off by default). When on, Jovie may charge approved AI crawlers for automated access to your public profile and related pages, and share a majority of the net proceeds with you. Some AI services may reduce or stop accessing your content if they do not pay. You can turn this off anytime. Payouts are monthly in USD via Stripe Connect once your balance reaches $10.',
+  optInConfirm:
+    'By turning this on, you authorize Jovie to (1) apply machine-access charges to automated requests for your opted-in content, (2) attribute those charges to your profile, and (3) pay you your revenue share under Jovie’s Machine-Access Revenue Share terms. You understand that charging may reduce free AI crawler access to your content.',
+  optOutNotice:
+    'Turning this off stops new charging attribution for your pages. Accrued unpaid balance remains payable under the payout policy.',
+} as const;
+
+export interface MachineAccessShareSplitCents {
+  readonly artistShareCents: number;
+  readonly platformShareCents: number;
+}
+
+/**
+ * Split net attributed revenue (integer cents) using the configured basis points.
+ * Remainder cents from integer division go to the platform so artist share never
+ * exceeds the configured rate.
+ */
+export function splitMachineAccessNetCents(
+  netAttributedCents: number,
+  artistShareBps: number = MACHINE_ACCESS_ARTIST_SHARE_BPS
+): MachineAccessShareSplitCents {
+  if (!Number.isFinite(netAttributedCents) || netAttributedCents < 0) {
+    throw new RangeError(
+      'netAttributedCents must be a non-negative finite number'
+    );
+  }
+  if (
+    !Number.isInteger(netAttributedCents) ||
+    !Number.isInteger(artistShareBps) ||
+    artistShareBps < 0 ||
+    artistShareBps > MACHINE_ACCESS_SHARE_BPS_TOTAL
+  ) {
+    throw new RangeError(
+      'artistShareBps must be an integer between 0 and 10000 inclusive; net must be integer cents'
+    );
+  }
+
+  const artistShareCents = Math.floor(
+    (netAttributedCents * artistShareBps) / MACHINE_ACCESS_SHARE_BPS_TOTAL
+  );
+  return {
+    artistShareCents,
+    platformShareCents: netAttributedCents - artistShareCents,
+  };
+}
+
+/** Whether an accrued unpaid balance clears the payout floor. */
+export function meetsMachineAccessPayoutFloor(
+  accruedUnpaidCents: number,
+  floorCents: number = MACHINE_ACCESS_PAYOUT_FLOOR_CENTS
+): boolean {
+  if (!Number.isFinite(accruedUnpaidCents) || accruedUnpaidCents < 0) {
+    throw new RangeError(
+      'accruedUnpaidCents must be a non-negative finite number'
+    );
+  }
+  return accruedUnpaidCents >= floorCents;
+}
+
+/**
+ * Whether calendar-year paid totals cross the U.S. information-return threshold.
+ * Used for finance tooling — form type (NEC vs MISC) is counsel’s call.
+ */
+export function exceedsUs1099Threshold(
+  calendarYearPaidCents: number,
+  thresholdCents: number = MACHINE_ACCESS_US_1099_THRESHOLD_CENTS
+): boolean {
+  if (!Number.isFinite(calendarYearPaidCents) || calendarYearPaidCents < 0) {
+    throw new RangeError(
+      'calendarYearPaidCents must be a non-negative finite number'
+    );
+  }
+  return calendarYearPaidCents >= thresholdCents;
+}
+
+/** True only when every JOV-3831 decision is marked approved in this module. */
+export function isMachineAccessDecisionSetFullySignedOff(
+  decisions: readonly MachineAccessDecisionRecord[] = MACHINE_ACCESS_DECISIONS
+): boolean {
+  return (
+    decisions.length > 0 &&
+    decisions.every(decision => decision.state === 'approved')
+  );
+}

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -54,7 +54,7 @@ This document is the canonical feature list for Jovie. It is designed for onboar
 | Analytics | AI-powered insights | Shipped | Pro+ | None | Insights dashboard (city growth, markets, momentum) |
 | Analytics | AI crawler intelligence | Shipped | Free teaser / Pro detail | None | Audience dashboard card + detail panel; Cloudflare edge analytics synced daily; Pro unlocks named crawlers and trends (GitHub #12747 P0) |
 | Analytics | Ad pixel tracking | Shipped | Pro+ | None | Entitlement-backed (`canAccessAdPixels`) |
-| Monetization (Planned) | Machine-access revenue share (Pay Per Crawl) | Planned | Pro+ | None | Gated on Cloudflare Pay Per Crawl beta — attribution ledger + Stripe Connect payouts (#12749) |
+| Monetization (Planned) | Machine-access revenue share (Pay Per Crawl) | Planned | Pro+ | None | Gated on Cloudflare Pay Per Crawl beta — attribution ledger + Stripe Connect payouts (#12749). Consent/tax/payout decision package: [machine-access-revenue-share-compliance.md](product/machine-access-revenue-share-compliance.md) (JOV-3831); policy constants `apps/web/lib/monetization/machine-access-payout-policy.ts` |
 | Monetization (Planned) | x402-paid artist datasets / MCP tools | Planned | Pro+ | None | Gated on Cloudflare Monetization Gateway access — spike #12750 |
 | Growth | Contact / subscriber capture | Shipped | Free+ | None | Contact limit varies by plan (100 / unlimited) |
 | Growth | Contact export | Shipped | Pro+ | None | Entitlement-backed (`canExportContacts`) |

--- a/docs/product/machine-access-revenue-share-compliance.md
+++ b/docs/product/machine-access-revenue-share-compliance.md
@@ -1,0 +1,265 @@
+# Machine-access revenue share — consent, terms & payout compliance
+
+> **JOV-3831** (needs-decision child of GitHub [#12749](https://github.com/JovieInc/Jovie/issues/12749) P1).  
+> Decision package for artist AI-access revenue share before P1 ships.  
+> Evidence captured 2026-07-31. **Final calls are Tim’s** — proposed defaults below are agent-drafted and marked for sign-off.
+
+**gbrain slug (when sync available):** `decisions/machine-access-revenue-share-compliance`
+
+**Code source of truth for numeric/policy knobs:**  
+`apps/web/lib/monetization/machine-access-payout-policy.ts`
+
+---
+
+## Status
+
+| Item | State |
+| --- | --- |
+| Decision set drafted | **Yes** — this document |
+| Tim sign-off | **Pending** (issue labeled needs-decision) |
+| Consent / ToS copy drafted | **Yes** — §5 + copy module |
+| Consent copy approved by Tim | **Pending** |
+| Tax reporting path documented | **Yes** — §6 |
+| Payout policy documented | **Yes** — §4 |
+| Pay Per Crawl beta agreement reviewed | **Partial** — public docs only; full beta agreement **UNVERIFIED** until zone access lands (§7) |
+| Unblocks P1 (#12749) build | **When Tim signs §3** |
+
+---
+
+## 1. Problem
+
+Paying artists a share of machine-access revenue (Cloudflare Pay Per Crawl → zone owner → per-artist attribution ledger → Stripe Connect) creates **consent**, **tax**, and **terms** obligations that must be settled before the P1 attribution/payout build ships.
+
+Parent product path (already sequenced):
+
+1. **P0 shipped** — AI crawler intelligence (#12747).
+2. **P1 gated** — per-artist attribution ledger + Connect payouts (#12749).
+3. **P2** — x402 / Monetization Gateway resource pricing ([spike](../spikes/x402-payment-gated-artist-resources.md)).
+
+---
+
+## 2. Money flow (canonical)
+
+```text
+AI crawler ──(pay intent headers)──► Cloudflare edge (zone: jov.ie)
+                                         │
+                                         │ MoR: charge crawler, aggregate
+                                         ▼
+                              Cloudflare → Jovie platform
+                              (dedicated PPC Stripe Connect; monthly)
+                                         │
+                                         │ attribution ledger (per artist path)
+                                         ▼
+                              Jovie → artist (Stripe Connect Express transfer)
+                              fiat only; monthly; $10 floor
+```
+
+**Rules:**
+
+- Cloudflare is **Merchant of Record** for crawler charges and pays the **zone owner** (Jovie), not individual artists.
+- Per-artist share is a **downstream commercial obligation of Jovie** (platform → creator), analogous to the merch payout ledger — not a Cloudflare sub-merchant relationship.
+- Artists never touch crypto or Cloudflare billing for P1.
+
+---
+
+## 3. Decision set (proposed — Tim sign-off required)
+
+Mark each row **Approved / Rejected / Revised** in Linear when Tim decides. Do not ship P1 until all four are signed.
+
+| ID | Decision | Proposed default | Owner | Status |
+| --- | --- | --- | --- | --- |
+| **D1** | Revenue-share split | **Artist 70% / Platform 30%** of net machine-access revenue attributed to that artist after Cloudflare MoR fees and any payment-rail costs. “Artist-majority” preserved; exact % is Tim’s call. | Tim | **Pending** |
+| **D2** | Opt-in model | Charging AI crawlers against an artist’s pages requires **explicit artist opt-in**. **Default OFF.** Clear copy that some AI services may then not access (or fully index) their content when they refuse to pay. | Tim | **Pending** |
+| **D3** | Payout floor + cadence | **Monthly** payout run; **$10.00 USD minimum** accrued balance; unpaid remainder rolls forward. Payouts only via **Stripe Connect Express** with `payoutsEnabled`. | Tim | **Pending** |
+| **D4** | Stablecoin / x402 (P2) | Platform **redeems USDC (or other stablecoin) to fiat** in treasury; artists are **always paid fiat** via Connect. No artist crypto wallets, gas, or tax-of-crypto handling in product. | Tim | **Pending** |
+
+### Decision triggers (systems, not events)
+
+| Trigger | Action |
+| --- | --- |
+| Tim signs D1–D4 | Remove needs-decision; #12749 may implement against `machine-access-payout-policy.ts` |
+| PPC beta agreement access lands | Re-run §7 verification; open follow-up if redistribution restricted |
+| First US artist year ≥ $600 machine-access payouts | Confirm Stripe Connect 1099 product filing path live for tax year |
+| Measured artist opt-in rate &lt; 5% after 30 days of GA offer | Re-evaluate copy + default framing (not the default-OFF rule itself) |
+| Platform margin on net rev-share after rails &lt; 50% of platform cut | Raise zone price or revisit D1 split (PRICING-PHILOSOPHY Principle 7) |
+
+---
+
+## 4. Payout policy (operational)
+
+Canonical constants: `apps/web/lib/monetization/machine-access-payout-policy.ts`.
+
+| Policy | Value |
+| --- | --- |
+| Currency artists receive | **USD fiat** via Stripe Connect Express |
+| Cadence | Calendar-month close; transfer batch in first 10 business days of following month |
+| Minimum transfer | **$10.00** accrued and unpaid |
+| Below floor | Balance rolls; no partial fee |
+| Eligibility | Artist opted in (D2), Connect `payoutsEnabled`, identity/tax profile complete per Stripe |
+| Accrual basis | Attributed crawl charge events after MoR settlement, multiplied by artist share (D1) |
+| Disputes | Ledger is append-only; reverse via compensating ledger entries only |
+| Chargebacks / MoR adjustments | Cloudflare adjustments reduce platform pool first; already-paid artists are not clawed back in-product without legal review |
+| Plan gate | Pro+ (matches FEATURE_REGISTRY planned monetization row) |
+
+### What is *not* in scope for P1
+
+- Per-path or per-crawler pricing (zone has one PPC price; policy engine allow/charge/block is product layer).
+- Paying artists in crypto or stablecoin.
+- Automatic Cloudflare → artist multi-party split (not supported; we own downstream share).
+
+---
+
+## 5. Consent & ToS language (draft for Tim + legal)
+
+**Do not paste into production ToS until Tim approves.** After approval, legal integrates into `apps/web/content/legal/terms.md` and the settings opt-in surface uses the short-form copy module.
+
+### 5.1 Settings toggle — short form (UI)
+
+**Title:** Share AI Access Revenue  
+
+**Description:**  
+Optional opt-in (off by default). When on, Jovie may charge approved AI crawlers for automated access to your public profile and related pages, and share a majority of the net proceeds with you. Some AI services may reduce or stop accessing your content if they do not pay. You can turn this off anytime. Payouts are monthly in USD via Stripe Connect once your balance reaches $10.
+
+**Confirm dialog (opt-in):**  
+By turning this on, you authorize Jovie to (1) apply machine-access charges to automated requests for your opted-in content, (2) attribute those charges to your profile, and (3) pay you your revenue share under Jovie’s Machine-Access Revenue Share terms. You understand that charging may reduce free AI crawler access to your content.
+
+**Opt-out notice:**  
+Turning this off stops new charging attribution for your pages. Accrued unpaid balance remains payable under the payout policy.
+
+### 5.2 ToS section draft — Machine-Access Revenue Share
+
+> **Machine-Access Revenue Share**  
+>
+> Jovie may participate in programs that charge automated agents and AI crawlers for access to content on the Jovie platform (including Cloudflare Pay Per Crawl or successor features). Cloudflare (or another designated merchant of record) may collect fees from crawlers and remit net amounts to Jovie as zone owner.
+>
+> **Opt-in required.** We will not attribute machine-access charges to your artist profile for revenue-share purposes unless you have explicitly opted in in your account settings. Opt-in is off by default. You may opt out at any time; opt-out applies prospectively.
+>
+> **Share of proceeds.** If you opt in, Jovie will attribute eligible net machine-access revenue associated with your public content using our attribution ledger and pay you the then-current artist share (displayed in product and changeable with notice). The platform retains the remainder. “Net” means amounts actually received by Jovie after merchant-of-record fees, refunds, chargebacks, currency conversion, and payment-processing costs.
+>
+> **Payouts.** Payouts are made in U.S. dollars (or another supported local currency via Stripe) to your connected Stripe Express account, on approximately a monthly cadence, subject to a minimum balance (currently $10 USD or equivalent) and successful completion of identity and tax onboarding. Balances below the minimum roll forward.
+>
+> **No guarantee of crawler access or revenue.** Opting in does not guarantee that any crawler will pay or crawl your content. Charging may cause some automated services to skip, partially fetch, or block access to your content. Jovie does not control third-party crawler behavior.
+>
+> **Taxes.** You are solely responsible for taxes on amounts paid to you. For U.S. taxpayers, Jovie (or Stripe on Jovie’s behalf) may issue information returns (e.g. Form 1099) as required by law. You agree to provide accurate tax information through Stripe Connect onboarding.
+>
+> **Stablecoin and agent payments (future).** If Jovie receives payment in stablecoins or other digital assets for automated access (including x402-style flows), Jovie may convert those assets to fiat at its discretion. Artist payouts under this program remain fiat payouts via Stripe Connect unless we expressly offer and you accept another settlement method.
+>
+> **Program changes.** We may modify share rates, floors, crawler policy maps, or suspend the program with reasonable notice when commercially practicable, except where immediate suspension is required for legal, security, or partner-agreement reasons.
+
+### 5.3 Privacy note (one line for Privacy Policy when shipping)
+
+> If you opt into Machine-Access Revenue Share, we process crawl charge and attribution data solely to operate the ledger, prevent fraud, and pay you.
+
+---
+
+## 6. Tax reporting path
+
+**Disclaimer:** Operational plan for engineering and finance — not legal advice. Confirm with counsel/CPA before first tax year with material payouts.
+
+### 6.1 Two distinct money events
+
+| Event | Who pays whom | Tax character (working model) |
+| --- | --- | --- |
+| A. PPC settlement | Cloudflare MoR → **Jovie platform** | Platform **gross receipts** (Jovie books income) |
+| B. Artist rev-share | **Jovie** → artist Connect account | Platform **expense** / payment to creator; may be reportable to artist |
+
+Do **not** treat Cloudflare’s 1099/K (if any) to Jovie as satisfying artist reporting. Artist reporting follows **event B**.
+
+### 6.2 United States artists
+
+| Topic | Path |
+| --- | --- |
+| Account type | Stripe Connect **Express** (already used: `apps/web/app/api/stripe-connect/onboard/route.ts`) |
+| Identity / TIN | Collected in Connect onboarding (SSN/EIN as Stripe requires) |
+| Likely form for rev-share transfers | **Form 1099-NEC** (nonemployee compensation) when calendar-year payments ≥ **$600** to a U.S. payee — *confirm with CPA whether licensing/royalty treatment (1099-MISC) is more accurate; product still needs reporting either way* |
+| When Stripe auto-issues 1099-K | Per [Stripe Connect tax reporting](https://docs.stripe.com/connect/tax-reporting): Stripe issues 1099-K when the connected account pays fees directly (`controller.fees.payer` = `account`, etc.). Express accounts where **the platform controls fees** typically **do not** get a Stripe-issued 1099-K for platform-priced transfers — **the platform remains responsible** for any required 1099. |
+| Product to enable | Stripe Connect **1099 tax reporting** product for in-scope connected accounts; e-delivery via Express Dashboard |
+| Threshold tracking | Ledger must store paid amounts per calendar year per artist for eligibility and audit |
+| State | Some states have additional thresholds; finance owns multi-state review |
+
+### 6.3 International artists
+
+| Topic | Path |
+| --- | --- |
+| Onboarding | Stripe Connect collects W-8BEN / W-8BEN-E (or local equivalent) as required |
+| U.S. 1099 | Generally **not** issued to non-U.S. persons for foreign-source services; confirm with CPA for U.S.-source characterization |
+| Withholding | Default **no** automatic FATCA/chapter-3 withholding in product unless counsel requires; freeze payouts if Stripe flags missing tax docs |
+| Local tax | Artist responsible for income tax in their jurisdiction; Jovie provides payout history export |
+| VAT/GST on rev-share | Treat as B2B creator compensation; do not add sales tax on top of rev-share transfers unless local law requires (finance + counsel) |
+
+### 6.4 Engineering requirements (for #12749)
+
+1. Persist opt-in timestamp, version of consent copy accepted, and IP/user-agent audit fields.
+2. Ledger columns: `gross_attributed_cents`, `artist_share_cents`, `platform_share_cents`, `currency`, `period`, `stripe_transfer_id`.
+3. Year-to-date paid total per Connect account for tax threshold tooling.
+4. No success toast that implies “tax free” or “we handle all your taxes.”
+
+---
+
+## 7. Pay Per Crawl beta — downstream revenue sharing
+
+### 7.1 What public docs establish
+
+Sources (public; not the private beta agreement):
+
+- [What is Pay Per Crawl?](https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl/) — closed beta; **Cloudflare is Merchant of Record**; price is **per zone**.
+- [Manage payouts](https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/manage-payouts/) — zone owner connects a **dedicated** Stripe account via Cloudflare dashboard; Cloudflare aggregates charges and pays publishers **monthly**; minimum thresholds / settlement periods apply; balance may not be fully visible in dashboard during beta.
+- [Introducing pay per crawl](https://blog.cloudflare.com/introducing-pay-per-crawl/) — site owners set allow / charge / block per crawler; flat domain-wide price.
+
+### 7.2 Downstream share by the zone owner
+
+| Question | Finding |
+| --- | --- |
+| Does Cloudflare pay multi-tenant creators on a shared zone? | **No.** Payouts go to the **zone owner’s** dedicated PPC Stripe connection. |
+| May the zone owner redistribute received proceeds to artists? | **Public docs do not forbid it.** Downstream share is a separate contractual relationship (Jovie ↔ artist). Functionally identical to merch: platform receives commercial proceeds, pays creators from its own books. |
+| Is artist Connect the same Stripe account as PPC? | **Must not be.** Cloudflare requires a **dedicated** PPC Stripe connection; artist Express accounts remain Jovie’s Connect platform accounts. |
+| Does beta agreement explicitly permit or restrict redistribution? | **UNVERIFIED.** Private beta terms are not published. |
+
+### 7.3 Gate when beta access lands
+
+Human / legal checklist (cannot automate without agreement PDF):
+
+1. Obtain Pay Per Crawl beta agreement and any Stripe Addendum.
+2. Confirm no exclusivity clause that forbids sharing proceeds with content owners on the zone.
+3. Confirm no ban on multi-tenant / marketplace use of a single zone price.
+4. Confirm MoR / tax characterization of Cloudflare → Jovie payments.
+5. Record outcome on this page + Linear JOV-3831 comment; open a **Required** follow-up issue if restricted.
+
+**Working assumption for P1 design (fail closed if wrong):** redistribution is permitted as ordinary platform COGS / creator payables after Jovie receives MoR net proceeds. If beta terms prohibit marketplace-style redistribution, **stop P1 payouts** and fall back to intelligence-only (P0) until terms or architecture change (e.g. per-artist zones — likely non-viable).
+
+---
+
+## 8. Alignment with P2 / x402
+
+The [x402 spike](../spikes/x402-payment-gated-artist-resources.md) already recommends treasury off-ramp + fiat artist settlement. **D4** freezes that as product policy:
+
+- On-chain receipt ledger is platform-internal.
+- Artist-facing earnings UI shows **fiat** accrued/paid only.
+- No Connect destination = crypto wallet.
+
+Unit economics remain in `apps/web/lib/x402-spike/unit-economics.ts` (margin gate ≥50%).
+
+---
+
+## 9. Acceptance mapping (JOV-3831)
+
+| Criterion | Where |
+| --- | --- |
+| Signed-off decision set recorded | This doc §3 + Linear issue comment when Tim signs; gbrain slug above when MCP available |
+| Consent copy approved | §5 draft; Tim + legal approval required before ToS merge |
+| Payout policy documented | §4 + `machine-access-payout-policy.ts` |
+| Unblocks P1 | After Tim signs D1–D4 |
+
+---
+
+## 10. Related
+
+| Artifact | Link |
+| --- | --- |
+| Linear | [JOV-3831](https://linear.app/jovie/issue/JOV-3831) |
+| P1 epic | [GitHub #12749](https://github.com/JovieInc/Jovie/issues/12749) |
+| P0 intelligence | FEATURE_REGISTRY — AI crawler intelligence |
+| Policy code | `apps/web/lib/monetization/machine-access-payout-policy.ts` |
+| Stripe Connect onboard | `apps/web/app/api/stripe-connect/onboard/route.ts` |
+| Stripe tax docs | https://docs.stripe.com/connect/tax-reporting |
+| Pricing canon | [`docs/company/PRICING-PHILOSOPHY.md`](../company/PRICING-PHILOSOPHY.md) |

--- a/docs/spikes/x402-payment-gated-artist-resources.md
+++ b/docs/spikes/x402-payment-gated-artist-resources.md
@@ -28,6 +28,7 @@ Worker template in front of a test asset (press-kit share drop or per-artist MCP
 | Cloudflare x402-proxy template | README + live demo (`/__x402/protected` → 402) |
 | x402 protocol (V2 headers) | [Cloudflare x402 docs](https://developers.cloudflare.com/agents/tools/payments/x402/) |
 | Pay Per Crawl (zone pricing) | [Cloudflare docs](https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl/) — closed beta, one-price-per-zone |
+| Consent / payout policy (JOV-3831) | [machine-access-revenue-share-compliance.md](../product/machine-access-revenue-share-compliance.md) — D4 freezes fiat-only artist settlement |
 | Monetization Gateway | [CF blog 2026-07-01](https://blog.cloudflare.com/monetization-gateway/) — waitlist, rules API |
 | Web Bot Auth | [CF Web Bot Auth](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/) — RFC 9421 HTTP message signatures |
 | Unit economics | `apps/web/lib/x402-spike/unit-economics.ts` (unit-tested) |


### PR DESCRIPTION
## Summary

Decision package for **JOV-3831** (needs-decision child of P1 #12749): consent, terms, tax, and payout policy for artist AI-access revenue share.

This ships the **agent-executable** deliverables only. **Tim sign-off is still required** on D1–D4 before P1 implementation.

### Deliverables

| Item | Location |
| --- | --- |
| Decision set (D1–D4 proposed defaults) | `docs/product/machine-access-revenue-share-compliance.md` §3 |
| Consent + ToS draft copy | Doc §5 + `MACHINE_ACCESS_CONSENT_COPY` |
| Tax reporting path (US 1099 / international) | Doc §6 |
| Payout policy (monthly, $10 floor, fiat Connect) | Doc §4 + policy module |
| Pay Per Crawl beta redistribution check | Doc §7 — public docs only; **private beta agreement UNVERIFIED** |
| Policy constants + unit tests | `apps/web/lib/monetization/machine-access-payout-policy.ts` |

### Proposed decisions (pending Tim)

1. **D1** Artist 70% / Platform 30% of net attributed machine-access revenue  
2. **D2** Explicit opt-in; **default OFF**  
3. **D3** Monthly Stripe Connect Express; **$10 USD** floor  
4. **D4** Platform redeems stablecoin → fiat; artists always paid fiat via Connect  

### Notes

- gbrain decision slug intended: `decisions/machine-access-revenue-share-compliance` (gbrain CLI unreachable from this environment; repo doc is source of truth).
- Do **not** merge production ToS until Tim + legal approve §5.
- Unblocks P1 (#12749) only after Tim signs D1–D4 on Linear.

## Test plan

- [x] `pnpm --filter @jovie/web exec vitest run lib/monetization/machine-access-payout-policy.test.ts` — **9/9 passed**
- [x] Biome check on touched TS files
- [x] Pre-push typecheck + full affected verify (passed)

## Fixes

Fixes JOV-3831

<!-- linear-issue-id:7c1dcc54-a8ff-4f12-8adf-2e3c06af3ed5 -->