### PR TITLE
feat(agentos): complete Design/Taste department policy + role (JOV-2012)

### DIFF
--- a/agentos/agents/README.md
+++ b/agentos/agents/README.md
@@ -4,10 +4,11 @@ Per-agent role definition files for AgentOS-specific agent types. One `.md` file
 
 See `.claude/skills/` for gstack skill examples of the general pattern. AgentOS agent roles defined here are product-specific and go beyond gstack's workflow skills.
 
-Planned roles (from the AgentOS architecture plan):
+Defined / planned roles:
 
-- `design-lever-scout.md` — discovers design improvement opportunities across authenticated routes
+- `design-taste-department.md` — Design/Taste department agent: policy-backed UI diff taste enforcement (JOV-2012)
 - `design-html-builder.md` — D5 builder: `/design-html` job for approved Design Lab proposals (JOV-1939)
-- `visual-qa-agent.md` — screenshot-based visual regression and consistency audit
+- `design-lever-scout.md` — (planned) discovers design improvement opportunities across authenticated routes
+- `visual-qa-agent.md` — (planned) screenshot-based visual regression and consistency audit
 
 Defined roles live as `.md` files in this directory. Add new role files when a new agent type is formally approved.

--- a/agentos/agents/design-taste-department.md
+++ b/agentos/agents/design-taste-department.md
@@ -1,0 +1,55 @@
+# design-taste-department
+
+Role definition for the AgentOS **Design/Taste department agent** (JOV-2012).
+
+Owns design-system consistency and taste enforcement across UI-touching changes.
+
+## Canonical policy
+
+1. `agentos/memory/design-taste.md` — runtime policy seed (required; read every run)
+2. `DESIGN.md` + `.claude/rules/ui.md` — parent doctrine
+
+## KPI domain
+
+- Design system coverage (token-compliant hunks vs hardcoded colors)
+- Taste rule violations caught per run / sprint
+- Surface elevation consistency score
+
+## Dispatch triggers
+
+| Trigger | When |
+| --- | --- |
+| `ui-pr` | Changed files include UI-touching paths (same filters as design-taste-jury) |
+| `scheduled-audit` | Explicit scheduled design-system audit (`--trigger=scheduled-audit`) |
+
+## Runtime
+
+- Library: `apps/web/lib/agent-os/departments/design-taste/`
+- CLI: `pnpm --filter @jovie/web run design-taste-department -- --run-id=<id> …`
+- Model route: **deterministic** (regex scanners; no paid model call)
+
+## Workflow
+
+1. Decide dispatch (`ui-pr` vs skip vs forced `scheduled-audit`).
+2. Load and excerpt `agentos/memory/design-taste.md` (fail closed if missing/empty).
+3. Parse unified diff added lines for reviewable UI files.
+4. Flag elevation, motion, emoji, casing, and hardcoded-token violations.
+5. Compute KPIs and build fix proposals:
+   - always a **PR comment** proposal
+   - plus **auto-fix branch** proposal when error-severity findings exist
+6. Record `AgentRunArtifact` (`kind: design_review`) + `manifest.json` + `pr-comment.md` + `complete.json` under `agentos/runs/design-taste/<run-id>/`.
+
+## Allowed actions
+
+`read`, `classify`, `rank`, `summarize`, `draft`, `open_pr`
+
+## Forbidden actions
+
+`merge`, `deploy`, `ready_pr`, `mutate_production_data`, `change_auth`, `change_billing`, `change_security`, `send_outbound`
+
+## Do not
+
+- Merge or ready PRs unattended
+- Invent product UI redesigns outside the diff under review
+- Skip writing the AgentRunArtifact when the department runs
+- Treat bot taste comments as merge blockers (advisory proposals only)

--- a/agentos/memory/design-taste.md
+++ b/agentos/memory/design-taste.md
@@ -1,6 +1,74 @@
 # Design Taste
 
-Visual and UX taste rules distilled from human feedback, DESIGN.md, and post-mortems.
-Design/Taste department (JOV-2012) reads this each run. Enforce: solid elevation, no hover motion/transition-all, no emoji, Title Case (no uppercase chrome), semantic tokens only (no arbitrary hex).
+Visual and UX taste rules distilled from human feedback, `DESIGN.md`, and `.claude/rules/ui.md`.
+Parent doctrine remains those sources; this file is the AgentOS runtime policy seed for the
+**Design/Taste department agent** (JOV-2012).
 
-(Empty — populate with human approval.)
+## Enforcement scope
+
+Deterministic scanners review **added lines** in UI-touching diffs (and scheduled audits that
+supply a diff). Findings map to:
+
+| Rule id | Severity | Signal |
+| --- | --- | --- |
+| `elevation` | error / warning | Semi-transparent surfaces, stripped card elevation, shell canvas on children |
+| `motion` | error | Decorative hover translate/scale, `transition-all` |
+| `emoji` | error | Emoji in product UI markup or strings |
+| `casing` | warning | All-caps `uppercase` chrome on labels |
+| `hardcoded-token` | error | Arbitrary hex colors (`text-[#…]`, `bg-[#…]`, …) |
+
+## Rules (ship checklist)
+
+### Surface elevation
+
+- Shared cards/panels use solid `bg-surface-1` (with border + shadow when elevated).
+- Recessed wells use solid `bg-surface-0`.
+- Never `bg-surface-0/XX` or `bg-surface-1/XX`.
+- Never `Card` / panel with both `border-0` and `shadow-none` when elevation is required.
+- Do not paint child cards with `bg-(--linear-app-content-surface)` (shell canvas).
+
+### Motion
+
+- No decorative hover lift/scale (`hover:translate-*`, `hover:scale-*`, `group-hover:` motion).
+- No `transition-all` in product UI.
+- Prefer color, border, opacity, or shadow hover feedback.
+- Intentional open/close motion for menus/drawers is out of scope for this scanner.
+
+### Emoji
+
+- Never use emoji characters in component markup, mock data, or UI strings.
+- Use Lucide icons or `SocialIcon` for brand marks.
+
+### Casing
+
+- Title Case for labels, headings, buttons, badges, column headers, nav items.
+- Sentence case for body, descriptions, tooltips, toasts.
+- Do not use Tailwind `uppercase` as product-label chrome.
+
+### Tokens
+
+- Prefer semantic Tailwind tokens (`text-primary-token`, `bg-surface-1`, `border-subtle`, accents).
+- No arbitrary hex utilities (`text-[#ff00aa]`, `bg-[#fff]`, …).
+- Converge arbitrary values; never add new ones for color.
+
+## KPIs (department run)
+
+- **Design system coverage** — fraction of reviewed added UI hunks without hardcoded-token hits.
+- **Taste rule violations caught** — total findings (by rule) for the run/sprint window.
+- **Surface elevation consistency score** — `1 - (elevation findings / files reviewed)` clamped to `[0,1]`.
+
+## Dispatch
+
+- **UI PR**: any PR whose changed paths match UI touch filters (same family as design-taste-jury).
+- **Scheduled audit**: explicit `--trigger=scheduled-audit` (or `forceScheduledAudit`).
+
+## Outputs
+
+- PR comment proposal (`pr-comment.md`) with findings + embedded AgentRunArtifact.
+- Auto-fix branch proposal when error-severity findings exist (proposal only; no unattended merge).
+- `AgentRunArtifact` (`kind: design_review`) under `agentos/runs/design-taste/<run-id>/`.
+
+## Do not expand without human approval
+
+Long-form taste essays, marketing-only layout doctrine, and non-diff full-tree rewrites stay in
+`DESIGN.md` / design skills — not duplicated here.

--- a/apps/web/tests/unit/agent-os/departments/design-taste/design-taste-department.test.ts
+++ b/apps/web/tests/unit/agent-os/departments/design-taste/design-taste-department.test.ts
@@ -15,32 +15,52 @@ vi.mock('server-only', () => ({}));
 const DIFF = `diff --git a/apps/web/components/features/dashboard/Card.tsx b/apps/web/components/features/dashboard/Card.tsx
 --- a/apps/web/components/features/dashboard/Card.tsx
 +++ b/apps/web/components/features/dashboard/Card.tsx
-@@ -1,3 +1,4 @@
+@@ -1,3 +1,5 @@
  export function Card() {
 -  return <div className="bg-surface-1">Ok</div>;
-+  return <div className="bg-surface-1/50 hover:translate-y-1 text-[#ff00aa]">Ship it 🚀</div>;
++  return (
++    <div className="bg-surface-1/50 hover:translate-y-1 uppercase text-[#ff00aa]">Ship it 🚀</div>
++  );
  }`;
+
 describe('design-taste department', () => {
   let policyPath = '';
   let rootDirectory = '';
+
   beforeEach(async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'dt-dept-'));
     policyPath = path.join(root, 'memory.md');
     rootDirectory = path.join(root, 'runs');
-    await writeFile(policyPath, '# Design Taste\n\n### Elevation\n- solid.\n');
+    await writeFile(
+      policyPath,
+      '# Design Taste\n\n### Elevation\n- solid surfaces only.\n### Motion\n- no hover translate.\n'
+    );
   });
-  it('loads policy, flags violations, records AgentRunArtifact', async () => {
+
+  it('skips non-UI PRs and runs scheduled audits', () => {
     expect(
       decideDesignTasteDispatch({
         changedFiles: ['apps/web/lib/db/schema.ts'],
       }).shouldRun
     ).toBe(false);
-    const rules = new Set(
-      reviewDesignTasteHunks(parseUnifiedDiff(DIFF)).map(f => f.ruleId)
-    );
+
+    const scheduled = decideDesignTasteDispatch({
+      changedFiles: ['apps/web/lib/db/schema.ts'],
+      forceScheduledAudit: true,
+    });
+    expect(scheduled.shouldRun).toBe(true);
+    expect(scheduled.trigger).toBe('scheduled-audit');
+  });
+
+  it('loads policy, flags violations, records AgentRunArtifact', async () => {
+    const findings = reviewDesignTasteHunks(parseUnifiedDiff(DIFF));
+    const rules = new Set(findings.map(f => f.ruleId));
     expect(rules.has('elevation')).toBe(true);
     expect(rules.has('motion')).toBe(true);
     expect(rules.has('emoji')).toBe(true);
+    expect(rules.has('casing')).toBe(true);
+    expect(rules.has('hardcoded-token')).toBe(true);
+
     const result = await runDesignTasteDepartment({
       runId: `r-${Date.now().toString(36)}`,
       changedFiles: ['apps/web/components/features/dashboard/Card.tsx'],
@@ -50,14 +70,44 @@ describe('design-taste department', () => {
       policyPath,
       rootDirectory,
     });
+
     expect(result.ran).toBe(true);
+    expect(result.trigger).toBe('ui-pr');
     expect(result.manifest?.policyExcerpt).toContain('Elevation');
+    expect(result.manifest?.kpis.violationsCaught).toBeGreaterThan(0);
+    expect(result.manifest?.kpis.designSystemCoverage).toBeLessThan(1);
+    expect(result.manifest?.kpis.surfaceElevationConsistencyScore).toBeLessThan(
+      1
+    );
     expect(result.manifest?.proposals.map(p => p.kind)).toEqual(
       expect.arrayContaining(['pr-comment', 'auto-fix-branch'])
     );
-    const parsed = safeParseAgentRunArtifact(
-      JSON.parse(await readFile(result.artifactPath!, 'utf8'))
+
+    const artifactRaw = JSON.parse(
+      await readFile(result.artifactPath!, 'utf8')
     );
-    expect(parsed.success && parsed.data.kind === 'design_review').toBe(true);
+    const parsed = safeParseAgentRunArtifact(artifactRaw);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.kind).toBe('design_review');
+      expect(parsed.data.metadata.department).toBe('design-taste');
+      expect(parsed.data.humanApprovalRequired).toBe(true);
+    }
+
+    const prComment = await readFile(result.prCommentPath!, 'utf8');
+    expect(prComment).toContain('Design/Taste Department Review');
+    expect(prComment).toContain('agent-run-artifact');
+  });
+
+  it('fails closed when design-taste policy is missing', async () => {
+    await expect(
+      runDesignTasteDepartment({
+        runId: 'missing-policy',
+        changedFiles: ['apps/web/components/features/dashboard/Card.tsx'],
+        unifiedDiff: DIFF,
+        policyPath: path.join(rootDirectory, 'does-not-exist.md'),
+        rootDirectory,
+      })
+    ).rejects.toThrow(/policy missing/i);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up polish for the Design/Taste department agent already landed in #15276.

- Full policy seed in `agentos/memory/design-taste.md` (elevation, motion, emoji, casing, tokens + KPIs + dispatch)
- Agent role definition `agentos/agents/design-taste-department.md` + agents README entry
- Stronger unit tests: scheduled dispatch, all five rule families, KPIs, fail-closed missing policy, PR comment artifact

Core runtime (`apps/web/lib/agent-os/departments/design-taste/`) and CLI already merged via #15276.

## Test plan / results

- [x] `pnpm --filter web exec vitest run tests/unit/agent-os/departments/design-taste` — **3/3 passed**
- [x] Pre-push affected verify passed (related tests + harness check)

## Risk

Low — docs/policy/tests only. No product runtime change.

## Fixes

Fixes JOV-2012

<!-- linear-issue-id:JOV-2012 -->