### PR TITLE
feat(storybook): full marketing page template library (JOV-4420)

### DIFF
--- a/apps/web/components/marketing/storybook/Recipes.stories.tsx
+++ b/apps/web/components/marketing/storybook/Recipes.stories.tsx
@@ -1,0 +1,616 @@
+/**
+ * Marketing recipe compositions — authoritative page-level visual catalog.
+ *
+ * Dark-only System A/B marketing surfaces; fully static (revalidate = false).
+ * Proven recipes use shipped reference route components or product composition paths.
+ * Stub recipes are tagged `stub` and optional for taste promotion.
+ *
+ * @see docs/marketing/AGENT_GUIDE.md
+ * @see apps/web/data/marketing/recipes.ts
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Check, Minus } from 'lucide-react';
+import Link from 'next/link';
+import { HomeTrustSection } from '@/components/features/home/HomeTrustSection';
+import { MarketingPricingPlans } from '@/components/features/pricing/MarketingPricingPlans';
+import { PricingComparisonChart } from '@/components/features/pricing/PricingComparisonChart';
+import {
+  FaqSection,
+  MarketingContainer,
+  MarketingHero,
+  MarketingPageShell,
+} from '@/components/marketing';
+import { ArtistNotificationsLanding } from '@/components/marketing/artist-notifications/ArtistNotificationsLanding';
+import { ArtistProfileLandingRoute } from '@/components/marketing/artist-profile/ArtistProfileLandingRoute';
+import { HomepageV2Route } from '@/components/marketing/homepage-v2/HomepageV2Route';
+import { MarketingFooterCta } from '@/components/site/MarketingFooterCta';
+import { PublicPageShell } from '@/components/site/PublicPageShell';
+import { APP_ROUTES } from '@/constants/routes';
+import { linktreeComparison } from '@/content/comparisons/linktree';
+import { ARTIST_NOTIFICATIONS_COPY } from '@/data/artistNotificationsCopy';
+import { MarketingStorySurface } from './story-surface';
+
+// Title must be a string literal so Storybook's static indexer can parse CSF.
+const meta: Meta = {
+  title: 'Marketing/Recipes',
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        component:
+          'Proven marketing page recipes. Dark-only; fully static (revalidate = false). Prefer real composition paths (reference route components). Proof sections omit when unverified (zero-proof path).',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+const recipeDocs = (recipeId: string, referenceRoute: string) =>
+  [
+    `Recipe \`${recipeId}\`. Reference route: \`${referenceRoute}\`.`,
+    'Dark-only marketing surface. Fully static (`revalidate = false`).',
+    'Mobile viewport companion stories use chromatic disable to protect snapshot budget.',
+  ].join(' ');
+
+/** homepage — reference /new via HomepageV2Route */
+export const Homepage: Story = {
+  name: 'homepage',
+  parameters: {
+    docs: { description: { story: recipeDocs('homepage', '/new') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-homepage'>
+      <HomepageV2Route />
+    </MarketingStorySurface>
+  ),
+};
+
+export const HomepageMobile: Story = {
+  name: 'homepage-mobile',
+  tags: ['mobile-viewport'],
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    chromatic: { disable: true },
+    docs: { description: { story: 'Mobile viewport of homepage recipe.' } },
+  },
+  render: Homepage.render,
+};
+
+/** pricing — product composition of shipped pricing sections */
+export const Pricing: Story = {
+  name: 'pricing',
+  parameters: {
+    docs: { description: { story: recipeDocs('pricing', '/pricing') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-pricing'>
+      <MarketingPageShell className='system-b-pricing-page'>
+        <MarketingHero
+          className='system-b-pricing-hero'
+          headingId='storybook-pricing-hero'
+          headline='Pricing'
+          subtitle='Artist profiles are free forever. Pro adds the release tools when you need them.'
+          primaryCta={{
+            label: 'Claim your profile',
+            href: `${APP_ROUTES.SIGNUP}?plan=free`,
+          }}
+          secondaryCta={{
+            label: 'Explore Artist Profiles',
+            href: APP_ROUTES.ARTIST_PROFILES,
+          }}
+          logos={false}
+        />
+        <section aria-label='Plans' className='system-b-pricing-section'>
+          <MarketingContainer width='page'>
+            <div className='system-b-pricing-plans'>
+              <MarketingPricingPlans ctaVariant='secondary' mode='expanded' />
+            </div>
+          </MarketingContainer>
+        </section>
+        {/* social-proof omitted: zero-proof (no verified customer quotes on pricing fixtures) */}
+        <section
+          aria-labelledby='storybook-pricing-compare-heading'
+          className='system-b-pricing-section'
+        >
+          <MarketingContainer width='page'>
+            <div className='system-b-pricing-section-inner'>
+              <div className='system-b-pricing-section-copy'>
+                <h2
+                  id='storybook-pricing-compare-heading'
+                  className='system-b-pricing-section-title'
+                >
+                  Compare all features
+                </h2>
+                <p className='system-b-pricing-section-body'>
+                  See the plan matrix for notifications, analytics, contacts,
+                  smart links, and release workspace capabilities.
+                </p>
+              </div>
+              <div className='system-b-pricing-chart-wrap'>
+                <PricingComparisonChart />
+              </div>
+            </div>
+          </MarketingContainer>
+        </section>
+        <FaqSection
+          heading='Pricing FAQ'
+          items={[
+            {
+              question: 'Is the artist profile free?',
+              answer:
+                'Yes. Artist profiles stay free. Pro unlocks release tools when you need them.',
+            },
+            {
+              question: 'Can I upgrade later?',
+              answer:
+                'Yes. Claim your profile first, then choose Pro when you want release automation.',
+            },
+          ]}
+        />
+        <MarketingFooterCta
+          title='Claim your free profile'
+          ctaLabel='Get started'
+          ctaHref={`${APP_ROUTES.SIGNUP}?plan=free`}
+        />
+      </MarketingPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+export const PricingMobile: Story = {
+  name: 'pricing-mobile',
+  tags: ['mobile-viewport'],
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    chromatic: { disable: true },
+  },
+  render: Pricing.render,
+};
+
+/** artist-lp — shipped ArtistProfileLandingRoute */
+export const ArtistLp: Story = {
+  name: 'artist-lp',
+  parameters: {
+    docs: {
+      description: { story: recipeDocs('artist-lp', '/artist-profiles') },
+    },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-artist-lp'>
+      <ArtistProfileLandingRoute />
+    </MarketingStorySurface>
+  ),
+};
+
+export const ArtistLpMobile: Story = {
+  name: 'artist-lp-mobile',
+  tags: ['mobile-viewport'],
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    chromatic: { disable: true },
+  },
+  render: ArtistLp.render,
+};
+
+/** feature — shipped ArtistNotificationsLanding */
+export const Feature: Story = {
+  name: 'feature',
+  parameters: {
+    docs: {
+      description: {
+        story: recipeDocs('feature', '/artist-notifications'),
+      },
+    },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-feature'>
+      <ArtistNotificationsLanding copy={ARTIST_NOTIFICATIONS_COPY} />
+    </MarketingStorySurface>
+  ),
+};
+
+/** comparison — linktree verified comparison data + product section chrome */
+export const Comparison: Story = {
+  name: 'comparison',
+  parameters: {
+    docs: {
+      description: {
+        story: recipeDocs('comparison', '/compare/linktree'),
+      },
+    },
+  },
+  render: () => {
+    const data = linktreeComparison;
+    return (
+      <MarketingStorySurface label='recipe-comparison'>
+        <PublicPageShell>
+          <MarketingHero variant='left'>
+            <p className='text-sm font-medium text-tertiary-token'>Compare</p>
+            <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+              {data.heroHeadline}
+            </h1>
+            <p className='mt-6 max-w-2xl text-lg leading-relaxed text-secondary-token'>
+              {data.heroSubheadline}
+            </p>
+          </MarketingHero>
+          <MarketingContainer width='prose' className='pb-16'>
+            <section data-testid='marketing-section-comparison'>
+              <h2 className='text-2xl font-semibold text-primary-token'>
+                Feature Comparison
+              </h2>
+              <div className='mt-8 overflow-x-auto'>
+                <table className='w-full min-w-md border-collapse text-left text-sm'>
+                  <thead>
+                    <tr className='border-b border-subtle'>
+                      <th className='py-3 pr-4 font-medium text-primary-token'>
+                        Feature
+                      </th>
+                      <th className='py-3 px-4 font-medium text-primary-token'>
+                        Jovie
+                      </th>
+                      <th className='py-3 pl-4 font-medium text-primary-token'>
+                        {data.competitor}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.features.map(feature => (
+                      <tr
+                        key={feature.name}
+                        className='border-b border-subtle/60'
+                      >
+                        <td className='py-3 pr-4 text-secondary-token'>
+                          <span className='text-primary-token'>
+                            {feature.name}
+                          </span>
+                          {feature.note ? (
+                            <span className='mt-1 block text-xs text-tertiary-token'>
+                              {feature.note}
+                            </span>
+                          ) : null}
+                        </td>
+                        <td className='py-3 px-4'>
+                          {feature.jovie ? (
+                            <Check
+                              aria-label='Included'
+                              className='size-4 text-primary-token'
+                            />
+                          ) : (
+                            <Minus
+                              aria-label='Not included'
+                              className='size-4 text-tertiary-token'
+                            />
+                          )}
+                        </td>
+                        <td className='py-3 pl-4'>
+                          {feature.competitor ? (
+                            <Check
+                              aria-label='Included'
+                              className='size-4 text-primary-token'
+                            />
+                          ) : (
+                            <Minus
+                              aria-label='Not included'
+                              className='size-4 text-tertiary-token'
+                            />
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className='mt-8 text-sm leading-relaxed text-secondary-token'>
+                {data.bottomLine}
+              </p>
+            </section>
+          </MarketingContainer>
+          <MarketingContainer width='page' className='pb-8'>
+            <div
+              className='grid gap-6 sm:grid-cols-3'
+              data-testid='marketing-section-feature-grid'
+            >
+              {[
+                {
+                  title: 'Smart Links',
+                  description:
+                    'Route every release to the right streaming destination.',
+                },
+                {
+                  title: 'Fan Capture',
+                  description:
+                    'Collect contacts when fans land on your profile.',
+                },
+                {
+                  title: 'Release Tools',
+                  description:
+                    'Notifications and automation when you need them.',
+                },
+              ].map(item => (
+                <div key={item.title}>
+                  <h3 className='font-medium text-primary-token'>
+                    {item.title}
+                  </h3>
+                  <p className='mt-2 text-sm leading-relaxed text-secondary-token'>
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </MarketingContainer>
+          <FaqSection
+            items={data.faq.map(item => ({
+              question: item.question,
+              answer: item.answer,
+            }))}
+          />
+          <MarketingFooterCta
+            title='Try Jovie'
+            ctaLabel='Get started'
+            ctaHref={APP_ROUTES.SIGNUP}
+          />
+        </PublicPageShell>
+      </MarketingStorySurface>
+    );
+  },
+};
+
+/** launch — product shell + hero + trust + final CTA (full /launch is long-form) */
+export const Launch: Story = {
+  name: 'launch',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          recipeDocs('launch', '/launch'),
+          'Story renders the product shell composition of the launch recipe skeleton;',
+          'the full long-form route remains the shipped reference.',
+        ].join(' '),
+      },
+    },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-launch'>
+      <MarketingPageShell>
+        <MarketingHero
+          headingId='storybook-launch-hero'
+          headline='Your entire music career. One intelligent link.'
+          subtitle='Import Spotify, create smart links for every release, and turn listeners into fans you own.'
+          primaryCta={{
+            label: 'Get started',
+            href: APP_ROUTES.SIGNUP,
+            signUp: true,
+          }}
+          secondaryCta={{
+            label: 'See how it works',
+            href: '#how-it-works',
+          }}
+        />
+        <HomeTrustSection presentation='inline-strip' />
+        <MarketingContainer width='page' className='py-16'>
+          <section
+            id='how-it-works'
+            data-testid='marketing-section-feature-split'
+          >
+            <h2 className='text-2xl font-semibold text-primary-token'>
+              Why Jovie launches now
+            </h2>
+            <p className='mt-4 max-w-2xl text-base leading-relaxed text-secondary-token'>
+              Independent artists need release infrastructure that captures fans
+              and reactivates them — without assembling five tools.
+            </p>
+          </section>
+        </MarketingContainer>
+        <MarketingFooterCta
+          title='Request access'
+          ctaLabel='Get started'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+      </MarketingPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+/** seo — about-style hero + prose + FAQ + CTA */
+export const Seo: Story = {
+  name: 'seo',
+  parameters: {
+    docs: { description: { story: recipeDocs('seo', '/about') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-seo'>
+      <PublicPageShell>
+        <MarketingHero variant='left'>
+          <p className='text-sm font-medium text-tertiary-token'>About</p>
+          <h1 className='mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+            Release More Music. Do Less Release Work.
+          </h1>
+          <p className='mt-6 max-w-2xl text-lg leading-relaxed text-secondary-token'>
+            Jovie is the release platform for independent musicians — smart
+            links, artist profiles, audience intelligence, and AI in one place.
+          </p>
+        </MarketingHero>
+        <MarketingContainer width='prose' className='pb-16'>
+          <section data-testid='marketing-section-content-prose'>
+            <h2 className='text-2xl font-semibold text-primary-token'>
+              Why Jovie Exists
+            </h2>
+            <div className='mt-6 space-y-5 text-base leading-relaxed text-secondary-token'>
+              <p>
+                Independent artists need marketing infrastructure without a
+                label team. Jovie handles the release work so musicians can
+                focus on making music.
+              </p>
+            </div>
+          </section>
+        </MarketingContainer>
+        <FaqSection
+          items={[
+            {
+              question: 'What is Jovie?',
+              answer:
+                'Jovie is a release platform for independent musicians with smart links, profiles, and fan tools.',
+            },
+            {
+              question: 'Is Jovie free to start?',
+              answer:
+                'Yes. Artist profiles are free forever. Paid plans unlock release automation.',
+            },
+          ]}
+        />
+        <MarketingFooterCta
+          title='Get started with Jovie'
+          ctaLabel='Get started'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+      </PublicPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+/** blog-landing — hero + fixture feed cards (no async filesystem/profile fetch) */
+export const BlogLanding: Story = {
+  name: 'blog-landing',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          recipeDocs('blog-landing', '/blog'),
+          'Story uses static fixture posts so Storybook stays free of server blog/profile I/O.',
+        ].join(' '),
+      },
+    },
+  },
+  render: () => (
+    <MarketingStorySurface label='recipe-blog-landing'>
+      <PublicPageShell>
+        <MarketingHero variant='left'>
+          <p className='mb-0 text-sm font-medium text-tertiary-token'>Blog</p>
+          <h1 className='mb-6 mt-6 max-w-2xl text-4xl font-semibold tracking-tight text-balance text-primary-token sm:text-5xl'>
+            Blog
+          </h1>
+          <p className='max-w-xl text-lg leading-relaxed text-secondary-token'>
+            Signals, playbooks, and product notes for independent artists.
+          </p>
+        </MarketingHero>
+        <MarketingContainer width='page' className='pb-16'>
+          <section
+            className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'
+            data-testid='marketing-section-blog-feed'
+          >
+            {[
+              {
+                title: 'How to claim your artist profile',
+                excerpt:
+                  'A short playbook for going live with a Jovie profile in under a minute.',
+                href: '/blog',
+              },
+              {
+                title: 'Smart links that actually convert',
+                excerpt:
+                  'Route fans to the right destination without a link-in-bio maze.',
+                href: '/blog',
+              },
+              {
+                title: 'Release week checklist',
+                excerpt:
+                  'Capture, notify, and re-engage fans when the music drops.',
+                href: '/blog',
+              },
+            ].map(post => (
+              <article
+                key={post.title}
+                className='rounded-2xl border border-subtle bg-surface-1 p-6'
+              >
+                <h2 className='text-lg font-semibold text-primary-token'>
+                  <Link href={post.href} className='hover:underline'>
+                    {post.title}
+                  </Link>
+                </h2>
+                <p className='mt-3 text-sm leading-relaxed text-secondary-token'>
+                  {post.excerpt}
+                </p>
+              </article>
+            ))}
+          </section>
+        </MarketingContainer>
+        <MarketingFooterCta
+          title='Build with Jovie'
+          ctaLabel='Get started'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+      </PublicPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+// ── Stub recipes (optional; behind tags) ─────────────────────────────────────
+
+const stubParameters = {
+  docs: { disable: true },
+} as const;
+
+function StubRecipeFrame({
+  recipeId,
+  headline,
+}: Readonly<{ recipeId: string; headline: string }>) {
+  return (
+    <MarketingStorySurface label={`recipe-${recipeId}`}>
+      <PublicPageShell>
+        <MarketingHero
+          headingId={`storybook-${recipeId}-hero`}
+          headline={headline}
+          subtitle='Stub recipe — order + arc only. First ship requires human taste (DX2).'
+          primaryCta={{ label: 'Talk to us', href: APP_ROUTES.SIGNUP }}
+          logos={false}
+        />
+        <MarketingFooterCta
+          title={headline}
+          ctaLabel='Talk to us'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+      </PublicPageShell>
+    </MarketingStorySurface>
+  );
+}
+
+export const AgencyLp: Story = {
+  name: 'agency-lp',
+  tags: ['stub'],
+  parameters: stubParameters,
+  render: () => (
+    <StubRecipeFrame
+      recipeId='agency-lp'
+      headline='Jovie for agencies managing multiple artists'
+    />
+  ),
+};
+
+export const Enterprise: Story = {
+  name: 'enterprise',
+  tags: ['stub'],
+  parameters: stubParameters,
+  render: () => (
+    <StubRecipeFrame
+      recipeId='enterprise'
+      headline='Jovie at enterprise scale'
+    />
+  ),
+};
+
+export const Waitlist: Story = {
+  name: 'waitlist',
+  tags: ['stub'],
+  parameters: stubParameters,
+  render: () => (
+    <StubRecipeFrame
+      recipeId='waitlist'
+      headline='Join the Jovie waitlist for early access'
+    />
+  ),
+};

--- a/apps/web/components/marketing/storybook/Sections.stories.tsx
+++ b/apps/web/components/marketing/storybook/Sections.stories.tsx
@@ -1,0 +1,509 @@
+/**
+ * Marketing section catalog — one composition story per MARKETING_SECTION_IDS entry.
+ *
+ * Uses registry `component` paths when importable. WIP/TBD/zero-proof gaps are
+ * tagged `wip` and render a documented gap panel (never silently omitted).
+ *
+ * @see apps/web/data/marketing/sections.ts
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Check, Minus } from 'lucide-react';
+import { HomeTrustSection } from '@/components/features/home/HomeTrustSection';
+import { MarketingPricingPlans } from '@/components/features/pricing/MarketingPricingPlans';
+import {
+  FaqSection,
+  MarketingContainer,
+  MarketingContentShell,
+  MarketingHero,
+  MarketingPageShell,
+} from '@/components/marketing';
+import { ArtistProfileCaptureSection } from '@/components/marketing/artist-profile/ArtistProfileCaptureSection';
+import { ArtistProfileHeroAdaptiveIntro } from '@/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro';
+import { ArtistProfileHowItWorks } from '@/components/marketing/artist-profile/ArtistProfileHowItWorks';
+import { ArtistProfileMonetizationSection } from '@/components/marketing/artist-profile/ArtistProfileMonetizationSection';
+import { ArtistProfileOutcomesCarousel } from '@/components/marketing/artist-profile/ArtistProfileOutcomesCarousel';
+import { ArtistProfileSocialProof } from '@/components/marketing/artist-profile/ArtistProfileSocialProof';
+import { ArtistProfileSpecWall } from '@/components/marketing/artist-profile/ArtistProfileSpecWall';
+import { MarketingFooterCta } from '@/components/site/MarketingFooterCta';
+import { APP_ROUTES } from '@/constants/routes';
+import { linktreeComparison } from '@/content/comparisons/linktree';
+import { ARTIST_PROFILE_COPY } from '@/data/artistProfileCopy';
+import { ARTIST_PROFILE_TRUTH_TILES } from '@/data/artistProfileFeatures';
+import { getMarketingSection } from '@/data/marketing';
+import { ARTIST_PROFILE_SOCIAL_PROOF } from '@/data/socialProof';
+import {
+  MarketingSectionGapPanel,
+  MarketingStorySurface,
+} from './story-surface';
+
+// Title must be a string literal so Storybook's static indexer can parse CSF.
+const meta: Meta = {
+  title: 'Marketing/Sections',
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        component:
+          'One story per marketing section id from the registry. Dark-only; fully static. Proof sections omit when unverified.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+const sectionDocs = (sectionId: string) => {
+  const section = getMarketingSection(
+    sectionId as Parameters<typeof getMarketingSection>[0]
+  );
+  return [
+    `Section \`${sectionId}\` (${section.label}).`,
+    `Registry component: \`${section.component}\`.`,
+    'Dark-only. Fully static (`revalidate = false`).',
+  ].join(' ');
+};
+
+/** hero — MarketingHero content mode */
+export const Hero: Story = {
+  name: 'hero',
+  parameters: {
+    docs: { description: { story: sectionDocs('hero') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-hero'>
+      <MarketingPageShell>
+        <MarketingHero
+          headingId='storybook-section-hero'
+          headline='One profile that captures every fan'
+          subtitle='Claim your handle, route streams, and own the relationship.'
+          primaryCta={{
+            label: 'Claim your Jovie',
+            href: APP_ROUTES.SIGNUP,
+            signUp: true,
+          }}
+          secondaryCta={{
+            label: 'See a live profile',
+            href: APP_ROUTES.ARTIST_PROFILES,
+          }}
+          testId='marketing-section-hero'
+        />
+      </MarketingPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+/** logo-cloud — HomeTrustSection */
+export const LogoCloud: Story = {
+  name: 'logo-cloud',
+  parameters: {
+    docs: { description: { story: sectionDocs('logo-cloud') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-logo-cloud'>
+      <div data-testid='marketing-section-logo-cloud'>
+        <HomeTrustSection presentation='inline-strip' />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** feature-grid — ArtistProfileOutcomesCarousel (registry) */
+export const FeatureGrid: Story = {
+  name: 'feature-grid',
+  parameters: {
+    docs: { description: { story: sectionDocs('feature-grid') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-feature-grid'>
+      <div data-testid='marketing-section-feature-grid'>
+        <ArtistProfileOutcomesCarousel
+          outcomes={ARTIST_PROFILE_COPY.outcomes}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/**
+ * feature-split — registry points at ArtistProfileAdaptiveIntro;
+ * shipped path is ArtistProfileHeroAdaptiveIntro (hero + adaptive).
+ */
+export const FeatureSplit: Story = {
+  name: 'feature-split',
+  parameters: {
+    docs: { description: { story: sectionDocs('feature-split') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-feature-split'>
+      <div data-testid='marketing-section-feature-split'>
+        <ArtistProfileHeroAdaptiveIntro
+          hero={ARTIST_PROFILE_COPY.hero}
+          adaptive={ARTIST_PROFILE_COPY.adaptive}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** how-it-works */
+export const HowItWorks: Story = {
+  name: 'how-it-works',
+  parameters: {
+    docs: { description: { story: sectionDocs('how-it-works') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-how-it-works'>
+      <div data-testid='marketing-section-how-it-works'>
+        <ArtistProfileHowItWorks howItWorks={ARTIST_PROFILE_COPY.howItWorks} />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/**
+ * social-proof — real component; returns null when quotes unverified (zero-proof).
+ * Story still mounts the product path and documents omit state.
+ */
+export const SocialProof: Story = {
+  name: 'social-proof',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          sectionDocs('social-proof'),
+          ARTIST_PROFILE_SOCIAL_PROOF.hasRealQuotes
+            ? 'Verified quotes present.'
+            : 'Zero-proof: component omits content when hasRealQuotes is false.',
+        ].join(' '),
+      },
+    },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-social-proof'>
+      <div data-testid='marketing-section-social-proof'>
+        <ArtistProfileSocialProof
+          socialProof={ARTIST_PROFILE_COPY.socialProof}
+          proofData={ARTIST_PROFILE_SOCIAL_PROOF}
+        />
+        {!ARTIST_PROFILE_SOCIAL_PROOF.hasRealQuotes ? (
+          <MarketingContainer width='page' className='py-12'>
+            <p className='text-sm text-tertiary-token'>
+              Social proof omitted — no verified quotes in fixture data
+              (zero-proof path).
+            </p>
+          </MarketingContainer>
+        ) : null}
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/**
+ * stats — registry points at HomeStatQuoteSection which defaults to fabricated
+ * metrics. Zero-proof path: omit product render; gap panel is the story.
+ */
+export const Stats: Story = {
+  name: 'stats',
+  tags: ['wip'],
+  parameters: {
+    docs: { description: { story: sectionDocs('stats') } },
+  },
+  render: () => (
+    <MarketingSectionGapPanel
+      sectionId='stats'
+      componentPath={getMarketingSection('stats').component}
+      reason='Zero-proof path: HomeStatQuoteSection defaults invent metrics. Do not render fabricated stats in Storybook; ship only with verified, attributable figures.'
+    />
+  ),
+};
+
+/** pricing — MarketingPricingPlans */
+export const Pricing: Story = {
+  name: 'pricing',
+  parameters: {
+    docs: { description: { story: sectionDocs('pricing') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-pricing'>
+      <MarketingContainer width='page' className='py-16'>
+        <div data-testid='marketing-section-pricing'>
+          <MarketingPricingPlans ctaVariant='secondary' mode='expanded' />
+        </div>
+      </MarketingContainer>
+    </MarketingStorySurface>
+  ),
+};
+
+/**
+ * comparison — data-driven from content/comparisons (registry notes render TBD).
+ * Story composes verified linktree comparison rows with product chrome.
+ */
+export const Comparison: Story = {
+  name: 'comparison',
+  tags: ['wip'],
+  parameters: {
+    docs: { description: { story: sectionDocs('comparison') } },
+  },
+  render: () => {
+    const data = linktreeComparison;
+    return (
+      <MarketingStorySurface label='section-comparison'>
+        <MarketingContainer width='prose' className='py-16'>
+          <section data-testid='marketing-section-comparison'>
+            <h2 className='text-2xl font-semibold text-primary-token'>
+              {data.heroHeadline}
+            </h2>
+            <p className='mt-3 text-sm text-secondary-token'>
+              {data.heroSubheadline}
+            </p>
+            <div className='mt-8 overflow-x-auto'>
+              <table className='w-full min-w-md border-collapse text-left text-sm'>
+                <thead>
+                  <tr className='border-b border-subtle'>
+                    <th className='py-3 pr-4 font-medium text-primary-token'>
+                      Feature
+                    </th>
+                    <th className='py-3 px-4 font-medium text-primary-token'>
+                      Jovie
+                    </th>
+                    <th className='py-3 pl-4 font-medium text-primary-token'>
+                      {data.competitor}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.features.slice(0, 6).map(feature => (
+                    <tr
+                      key={feature.name}
+                      className='border-b border-subtle/60'
+                    >
+                      <td className='py-3 pr-4 text-primary-token'>
+                        {feature.name}
+                      </td>
+                      <td className='py-3 px-4'>
+                        {feature.jovie ? (
+                          <Check
+                            aria-label='Included'
+                            className='size-4 text-primary-token'
+                          />
+                        ) : (
+                          <Minus
+                            aria-label='Not included'
+                            className='size-4 text-tertiary-token'
+                          />
+                        )}
+                      </td>
+                      <td className='py-3 pl-4'>
+                        {feature.competitor ? (
+                          <Check
+                            aria-label='Included'
+                            className='size-4 text-primary-token'
+                          />
+                        ) : (
+                          <Minus
+                            aria-label='Not included'
+                            className='size-4 text-tertiary-token'
+                          />
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className='mt-6 text-xs text-tertiary-token'>
+              Composition from verified comparison fixtures (
+              {getMarketingSection('comparison').component}).
+            </p>
+          </section>
+        </MarketingContainer>
+      </MarketingStorySurface>
+    );
+  },
+};
+
+/** faq */
+export const Faq: Story = {
+  name: 'faq',
+  parameters: {
+    docs: { description: { story: sectionDocs('faq') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-faq'>
+      <div data-testid='marketing-section-faq'>
+        <FaqSection
+          items={ARTIST_PROFILE_COPY.faq.items.map(item => ({
+            question: item.question,
+            answer: item.answer,
+          }))}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** cta — MarketingFooterCta (shipped under components/site) */
+export const Cta: Story = {
+  name: 'cta',
+  parameters: {
+    docs: { description: { story: sectionDocs('cta') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-cta'>
+      <div data-testid='marketing-section-cta'>
+        <MarketingFooterCta
+          title='Claim your Jovie'
+          ctaLabel='Claim your Jovie'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** spec-wall */
+export const SpecWall: Story = {
+  name: 'spec-wall',
+  parameters: {
+    docs: { description: { story: sectionDocs('spec-wall') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-spec-wall'>
+      <div data-testid='marketing-section-spec-wall'>
+        <ArtistProfileSpecWall
+          specWall={ARTIST_PROFILE_COPY.specWall}
+          truthTiles={ARTIST_PROFILE_TRUTH_TILES}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** capture */
+export const Capture: Story = {
+  name: 'capture',
+  parameters: {
+    docs: { description: { story: sectionDocs('capture') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-capture'>
+      <div data-testid='marketing-section-capture'>
+        <ArtistProfileCaptureSection capture={ARTIST_PROFILE_COPY.capture} />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** monetization */
+export const Monetization: Story = {
+  name: 'monetization',
+  parameters: {
+    docs: { description: { story: sectionDocs('monetization') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-monetization'>
+      <div data-testid='marketing-section-monetization'>
+        <ArtistProfileMonetizationSection
+          monetization={ARTIST_PROFILE_COPY.monetization}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+/** ownership — TBD component path */
+export const Ownership: Story = {
+  name: 'ownership',
+  tags: ['wip'],
+  parameters: {
+    docs: { description: { story: sectionDocs('ownership') } },
+  },
+  render: () => (
+    <MarketingSectionGapPanel
+      sectionId='ownership'
+      componentPath={getMarketingSection('ownership').component}
+      reason='Registry component is TBD (ArtistProfileOwnershipSection not shipped). First implementer creates the section; story remains so the catalog does not silently drop the id.'
+    />
+  ),
+};
+
+/** content-prose — MarketingContentShell prose (route-level blog body is not extracted) */
+export const ContentProse: Story = {
+  name: 'content-prose',
+  tags: ['wip'],
+  parameters: {
+    docs: { description: { story: sectionDocs('content-prose') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-content-prose'>
+      <MarketingContentShell>
+        <article data-testid='marketing-section-content-prose'>
+          <h1 className='text-3xl font-semibold tracking-tight text-primary-token'>
+            Long-form marketing prose
+          </h1>
+          <p className='mt-6 leading-relaxed'>
+            Content-prose sections carry SEO and launch narrative body copy. The
+            registry still points at the blog post page for full article render;
+            this story documents the product prose shell used by marketing
+            compositions.
+          </p>
+          <p className='mt-4 leading-relaxed'>
+            Keep copy in data files. Fully static. Dark-only.
+          </p>
+        </article>
+      </MarketingContentShell>
+    </MarketingStorySurface>
+  ),
+};
+
+/** blog-feed — static card grid (BlogCard needs full post/author pipeline) */
+export const BlogFeed: Story = {
+  name: 'blog-feed',
+  tags: ['wip'],
+  parameters: {
+    docs: { description: { story: sectionDocs('blog-feed') } },
+  },
+  render: () => (
+    <MarketingStorySurface label='section-blog-feed'>
+      <MarketingContainer width='page' className='py-16'>
+        <section
+          className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'
+          data-testid='marketing-section-blog-feed'
+        >
+          {[
+            {
+              title: 'Claim your profile in sixty seconds',
+              body: 'A short playbook for going live.',
+            },
+            {
+              title: 'Smart links that convert',
+              body: 'Route fans without a link maze.',
+            },
+            {
+              title: 'Release week checklist',
+              body: 'Capture and re-engage when music drops.',
+            },
+          ].map(post => (
+            <article
+              key={post.title}
+              className='rounded-2xl border border-subtle bg-surface-1 p-6'
+            >
+              <h2 className='text-lg font-semibold text-primary-token'>
+                {post.title}
+              </h2>
+              <p className='mt-3 text-sm text-secondary-token'>{post.body}</p>
+            </article>
+          ))}
+        </section>
+        <p className='mt-8 text-xs text-tertiary-token'>
+          Fixture feed — full BlogCard path is route-async (
+          {getMarketingSection('blog-feed').component}).
+        </p>
+      </MarketingContainer>
+    </MarketingStorySurface>
+  ),
+};

--- a/apps/web/components/marketing/storybook/Shells.stories.tsx
+++ b/apps/web/components/marketing/storybook/Shells.stories.tsx
@@ -1,0 +1,183 @@
+/**
+ * Marketing shells and chrome — PublicPageShell, containers, header/footer/CTA.
+ *
+ * @see apps/web/components/site/PublicPageShell.tsx
+ * @see apps/web/components/marketing/MarketingPageShell.tsx
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import {
+  MarketingContainer,
+  MarketingContentShell,
+  MarketingHero,
+  MarketingPageShell,
+} from '@/components/marketing';
+import { MarketingFinalCTA } from '@/components/site/MarketingFinalCTA';
+import { MarketingFooter } from '@/components/site/MarketingFooter';
+import { MarketingFooterCta } from '@/components/site/MarketingFooterCta';
+import { MarketingHeader } from '@/components/site/MarketingHeader';
+import { PublicPageShell } from '@/components/site/PublicPageShell';
+import { APP_ROUTES } from '@/constants/routes';
+import { MarketingStorySurface } from './story-surface';
+
+// Title must be a string literal so Storybook's static indexer can parse CSF.
+const meta: Meta = {
+  title: 'Marketing/Shells',
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        component:
+          'Shared marketing/public shells and chrome. Dark-only product surfaces. Fully static marketing pages use revalidate = false.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const PublicPageShellStory: Story = {
+  name: 'PublicPageShell',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Canonical public marketing shell: skip link, header, main offset, footer.',
+      },
+    },
+  },
+  render: () => (
+    <MarketingStorySurface label='shell-public-page'>
+      <PublicPageShell>
+        <MarketingHero
+          headingId='storybook-public-shell-hero'
+          headline='Public page shell'
+          subtitle='Header, main content offset, and footer from the product shell.'
+          primaryCta={{ label: 'Get started', href: APP_ROUTES.SIGNUP }}
+          logos={false}
+        />
+        <MarketingContainer width='page' className='pb-16'>
+          <p className='text-sm text-secondary-token'>
+            Content renders inside the public main region with the fixed-header
+            offset contract.
+          </p>
+        </MarketingContainer>
+      </PublicPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+export const MarketingPageShellStory: Story = {
+  name: 'MarketingPageShell',
+  render: () => (
+    <MarketingStorySurface label='shell-marketing-page'>
+      <MarketingPageShell>
+        <MarketingContainer width='page' className='py-16'>
+          <h1 className='text-3xl font-semibold text-primary-token'>
+            Marketing page shell
+          </h1>
+          <p className='mt-4 max-w-2xl text-secondary-token'>
+            Minimal full-height marketing page wrapper used by landing routes
+            that own their own header chrome.
+          </p>
+        </MarketingContainer>
+      </MarketingPageShell>
+    </MarketingStorySurface>
+  ),
+};
+
+export const MarketingContentShellStory: Story = {
+  name: 'MarketingContentShell',
+  render: () => (
+    <MarketingStorySurface label='shell-marketing-content'>
+      <MarketingContentShell>
+        <h1 className='text-3xl font-semibold text-primary-token'>
+          Content shell
+        </h1>
+        <p className='mt-4'>
+          Prose-width shell for about, support, and long-form marketing pages.
+        </p>
+      </MarketingContentShell>
+    </MarketingStorySurface>
+  ),
+};
+
+export const MarketingContainerStory: Story = {
+  name: 'MarketingContainer',
+  render: () => (
+    <MarketingStorySurface label='shell-marketing-container'>
+      <div className='space-y-10 py-12'>
+        <MarketingContainer width='page'>
+          <div className='rounded-xl border border-subtle bg-surface-1 p-6'>
+            <p className='text-sm font-medium text-primary-token'>
+              width=&apos;page&apos;
+            </p>
+            <p className='mt-2 text-sm text-secondary-token'>
+              Canonical public content max width.
+            </p>
+          </div>
+        </MarketingContainer>
+        <MarketingContainer width='prose'>
+          <div className='rounded-xl border border-subtle bg-surface-1 p-6'>
+            <p className='text-sm font-medium text-primary-token'>
+              width=&apos;prose&apos;
+            </p>
+            <p className='mt-2 text-sm text-secondary-token'>
+              Canonical prose max width for long-form.
+            </p>
+          </div>
+        </MarketingContainer>
+        <MarketingContainer width='landing'>
+          <div className='rounded-xl border border-subtle bg-surface-1 p-6'>
+            <p className='text-sm font-medium text-primary-token'>
+              width=&apos;landing&apos;
+            </p>
+            <p className='mt-2 text-sm text-secondary-token'>
+              Legacy alias of page width (same token).
+            </p>
+          </div>
+        </MarketingContainer>
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+export const HeaderFooterChrome: Story = {
+  name: 'HeaderFooterChrome',
+  render: () => (
+    <MarketingStorySurface label='shell-header-footer'>
+      <div className='flex min-h-screen flex-col'>
+        <MarketingHeader variant='landing' logoSize='xs' />
+        <main className='flex-1 px-6 py-16'>
+          <p className='text-sm text-secondary-token'>
+            Isolated header + footer chrome (product components).
+          </p>
+        </main>
+        <MarketingFooter />
+      </div>
+    </MarketingStorySurface>
+  ),
+};
+
+export const FinalCta: Story = {
+  name: 'FinalCta',
+  render: () => (
+    <MarketingStorySurface label='shell-final-cta'>
+      <div className='space-y-16 py-8'>
+        <MarketingFinalCTA
+          title='Request private launch access.'
+          ctaLabel='Request Access'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+        <MarketingFooterCta
+          title='Request Access to Jovie.'
+          ctaLabel='Get started'
+          ctaHref={APP_ROUTES.SIGNUP}
+        />
+      </div>
+    </MarketingStorySurface>
+  ),
+};

--- a/apps/web/components/marketing/storybook/catalog.ts
+++ b/apps/web/components/marketing/storybook/catalog.ts
@@ -1,0 +1,80 @@
+/**
+ * Marketing Storybook catalog — source of truth for title inventory.
+ *
+ * CI asserts proven recipes + all section ids appear under these title paths.
+ * Stories live in Recipes/Sections/Shells.stories.tsx and must keep titles in sync.
+ */
+
+import {
+  MARKETING_RECIPE_IDS,
+  MARKETING_RECIPES,
+  MARKETING_SECTION_IDS,
+  type MarketingSectionId,
+  type RecipeId,
+} from '@/data/marketing';
+
+/** Storybook sidebar title prefix for recipe stories. */
+export const MARKETING_RECIPE_STORY_ROOT = 'Marketing/Recipes' as const;
+
+/** Storybook sidebar title prefix for section stories. */
+export const MARKETING_SECTION_STORY_ROOT = 'Marketing/Sections' as const;
+
+/** Storybook sidebar title prefix for shell/chrome stories. */
+export const MARKETING_SHELL_STORY_ROOT = 'Marketing/Shells' as const;
+
+export const PROVEN_RECIPE_IDS: readonly RecipeId[] = MARKETING_RECIPES.filter(
+  recipe => recipe.status === 'proven'
+).map(recipe => recipe.id);
+
+export const STUB_RECIPE_IDS: readonly RecipeId[] = MARKETING_RECIPES.filter(
+  recipe => recipe.status === 'stub'
+).map(recipe => recipe.id);
+
+/** Full Storybook title path for a recipe (meta title + story name). */
+export function recipeStoryTitle(recipeId: RecipeId): string {
+  return `${MARKETING_RECIPE_STORY_ROOT}/${recipeId}`;
+}
+
+/** Full Storybook title path for a section. */
+export function sectionStoryTitle(sectionId: MarketingSectionId): string {
+  return `${MARKETING_SECTION_STORY_ROOT}/${sectionId}`;
+}
+
+/**
+ * Sections whose registry `component` path is TBD, legacy, or not a direct
+ * product import. Stories are tagged `wip` and must still exist (not omitted).
+ */
+export const WIP_SECTION_IDS: readonly MarketingSectionId[] = [
+  'stats', // HomeStatQuoteSection defaults fabricate metrics — zero-proof omit
+  'comparison', // data-driven; table composition from content/comparisons
+  'ownership', // TBD — ArtistProfileOwnershipSection not shipped
+  'content-prose', // route-level blog body; story uses MarketingContentShell prose
+  'blog-feed', // BlogCard exists; full feed is route-async
+] as const;
+
+export const MARKETING_SHELL_STORY_NAMES = [
+  'PublicPageShell',
+  'MarketingPageShell',
+  'MarketingContentShell',
+  'MarketingContainer',
+  'HeaderFooterChrome',
+  'FinalCta',
+] as const;
+
+export type MarketingShellStoryName =
+  (typeof MARKETING_SHELL_STORY_NAMES)[number];
+
+export function shellStoryTitle(name: MarketingShellStoryName): string {
+  return `${MARKETING_SHELL_STORY_ROOT}/${name}`;
+}
+
+/** Inventory receipt for CI / build-storybook count checks. */
+export const MARKETING_STORY_INVENTORY = {
+  provenRecipeTitles: PROVEN_RECIPE_IDS.map(recipeStoryTitle),
+  stubRecipeTitles: STUB_RECIPE_IDS.map(recipeStoryTitle),
+  sectionTitles: MARKETING_SECTION_IDS.map(sectionStoryTitle),
+  shellTitles: MARKETING_SHELL_STORY_NAMES.map(shellStoryTitle),
+  recipeIds: MARKETING_RECIPE_IDS,
+  sectionIds: MARKETING_SECTION_IDS,
+  wipSectionIds: WIP_SECTION_IDS,
+} as const;

--- a/apps/web/components/marketing/storybook/story-surface.tsx
+++ b/apps/web/components/marketing/storybook/story-surface.tsx
@@ -1,0 +1,80 @@
+/**
+ * Shared Storybook surface chrome for marketing compositions.
+ * Uses System B surfaces (bg-base) — never pure black void.
+ */
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface MarketingStorySurfaceProps {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly label?: string;
+}
+
+export function MarketingStorySurface({
+  children,
+  className,
+  label,
+}: Readonly<MarketingStorySurfaceProps>) {
+  return (
+    <div
+      className={cn(
+        'min-h-screen bg-base text-primary-token antialiased',
+        className
+      )}
+      data-marketing-story-surface=''
+      data-testid={
+        label ? `marketing-story-${label}` : 'marketing-story-surface'
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Documented zero-proof / WIP gap panel. Renders real shell surface chrome
+ * without fabricating proof data.
+ */
+export function MarketingSectionGapPanel({
+  sectionId,
+  reason,
+  componentPath,
+}: Readonly<{
+  readonly sectionId: string;
+  readonly reason: string;
+  readonly componentPath: string;
+}>) {
+  return (
+    <MarketingStorySurface label={`section-gap-${sectionId}`}>
+      <section
+        className='mx-auto max-w-public-content px-6 py-16 sm:px-8'
+        data-testid={`marketing-section-${sectionId}`}
+        data-section-status='wip'
+      >
+        <p className='text-sm font-medium text-tertiary-token'>
+          Marketing / Sections / {sectionId}
+        </p>
+        <h1 className='mt-3 text-2xl font-semibold tracking-tight text-primary-token'>
+          Section Story (Gap)
+        </h1>
+        <p className='mt-4 max-w-2xl text-sm leading-relaxed text-secondary-token'>
+          {reason}
+        </p>
+        <dl className='mt-8 grid gap-3 text-sm text-secondary-token sm:grid-cols-2'>
+          <div className='rounded-xl border border-subtle bg-surface-1 p-4'>
+            <dt className='text-tertiary-token'>Registry component</dt>
+            <dd className='mt-1 font-mono text-xs text-primary-token break-all'>
+              {componentPath}
+            </dd>
+          </div>
+          <div className='rounded-xl border border-subtle bg-surface-1 p-4'>
+            <dt className='text-tertiary-token'>Status</dt>
+            <dd className='mt-1 text-primary-token'>wip · zero-proof safe</dd>
+          </div>
+        </dl>
+      </section>
+    </MarketingStorySurface>
+  );
+}

--- a/apps/web/tests/unit/marketing/storybook-catalog.test.ts
+++ b/apps/web/tests/unit/marketing/storybook-catalog.test.ts
@@ -114,10 +114,11 @@ describe('marketing Storybook catalog inventory (JOV-4420)', () => {
     expect(recipesSource).toContain("tags: ['stub']");
   });
 
-  it('story files use the Marketing/* title roots', () => {
-    expect(recipesSource).toContain('title: MARKETING_RECIPE_STORY_ROOT');
-    expect(sectionsSource).toContain('title: MARKETING_SECTION_STORY_ROOT');
-    expect(shellsSource).toContain('title: MARKETING_SHELL_STORY_ROOT');
+  it('story files use the Marketing/* title roots as string literals', () => {
+    // Storybook's CSF indexer requires static string titles (not imported consts).
+    expect(recipesSource).toContain("title: 'Marketing/Recipes'");
+    expect(sectionsSource).toContain("title: 'Marketing/Sections'");
+    expect(shellsSource).toContain("title: 'Marketing/Shells'");
   });
 
   it('inventory receipt counts are stable and non-empty', () => {

--- a/apps/web/tests/unit/marketing/storybook-catalog.test.ts
+++ b/apps/web/tests/unit/marketing/storybook-catalog.test.ts
@@ -12,16 +12,16 @@ import { describe, expect, it } from 'vitest';
 import {
   MARKETING_STORY_INVENTORY,
   PROVEN_RECIPE_IDS,
-  STUB_RECIPE_IDS,
-  WIP_SECTION_IDS,
   recipeStoryTitle,
+  STUB_RECIPE_IDS,
   sectionStoryTitle,
   shellStoryTitle,
+  WIP_SECTION_IDS,
 } from '@/components/marketing/storybook/catalog';
 import {
+  isProvenRecipe,
   MARKETING_RECIPE_IDS,
   MARKETING_SECTION_IDS,
-  isProvenRecipe,
 } from '@/data/marketing';
 
 const storybookDir = join(
@@ -115,15 +115,15 @@ describe('marketing Storybook catalog inventory (JOV-4420)', () => {
   });
 
   it('story files use the Marketing/* title roots', () => {
-    expect(recipesSource).toContain("title: MARKETING_RECIPE_STORY_ROOT");
-    expect(sectionsSource).toContain("title: MARKETING_SECTION_STORY_ROOT");
-    expect(shellsSource).toContain("title: MARKETING_SHELL_STORY_ROOT");
+    expect(recipesSource).toContain('title: MARKETING_RECIPE_STORY_ROOT');
+    expect(sectionsSource).toContain('title: MARKETING_SECTION_STORY_ROOT');
+    expect(shellsSource).toContain('title: MARKETING_SHELL_STORY_ROOT');
   });
 
   it('inventory receipt counts are stable and non-empty', () => {
-    expect(MARKETING_STORY_INVENTORY.provenRecipeTitles.length).toBeGreaterThanOrEqual(
-      8
-    );
+    expect(
+      MARKETING_STORY_INVENTORY.provenRecipeTitles.length
+    ).toBeGreaterThanOrEqual(8);
     expect(MARKETING_STORY_INVENTORY.sectionTitles).toHaveLength(
       MARKETING_SECTION_IDS.length
     );

--- a/apps/web/tests/unit/marketing/storybook-catalog.test.ts
+++ b/apps/web/tests/unit/marketing/storybook-catalog.test.ts
@@ -1,0 +1,134 @@
+/**
+ * JOV-4420 — Marketing Storybook inventory gate.
+ *
+ * Asserts proven recipes and all section ids are represented as Storybook
+ * story names under Marketing/Recipes and Marketing/Sections. Fails on drift.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  MARKETING_STORY_INVENTORY,
+  PROVEN_RECIPE_IDS,
+  STUB_RECIPE_IDS,
+  WIP_SECTION_IDS,
+  recipeStoryTitle,
+  sectionStoryTitle,
+  shellStoryTitle,
+} from '@/components/marketing/storybook/catalog';
+import {
+  MARKETING_RECIPE_IDS,
+  MARKETING_SECTION_IDS,
+  isProvenRecipe,
+} from '@/data/marketing';
+
+const storybookDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../components/marketing/storybook'
+);
+
+function readStoryFile(name: string): string {
+  return readFileSync(join(storybookDir, name), 'utf8');
+}
+
+/** Extract CSF `name: '...'` story names from a stories file. */
+function extractStoryNames(source: string): Set<string> {
+  const names = new Set<string>();
+  const re = /name:\s*'([^']+)'/g;
+  for (const match of source.matchAll(re)) {
+    const name = match[1];
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+describe('marketing Storybook catalog inventory (JOV-4420)', () => {
+  const recipesSource = readStoryFile('Recipes.stories.tsx');
+  const sectionsSource = readStoryFile('Sections.stories.tsx');
+  const shellsSource = readStoryFile('Shells.stories.tsx');
+
+  const recipeNames = extractStoryNames(recipesSource);
+  const sectionNames = extractStoryNames(sectionsSource);
+  const shellNames = extractStoryNames(shellsSource);
+
+  it('catalog matches the marketing registry recipe/section ids', () => {
+    expect([...MARKETING_STORY_INVENTORY.recipeIds]).toEqual([
+      ...MARKETING_RECIPE_IDS,
+    ]);
+    expect([...MARKETING_STORY_INVENTORY.sectionIds]).toEqual([
+      ...MARKETING_SECTION_IDS,
+    ]);
+    for (const id of PROVEN_RECIPE_IDS) {
+      expect(isProvenRecipe(id)).toBe(true);
+    }
+    for (const id of STUB_RECIPE_IDS) {
+      expect(isProvenRecipe(id)).toBe(false);
+    }
+  });
+
+  it('every proven recipe has a Storybook story name under Marketing/Recipes', () => {
+    for (const recipeId of PROVEN_RECIPE_IDS) {
+      expect(
+        recipeNames.has(recipeId),
+        `missing recipe story for ${recipeStoryTitle(recipeId)}`
+      ).toBe(true);
+    }
+  });
+
+  it('every section id has a Storybook story name under Marketing/Sections', () => {
+    for (const sectionId of MARKETING_SECTION_IDS) {
+      expect(
+        sectionNames.has(sectionId),
+        `missing section story for ${sectionStoryTitle(sectionId)}`
+      ).toBe(true);
+    }
+  });
+
+  it('required shells are story-covered', () => {
+    for (const name of MARKETING_STORY_INVENTORY.shellTitles.map(title =>
+      title.replace('Marketing/Shells/', '')
+    )) {
+      expect(
+        shellNames.has(name),
+        `missing shell story for ${shellStoryTitle(name as never)}`
+      ).toBe(true);
+    }
+  });
+
+  it('WIP section ids are tagged in section stories (not silently omitted)', () => {
+    for (const sectionId of WIP_SECTION_IDS) {
+      expect(sectionNames.has(sectionId)).toBe(true);
+      // Each WIP export should sit near a tags: ['wip'] declaration
+      const storyBlock = sectionsSource.includes(`name: '${sectionId}'`);
+      expect(storyBlock).toBe(true);
+    }
+    expect(sectionsSource).toContain("tags: ['wip']");
+  });
+
+  it('stub recipes are present and tagged stub', () => {
+    for (const recipeId of STUB_RECIPE_IDS) {
+      expect(recipeNames.has(recipeId)).toBe(true);
+    }
+    expect(recipesSource).toContain("tags: ['stub']");
+  });
+
+  it('story files use the Marketing/* title roots', () => {
+    expect(recipesSource).toContain("title: MARKETING_RECIPE_STORY_ROOT");
+    expect(sectionsSource).toContain("title: MARKETING_SECTION_STORY_ROOT");
+    expect(shellsSource).toContain("title: MARKETING_SHELL_STORY_ROOT");
+  });
+
+  it('inventory receipt counts are stable and non-empty', () => {
+    expect(MARKETING_STORY_INVENTORY.provenRecipeTitles.length).toBeGreaterThanOrEqual(
+      8
+    );
+    expect(MARKETING_STORY_INVENTORY.sectionTitles).toHaveLength(
+      MARKETING_SECTION_IDS.length
+    );
+    expect(MARKETING_STORY_INVENTORY.shellTitles.length).toBeGreaterThanOrEqual(
+      5
+    );
+  });
+});

--- a/docs/design-system/template-inventory.md
+++ b/docs/design-system/template-inventory.md
@@ -16,7 +16,7 @@ This inventory defines the current page-template families and the canonical shel
 - CTA pattern: shared public primary/secondary/inline actions
 - Empty/error/loading: route-local loading pages where present
 - Mobile collapse behavior: stacked hero/content, shared fixed-header offset
-- Storybook: `Marketing/Recipes/homepage`, `Marketing/Recipes/launch`, `Marketing/Shells/PublicPageShell`
+- **Storybook:** `Marketing/Recipes/homepage`, `Marketing/Recipes/launch`, `Marketing/Shells/PublicPageShell`
 
 ## Marketing detail page
 
@@ -27,7 +27,7 @@ This inventory defines the current page-template families and the canonical shel
 - CTA pattern: shared public primary/secondary/inline actions
 - Empty/error/loading: route-local loading states
 - Mobile collapse behavior: single-column stacking, no page-local horizontal overflow
-- Storybook: `Marketing/Recipes/artist-lp`, `Marketing/Recipes/comparison`, `Marketing/Recipes/seo`
+- **Storybook:** `Marketing/Recipes/artist-lp`, `Marketing/Recipes/comparison`, `Marketing/Recipes/seo`, `Marketing/Sections/*`
 
 ## Pricing page
 
@@ -38,7 +38,7 @@ This inventory defines the current page-template families and the canonical shel
 - CTA pattern: shared primary and secondary public actions
 - Empty/error/loading: N/A for static pricing page
 - Mobile collapse behavior: comparison chart switches to plan selector pattern
-- Storybook: `Marketing/Recipes/pricing`, `Marketing/Sections/pricing`
+- **Storybook:** `Marketing/Recipes/pricing`, `Marketing/Sections/pricing`
 
 ## Support page
 
@@ -49,7 +49,7 @@ This inventory defines the current page-template families and the canonical shel
 - CTA pattern: inline public action links plus one primary contact action
 - Empty/error/loading: route loading page
 - Mobile collapse behavior: channels stack from three-column to single-column
-- Storybook: `Marketing/Recipes/seo`, `Marketing/Shells/MarketingContentShell`
+- **Storybook:** `Marketing/Recipes/seo`, `Marketing/Shells/MarketingContentShell`
 
 ## Legal document page
 
@@ -71,7 +71,7 @@ This inventory defines the current page-template families and the canonical shel
 - CTA pattern: inline links and shared TOC/document actions
 - Empty/error/loading: blog fallback states, route loading pages where present
 - Mobile collapse behavior: TOC hidden below large breakpoint, content stays single-column
-- Storybook: `Marketing/Recipes/blog-landing`, `Marketing/Sections/blog-feed`, `Marketing/Sections/content-prose`
+- **Storybook:** `Marketing/Recipes/blog-landing`, `Marketing/Sections/blog-feed`, `Marketing/Sections/content-prose`
 
 ## Auth page
 

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -58,25 +58,27 @@ The resolver is deterministic. Same Brief → same Composition, every time
 (tested by the golden-fixture determinism gate on every PR). The `trace`
 field shows every decision step — use it to debug.
 
-### 2.5. Visual catalog (Storybook)
+### 2b. Open the visual catalog (Storybook)
 
-After you know the `recipeId` and section list, open the **authoritative visual
-catalog** in Storybook before inventing layout:
+After `resolveComposition`, browse the product compositions in Storybook before
+hand-rolling chrome. Titles are the visual entry for recipes, sections, and shells:
 
-| Catalog | Storybook title |
-| --- | --- |
-| Proven recipes | `Marketing/Recipes/<recipeId>` (e.g. `homepage`, `artist-lp`, `pricing`) |
-| All 17 sections | `Marketing/Sections/<sectionId>` |
-| Shells / chrome | `Marketing/Shells/*` (`PublicPageShell`, containers, header/footer/CTA) |
+| Catalog | Storybook path | Source |
+| --- | --- | --- |
+| Proven recipes | `Marketing/Recipes/<recipeId>` | `components/marketing/storybook/Recipes.stories.tsx` |
+| Sections (all 17) | `Marketing/Sections/<sectionId>` | `components/marketing/storybook/Sections.stories.tsx` |
+| Shells / chrome | `Marketing/Shells/*` | `components/marketing/storybook/Shells.stories.tsx` |
 
-Source: `apps/web/components/marketing/storybook/`. Coverage is CI-gated by
-`apps/web/tests/unit/marketing/storybook-catalog-coverage.test.ts`. Stories are
-product compositions (System A, dark-only, `revalidate = false` on live routes)
-— not design-studio leftovers. Stub recipes may be tagged `stub`; TBD section
-component paths are tagged `wip` and listed in
-`MARKETING_SECTION_STORY_GAPS`.
+Inventory (CI): `apps/web/components/marketing/storybook/catalog.ts` +
+`apps/web/tests/unit/marketing/storybook-catalog.test.ts` assert proven recipes
+and section ids stay covered. Stub recipes are tagged `stub`; TBD/zero-proof
+sections are tagged `wip` (never silently omitted).
 
-Local: `pnpm --filter web storybook` → browse the `Marketing/` tree.
+```bash
+pnpm --filter web run storybook          # interactive
+pnpm --filter web run build-storybook    # static build receipt
+pnpm --filter web run test:a11y          # story a11y (vitest + addon-a11y)
+```
 
 ### 3. Render the sections
 


### PR DESCRIPTION
## Summary

Makes Storybook the authoritative visual catalog for marketing page creation (JOV-4420).

- **Recipes** (`Marketing/Recipes/*`): all proven recipes (`homepage`, `pricing`, `artist-lp`, `feature`, `comparison`, `launch`, `seo`, `blog-landing`) via real composition paths / reference route components; stubs (`agency-lp`, `enterprise`, `waitlist`) tagged `stub`.
- **Sections** (`Marketing/Sections/*`): all 17 `MARKETING_SECTION_IDS`; TBD/zero-proof gaps tagged `wip` with documented gap panels (never silently omitted).
- **Shells** (`Marketing/Shells/*`): `PublicPageShell`, page/content shells, container widths, header/footer chrome, final CTA.
- **Inventory gate**: `apps/web/tests/unit/marketing/storybook-catalog.test.ts` fails CI if proven recipes or section ids drift from story names.
- **Docs**: `docs/marketing/AGENT_GUIDE.md` step 2b points to Storybook paths; `docs/design-system/template-inventory.md` links template families → Storybook titles.
- **Build fix**: mock `@anthropic-ai/sdk` in Storybook so `build-storybook` is browser-safe (pre-existing node:crypto failure on main).

## Test plan / results

- [x] `pnpm --filter @jovie/web run typecheck` — pass
- [x] `pnpm biome check` on touched files — pass
- [x] `node scripts/storybook-story-quality-guard.mjs` — clean (105 stories)
- [x] `pnpm --filter web exec vitest run tests/unit/marketing/storybook-catalog.test.ts tests/unit/storybook/story-quality-guard.test.ts` — 9/9 pass
- [x] `pnpm --filter web run build-storybook` — green
- [x] Storybook index receipt: **40 marketing stories** (`Marketing/Recipes` 15, `Marketing/Sections` 18 incl. Docs, `Marketing/Shells` 7)
- [ ] Focused a11y: local `test:a11y` blocked by pre-existing `@storybook/addon-vitest` 10.5.x vs `storybook` 10.4.x channel export mismatch (not introduced here). Stories ship with a11y addon in the static build.

## Non-goals

- No live marketing route rewrites
- No stub recipe promotion
- Mobile companion stories use `chromatic: { disable: true }` to protect snapshot budget

<!-- linear-issue-id: JOV-4420 -->
Fixes JOV-4420