### PR TITLE
refactor(tasks): centralize task action menus (JOV-4690)

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -60,7 +60,6 @@ import { ReleaseDueBadge } from '@/components/molecules/ReleaseDueBadge';
 import { PageShell } from '@/components/organisms/PageShell';
 import { ReleaseSidebar } from '@/components/organisms/release-sidebar';
 import {
-  type ContextMenuItemType,
   ShellListRowButton,
   TableEmptyState,
 } from '@/components/organisms/table';
@@ -124,6 +123,12 @@ import {
   TaskWorkspaceHeaderBar,
 } from './TaskWorkspaceHeaderBar';
 import { TaskWorkspaceLoadingRows } from './TaskWorkspaceLoadingRows';
+import {
+  buildTaskActionMenuItems,
+  TASK_ASSIGNEE_OPTIONS,
+  TASK_PRIORITY_OPTIONS,
+  TASK_STATUS_OPTIONS,
+} from './task-action-registry';
 import { distinctTaskTitles, taskSearchFromPills } from './task-header-search';
 import {
   getTaskAssigneeVisual,
@@ -146,27 +151,6 @@ function isTaskRowNavigationAction(
 ): action is 'next' | 'prev' {
   return action === 'next' || action === 'prev';
 }
-
-const TASK_STATUS_OPTIONS = [
-  ['backlog', 'Backlog'],
-  ['todo', 'Todo'],
-  ['in_progress', 'In Progress'],
-  ['done', 'Done'],
-  ['cancelled', 'Cancelled'],
-] as const satisfies ReadonlyArray<readonly [TaskStatus, string]>;
-
-const TASK_PRIORITY_OPTIONS = [
-  ['urgent', 'Urgent'],
-  ['high', 'High'],
-  ['medium', 'Medium'],
-  ['low', 'Low'],
-  ['none', 'None'],
-] as const satisfies ReadonlyArray<readonly [TaskPriority, string]>;
-
-const TASK_ASSIGNEE_OPTIONS = [
-  ['human', 'Me'],
-  ['jovie', 'Jovie'],
-] as const satisfies ReadonlyArray<readonly [TaskAssigneeKind, string]>;
 
 const NOOP = () => {};
 const NOOP_TASK_OPEN = (_task: TaskView) => {};
@@ -608,6 +592,7 @@ function TaskDocumentPanel({
   onUpdateStatus,
   onUpdatePriority,
   onUpdateAssignee,
+  actionItems,
   artistName,
   isDesktopLayout,
   compactMetadata = false,
@@ -622,6 +607,7 @@ function TaskDocumentPanel({
   onUpdateStatus: (taskId: string, status: TaskStatus) => void;
   onUpdatePriority: (taskId: string, priority: TaskPriority) => void;
   onUpdateAssignee: (taskId: string, assigneeKind: TaskAssigneeKind) => void;
+  actionItems: ReturnType<typeof buildTaskActionMenuItems>;
   artistName?: string | null;
   isDesktopLayout: boolean;
   compactMetadata?: boolean;
@@ -701,7 +687,12 @@ function TaskDocumentPanel({
           data-testid='task-document-scroll-region'
         >
           <div className='mx-auto flex w-full max-w-xl flex-col gap-4 px-4 pb-6 pt-5 sm:px-5 sm:pb-7 sm:pt-6'>
-            <TaskTitleEditor value={title} onChange={onTitleChange} />
+            <div className='flex min-w-0 items-start gap-2'>
+              <div className='min-w-0 flex-1'>
+                <TaskTitleEditor value={title} onChange={onTitleChange} />
+              </div>
+              <TaskRowActionMenu items={actionItems} />
+            </div>
 
             <div
               className={cn(
@@ -1210,121 +1201,59 @@ function useTaskActions({
     [onRequestDelete]
   );
 
-  const getTaskContextMenuItems = useCallback(
-    (task: TaskView): ContextMenuItemType[] => {
+  const getTaskActionMenuItems = useCallback(
+    (task: TaskView, surface: 'context' | 'overflow' | 'detail') => {
       const StageIcon = getTaskStageVisual(task.status, task.agentStatus).icon;
-      const canGeneratePitch = Boolean(
-        task.releaseId &&
-          task.releaseTitle &&
-          isPitchRelatedText(`${task.title} ${task.category ?? ''}`)
-      );
-      const statusIcon = (
-        <StageIcon
-          className={cn('h-4 w-4', task.status === 'done' && 'fill-current')}
-        />
-      );
-      return [
-        {
-          id: 'open-task',
-          label: 'Open Task',
-          icon: <FileText className='h-4 w-4' />,
-          onClick: () => openTaskDocument(task),
+
+      return buildTaskActionMenuItems({
+        task,
+        surface,
+        canGeneratePitch: Boolean(
+          task.releaseId &&
+            task.releaseTitle &&
+            isPitchRelatedText(`${task.title} ${task.category ?? ''}`)
+        ),
+        handlers: {
+          onOpenTask: openTaskDocument,
+          onOpenRelease: openReleaseSidebar,
+          onGeneratePitch,
+          onRequestDelete: handleDeleteTask,
+          onUpdateStatus: (taskId, status) =>
+            updateTaskField(taskId, { status }),
+          onUpdatePriority: (taskId, priority) =>
+            updateTaskField(taskId, { priority }),
+          onUpdateAssignee: (taskId, assigneeKind) =>
+            updateTaskField(taskId, { assigneeKind }),
         },
-        ...(task.releaseId
-          ? [
-              {
-                id: 'open-release',
-                label: 'Open Release',
-                icon: <Disc3 className='h-4 w-4' />,
-                onClick: () => openReleaseSidebar(task),
-              } satisfies ContextMenuItemType,
-              ...(canGeneratePitch
-                ? [
-                    {
-                      id: 'generate-pitch',
-                      label: 'Generate Pitch',
-                      icon: <Sparkles className='h-4 w-4' />,
-                      onClick: () => onGeneratePitch(task),
-                    } satisfies ContextMenuItemType,
-                  ]
-                : []),
-              { type: 'separator' } satisfies ContextMenuItemType,
-            ]
-          : []),
-        {
-          id: 'change-status',
-          label: 'Status',
-          icon: statusIcon,
-          items: TASK_STATUS_OPTIONS.map(([value, label]) => ({
-            id: `status-${value}`,
-            label,
-            icon: <TaskStatusLeadingVisual status={value} />,
-            onClick: () => updateTaskField(task.id, { status: value }),
-            disabled: task.status === value,
-          })),
-        },
-        {
-          id: 'change-priority',
-          label: 'Priority',
-          icon: <TaskPriorityLeadingVisual priority={task.priority} />,
-          items: TASK_PRIORITY_OPTIONS.map(([value, label]) => ({
-            id: `priority-${value}`,
-            label,
-            icon: <TaskPriorityLeadingVisual priority={value} />,
-            onClick: () => updateTaskField(task.id, { priority: value }),
-            disabled: task.priority === value,
-          })),
-        },
-        {
-          id: 'change-assignee',
-          label: 'Assignee',
-          icon: (
+        visuals: {
+          openTask: <FileText className='h-4 w-4' />,
+          openRelease: <Disc3 className='h-4 w-4' />,
+          generatePitch: <Sparkles className='h-4 w-4' />,
+          deleteTask: <Trash2 className='h-4 w-4' />,
+          status: status => {
+            const StatusIcon =
+              status === task.status
+                ? StageIcon
+                : getTaskStatusVisual(status).icon;
+            return (
+              <StatusIcon
+                className={cn('h-4 w-4', status === 'done' && 'fill-current')}
+              />
+            );
+          },
+          priority: priority => (
+            <TaskPriorityLeadingVisual priority={priority} />
+          ),
+          assignee: assigneeKind => (
             <span aria-hidden='true'>
               <TaskAssigneeLeadingVisual
-                assigneeKind={task.assigneeKind}
+                assigneeKind={assigneeKind}
                 artistName={artistName}
               />
             </span>
           ),
-          items: [
-            {
-              id: 'assignee-human',
-              label: 'Me',
-              icon: (
-                <span aria-hidden='true'>
-                  <TaskAssigneeLeadingVisual
-                    assigneeKind='human'
-                    artistName={artistName}
-                  />
-                </span>
-              ),
-              onClick: () =>
-                updateTaskField(task.id, { assigneeKind: 'human' }),
-              disabled: task.assigneeKind === 'human',
-            },
-            {
-              id: 'assignee-jovie',
-              label: 'Jovie',
-              icon: (
-                <span aria-hidden='true'>
-                  <TaskAssigneeLeadingVisual assigneeKind='jovie' />
-                </span>
-              ),
-              onClick: () =>
-                updateTaskField(task.id, { assigneeKind: 'jovie' }),
-              disabled: task.assigneeKind === 'jovie',
-            },
-          ],
         },
-        { type: 'separator' },
-        {
-          id: 'delete-task',
-          label: 'Delete Task',
-          icon: <Trash2 className='h-4 w-4' />,
-          destructive: true,
-          onClick: () => handleDeleteTask(task),
-        },
-      ];
+      });
     },
     [
       artistName,
@@ -1336,7 +1265,25 @@ function useTaskActions({
     ]
   );
 
-  return { getTaskContextMenuItems, handleDeleteTask, updateTaskField };
+  const getTaskContextMenuItems = useCallback(
+    (task: TaskView) => getTaskActionMenuItems(task, 'context'),
+    [getTaskActionMenuItems]
+  );
+  const getTaskOverflowMenuItems = useCallback(
+    (task: TaskView) => getTaskActionMenuItems(task, 'overflow'),
+    [getTaskActionMenuItems]
+  );
+  const getTaskDetailMenuItems = useCallback(
+    (task: TaskView) => getTaskActionMenuItems(task, 'detail'),
+    [getTaskActionMenuItems]
+  );
+
+  return {
+    getTaskContextMenuItems,
+    getTaskDetailMenuItems,
+    getTaskOverflowMenuItems,
+    updateTaskField,
+  };
 }
 
 export function TasksPageClient() {
@@ -1707,7 +1654,12 @@ export function TasksPageClient() {
     [router]
   );
 
-  const { getTaskContextMenuItems, updateTaskField } = useTaskActions({
+  const {
+    getTaskContextMenuItems,
+    getTaskDetailMenuItems,
+    getTaskOverflowMenuItems,
+    updateTaskField,
+  } = useTaskActions({
     artistName,
     onGeneratePitch: handleGenerateTaskPitch,
     onRequestDelete: setTaskPendingDelete,
@@ -2015,7 +1967,7 @@ export function TasksPageClient() {
           hideDue={hideSelectedRowDue && isRowSelected}
           actionSlot={
             <TaskRowActionMenu
-              items={getTaskContextMenuItems(info.row.original)}
+              items={getTaskOverflowMenuItems(info.row.original)}
               selected={isRowSelected}
               visibility='hover'
             />
@@ -2026,7 +1978,7 @@ export function TasksPageClient() {
     [
       artistName,
       effectiveSelectedTaskId,
-      getTaskContextMenuItems,
+      getTaskOverflowMenuItems,
       openReleaseSidebar,
       showAssigneeInListRows,
       hideSelectedRowDue,
@@ -2097,7 +2049,7 @@ export function TasksPageClient() {
         onOpenTask={openTaskDocument}
         onCreateTask={() => setHeaderMode('create')}
         onMoveTask={handleMoveTask}
-        getTaskContextMenuItems={getTaskContextMenuItems}
+        getTaskContextMenuItems={getTaskOverflowMenuItems}
       />
     );
   } else if (isDesktopTaskLayout) {
@@ -2320,6 +2272,7 @@ export function TasksPageClient() {
                     onUpdateAssignee={(taskId, assigneeKind) =>
                       updateTaskField(taskId, { assigneeKind })
                     }
+                    actionItems={getTaskDetailMenuItems(selectedTask)}
                     artistName={artistName}
                     isDesktopLayout={isDesktopTaskLayout}
                     compactMetadata={isBoardMode}
@@ -2336,6 +2289,7 @@ export function TasksPageClient() {
                     onUpdateStatus={NOOP_TASK_STATUS_UPDATE}
                     onUpdatePriority={NOOP_TASK_PRIORITY_UPDATE}
                     onUpdateAssignee={NOOP_TASK_ASSIGNEE_UPDATE}
+                    actionItems={[]}
                     artistName={artistName}
                     isDesktopLayout={isDesktopTaskLayout}
                     compactMetadata={false}

--- a/apps/web/components/features/dashboard/tasks/task-action-registry.test.tsx
+++ b/apps/web/components/features/dashboard/tasks/task-action-registry.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ContextMenuItemType } from '@/components/organisms/table';
+import type { TaskView } from '@/lib/tasks/types';
+import { buildTaskActionMenuItems } from './task-action-registry';
+
+const task = {
+  id: 'task-1',
+  taskNumber: 24,
+  title: 'Pitch the release',
+  status: 'todo',
+  priority: 'high',
+  assigneeKind: 'human',
+  releaseId: 'release-1',
+  releaseTitle: 'Midnight Radio',
+} as TaskView;
+
+function itemIds(items: readonly ContextMenuItemType[]): string[] {
+  return items.flatMap(item => ('id' in item ? [item.id] : []));
+}
+
+function renderActions(surface: 'context' | 'overflow' | 'detail') {
+  return buildTaskActionMenuItems({
+    task,
+    surface,
+    canGeneratePitch: true,
+    handlers: {
+      onOpenTask: vi.fn(),
+      onOpenRelease: vi.fn(),
+      onGeneratePitch: vi.fn(),
+      onRequestDelete: vi.fn(),
+      onUpdateStatus: vi.fn(),
+      onUpdatePriority: vi.fn(),
+      onUpdateAssignee: vi.fn(),
+    },
+    visuals: {
+      openTask: 'open-task',
+      openRelease: 'open-release',
+      generatePitch: 'generate-pitch',
+      deleteTask: 'delete-task',
+      status: status => status,
+      priority: priority => priority,
+      assignee: assignee => assignee,
+    },
+  });
+}
+
+describe('buildTaskActionMenuItems', () => {
+  it('keeps Open Task exclusive to the context menu while preserving core mutations in overflow', () => {
+    expect(itemIds(renderActions('context'))).toEqual(
+      expect.arrayContaining([
+        'open-task',
+        'change-status',
+        'change-priority',
+        'change-assignee',
+        'open-release',
+        'generate-pitch',
+        'delete-task',
+      ])
+    );
+    expect(itemIds(renderActions('overflow'))).not.toContain('open-task');
+    expect(itemIds(renderActions('overflow'))).toEqual(
+      expect.arrayContaining([
+        'change-status',
+        'change-priority',
+        'change-assignee',
+        'open-release',
+        'generate-pitch',
+        'delete-task',
+      ])
+    );
+  });
+
+  it('removes redundant property and release actions from task detail while retaining eligible generation and delete', () => {
+    expect(itemIds(renderActions('detail'))).toEqual([
+      'generate-pitch',
+      'delete-task',
+    ]);
+  });
+});

--- a/apps/web/components/features/dashboard/tasks/task-action-registry.tsx
+++ b/apps/web/components/features/dashboard/tasks/task-action-registry.tsx
@@ -1,0 +1,168 @@
+import type { ReactNode } from 'react';
+import type { ContextMenuItemType } from '@/components/organisms/table';
+import type {
+  TaskAssigneeKind,
+  TaskPriority,
+  TaskStatus,
+  TaskView,
+} from '@/lib/tasks/types';
+
+export const TASK_STATUS_OPTIONS = [
+  ['backlog', 'Backlog'],
+  ['todo', 'Todo'],
+  ['in_progress', 'In Progress'],
+  ['done', 'Done'],
+  ['cancelled', 'Cancelled'],
+] as const satisfies ReadonlyArray<readonly [TaskStatus, string]>;
+
+export const TASK_PRIORITY_OPTIONS = [
+  ['urgent', 'Urgent'],
+  ['high', 'High'],
+  ['medium', 'Medium'],
+  ['low', 'Low'],
+  ['none', 'None'],
+] as const satisfies ReadonlyArray<readonly [TaskPriority, string]>;
+
+export const TASK_ASSIGNEE_OPTIONS = [
+  ['human', 'Me'],
+  ['jovie', 'Jovie'],
+] as const satisfies ReadonlyArray<readonly [TaskAssigneeKind, string]>;
+
+/** The invoking surface controls only redundancy, never available capability. */
+export type TaskActionSurface = 'context' | 'overflow' | 'detail';
+
+interface TaskActionHandlers {
+  readonly onOpenTask: (task: TaskView) => void;
+  readonly onOpenRelease: (task: TaskView) => void;
+  readonly onGeneratePitch: (task: TaskView) => void;
+  readonly onRequestDelete: (task: TaskView) => void;
+  readonly onUpdateStatus: (taskId: string, status: TaskStatus) => void;
+  readonly onUpdatePriority: (taskId: string, priority: TaskPriority) => void;
+  readonly onUpdateAssignee: (
+    taskId: string,
+    assigneeKind: TaskAssigneeKind
+  ) => void;
+}
+
+interface TaskActionVisuals {
+  readonly openTask: ReactNode;
+  readonly openRelease: ReactNode;
+  readonly generatePitch: ReactNode;
+  readonly deleteTask: ReactNode;
+  readonly status: (status: TaskStatus) => ReactNode;
+  readonly priority: (priority: TaskPriority) => ReactNode;
+  readonly assignee: (assigneeKind: TaskAssigneeKind) => ReactNode;
+}
+
+function withSeparator(
+  items: ContextMenuItemType[],
+  group: ContextMenuItemType[]
+): ContextMenuItemType[] {
+  if (items.length > 0 && group.length > 0) {
+    items.push({ type: 'separator' });
+  }
+  items.push(...group);
+  return items;
+}
+
+/**
+ * Canonical Task action source for table context menus, overflow triggers, and
+ * the task detail surface. Detail already exposes the three frequent property
+ * controls inline, so its overflow intentionally omits those duplicates.
+ */
+export function buildTaskActionMenuItems({
+  task,
+  surface,
+  canGeneratePitch,
+  handlers,
+  visuals,
+}: Readonly<{
+  task: TaskView;
+  surface: TaskActionSurface;
+  canGeneratePitch: boolean;
+  handlers: TaskActionHandlers;
+  visuals: TaskActionVisuals;
+}>): ContextMenuItemType[] {
+  const items: ContextMenuItemType[] = [];
+
+  if (surface === 'context') {
+    items.push({
+      id: 'open-task',
+      label: 'Open Task',
+      icon: visuals.openTask,
+      onClick: () => handlers.onOpenTask(task),
+    });
+  }
+
+  if (surface !== 'detail') {
+    withSeparator(items, [
+      {
+        id: 'change-status',
+        label: 'Status',
+        icon: visuals.status(task.status),
+        items: TASK_STATUS_OPTIONS.map(([value, label]) => ({
+          id: `status-${value}`,
+          label,
+          icon: visuals.status(value),
+          onClick: () => handlers.onUpdateStatus(task.id, value),
+          disabled: task.status === value,
+        })),
+      },
+      {
+        id: 'change-priority',
+        label: 'Priority',
+        icon: visuals.priority(task.priority),
+        items: TASK_PRIORITY_OPTIONS.map(([value, label]) => ({
+          id: `priority-${value}`,
+          label,
+          icon: visuals.priority(value),
+          onClick: () => handlers.onUpdatePriority(task.id, value),
+          disabled: task.priority === value,
+        })),
+      },
+      {
+        id: 'change-assignee',
+        label: 'Assignee',
+        icon: visuals.assignee(task.assigneeKind),
+        items: TASK_ASSIGNEE_OPTIONS.map(([value, label]) => ({
+          id: `assignee-${value}`,
+          label,
+          icon: visuals.assignee(value),
+          onClick: () => handlers.onUpdateAssignee(task.id, value),
+          disabled: task.assigneeKind === value,
+        })),
+      },
+    ]);
+  }
+
+  const relatedItems: ContextMenuItemType[] = [];
+  if (task.releaseId && surface !== 'detail') {
+    relatedItems.push({
+      id: 'open-release',
+      label: 'Open Release',
+      icon: visuals.openRelease,
+      onClick: () => handlers.onOpenRelease(task),
+    });
+  }
+  if (canGeneratePitch) {
+    relatedItems.push({
+      id: 'generate-pitch',
+      label: 'Generate Pitch',
+      icon: visuals.generatePitch,
+      onClick: () => handlers.onGeneratePitch(task),
+    });
+  }
+  withSeparator(items, relatedItems);
+
+  withSeparator(items, [
+    {
+      id: 'delete-task',
+      label: 'Delete Task',
+      icon: visuals.deleteTask,
+      destructive: true,
+      onClick: () => handlers.onRequestDelete(task),
+    },
+  ]);
+
+  return items;
+}


### PR DESCRIPTION
## Summary

- centralize task actions in one typed registry shared by table context menus, row and board overflow menus, and the task detail overflow
- keep direct detail controls for status, priority, assignee, and linked release while removing duplicate menu entries
- preserve the existing delete confirmation and pitch eligibility rules without adding unsupported archive or due-date behavior

## Verification

- pnpm biome check on all three changed files
- 57 focused Vitest assertions passed
- @jovie/web typecheck passed
- git diff origin/main...HEAD --check passed

<!-- linear-issue-id:JOV-4690 -->