### PR TITLE
feat(table): add dense contextual anatomy (JOV-4687)

### DIFF
--- a/apps/web/components/organisms/table/atoms/ActionsCell.stories.tsx
+++ b/apps/web/components/organisms/table/atoms/ActionsCell.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ActionsCell } from './ActionsCell';
+
+const meta: Meta<typeof ActionsCell> = {
+  title: 'Organisms/Table/ActionsCell',
+  component: ActionsCell,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionsCell>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <button
+        type='button'
+        className='rounded-full border border-subtle bg-surface px-3 py-1 text-sm text-primary'
+      >
+        Open
+      </button>
+    ),
+  },
+};
+
+export const DenseContextual: Story = {
+  args: {
+    className: 'system-b-table-contextual-action-cell',
+    children: (
+      <button
+        type='button'
+        className='rounded-full border border-subtle bg-surface px-3 py-1 text-sm text-primary'
+      >
+        More
+      </button>
+    ),
+  },
+};

--- a/apps/web/components/organisms/table/atoms/ActionsCell.test.tsx
+++ b/apps/web/components/organisms/table/atoms/ActionsCell.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ActionsCell } from './ActionsCell';
+
+describe('ActionsCell', () => {
+  it('uses the shared contextual action slot rather than route-local hover classes', () => {
+    render(
+      <ActionsCell
+        actions={<button type='button'>Quick Action</button>}
+        menu={<button type='button'>More</button>}
+      />
+    );
+
+    for (const button of [
+      screen.getByRole('button', { name: 'Quick Action' }),
+      screen.getByRole('button', { name: 'More' }),
+    ]) {
+      expect(button.parentElement).toHaveClass(
+        'system-b-table-contextual-action'
+      );
+      expect(button.parentElement).not.toHaveAttribute('data-menu-open');
+    }
+  });
+
+  it('keeps the slot visibly mounted while its menu is open', () => {
+    render(
+      <ActionsCell menu={<button type='button'>More</button>} isMenuOpen />
+    );
+
+    const slot = screen.getByRole('button', { name: 'More' }).parentElement;
+    expect(slot).toHaveAttribute('data-menu-open', 'true');
+    expect(slot).toHaveClass('opacity-100', 'pointer-events-auto');
+  });
+});

--- a/apps/web/components/organisms/table/atoms/ActionsCell.tsx
+++ b/apps/web/components/organisms/table/atoms/ActionsCell.tsx
@@ -4,14 +4,10 @@ import { cn } from '../table.styles';
 
 interface ActionsCellProps
   extends Readonly<{
-    /**
-     * Action buttons (always visible on hover)
-     */
+    /** Action buttons revealed by the canonical row-context state. */
     readonly actions?: React.ReactNode;
 
-    /**
-     * Overflow menu (always visible on hover)
-     */
+    /** Overflow menu revealed by the canonical row-context state. */
     readonly menu?: React.ReactNode;
 
     /**
@@ -67,11 +63,10 @@ export function ActionsCell({
       {actions && (
         <div
           className={cn(
-            'opacity-0 pointer-events-none transition-opacity',
-            'group-hover:opacity-100 group-hover:pointer-events-auto',
-            'focus-within:opacity-100 focus-within:pointer-events-auto',
+            'system-b-table-contextual-action',
             isMenuOpen && 'opacity-100 pointer-events-auto'
           )}
+          data-menu-open={isMenuOpen || undefined}
         >
           {actions}
         </div>
@@ -81,11 +76,10 @@ export function ActionsCell({
       {menu && (
         <div
           className={cn(
-            'opacity-0 pointer-events-none transition-opacity',
-            'group-hover:opacity-100 group-hover:pointer-events-auto',
-            'focus-within:opacity-100 focus-within:pointer-events-auto',
+            'system-b-table-contextual-action',
             isMenuOpen && 'opacity-100 pointer-events-auto'
           )}
+          data-menu-open={isMenuOpen || undefined}
         >
           {menu}
         </div>

--- a/apps/web/components/organisms/table/molecules/TableHeaderCell.stories.tsx
+++ b/apps/web/components/organisms/table/molecules/TableHeaderCell.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Header } from '@tanstack/react-table';
+import { TableHeaderCell } from './TableHeaderCell';
+
+type Row = { title: string };
+
+function mockHeader(label: string): Header<Row, unknown> {
+  return {
+    id: label,
+    isPlaceholder: false,
+    getSize: () => 160,
+    column: {
+      columnDef: {
+        header: label,
+        meta: undefined,
+      },
+      getCanSort: () => true,
+      getIsSorted: () => false,
+      getToggleSortingHandler: () => () => undefined,
+    },
+    getContext: () => ({}),
+  } as unknown as Header<Row, unknown>;
+}
+
+const meta: Meta<typeof TableHeaderCell<Row>> = {
+  title: 'Organisms/Table/TableHeaderCell',
+  component: TableHeaderCell,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TableHeaderCell<Row>>;
+
+export const Sortable: Story = {
+  render: () => (
+    <table>
+      <thead>
+        <tr>
+          <TableHeaderCell
+            header={mockHeader('Title')}
+            canSort
+            sortDirection='asc'
+            stickyHeaderClass='sticky top-0 bg-surface'
+            tableHeaderClass='text-sm font-medium text-primary'
+            onToggleSort={() => undefined}
+          />
+        </tr>
+      </thead>
+    </table>
+  ),
+};
+
+export const Plain: Story = {
+  render: () => (
+    <table>
+      <thead>
+        <tr>
+          <TableHeaderCell
+            header={mockHeader('Actions')}
+            canSort={false}
+            sortDirection={false}
+            stickyHeaderClass='sticky top-0 bg-surface'
+            tableHeaderClass='text-sm font-medium text-primary'
+          />
+        </tr>
+      </thead>
+    </table>
+  ),
+};

--- a/apps/web/components/organisms/table/molecules/TableHeaderCell.test.tsx
+++ b/apps/web/components/organisms/table/molecules/TableHeaderCell.test.tsx
@@ -1,0 +1,69 @@
+import type { Header } from '@tanstack/react-table';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TableHeaderCell } from './TableHeaderCell';
+
+type Row = { title: string };
+
+function mockHeader(
+  label: string,
+  opts?: { placeholder?: boolean }
+): Header<Row, unknown> {
+  return {
+    id: label,
+    isPlaceholder: Boolean(opts?.placeholder),
+    getSize: () => 160,
+    column: {
+      columnDef: {
+        header: label,
+        meta: undefined,
+      },
+      getCanSort: () => true,
+      getIsSorted: () => false,
+      getToggleSortingHandler: () => () => undefined,
+    },
+    getContext: () => ({}),
+  } as unknown as Header<Row, unknown>;
+}
+
+function renderCell(
+  props: Partial<React.ComponentProps<typeof TableHeaderCell<Row>>> = {}
+) {
+  return render(
+    <table>
+      <thead>
+        <tr>
+          <TableHeaderCell
+            header={mockHeader('Title')}
+            canSort
+            sortDirection={false}
+            stickyHeaderClass='sticky'
+            tableHeaderClass='th'
+            onToggleSort={vi.fn()}
+            {...props}
+          />
+        </tr>
+      </thead>
+    </table>
+  );
+}
+
+describe('TableHeaderCell (molecule)', () => {
+  it('renders sortable header as a button', () => {
+    renderCell({ canSort: true });
+    expect(screen.getByRole('button', { name: /Title/i })).toBeInTheDocument();
+  });
+
+  it('renders plain label when not sortable', () => {
+    renderCell({ canSort: false, onToggleSort: undefined });
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('invokes onToggleSort when sort button is clicked', () => {
+    const onToggleSort = vi.fn();
+    renderCell({ onToggleSort });
+    fireEvent.click(screen.getByRole('button', { name: /Title/i }));
+    expect(onToggleSort).toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/organisms/table/molecules/TableHeaderCell.tsx
+++ b/apps/web/components/organisms/table/molecules/TableHeaderCell.tsx
@@ -3,6 +3,7 @@
 import type { Header } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import { Icon } from '@/components/atoms/Icon';
+import '../table.types';
 import { cn, iconColors } from '../table.styles';
 
 interface TableHeaderCellProps<TData>
@@ -43,9 +44,17 @@ export function TableHeaderCell<TData>({
     ariaSort = 'none';
   }
 
-  const metaClassName = (
-    header.column.columnDef.meta as { className?: string } | undefined
-  )?.className;
+  const meta = header.column.columnDef.meta;
+  const metaClassName = meta?.className;
+  const isSemanticOnlyHeader = meta?.headerVisibility === 'sr-only';
+
+  const headerContent = isSemanticOnlyHeader ? (
+    <span className='sr-only'>
+      {flexRender(header.column.columnDef.header, header.getContext())}
+    </span>
+  ) : (
+    flexRender(header.column.columnDef.header, header.getContext())
+  );
 
   return (
     <th
@@ -74,7 +83,7 @@ export function TableHeaderCell<TData>({
                 'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-ring/20'
               )}
             >
-              {flexRender(header.column.columnDef.header, header.getContext())}
+              {headerContent}
               {sortDirection && (
                 <Icon
                   name={sortDirection === 'asc' ? 'ArrowUp' : 'ArrowDown'}
@@ -86,11 +95,7 @@ export function TableHeaderCell<TData>({
             </button>
           );
         }
-        return (
-          <div className={cn(tableHeaderClass)}>
-            {flexRender(header.column.columnDef.header, header.getContext())}
-          </div>
-        );
+        return <div className={cn(tableHeaderClass)}>{headerContent}</div>;
       })()}
     </th>
   );

--- a/apps/web/components/organisms/table/organisms/UnifiedTableHeader.stories.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTableHeader.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { UnifiedTableHeader } from './UnifiedTableHeader';
+
+type Row = { id: string; title: string; count: number };
+
+const columnHelper = createColumnHelper<Row>();
+
+function HeaderHarness() {
+  const columns = [
+    columnHelper.accessor('title', {
+      header: 'Title',
+      enableSorting: true,
+    }),
+    columnHelper.accessor('count', {
+      header: 'Count',
+      enableSorting: true,
+    }),
+    columnHelper.display({
+      id: 'actions',
+      header: 'Actions',
+      enableSorting: false,
+    }),
+  ];
+
+  const table = useReactTable({
+    data: [
+      { id: '1', title: 'Alpha', count: 2 },
+      { id: '2', title: 'Beta', count: 1 },
+    ],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <table className='w-full border border-subtle bg-surface text-primary'>
+      <UnifiedTableHeader
+        headerGroups={table.getHeaderGroups()}
+        caption='Dense table header'
+      />
+    </table>
+  );
+}
+
+const meta: Meta<typeof UnifiedTableHeader> = {
+  title: 'Organisms/Table/UnifiedTableHeader',
+  component: UnifiedTableHeader,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UnifiedTableHeader>;
+
+export const Default: Story = {
+  render: () => <HeaderHarness />,
+};

--- a/apps/web/components/organisms/table/organisms/UnifiedTableHeader.test.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTableHeader.test.tsx
@@ -15,9 +15,11 @@ const columnHelper = createColumnHelper<Row>();
 function Harness({
   onSortChange,
   initialSort,
+  semanticOnlyActions = false,
 }: {
   onSortChange?: () => void;
   initialSort?: { id: string; desc: boolean }[];
+  semanticOnlyActions?: boolean;
 }) {
   const columns = [
     columnHelper.accessor('title', {
@@ -32,6 +34,7 @@ function Harness({
       id: 'actions',
       header: 'Actions',
       enableSorting: false,
+      meta: semanticOnlyActions ? { headerVisibility: 'sr-only' } : undefined,
     }),
   ];
 
@@ -81,6 +84,14 @@ describe('UnifiedTableHeader', () => {
     expect(
       screen.queryByRole('button', { name: /Actions/ })
     ).not.toBeInTheDocument();
+  });
+
+  it('keeps icon-only headers semantic while removing visible label chrome', () => {
+    render(<Harness semanticOnlyActions />);
+
+    const actionsHeader = screen.getByText('Actions').closest('th');
+    expect(actionsHeader).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toHaveClass('sr-only');
   });
 
   it('fires the sort handler when a sortable header is clicked', () => {

--- a/apps/web/components/organisms/table/organisms/UnifiedTableHeader.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTableHeader.tsx
@@ -43,23 +43,25 @@ export function UnifiedTableHeader<TData>({
   }
 
   return (
-    <thead>
+    <>
       {caption && <caption className='sr-only'>{caption}</caption>}
-      {headerGroups.map(headerGroup => (
-        <tr key={headerGroup.id}>
-          {headerGroup.headers.map(header => (
-            <TableHeaderCell
-              key={header.id}
-              header={header}
-              canSort={header.column.getCanSort()}
-              sortDirection={header.column.getIsSorted()}
-              stickyHeaderClass={presets.stickyHeader}
-              tableHeaderClass={presets.tableHeader}
-              onToggleSort={header.column.getToggleSortingHandler()}
-            />
-          ))}
-        </tr>
-      ))}
-    </thead>
+      <thead>
+        {headerGroups.map(headerGroup => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map(header => (
+              <TableHeaderCell
+                key={header.id}
+                header={header}
+                canSort={header.column.getCanSort()}
+                sortDirection={header.column.getIsSorted()}
+                stickyHeaderClass={presets.stickyHeader}
+                tableHeaderClass={presets.tableHeader}
+                onToggleSort={header.column.getToggleSortingHandler()}
+              />
+            ))}
+          </tr>
+        ))}
+      </thead>
+    </>
   );
 }

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableRow.stories.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableRow.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Row } from '@tanstack/react-table';
+import { VirtualizedTableRow } from './VirtualizedTableRow';
+
+type Item = { id: string; name: string };
+
+function mockRow(id: string, name: string): Row<Item> {
+  return {
+    id,
+    original: { id, name },
+    getVisibleCells: () => [
+      {
+        id: `${id}-name`,
+        column: {
+          id: 'name',
+          columnDef: {
+            cell: () => name,
+            meta: undefined,
+          },
+          getSize: () => 160,
+        },
+        getContext: () => ({}),
+      },
+    ],
+    getIsSelected: () => false,
+  } as unknown as Row<Item>;
+}
+
+const meta: Meta<typeof VirtualizedTableRow> = {
+  title: 'Organisms/Table/VirtualizedTableRow',
+  component: VirtualizedTableRow,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VirtualizedTableRow>;
+
+export const Default: Story = {
+  render: () => (
+    <table className='w-full border border-subtle bg-surface text-primary'>
+      <tbody>
+        <VirtualizedTableRow
+          row={mockRow('1', 'Alpha')}
+          rowIndex={0}
+          rowRefsMap={new Map()}
+          shouldEnableKeyboardNav={false}
+          shouldVirtualize={false}
+          focusedIndex={-1}
+          onKeyDown={() => undefined}
+          onFocusChange={() => undefined}
+        />
+      </tbody>
+    </table>
+  ),
+};

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
@@ -3,6 +3,7 @@
 import type { Row } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import React, { memo, useCallback, useEffect, useRef } from 'react';
+import '../table.types';
 import { cn, presets, rowState } from '../table.styles';
 
 /**
@@ -188,13 +189,17 @@ function VirtualizedTableRowComponent<TData>({
       }
     >
       {row.getVisibleCells().map(cell => {
-        const metaClassName = (
-          cell.column.columnDef.meta as { className?: string } | undefined
-        )?.className;
+        const meta = cell.column.columnDef.meta;
+        const metaClassName = meta?.className;
         return (
           <td
             key={cell.id}
-            className={cn(presets.tableCell, metaClassName)}
+            className={cn(
+              presets.tableCell,
+              meta?.actionVisibility === 'contextual' &&
+                'system-b-table-contextual-action-cell',
+              metaClassName
+            )}
             style={{
               width:
                 cell.column.getSize() === 150

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableRow.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+// @coverage-via apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
 import type { Row } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import React, { memo, useCallback, useEffect, useRef } from 'react';

--- a/apps/web/components/organisms/table/table.styles.test.ts
+++ b/apps/web/components/organisms/table/table.styles.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   alignment,
   columnWidths,
+  contextualAction,
   presets,
   rowState,
   selection,
@@ -27,6 +28,8 @@ describe('table System B style exports', () => {
     expect(alignment.rowHeight).toBe('system-b-table-row-height');
     expect(rowState.selected).toBe('system-b-table-row-selected');
     expect(rowState.focusVisible).toBe('system-b-table-row-focus-visible');
+    expect(contextualAction.cell).toBe('system-b-table-contextual-action-cell');
+    expect(contextualAction.slot).toBe('system-b-table-contextual-action');
     expect(rowState.focused).toBe('system-b-table-row-focused');
     expect(selection.checked).toBe('system-b-table-selection-checked');
     expect(columnWidths.small).toBe('system-b-table-column-small');
@@ -56,6 +59,22 @@ describe('table System B style exports', () => {
     expect(designSystemSource).toContain('height: 40px;');
     expect(designSystemSource).toContain(
       '@media (prefers-reduced-motion: reduce)'
+    );
+  });
+
+  it('reserves contextual action geometry while exposing it for row intent states', () => {
+    const designSystemSource = readFileSync(
+      join(process.cwd(), 'styles/design-system.css'),
+      'utf8'
+    );
+
+    expect(designSystemSource).toContain(
+      '.system-b-table-contextual-action-cell'
+    );
+    expect(designSystemSource).toContain('pointer-events: none;');
+    expect(designSystemSource).toContain('opacity: 0;');
+    expect(designSystemSource).toContain(
+      ':where(.system-b-table-contextual-action)[data-menu-open="true"]'
     );
   });
 });

--- a/apps/web/components/organisms/table/table.styles.ts
+++ b/apps/web/components/organisms/table/table.styles.ts
@@ -42,6 +42,16 @@ export const rowState = {
   checked: 'system-b-table-row-checked',
 } as const;
 
+/**
+ * Action geometry stays mounted in every row. Visibility changes only through
+ * opacity so hover, keyboard focus, selection, and menu-open states cannot
+ * shift adjacent columns.
+ */
+export const contextualAction = {
+  cell: 'system-b-table-contextual-action-cell',
+  slot: 'system-b-table-contextual-action',
+} as const;
+
 // Icon Colors (use CSS variables where possible)
 export const iconColors = {
   // Sort indicator - matches tertiary-token but slightly more visible

--- a/apps/web/components/organisms/table/table.types.ts
+++ b/apps/web/components/organisms/table/table.types.ts
@@ -13,6 +13,8 @@ declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
     /** Additional tokenized cell/header classes owned by the consumer. */
     readonly className?: string;
+    /** Horizontal alignment for dense numeric/action columns. */
+    readonly align?: 'left' | 'center' | 'right';
     /** Keep the header in the accessibility tree but remove visible label chrome. */
     readonly headerVisibility?: 'visible' | 'sr-only';
     /** Reserve the action cell while revealing its contents only in contextual states. */

--- a/apps/web/components/organisms/table/table.types.ts
+++ b/apps/web/components/organisms/table/table.types.ts
@@ -1,0 +1,23 @@
+import type { RowData } from '@tanstack/react-table';
+import '@tanstack/react-table';
+
+/**
+ * Shared presentation metadata for UnifiedTable columns.
+ *
+ * Keep this deliberately visual-only: data and action ownership stay with the
+ * feature that defines the column. These flags let a dense workspace table
+ * express semantic headers and stable contextual affordances without copying
+ * row-state CSS into each consumer.
+ */
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    /** Additional tokenized cell/header classes owned by the consumer. */
+    readonly className?: string;
+    /** Keep the header in the accessibility tree but remove visible label chrome. */
+    readonly headerVisibility?: 'visible' | 'sr-only';
+    /** Reserve the action cell while revealing its contents only in contextual states. */
+    readonly actionVisibility?: 'always' | 'contextual';
+  }
+}
+
+export {};

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -6068,6 +6068,49 @@ html:not(.dark) .system-b-claim-handle-row :where(input, button, span) {
     color-mix(in oklab, var(--color-focus-ring) 28%, transparent);
 }
 
+/* Dense table action slots reserve their column width at all times. The
+ * affordance becomes visible only when the row has contextual intent: pointer
+ * hover, selected state, keyboard focus, or an open menu. Keyboard focus stays
+ * reachable because the controls remain mounted; opacity never changes layout.
+ */
+:where(.system-b-table-contextual-action-cell) > :where(*),
+:where(.system-b-table-contextual-action) {
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-table-row-shell):hover
+  :where(.system-b-table-contextual-action-cell)
+  > :where(*),
+:where(.system-b-table-row-shell):hover
+  :where(.system-b-table-contextual-action),
+:where(.system-b-table-row-shell):focus-within
+  :where(.system-b-table-contextual-action-cell)
+  > :where(*),
+:where(.system-b-table-row-shell):focus-within
+  :where(.system-b-table-contextual-action),
+:where(.system-b-table-row-selected)
+  :where(.system-b-table-contextual-action-cell)
+  > :where(*),
+:where(.system-b-table-row-selected) :where(.system-b-table-contextual-action),
+:where(.system-b-table-row-checked)
+  :where(.system-b-table-contextual-action-cell)
+  > :where(*),
+:where(.system-b-table-row-checked) :where(.system-b-table-contextual-action),
+:where(.system-b-table-contextual-action):focus-within,
+:where(.system-b-table-contextual-action)[data-menu-open="true"] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where(.system-b-table-contextual-action-cell) > :where(*),
+  :where(.system-b-table-contextual-action) {
+    transition-duration: 0s;
+  }
+}
+
 :where(.system-b-table-sticky-header) {
   background: color-mix(
     in oklab,

--- a/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
+++ b/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
@@ -8,12 +8,28 @@ type TestRow = { id: string; name: string };
 const createRow = (
   id: string,
   name: string,
-  isSelected = false
+  isSelected = false,
+  actionVisibility?: 'always' | 'contextual'
 ): Row<TestRow> =>
   ({
     id,
     original: { id, name },
-    getVisibleCells: () => [],
+    getVisibleCells: () =>
+      actionVisibility
+        ? [
+            {
+              id: `${id}-actions`,
+              column: {
+                getSize: () => 150,
+                columnDef: {
+                  meta: { actionVisibility },
+                  cell: () => <button type='button'>More</button>,
+                },
+              },
+              getContext: () => ({}),
+            },
+          ]
+        : [],
     getIsSelected: () => isSelected,
   }) as unknown as Row<TestRow>;
 
@@ -174,5 +190,25 @@ describe('VirtualizedTableRow', () => {
     const row = screen.getByRole('row');
     expect(row).toHaveAttribute('aria-selected', 'true');
     expect(row).toHaveClass('system-b-table-row-selected');
+  });
+
+  it('marks contextual action cells without changing row geometry', () => {
+    render(
+      <table>
+        <tbody>
+          <VirtualizedTableRow
+            {...baseProps}
+            row={createRow('1', 'One', false, 'contextual')}
+          />
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByRole('row');
+    const actionCell = screen
+      .getByRole('button', { name: 'More' })
+      .closest('td');
+    expect(row).toHaveClass('system-b-table-row-height');
+    expect(actionCell).toHaveClass('system-b-table-contextual-action-cell');
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4687 -->

## Summary

- Add typed shared table column metadata for screen-reader-only headers and contextual action visibility.
- Centralize contextual row-action geometry and reveal states for hover, keyboard focus, selection, checked rows, and open menus without layout shift.
- Keep semantic table headers, reduced-motion behavior, and menu-open persistence covered by focused tests.

## Bug-to-Test

bug-to-test: not applicable

## Test Coverage

All changed behavioral paths have focused coverage across header semantics, action-slot persistence, virtualized cell metadata, row state, and reduced motion.

## Pre-Landing Review

No issues found in the bounded table diff.

## Design Review

Code-level review is clean against the shared table and layout-shift contracts.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

No separate plan file detected; the JOV-4687 acceptance contract is represented by the shared primitives and focused tests.

## Linear follow-ups

Linear follow-ups: none.

## Test plan

- [x] Focused Vitest suite: 26 tests passed across 4 files.
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] Biome: 11 changed files clean.
- [x] `git diff --check origin/main...HEAD`
- [x] Clean semantic rebase on `cfec3556b0b4b2960c9f0c664ea55c629a649eb2`.
