### PR TITLE
feat(connections): add in-flow connection rail

### DIFF
--- a/apps/web/app/app/(shell)/profiles/AddConnectionRail.tsx
+++ b/apps/web/app/app/(shell)/profiles/AddConnectionRail.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { Button, Input } from '@jovie/ui';
+import {
+  Cable,
+  CalendarDays,
+  ChevronLeft,
+  Link2,
+  Mail,
+  Plus,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useMemo, useState } from 'react';
+import {
+  DrawerSection,
+  EntityHeaderCard,
+  EntitySidebarShell,
+} from '@/components/molecules/drawer';
+import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
+import { APP_ROUTES } from '@/constants/routes';
+import { getConnectorDefinitions } from '@/lib/connectors/registry';
+import { canonicalizeSurfaceUrl } from '@/lib/profile-surfaces/contracts';
+import { cn } from '@/lib/utils';
+import type { ProfilesWorkspaceData } from './data';
+
+type AddConnectionView = 'home' | 'services' | 'profile';
+
+function ConnectorIcon({
+  iconKey,
+  className,
+}: Readonly<{ iconKey: 'mail' | 'calendar'; className?: string }>) {
+  const Icon = iconKey === 'mail' ? Mail : CalendarDays;
+  return <Icon className={className} aria-hidden />;
+}
+
+function ChoiceRow({
+  icon,
+  title,
+  description,
+  onClick,
+}: Readonly<{
+  icon: ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+}>) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className='group flex w-full items-start gap-3 rounded-lg px-3 py-3 text-left transition-colors duration-fast hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus/50'
+    >
+      <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-surface-2 text-secondary-token group-hover:text-accent'>
+        {icon}
+      </span>
+      <span className='min-w-0 space-y-0.5'>
+        <span className='block text-sm font-medium text-primary-token'>
+          {title}
+        </span>
+        <span className='block text-xs leading-5 text-secondary-token'>
+          {description}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+/**
+ * In-flow add surface for the Connections workspace. Provider availability is
+ * intentionally derived from the connector registry: unsupported DSP/social
+ * services never appear as implied integrations.
+ */
+export function AddConnectionRail({
+  data,
+  onClose,
+  onReviewSuggestions,
+}: Readonly<{
+  data: ProfilesWorkspaceData;
+  onClose: () => void;
+  onReviewSuggestions: () => void;
+}>) {
+  const router = useRouter();
+  const [view, setView] = useState<AddConnectionView>('home');
+  const [profileUrl, setProfileUrl] = useState('');
+  const canonicalUrl = useMemo(
+    () => canonicalizeSurfaceUrl(profileUrl),
+    [profileUrl]
+  );
+  const suggestedCount = data.rows.filter(
+    row => row.rowType === 'surface' && row.qualificationStatus === 'suggested'
+  ).length;
+  const connectors = getConnectorDefinitions();
+
+  const title =
+    view === 'services'
+      ? 'Connect services'
+      : view === 'profile'
+        ? 'Add public profile'
+        : 'Add connection';
+
+  return (
+    <EntitySidebarShell
+      isOpen
+      ariaLabel='Add connection'
+      scrollStrategy='shell'
+      workspaceSurface='raised'
+      headerMode='minimal'
+      hideMinimalHeaderBar
+      entityHeaderSurface='flat'
+      entityHeader={
+        <EntityHeaderCard
+          image={
+            <div className='flex h-9 w-9 items-center justify-center rounded-md bg-surface-2 text-accent'>
+              <Plus className='h-4 w-4' aria-hidden />
+            </div>
+          }
+          title={title}
+          subtitle='Connections'
+          stableLayout
+          reserveSubtitleSlot
+          actions={
+            <DrawerHeaderActions
+              primaryActions={
+                view === 'home'
+                  ? []
+                  : [
+                      {
+                        id: 'back',
+                        label: 'Back',
+                        icon: ChevronLeft,
+                        onClick: () => setView('home'),
+                      },
+                    ]
+              }
+              overflowActions={[]}
+              onClose={onClose}
+            />
+          }
+          bodyClassName='pr-8'
+          data-testid='profiles-add-connection-header'
+        />
+      }
+    >
+      {view === 'home' ? (
+        <DrawerSection sectionKind='details' surface='plain' className='py-1'>
+          <ChoiceRow
+            icon={<CableIcon />}
+            title='Connect services'
+            description='Connect the services Jovie can securely support today.'
+            onClick={() => setView('services')}
+          />
+          <ChoiceRow
+            icon={<Link2 className='h-4 w-4' aria-hidden />}
+            title='Add public profile'
+            description='Add a public URL with canonicalization before review.'
+            onClick={() => setView('profile')}
+          />
+          <ChoiceRow
+            icon={<ReviewIcon />}
+            title='Review suggestions'
+            description={
+              suggestedCount > 0
+                ? `${suggestedCount} suggested ${suggestedCount === 1 ? 'profile' : 'profiles'} to review.`
+                : 'No suggested profiles are waiting for review.'
+            }
+            onClick={onReviewSuggestions}
+          />
+        </DrawerSection>
+      ) : null}
+
+      {view === 'services' ? (
+        <DrawerSection sectionKind='details' surface='plain' className='py-1'>
+          <div className='divide-y divide-subtle'>
+            {connectors.map(connector => (
+              <button
+                key={connector.id}
+                type='button'
+                onClick={() =>
+                  router.push(
+                    `/api/connectors/google/authorize?returnTo=${encodeURIComponent(APP_ROUTES.PROFILES)}`
+                  )
+                }
+                className='flex w-full items-start gap-3 px-3 py-3 text-left transition-colors duration-fast hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus/50'
+              >
+                <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-surface-2 text-secondary-token'>
+                  <ConnectorIcon
+                    iconKey={connector.iconKey}
+                    className='h-4 w-4'
+                  />
+                </span>
+                <span className='min-w-0 flex-1'>
+                  <span className='block text-sm font-medium text-primary-token'>
+                    {connector.label}
+                  </span>
+                  <span className='block text-xs leading-5 text-secondary-token'>
+                    {connector.description}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </DrawerSection>
+      ) : null}
+
+      {view === 'profile' ? (
+        <DrawerSection title='Public URL' sectionKind='details' surface='plain'>
+          <div className='space-y-2 px-3 pb-2'>
+            <Input
+              aria-label='Public profile URL'
+              autoComplete='url'
+              inputMode='url'
+              placeholder='https://…'
+              value={profileUrl}
+              onChange={event => setProfileUrl(event.target.value)}
+            />
+            {profileUrl ? (
+              canonicalUrl ? (
+                <p className='text-xs leading-5 text-secondary-token'>
+                  Canonical URL:{' '}
+                  <span className='break-all text-primary-token'>
+                    {canonicalUrl.url}
+                  </span>
+                </p>
+              ) : (
+                <p className='text-xs leading-5 text-error'>
+                  Enter a public http or https URL without credentials.
+                </p>
+              )
+            ) : null}
+            <p className='text-xs leading-5 text-tertiary-token'>
+              Jovie will classify the URL before it is added. Service
+              connections are only available from the supported list above.
+            </p>
+            <Button
+              type='button'
+              size='sm'
+              className={cn('w-full')}
+              disabled={!canonicalUrl}
+              onClick={onReviewSuggestions}
+            >
+              Review profile
+            </Button>
+          </div>
+        </DrawerSection>
+      ) : null}
+    </EntitySidebarShell>
+  );
+}
+
+function CableIcon() {
+  return <Cable className='h-4 w-4' aria-hidden />;
+}
+
+function ReviewIcon() {
+  return <Link2 className='h-4 w-4' aria-hidden />;
+}

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -174,6 +174,40 @@ describe('ProfilesWorkspace', () => {
     expect(vi.mocked(useRegisterRightPanel)).toHaveBeenLastCalledWith(null);
   });
 
+  it('opens the in-flow add rail with registry-backed services and canonical URL review', async () => {
+    const user = userEvent.setup();
+    renderWorkspace(data);
+
+    await user.click(screen.getByRole('button', { name: 'Add connection' }));
+    const panel = vi.mocked(useRegisterRightPanel).mock.calls.at(-1)?.[0];
+    expect(panel).not.toBeNull();
+
+    render(<TooltipProvider>{panel as ReactElement}</TooltipProvider>);
+    expect(
+      screen.getByRole('complementary', { name: 'Add connection' })
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Connect services/i }));
+    expect(
+      screen.getByRole('button', {
+        name: 'Gmail Scan booking emails for tour confirmation signals.',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Google Calendar/i })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    await user.click(
+      screen.getByRole('button', { name: /Add public profile/i })
+    );
+    const url = screen.getByRole('textbox', { name: 'Public profile URL' });
+    await user.type(url, 'https://www.instagram.com/tim/?utm_source=test');
+    expect(screen.getByText(/instagram\.com\/tim/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Review profile' })
+    ).toBeEnabled();
+  });
+
   it('preserves the compact mobile table contract', () => {
     renderWorkspace(data);
 
@@ -189,7 +223,7 @@ describe('ProfilesWorkspace', () => {
     expect(screen.getByText('tim@example.com')).toHaveClass('max-sm:hidden');
 
     const summary = screen.getByTestId('connections-summary');
-    expect(summary.parentElement).toHaveClass('overflow-x-auto');
+    expect(summary.parentElement?.parentElement).toHaveClass('overflow-x-auto');
     expect(screen.getByText('Best Rank #2')).toHaveClass('max-sm:hidden');
     expect(screen.getByText('Monitoring Active')).toHaveClass('max-sm:hidden');
   });

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -13,12 +13,13 @@ import {
   LockKeyhole,
   MoreHorizontal,
   Orbit,
+  Plus,
   Share2,
   UserRound,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { EmptyCell } from '@/components/atoms/EmptyCell';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
@@ -53,6 +54,7 @@ import {
   summarizeProfileWorkspaceRows,
 } from '@/lib/profile-surfaces/workspace';
 import { cn } from '@/lib/utils';
+import { AddConnectionRail } from './AddConnectionRail';
 import { buildConnectionActions } from './connection-actions';
 import type {
   ProfilesWorkspaceData,
@@ -412,7 +414,15 @@ export function ProfilesWorkspace({
 }: Readonly<{ data: ProfilesWorkspaceData | null }>) {
   const [filter, setFilter] = useState<ProfilesWorkspaceFilter>('all');
   const [selected, setSelected] = useState<ProfileWorkspaceRow | null>(null);
+  const [isAddConnectionOpen, setIsAddConnectionOpen] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    if (searchParams.get('add') === 'service') {
+      setSelected(null);
+      setIsAddConnectionOpen(true);
+    }
+  }, [searchParams]);
   const rows = useMemo(
     () =>
       sortProfileWorkspaceRows(
@@ -446,7 +456,7 @@ export function ProfilesWorkspace({
             action === 'upgrade'
               ? APP_ROUTES.SETTINGS_BILLING
               : connection.rowType === 'connector'
-                ? APP_ROUTES.SETTINGS_CONNECTORS
+                ? `${APP_ROUTES.PROFILES}?add=service`
                 : APP_ROUTES.SETTINGS_ARTIST_PROFILE
           );
         },
@@ -480,7 +490,7 @@ export function ProfilesWorkspace({
       }),
       columnHelper.display({
         id: 'type',
-        header: 'Type',
+        header: () => <span className='sr-only'>Type</span>,
         size: 48,
         meta: { className: 'px-1 sm:px-3' },
         cell: context => <TypeCell row={context.row.original} />,
@@ -569,15 +579,27 @@ export function ProfilesWorkspace({
   );
 
   useRegisterRightPanel(
-    data && selected ? (
-      <ConnectionRail
-        data={data}
-        row={selected}
-        onClose={() => setSelected(null)}
-        contextMenuItems={convertToCommonDropdownItems(
-          getContextMenuItems(selected)
-        )}
-      />
+    data ? (
+      isAddConnectionOpen ? (
+        <AddConnectionRail
+          data={data}
+          onClose={() => setIsAddConnectionOpen(false)}
+          onReviewSuggestions={() => {
+            setFilter('all');
+            setSelected(null);
+            setIsAddConnectionOpen(false);
+          }}
+        />
+      ) : selected ? (
+        <ConnectionRail
+          data={data}
+          row={selected}
+          onClose={() => setSelected(null)}
+          contextMenuItems={convertToCommonDropdownItems(
+            getContextMenuItems(selected)
+          )}
+        />
+      ) : null
     ) : null
   );
 
@@ -624,28 +646,41 @@ export function ProfilesWorkspace({
             />
           ))}
           end={
-            <div
-              data-testid='connections-summary'
-              className='flex items-center gap-3 whitespace-nowrap text-xs text-tertiary-token'
-            >
-              <span>{summary.connectionCount} Connections</span>
-              <span>{limitLabel}</span>
-              <span>Needs Attention {summary.needsAttentionCount}</span>
-              <span className='max-sm:hidden'>
-                Best Rank{' '}
-                {summary.bestRank === null ? (
-                  <SimpleTooltip content='No search rank has been measured yet.'>
-                    <span role='img' aria-label='Best Rank Unavailable'>
-                      —
-                    </span>
-                  </SimpleTooltip>
-                ) : (
-                  `#${summary.bestRank}`
-                )}
-              </span>
-              <span className='max-sm:hidden'>
-                Monitoring {summary.monitoringLabel}
-              </span>
+            <div className='flex items-center gap-3 whitespace-nowrap'>
+              <div
+                data-testid='connections-summary'
+                className='flex items-center gap-3 text-xs text-tertiary-token'
+              >
+                <span>{summary.connectionCount} Connections</span>
+                <span>{limitLabel}</span>
+                <span>Needs Attention {summary.needsAttentionCount}</span>
+                <span className='max-sm:hidden'>
+                  Best Rank{' '}
+                  {summary.bestRank === null ? (
+                    <SimpleTooltip content='No search rank has been measured yet.'>
+                      <span role='img' aria-label='Best Rank Unavailable'>
+                        —
+                      </span>
+                    </SimpleTooltip>
+                  ) : (
+                    `#${summary.bestRank}`
+                  )}
+                </span>
+                <span className='max-sm:hidden'>
+                  Monitoring {summary.monitoringLabel}
+                </span>
+              </div>
+              <Button
+                type='button'
+                size='sm'
+                onClick={() => {
+                  setSelected(null);
+                  setIsAddConnectionOpen(true);
+                }}
+              >
+                <Plus className='h-3.5 w-3.5' aria-hidden />
+                Add connection
+              </Button>
             </div>
           }
         />

--- a/apps/web/app/app/(shell)/settings/connectors/page.tsx
+++ b/apps/web/app/app/(shell)/settings/connectors/page.tsx
@@ -1,40 +1,6 @@
-import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { loadAppShellRouteContext } from '../../app-shell-route-context';
-import { ConnectorsClient } from './ConnectorsClient';
-import { loadSettingsConnectorsData } from './connectors-data';
-
-export const runtime = 'nodejs';
-export const dynamic = 'force-dynamic';
-
-export const metadata: Metadata = {
-  title: 'Connectors',
-};
 
 export default async function SettingsConnectorsPage() {
-  const routeContext = await loadAppShellRouteContext({
-    route: APP_ROUTES.SETTINGS_CONNECTORS,
-    dashboardErrorLogMessage:
-      'Dashboard data load failed on settings connectors page',
-    dashboardErrorMessage:
-      'Failed to load connector settings. Please refresh the page.',
-  });
-  if (!routeContext.ok) {
-    return routeContext.error;
-  }
-
-  const connectorsData = await loadSettingsConnectorsData(routeContext.userId);
-  if (!connectorsData) {
-    redirect(APP_ROUTES.DASHBOARD);
-  }
-
-  return (
-    <ConnectorsClient
-      gmail={connectorsData.gmail}
-      calendar={connectorsData.calendar}
-      suggestedActions={connectorsData.suggestedActions}
-      isDev={process.env.NODE_ENV !== 'production'}
-    />
-  );
+  redirect(`${APP_ROUTES.PROFILES}?add=service`);
 }

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -83,6 +83,17 @@ const SETTINGS_ALIAS_ROUTES = [
       )
     ),
   },
+  {
+    route: 'settings connectors',
+    expectedDestination: '`${APP_ROUTES.PROFILES}?add=service`',
+    filePath: findSourceFile(
+      resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
+      resolve(
+        process.cwd(),
+        'apps/web/app/app/(shell)/settings/connectors/page.tsx'
+      )
+    ),
+  },
 ] as const;
 
 const SETTINGS_SHARED_ROUTE_CONTEXT_FILES = [
@@ -96,13 +107,6 @@ const SETTINGS_SHARED_ROUTE_CONTEXT_FILES = [
   findSourceFile(
     resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
     resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/touring/page.tsx')
-  ),
-  findSourceFile(
-    resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
-    resolve(
-      process.cwd(),
-      'apps/web/app/app/(shell)/settings/connectors/page.tsx'
-    )
   ),
   findSourceFile(
     resolve(process.cwd(), 'app/app/(shell)/settings/artist-profile/page.tsx'),
@@ -127,7 +131,6 @@ const SETTINGS_SHARED_ROUTE_CONTEXT_FILES = [
 const SETTINGS_SHARED_ROUTE_CONTEXT_CANDIDATES = [
   resolve(process.cwd(), 'app/app/(shell)/settings/contacts/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
-  resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/artist-profile/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/admin/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/payments/page.tsx'),
@@ -287,8 +290,11 @@ describe('settings shell normalization', () => {
     }
 
     const source = readFileSync(SETTINGS_CONNECTORS_PAGE, 'utf8');
-    expect(source).toContain('loadAppShellRouteContext');
-    expect(source).toContain('loadSettingsConnectorsData');
+    expect(source).toContain("import { redirect } from 'next/navigation'");
+    expect(source).toContain('APP_ROUTES.PROFILES');
+    expect(source).toContain('?add=service');
+    expect(source).not.toContain('loadAppShellRouteContext');
+    expect(source).not.toContain('loadSettingsConnectorsData');
     expect(source).not.toContain('@/lib/db');
     expect(source).not.toContain('@/lib/db/queries/shared');
     expect(source).not.toContain('@/lib/db/schema/connectors');

--- a/apps/web/tests/unit/routes/shell-redirect-stubs.baseline.json
+++ b/apps/web/tests/unit/routes/shell-redirect-stubs.baseline.json
@@ -37,6 +37,7 @@
     "/app/settings",
     "/app/settings/admin",
     "/app/settings/appearance",
+    "/app/settings/connectors",
     "/app/settings/delete-account",
     "/app/settings/profile",
     "/app/threads",


### PR DESCRIPTION
## Summary
- add an in-flow **Add connection** action to Connections using the shared raised right-rail system
- route registry-backed Gmail and Google Calendar OAuth, public-profile URL review, and detected suggestions through one compact surface
- redirect the legacy Settings connectors route back to Connections and hide the decorative Type column heading visually

## Verification
- `pnpm biome check --write` on the four changed files
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1` (6/6)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

## Product boundary
Manual public-profile URL entry is canonicalized and routed into the existing review flow; this slice does not claim a persistent profile-surface write because no non-destructive canonical create endpoint exists.

Linear: JOV-4688

Visual review is advisory and will be handled post-ship per the nonblocking taste policy.