### PR TITLE
fix(navigation): retain Tasks contextually

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -4,6 +4,7 @@ import { Button } from '@jovie/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 import {
   useCallback,
   useEffect,
@@ -27,6 +28,7 @@ import {
 import { NavigationDestinationReady } from '@/components/features/dashboard/NavigationDestinationReady';
 import { PageContent, PageShell } from '@/components/organisms/PageShell';
 import { PageToolbar } from '@/components/organisms/table';
+import { buildReleaseTasksRoute } from '@/constants/routes';
 import { getEventLocalDateKey } from '@/lib/events/date';
 import { normalizeTicketUrl } from '@/lib/events/ticket-url';
 import { queryKeys } from '@/lib/queries';
@@ -654,8 +656,16 @@ export function CalendarPageClient() {
                           )}
                         </div>
                         <div className='min-w-0 flex-1'>
-                          <div className='system-b-calendar-row-title truncate font-caption'>
-                            {r.title}
+                          <div className='flex min-w-0 items-center gap-2'>
+                            <div className='system-b-calendar-row-title truncate font-caption'>
+                              {r.title}
+                            </div>
+                            <Link
+                              href={buildReleaseTasksRoute(r.id)}
+                              className='system-b-calendar-context-link shrink-0 font-medium'
+                            >
+                              Tasks
+                            </Link>
                           </div>
                           <div className='system-b-calendar-row-meta capitalize'>
                             {r.status}

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
-import { NavBadge } from '@/components/atoms/NavBadge';
 import { toast } from '@/components/feedback';
 import {
   SidebarGroup,
@@ -25,9 +24,7 @@ import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import { shouldShowInboxNavigation } from '@/lib/inbox/navigation-availability';
 import { NAV_SHORTCUTS } from '@/lib/keyboard-shortcuts';
-import { usePlanGate } from '@/lib/queries';
 import { useChatConversationsQuery } from '@/lib/queries/useChatConversationsQuery';
-import { useTaskStatsQuery } from '@/lib/queries/useTasksQuery';
 import {
   type NavigationTelemetryContext,
   startNavigationTelemetry,
@@ -97,38 +94,6 @@ function normalizeTrailingSlash(pathname: string): string {
   return pathname === '/' ? pathname : pathname.replace(/\/$/, '');
 }
 
-const TASKS_SEEN_STORAGE_KEY = 'jovie:tasks-seen-at';
-
-function readTasksSeenAt(): string | null {
-  try {
-    return globalThis.localStorage?.getItem(TASKS_SEEN_STORAGE_KEY) ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function writeTasksSeenAt(value: string): void {
-  try {
-    globalThis.localStorage?.setItem(TASKS_SEEN_STORAGE_KEY, value);
-  } catch {
-    // Storage can be unavailable in restricted browsers; the badge still works.
-  }
-}
-
-function formatTaskBadge(
-  taskStats:
-    | { activeTodoCount: number; newActiveTodoCount?: number }
-    | undefined,
-  seenAt: string | null
-): string | number | undefined {
-  if (!taskStats || taskStats.activeTodoCount <= 0) return undefined;
-  const count = seenAt
-    ? (taskStats.newActiveTodoCount ?? 0)
-    : taskStats.activeTodoCount;
-  if (count <= 0) return undefined;
-  return count > 99 ? '99+' : count;
-}
-
 export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   const { inboxNavigation, selectedProfile } = useDashboardData();
   const { isMobile, openMobile, state: sidebarState } = useSidebar();
@@ -142,7 +107,6 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   const [threadReadAtById, setThreadReadAtById] = useState<
     Record<string, string>
   >({});
-  const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(null);
   const [hasHydratedPersistedState, setHasHydratedPersistedState] =
     useState(false);
   const profileId = selectedProfile?.id ?? '';
@@ -155,12 +119,6 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
     }),
     [isElectron, isMobile]
   );
-  const { canAccessTasksWorkspace, isLoading: isPlanGateLoading } =
-    usePlanGate();
-  const { data: taskStats } = useTaskStatsQuery(profileId, {
-    enabled: !isDemo && canAccessTasksWorkspace,
-    seenAt: tasksSeenAt,
-  });
   const isInSettings = pathname.startsWith(APP_ROUTES.SETTINGS);
   const eligiblePrimaryNavigation = useMemo(
     () =>
@@ -208,7 +166,6 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
 
   useEffect(() => {
     setThreadReadAtById(readThreadReadState());
-    setTasksSeenAt(readTasksSeenAt());
     setHasHydratedPersistedState(true);
   }, []);
 
@@ -236,13 +193,6 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   }, [conversations, hasHydratedPersistedState]);
 
   useEffect(() => {
-    if (normalizeTrailingSlash(pathname) !== APP_ROUTES.TASKS) return;
-    const nextSeenAt = new Date().toISOString();
-    writeTasksSeenAt(nextSeenAt);
-    setTasksSeenAt(nextSeenAt);
-  }, [pathname]);
-
-  useEffect(() => {
     if (isDemo || isMobile) return;
     trackNavigationImpressions(
       isInSettings
@@ -262,50 +212,17 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
 
   const artistSettingsLabel = 'Artist';
 
-  const decorateItem = useCallback(
-    (item: NavItem): NavItem => {
-      if (item.id === 'tasks') {
-        const taskCount = canAccessTasksWorkspace
-          ? formatTaskBadge(taskStats, tasksSeenAt)
-          : undefined;
-
-        return {
-          ...item,
-          badge: (() => {
-            if (isPlanGateLoading) return undefined;
-            if (canAccessTasksWorkspace) {
-              return taskCount == null ? undefined : (
-                <NavBadge
-                  variant='count'
-                  count={taskCount}
-                  aria-label={`${taskCount} ${tasksSeenAt ? 'new ' : ''}active tasks`}
-                />
-              );
-            }
-            return <NavBadge variant='pro' />;
-          })(),
-        };
-      }
-
-      return item;
-    },
-    [canAccessTasksWorkspace, isPlanGateLoading, taskStats, tasksSeenAt]
-  );
-
   // Memoize nav sections for dashboard (non-settings) mode
   const navSections = useMemo<readonly DashboardNavSection[]>(
     () => [
       {
         key: 'primary',
-        items: visiblePrimaryNavigation.map(decorateItem),
+        items: [...visiblePrimaryNavigation],
       },
     ],
-    [decorateItem, visiblePrimaryNavigation]
+    [visiblePrimaryNavigation]
   );
-  const moreNavItems = useMemo(
-    () => morePrimaryNavigation.map(decorateItem),
-    [decorateItem, morePrimaryNavigation]
-  );
+  const moreNavItems = morePrimaryNavigation;
 
   // Debounced prefetch: avoid firing on fast mouse sweeps across nav items
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
@@ -57,7 +57,6 @@ describe('partitionCustomerNavigation', () => {
       'contacts',
       'profiles',
       'calendar',
-      'tasks',
     ]);
     expect(partition.visible).toEqual(mobilePrimaryNavigation);
     expect(partition.more).toEqual(mobileExpandedNavigation);
@@ -85,10 +84,11 @@ describe('partitionCustomerNavigation', () => {
       visibleCap: CUSTOMER_NAV_CAPACITY.desktopPrimaryVisible,
     });
 
-    expect(partition.visible.map(item => item.id)).toEqual(
-      primaryNavigation.map(item => item.id)
-    );
-    expect(partition.more.map(item => item.id)).toEqual(['labs', 'signals']);
+    expect(partition.visible.map(item => item.id)).toEqual([
+      ...primaryNavigation.map(item => item.id),
+      'labs',
+    ]);
+    expect(partition.more.map(item => item.id)).toEqual(['signals']);
     expect(partition.more.every(item => item.tier === 'experimental')).toBe(
       true
     );
@@ -114,22 +114,19 @@ describe('partitionCustomerNavigation', () => {
     expect(partition.more).toEqual([]);
   });
 
-  it('never hides the active route — promotes active overflow into visible', () => {
+  it('keeps the stable three-item mobile strip when a contextual route is active', () => {
     const partition = partitionCustomerNavigation(primaryNavigation, {
       visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
-      activeItemId: 'tasks',
+      activeItemId: null,
     });
 
-    expect(partition.visible.map(item => item.id)).toContain('tasks');
     expect(partition.visible).toHaveLength(
       CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible
     );
-    expect(partition.more.map(item => item.id)).not.toContain('tasks');
-    // Prefer displacing the last non-promoted slot while preserving order.
     expect(partition.visible.map(item => item.id)).toEqual([
       'chat',
       'inbox',
-      'tasks',
+      'library',
     ]);
   });
 

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -17,7 +17,6 @@ const CANONICAL_NAVIGATION = [
   ['contacts', 'Contacts', APP_ROUTES.CONTACTS],
   ['profiles', 'Connections', APP_ROUTES.PROFILES],
   ['calendar', 'Calendar', APP_ROUTES.CALENDAR],
-  ['tasks', 'Tasks', APP_ROUTES.TASKS],
 ] as const;
 
 function toContract(items: readonly (typeof primaryNavigation)[number][]) {
@@ -69,19 +68,32 @@ describe('canonical customer shell navigation', () => {
     );
   });
 
-  it('excludes retired primary destinations while preserving the Connections route', () => {
+  it('excludes retired primary destinations while preserving contextual Task routes', () => {
     const ids = primaryNavigation.map(item => item.id);
     const labels = primaryNavigation.map(item => item.name);
 
     expect(ids).not.toEqual(
-      expect.arrayContaining(['search', 'touring', 'audience', 'releases'])
+      expect.arrayContaining([
+        'search',
+        'touring',
+        'audience',
+        'releases',
+        'tasks',
+      ])
     );
     expect(labels).not.toEqual(
-      expect.arrayContaining(['Search', 'Touring', 'Audience', 'Releases'])
+      expect.arrayContaining([
+        'Search',
+        'Touring',
+        'Audience',
+        'Releases',
+        'Tasks',
+      ])
     );
     expect(APP_ROUTES.TOUR_DATES).toBe('/app/tour-dates');
     expect(APP_ROUTES.AUDIENCE).toBe('/app/audience');
     expect(APP_ROUTES.PROFILES).toBe('/app/profiles');
     expect(APP_ROUTES.RELEASES).toBe('/app/releases');
+    expect(APP_ROUTES.TASKS).toBe('/app/tasks');
   });
 });

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -1,7 +1,6 @@
 import {
   Banknote,
   CalendarDays,
-  CheckSquare,
   Gauge,
   HandCoins,
   Home,
@@ -92,15 +91,6 @@ export const calendarNavItem: NavItem = {
   description: 'See release dates, events, and calendar moments',
 };
 
-export const tasksNavItem: NavItem = {
-  name: 'Tasks',
-  href: APP_ROUTES.TASKS,
-  id: 'tasks',
-  icon: CheckSquare,
-  tier: 'core',
-  description: 'Track release work and general artist operations',
-};
-
 /**
  * Founder-approved customer shell IA. This ordered tuple is the only source
  * consumed by desktop and mobile navigation (JOV-3763).
@@ -117,7 +107,6 @@ export const primaryNavigation = [
   contactsNavItem,
   profilesNavItem,
   calendarNavItem,
-  tasksNavItem,
 ] as const satisfies readonly NavItem[];
 
 export const settingsNavItem: NavItem = {

--- a/apps/web/components/features/dashboard/dashboard-nav/index.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/index.ts
@@ -22,7 +22,6 @@ export {
   primaryNavigation,
   settingsNavItem,
   settingsNavigation,
-  tasksNavItem,
   userSettingsNavigation,
 } from './config';
 export { DashboardNav } from './DashboardNav';

--- a/apps/web/scripts/performance-route-manifest.ts
+++ b/apps/web/scripts/performance-route-manifest.ts
@@ -1459,7 +1459,7 @@ const CREATOR_SHELL_ROUTES = [
     seedProfile: 'active-user',
   },
   {
-    id: 'creator-tasks-cold',
+    id: 'creator-tasks',
     group: 'creator-shell',
     surface: 'creator-app',
     path: APP_ROUTES.TASKS,
@@ -1479,39 +1479,6 @@ const CREATOR_SHELL_ROUTES = [
       { metric: 'cumulative-layout-shift', budget: 0.05 },
       { metric: 'first-input-delay', budget: 100 },
       { metric: 'time-to-first-byte', budget: 1600 },
-      { metric: 'skeleton-to-content', budget: 1000 },
-    ],
-    resourceSizes: RELEASES_RESOURCE_BUDGETS,
-    priority: 14,
-    seedProfile: 'active-user',
-  },
-  {
-    id: 'creator-tasks',
-    group: 'creator-shell',
-    surface: 'creator-app',
-    path: APP_ROUTES.TASKS,
-    navigationItemId: 'tasks',
-    warmNavigationStartPath: APP_ROUTES.DASHBOARD,
-    requiresAuth: true,
-    warmupStrategy: 'authenticated-shell',
-    measureMode: 'warm-navigation',
-    readySelectors: {
-      shell: [
-        '[data-testid="tasks-workspace"]',
-        '[data-testid="tasks-upgrade-interstitial"]',
-      ],
-      content: [
-        '[data-testid="tasks-workspace"]',
-        '[data-testid="tasks-upgrade-interstitial"]',
-        '[data-testid="release-plan-upgrade-interstitial"]',
-      ],
-      navTrigger: [
-        `a[href="${APP_ROUTES.TASKS}"]`,
-        `a[href^="${APP_ROUTES.TASKS}?"]`,
-      ],
-    },
-    timings: [
-      { metric: 'warm-shell-response', budget: 100 },
       { metric: 'skeleton-to-content', budget: 1000 },
     ],
     resourceSizes: RELEASES_RESOURCE_BUDGETS,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -7289,7 +7289,8 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.system-b-calendar-action-reject),
 :where(.system-b-calendar-action-ghost),
 :where(.system-b-calendar-action-danger-ghost),
-:where(.system-b-calendar-action-secondary) {
+:where(.system-b-calendar-action-secondary),
+:where(.system-b-calendar-context-link) {
   font-size: var(--text-2xs);
 }
 
@@ -7508,6 +7509,21 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
 :where(.system-b-calendar-action-ghost:hover) {
   background: var(--system-b-bg-surface-1);
   color: var(--color-text-primary-token);
+}
+
+:where(.system-b-calendar-context-link) {
+  color: var(--color-accent-blue);
+}
+
+:where(.system-b-calendar-context-link:hover) {
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-calendar-context-link:focus-visible) {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--color-focus),
+    0 0 0 4px var(--system-b-bg-surface-1);
 }
 
 :where(.system-b-calendar-rejected-toggle) {

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -29,7 +29,6 @@ const PRIMARY_LABELS = [
   'Contacts',
   'Connections',
   'Calendar',
-  'Tasks',
 ] as const;
 
 describe('DashboardNav interactions', () => {
@@ -235,12 +234,12 @@ describe('DashboardNav interactions', () => {
       },
     });
 
-    fireEvent.mouseEnter(screen.getByRole('link', { name: 'Tasks' }));
+    fireEvent.mouseEnter(screen.getByRole('link', { name: 'Calendar' }));
     expect(prefetchForRouteMock).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(150);
 
     expect(prefetchForRouteMock).toHaveBeenCalledWith(
-      'tasks',
+      'calendar',
       expect.anything(),
       'profile_123'
     );
@@ -251,12 +250,12 @@ describe('DashboardNav interactions', () => {
     mockUsePathname.mockReturnValue('/demo/showcase/settings');
     renderDashboardNav({ renderFn: render });
 
-    const tasksLink = screen.getByRole('link', { name: 'Tasks' });
-    expect(tasksLink).toHaveAttribute('href', APP_ROUTES.TASKS);
-    await user.click(tasksLink);
+    const calendarLink = screen.getByRole('link', { name: 'Calendar' });
+    expect(calendarLink).toHaveAttribute('href', APP_ROUTES.CALENDAR);
+    await user.click(calendarLink);
 
     expect(mockToastInfo).toHaveBeenCalledWith(
-      'Tasks is not available in demo mode'
+      'Calendar is not available in demo mode'
     );
   });
 });

--- a/apps/web/tests/e2e/canonical-customer-shell-navigation.spec.ts
+++ b/apps/web/tests/e2e/canonical-customer-shell-navigation.spec.ts
@@ -18,21 +18,21 @@ test.skip(
 );
 
 const CANONICAL_LABELS = [
+  'New Chat',
   'Inbox',
-  'Chat',
   'Library',
   'Contacts',
+  'Connections',
   'Calendar',
-  'Tasks',
 ] as const;
 
 const CANONICAL_HREFS = [
-  APP_ROUTES.DASHBOARD,
   APP_ROUTES.CHAT,
+  APP_ROUTES.DASHBOARD,
   APP_ROUTES.LIBRARY,
   APP_ROUTES.CONTACTS,
+  APP_ROUTES.PROFILES,
   APP_ROUTES.CALENDAR,
-  APP_ROUTES.TASKS,
 ] as const;
 
 const FORBIDDEN_LABELS = [

--- a/apps/web/tests/e2e/shell-route-persistence.spec.ts
+++ b/apps/web/tests/e2e/shell-route-persistence.spec.ts
@@ -450,11 +450,6 @@ test('app shell persists across core app routes without duplicate request bursts
     'library back route'
   );
 
-  await clickFirstVisibleAppLink(page, [APP_ROUTES.TASKS], [APP_ROUTES.TASKS]);
-  await expectRouteContent(page, 'tasks');
-  await assertPersistentShellFrame(page, 'tasks route');
-  await assertNoDocumentReloadSince(page, baselineLoadCount, 'tasks route');
-
   const openedThreadLink = await clickOptionalFirstVisibleAppLink(
     page,
     [chatThreadPath],

--- a/apps/web/tests/scripts/performance-route-manifest.test.ts
+++ b/apps/web/tests/scripts/performance-route-manifest.test.ts
@@ -79,10 +79,9 @@ const CREATOR_SHELL_SLICE_ROUTES = [
   {
     id: 'creator-tasks',
     path: APP_ROUTES.TASKS,
-    measureMode: 'warm-navigation',
-    warmupStrategy: 'authenticated-shell',
-    primaryMetric: 'warm-shell-response',
-    navTrigger: `a[href="${APP_ROUTES.TASKS}"]`,
+    measureMode: 'page-load',
+    warmupStrategy: 'authenticated-route',
+    primaryMetric: 'skeleton-to-content',
   },
   {
     id: 'creator-audience',
@@ -105,7 +104,6 @@ const RELEASE_BUDGET_CREATOR_SHELL_ROUTE_IDS = [
   'creator-releases',
   'creator-library-cold',
   'creator-library',
-  'creator-tasks-cold',
   'creator-tasks',
   'creator-lyrics',
 ] as const;
@@ -135,11 +133,6 @@ const CANONICAL_SHELL_PERF_PAIRS = [
     itemId: 'calendar',
     coldRouteId: 'creator-calendar-cold',
     warmRouteId: 'creator-calendar',
-  },
-  {
-    itemId: 'tasks',
-    coldRouteId: 'creator-tasks-cold',
-    warmRouteId: 'creator-tasks',
   },
 ] as const;
 

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CalendarPageClient } from '@/app/app/(shell)/calendar/CalendarPageClient';
+import { buildReleaseTasksRoute } from '@/constants/routes';
 import type { EventRecord } from '@/lib/queries/useEventsQuery';
 
 const mocks = vi.hoisted(() => ({
@@ -148,6 +149,11 @@ describe('CalendarPageClient', () => {
     expect(
       screen.queryByText('Releases and events at a glance.')
     ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /17 May Release/ }));
+    expect(screen.getByRole('link', { name: 'Tasks' })).toHaveAttribute(
+      'href',
+      buildReleaseTasksRoute(release.id)
+    );
   });
 
   it('keeps event review filtering backed by the event query', () => {

--- a/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
@@ -44,7 +44,6 @@ const CANONICAL_LABELS = [
   'Contacts',
   'Connections',
   'Calendar',
-  'Tasks',
 ] as const;
 
 describe('DashboardMobileTabs', () => {
@@ -105,7 +104,7 @@ describe('DashboardMobileTabs', () => {
     });
   });
 
-  it('shows the exact seven in order, with Settings separated as utility', async () => {
+  it('shows the exact six in order, with Settings separated as utility', async () => {
     const user = userEvent.setup();
     render(<DashboardMobileTabs />);
 
@@ -115,20 +114,19 @@ describe('DashboardMobileTabs', () => {
     });
     const links = within(menu).getAllByRole('link');
 
-    expect(links.slice(0, 7).map(link => link.textContent?.trim())).toEqual(
+    expect(links.slice(0, 6).map(link => link.textContent?.trim())).toEqual(
       CANONICAL_LABELS
     );
-    expect(links.slice(0, 7).map(link => link.getAttribute('href'))).toEqual([
+    expect(links.slice(0, 6).map(link => link.getAttribute('href'))).toEqual([
       APP_ROUTES.CHAT,
       APP_ROUTES.DASHBOARD,
       APP_ROUTES.LIBRARY,
       APP_ROUTES.CONTACTS,
       APP_ROUTES.PROFILES,
       APP_ROUTES.CALENDAR,
-      APP_ROUTES.TASKS,
     ]);
-    expect(links.at(7)).toHaveTextContent('Settings');
-    expect(links.at(7)).toHaveAttribute('href', APP_ROUTES.SETTINGS);
+    expect(links.at(6)).toHaveTextContent('Settings');
+    expect(links.at(6)).toHaveAttribute('href', APP_ROUTES.SETTINGS);
 
     for (const label of ['Search', 'Touring', 'Audience', 'Releases']) {
       expect(within(menu).queryByRole('link', { name: label })).toBeNull();
@@ -189,7 +187,7 @@ describe('DashboardMobileTabs', () => {
     );
   });
 
-  it('promotes an active overflow destination into the primary tab strip', () => {
+  it('does not reintroduce Tasks into mobile primary navigation on its direct route', () => {
     mockPathname.mockReturnValue(APP_ROUTES.TASKS);
     render(<DashboardMobileTabs />);
 
@@ -198,11 +196,8 @@ describe('DashboardMobileTabs', () => {
     expect(directLinks.map(link => link.textContent?.trim())).toEqual([
       'New Chat',
       'Inbox',
-      'Tasks',
+      'Library',
     ]);
-    expect(within(tabs).getByRole('link', { name: 'Tasks' })).toHaveAttribute(
-      'aria-current',
-      'page'
-    );
+    expect(within(tabs).queryByRole('link', { name: 'Tasks' })).toBeNull();
   });
 });

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -7,8 +7,6 @@ import { APP_ROUTES } from '@/constants/routes';
 import {
   mockUseChatConversationsQuery,
   mockUsePathname,
-  mockUsePlanGate,
-  mockUseTaskStatsQuery,
   renderDashboardNav,
   resetDashboardNavTestMocks,
 } from '@/tests/utils/dashboard-nav-test-support';
@@ -25,7 +23,6 @@ const CANONICAL_NAV = [
   ['Contacts', APP_ROUTES.CONTACTS],
   ['Connections', APP_ROUTES.PROFILES],
   ['Calendar', APP_ROUTES.CALENDAR],
-  ['Tasks', APP_ROUTES.TASKS],
 ] as const;
 
 const FORBIDDEN_PRIMARY_LABELS = [
@@ -59,17 +56,12 @@ describe('DashboardNav', () => {
       'const [threadReadAtById, setThreadReadAtById] = useState<'
     );
     expect(source).toContain('>({});');
-    expect(source).toContain(
-      'const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(null);'
-    );
     expect(source).toContain('setThreadReadAtById(readThreadReadState());');
-    expect(source).toContain('setTasksSeenAt(readTasksSeenAt());');
     expect(source).not.toContain(
       'useState<Record<string, string>>(readThreadReadState)'
     );
-    expect(source).not.toContain(
-      'useState<string | null>(\n    readTasksSeenAt'
-    );
+    expect(source).not.toContain('useTaskStatsQuery');
+    expect(source).not.toContain('readTasksSeenAt');
   });
 
   it('renders the canonical navigation in exact order and no forbidden primary rows', () => {
@@ -341,7 +333,7 @@ describe('DashboardNav', () => {
       sidebarProps: { defaultOpen: false },
     });
 
-    expect(primaryLinks(container)).toHaveLength(7);
+    expect(primaryLinks(container)).toHaveLength(6);
     expect(getByRole('link', { name: 'New Chat' }).className).toContain(
       'group-data-[collapsible=icon]:justify-center'
     );
@@ -363,113 +355,5 @@ describe('DashboardNav', () => {
       getByRole('link', { name: 'Audience & Tracking' }).getAttribute('href')
     ).toBe(APP_ROUTES.SETTINGS_AUDIENCE);
     expect(queryByText('Workspace')).toBeNull();
-  });
-
-  it('disables task stats query on nested demo routes', () => {
-    mockUsePathname.mockReturnValue('/demo/showcase/settings');
-    renderDashboardNav({
-      renderFn: fastRender,
-      overrides: {
-        selectedProfile: {
-          id: 'profile_123',
-          displayName: 'Tim White',
-          username: 'tim',
-          usernameNormalized: 'tim',
-        } as DashboardData['selectedProfile'],
-      },
-    });
-
-    expect(mockUseTaskStatsQuery).toHaveBeenCalledWith('profile_123', {
-      enabled: false,
-      seenAt: null,
-    });
-  });
-
-  it('renders stable task count geometry and accessible metadata', () => {
-    mockUseTaskStatsQuery.mockReturnValue({
-      data: {
-        backlog: 1,
-        todo: 2,
-        inProgress: 4,
-        done: 0,
-        cancelled: 0,
-        activeTodoCount: 7,
-      },
-    });
-
-    const { getByRole, getByText } = renderDashboardNav({
-      renderFn: fastRender,
-    });
-    const tasksLink = getByRole('link', { name: 'Tasks 7 active tasks' });
-
-    expect(tasksLink).toHaveClass(
-      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
-    );
-    expect(getByText('7')).toHaveAttribute('data-nav-badge', 'count');
-    expect(getByText('7')).toHaveAttribute('aria-label', '7 active tasks');
-  });
-
-  it('uses the new task count after Tasks has been opened', () => {
-    localStorage.setItem('jovie:tasks-seen-at', '2026-05-24T00:00:00.000Z');
-    mockUseTaskStatsQuery.mockReturnValue({
-      data: {
-        backlog: 1,
-        todo: 2,
-        inProgress: 4,
-        done: 0,
-        cancelled: 0,
-        activeTodoCount: 7,
-        newActiveTodoCount: 2,
-      },
-    });
-
-    const { getByText, queryByText } = renderDashboardNav({
-      renderFn: fastRender,
-      overrides: {
-        selectedProfile: {
-          id: 'profile_123',
-          displayName: 'Tim White',
-          username: 'tim',
-          usernameNormalized: 'tim',
-        } as DashboardData['selectedProfile'],
-      },
-    });
-
-    expect(getByText('2')).toHaveAttribute('aria-label', '2 new active tasks');
-    expect(queryByText('7')).toBeNull();
-    expect(mockUseTaskStatsQuery).toHaveBeenCalledWith('profile_123', {
-      enabled: true,
-      seenAt: '2026-05-24T00:00:00.000Z',
-    });
-  });
-
-  it('reserves task metadata geometry when no badge is present', () => {
-    const { container, getByRole } = renderDashboardNav({
-      renderFn: fastRender,
-    });
-
-    expect(getByRole('link', { name: 'Tasks' })).toHaveClass(
-      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
-    );
-    expect(
-      container.querySelector('[data-nav-badge="count"]')
-    ).not.toBeInTheDocument();
-  });
-
-  it('renders the Pro badge only after task entitlements resolve as locked', () => {
-    mockUsePlanGate.mockReturnValue({
-      canAccessTasksWorkspace: false,
-      isLoading: false,
-    });
-    const locked = renderDashboardNav({ renderFn: fastRender });
-    expect(locked.getByText('Pro')).toHaveAttribute('data-nav-badge', 'pro');
-    locked.unmount();
-
-    mockUsePlanGate.mockReturnValue({
-      canAccessTasksWorkspace: false,
-      isLoading: true,
-    });
-    const loading = renderDashboardNav({ renderFn: fastRender });
-    expect(loading.queryByText('Pro')).toBeNull();
   });
 });

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -32,6 +32,8 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
     'Retained customer workspace reachable by direct links and shortcuts after primary navigation consolidation',
   '/app/profiles':
     'Retained customer workspace reachable by direct links after primary navigation consolidation',
+  '/app/tasks':
+    'Retained work-record workspace reached from release, Calendar, and artist-workspace contexts after primary navigation consolidation',
   '/app/tour-dates':
     'Retained customer workspace reachable by direct links and Settings after primary navigation consolidation',
   '/app/threads': 'Legacy all threads route redirects to chats',

--- a/apps/web/tests/utils/dashboard-nav-test-support.tsx
+++ b/apps/web/tests/utils/dashboard-nav-test-support.tsx
@@ -12,13 +12,8 @@ import { AppFlagProvider } from '@/lib/flags/client';
 import { APP_FLAG_DEFAULTS, type AppFlagSnapshot } from '@/lib/flags/contracts';
 
 export const mockUsePathname = vi.fn<() => string>(() => APP_ROUTES.CHAT);
-export const mockUseTaskStatsQuery = vi.fn(() => ({ data: undefined }));
 export const mockUseChatConversationsQuery = vi.fn(() => ({
   data: undefined,
-}));
-export const mockUsePlanGate = vi.fn(() => ({
-  canAccessTasksWorkspace: true,
-  isLoading: false,
 }));
 export const mockToastInfo = vi.fn();
 export const mockShowPendingShell = vi.fn();
@@ -109,24 +104,6 @@ vi.mock('@/lib/queries/useReleasesQuery', () => ({
   useReleasesQuery: () => ({ data: undefined, isLoading: false }),
 }));
 
-vi.mock('@/lib/queries/useTasksQuery', () => ({
-  useTaskStatsQuery: (...args: unknown[]) => mockUseTaskStatsQuery(...args),
-}));
-
-vi.mock('@/lib/queries', async () => {
-  const actual =
-    await vi.importActual<typeof import('@/lib/queries')>('@/lib/queries');
-
-  return {
-    ...actual,
-    usePlanGate: (...args: unknown[]) => mockUsePlanGate(...args),
-    useDeleteConversationMutation: () => ({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    }),
-  };
-});
-
 vi.mock('@jovie/ui', async () => {
   const actual = await vi.importActual<typeof import('@jovie/ui')>('@jovie/ui');
 
@@ -175,15 +152,8 @@ export function resetDashboardNavTestMocks() {
   localStorage.clear();
   mockUsePathname.mockReset();
   mockUsePathname.mockReturnValue(APP_ROUTES.CHAT);
-  mockUseTaskStatsQuery.mockReset();
-  mockUseTaskStatsQuery.mockReturnValue({ data: undefined });
   mockUseChatConversationsQuery.mockReset();
   mockUseChatConversationsQuery.mockReturnValue({ data: undefined });
-  mockUsePlanGate.mockReset();
-  mockUsePlanGate.mockReturnValue({
-    canAccessTasksWorkspace: true,
-    isLoading: false,
-  });
   mockToastInfo.mockReset();
   mockShowPendingShell.mockReset();
   mockClearPendingShell.mockReset();


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2344 -->

## Summary
- Remove Tasks from shared desktop and mobile primary navigation.
- Keep `/app/tasks` as a direct workspace with performance coverage.
- Preserve release and artist-workspace access and add selected Calendar release → Tasks access.

## Verification
- Focused navigation, Calendar, route, and manifest suites: 83 passed.
- Node 22 typecheck.
- Biome and diff check.
- Normal pre-push gate: all 8 shards passed.

No browser or Kimi review was run: this isolated UI/nav slice follows the current advisory taste-review policy; no local server was started.