### PR TITLE
feat(agentos): finish Design/Taste department ship surface (JOV-2012)

### DIFF
--- a/agentos/README.md
+++ b/agentos/README.md
@@ -9,6 +9,14 @@ AgentOS is the private orchestration surface for Jovie. Linear is the canonical 
 | `agents/` | Per-agent role definition files for AgentOS-specific agent types |
 | `runs/` | Agent run output artifacts (screenshots, diffs, generated proposals) |
 
+## Department agents
+
+| Role | Policy | Runtime | CLI |
+|------|--------|---------|-----|
+| Design/Taste ([`agents/design-taste-department.md`](./agents/design-taste-department.md)) | [`memory/design-taste.md`](./memory/design-taste.md) | `apps/web/lib/agent-os/departments/design-taste/` | `pnpm --filter @jovie/web run design-taste-department -- --run-id=<id>` |
+
+Design/Taste dispatches on UI-touching PRs (`ui-pr`) or forced scheduled audits (`--trigger=scheduled-audit`). Runs write `AgentRunArtifact` under `runs/design-taste/<run-id>/`.
+
 ## References
 
 - Phase 0 ADR: [`docs/AGENT_OS_ARCHITECTURE.md`](../docs/AGENT_OS_ARCHITECTURE.md)

--- a/agentos/runs/README.md
+++ b/agentos/runs/README.md
@@ -7,6 +7,7 @@ Run directories follow the naming convention: `<run-type>/<YYYY-MM-DD>/<run-id>/
 Examples:
 - `design-review/2026-05-08/abc123/`
 - `qa/2026-05-08/def456/`
+- `design-taste/<run-id>/{manifest,agent-run-artifact,pr-comment,complete}.json|md` (Design/Taste department; JOV-2012)
 - `visual-qa/<run_id>/<surface>/{baseline,after}-{dark,light}.png` (proposal-validation captures; see `apps/web/lib/visual-qa/registry.ts`)
 - `visual-qa/<run_id>/<surface>/diff-overlay.png` (pixel-diff overlay artifacts)
 - `visual-qa/<run_id>/diff-summary.json` (pixel-diff summary)

--- a/scripts/repo-hygiene-guard.mjs
+++ b/scripts/repo-hygiene-guard.mjs
@@ -97,7 +97,7 @@ const FORBIDDEN_GENERATED_PATHS = [
   /^\.context\/qa\/releases-dashboard(?:\/|$)/,
   /^apps\/web\/audit-screenshots(?:\/|$)/,
   /^apps\/web\/\.issues(?:\/|$)/,
-  /^agentos\/runs\/(?:design-lab|design-taste-jury)(?:\/|$)/,
+  /^agentos\/runs\/(?:design-lab|design-taste|design-taste-jury)(?:\/|$)/,
 ];
 
 const TEMP_FILE_PATTERN =

--- a/scripts/repo-hygiene-guard.test.mjs
+++ b/scripts/repo-hygiene-guard.test.mjs
@@ -120,6 +120,7 @@ test('blocks every ignored generated output even when presented as an added path
     'apps/web/audit-screenshots/signin.png',
     'apps/web/.issues/sonar-issues-latest.json',
     'agentos/runs/design-lab/dispatches/design-lab-id.json',
+    'agentos/runs/design-taste/run-1/manifest.json',
     'agentos/runs/design-taste-jury/run-1/manifest.json',
     'scripts/node_modules/.vite/vitest/results.json',
   ]) {


### PR DESCRIPTION
## Summary

Final ship-surface completion for JOV-2012 after the department runtime (#15276) and policy/role/tests (#15329) landed.

- Document Design/Taste department entry points in `agentos/README.md`
- Note department run layout in `agentos/runs/README.md`
- Treat `agentos/runs/design-taste/**` as generated output in repo hygiene (alongside design-lab / design-taste-jury)

### JOV-2012 acceptance (full stack)

| Criterion | Status |
| --- | --- |
| Reads `agentos/memory/design-taste.md` | On main (#15276 + #15329) |
| Reviews diffs for elevation/motion/emoji/casing (+ tokens) | On main (#15276) |
| Proposes PR comment or auto-fix branch | On main (#15276) |
| Records `AgentRunArtifact` | On main (#15276) |
| KPI domain + role policy seed | On main (#15329) |
| Hygiene/docs ship surface | **This PR** |

CLI: `pnpm --filter @jovie/web run design-taste-department -- --run-id=<id> [--trigger=scheduled-audit]`

## Test plan / results

- [x] `pnpm --filter web exec vitest run tests/unit/agent-os/departments/design-taste` — **3/3 passed** (pre-push)
- [x] Hygiene path: `agentos/runs/design-taste/**` blocked as generated output
- [x] Pre-push typecheck/lint/harness — **passed**

## Risk

Low — docs + hygiene path only. No product runtime change.

## Fixes

Fixes JOV-2012

<!-- linear-issue-id:JOV-2012 -->