### PR TITLE
fix(shell): refine sidebar chrome [JOV-4695]

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -474,7 +474,7 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
                       {index === 0 && searchSurface ? (
                         <div
                           data-sidebar-search-slot='true'
-                          className='mb-3 mt-1.5 h-7 shrink-0 group-data-[collapsible=icon]:hidden'
+                          className='mb-4 mt-1.5 h-7 shrink-0 group-data-[collapsible=icon]:hidden'
                         >
                           {searchSurface}
                         </div>

--- a/apps/web/components/molecules/WorkspaceSelector.stories.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { WorkspaceSelector } from './WorkspaceSelector';
+
+const workspaces = [
+  {
+    id: 'customer',
+    label: 'Jovie',
+    href: '/app',
+    brandVariant: 'jovie' as const,
+  },
+  {
+    id: 'ov',
+    label: 'OV',
+    href: '/app/ov',
+    brandVariant: 'ov' as const,
+  },
+  {
+    id: 'support',
+    label: 'Support',
+    href: '/app/support',
+    brandVariant: 'jovie' as const,
+  },
+] as const;
+
+const meta: Meta<typeof WorkspaceSelector> = {
+  title: 'Molecules/WorkspaceSelector',
+  component: WorkspaceSelector,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    currentWorkspaceId: 'customer',
+    workspaces,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const OVActive: Story = {
+  args: {
+    currentWorkspaceId: 'ov',
+  },
+};

--- a/apps/web/components/molecules/WorkspaceSelector.test.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.test.tsx
@@ -45,9 +45,9 @@ describe('WorkspaceSelector', () => {
       <WorkspaceSelector currentWorkspaceId='ov' workspaces={workspaces} />
     );
 
-    expect(
-      screen.getByRole('button', { name: 'Switch Workspace' })
-    ).toHaveTextContent('OV');
+    const trigger = screen.getByRole('button', { name: 'Switch Workspace' });
+    expect(trigger).toHaveTextContent('OV');
+    expect(trigger.querySelector('svg.lucide-chevron-down')).toBeNull();
   });
 
   it('renders every supplied workspace with the active destination marked', () => {

--- a/apps/web/components/molecules/WorkspaceSelector.tsx
+++ b/apps/web/components/molecules/WorkspaceSelector.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@jovie/ui';
-import { Check, ChevronDown } from 'lucide-react';
+import { Check } from 'lucide-react';
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
@@ -52,10 +52,6 @@ export function WorkspaceSelector<Id extends string>({
           <span className='truncate flex-1 text-left text-app tracking-tight text-sidebar-item-foreground [font-weight:var(--font-weight-nav)] group-data-[collapsible=icon]:hidden'>
             {currentWorkspace.label}
           </span>
-          <ChevronDown
-            className='size-2.5 shrink-0 text-sidebar-item-icon group-data-[collapsible=icon]:hidden'
-            aria-hidden='true'
-          />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='start' sideOffset={4} className='w-48'>

--- a/apps/web/components/organisms/user-button/UserButton.stories.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { UserButton } from './UserButton';
+
+const meta: Meta<typeof UserButton> = {
+  title: 'Organisms/UserButton',
+  component: UserButton,
+  parameters: {
+    layout: 'centered',
+    jovie: {
+      uncoveredProps: ['disabled', 'loading'],
+    },
+  },
+  args: {
+    showUserInfo: true,
+    profileHref: '/app/settings/profile',
+    settingsHref: '/app/settings',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Compact: Story = {
+  args: {
+    showUserInfo: false,
+  },
+};

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -26,6 +26,7 @@ import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import { GLYPH_CMD, GLYPH_OPT, GLYPH_SHIFT } from '@/lib/keyboard-shortcuts';
 import { useFeedbackMutation } from '@/lib/queries';
+import { cn } from '@/lib/utils';
 import { Icon } from '../../atoms/Icon';
 import { Avatar } from '../../molecules/Avatar/Avatar';
 import type { UserButtonProps } from './types';
@@ -554,7 +555,7 @@ export function UserButton({
     (showUserInfo ? (
       <button
         type='button'
-        className='flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-0'
+        className='group/user-button flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-0'
       >
         <Avatar
           src={userImageUrl}
@@ -577,7 +578,12 @@ export function UserButton({
         <Icon
           name='ChevronRight'
           data-user-button-chevron
-          className='size-3 text-sidebar-item-icon group-data-[collapsible=icon]:hidden'
+          className={cn(
+            'size-3 text-sidebar-item-icon transition-opacity duration-subtle group-data-[collapsible=icon]:hidden',
+            isMenuOpen
+              ? 'opacity-100'
+              : 'opacity-0 group-hover/user-button:opacity-100 group-focus-visible/user-button:opacity-100'
+          )}
           aria-hidden='true'
         />
       </button>

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+// @coverage-via apps/web/tests/components/user-button.test.tsx
+
 import type { CommonDropdownItem, CommonDropdownSubmenu } from '@jovie/ui';
 import { Button, CommonDropdown } from '@jovie/ui';
 import {

--- a/apps/web/components/shell/HeaderSearchSurfaceFromContext.tsx
+++ b/apps/web/components/shell/HeaderSearchSurfaceFromContext.tsx
@@ -3,6 +3,10 @@
 import { Search } from 'lucide-react';
 import { useHeaderActions } from '@/contexts/HeaderActionsContext';
 import { cn } from '@/lib/utils';
+import {
+  getSidebarNavIconClassName,
+  getSidebarNavRowClassName,
+} from './SidebarNavItem';
 
 /**
  * Sidebar entry for the one shell-owned search/command surface.
@@ -23,12 +27,17 @@ export function HeaderSearchSurfaceFromContext({
       data-app-search-trigger='true'
       onClick={openCommandPalette}
       className={cn(
-        'inline-flex h-9 min-h-9 w-full min-w-0 items-center justify-start gap-2 rounded-xl border border-subtle bg-surface-0 px-3 text-left text-xs text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle ease-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-ring-themed',
+        getSidebarNavRowClassName({}),
+        'grid-cols-[18px_minmax(0,1fr)_auto] text-left',
         className
       )}
       aria-label='Search Jovie'
     >
-      <Search className='size-4 shrink-0' aria-hidden='true' />
+      <Search
+        className={getSidebarNavIconClassName({})}
+        aria-hidden='true'
+        strokeWidth={2}
+      />
       <span className='min-w-0 flex-1 truncate'>Search</span>
       <kbd className='shrink-0 text-2xs text-tertiary-token'>⌘K</kbd>
     </button>

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -36,11 +36,11 @@ interface SidebarNavChromeOptions {
   readonly className?: string;
 }
 
-// Create actions are deliberately not a second selected-nav treatment. The
-// compact light pill distinguishes creation without competing with the route's
-// neutral active state, including when the chat route is current.
+// Create actions are deliberately not a second selected-nav treatment. Keep
+// them compact and secondary so the active destination remains the strongest
+// signal in the rail.
 const SIDEBAR_PRIMARY_CHROME =
-  'w-fit grid-cols-[22px_auto] gap-x-2 bg-btn-primary px-3 text-btn-primary-foreground font-medium shadow-none hover:bg-btn-primary-hover';
+  'w-fit grid-cols-[18px_auto] gap-x-1.5 bg-sidebar-accent/40 px-2.5 text-sidebar-item-foreground font-medium shadow-none hover:bg-sidebar-accent/70';
 
 // Active state uses a quiet neutral fill with white type and a Jovie teal icon.
 // Avoid a left rail or guide decoration so every shared sidebar consumer keeps
@@ -86,8 +86,8 @@ export function getSidebarNavRowClassName({
       ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center'
       : cn(
           trailingOverlay
-            ? 'grid-cols-[22px_minmax(0,1fr)]'
-            : 'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
+            ? 'grid-cols-[18px_minmax(0,1fr)]'
+            : 'grid-cols-[18px_minmax(0,1fr)_minmax(34px,auto)]',
           nonCollapsedSize,
           'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'
         ),
@@ -113,7 +113,7 @@ export function getSidebarNavIconClassName({
     // The selected row deliberately owns white label text. Keep its icon on
     // the canonical Jovie teal token so the active signal remains quiet.
     tone === 'primary'
-      ? 'text-btn-primary-foreground'
+      ? 'text-accent-teal!'
       : active
         ? 'text-accent-teal!'
         : inactiveIconColor,
@@ -144,7 +144,7 @@ export function SidebarNavItem({
           nested,
           tight,
         })}
-        strokeWidth={2.25}
+        strokeWidth={2}
       />
       {!collapsed && (
         <span className='min-w-0 justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left [mask-image:linear-gradient(to_right,black_calc(100%_-_1rem),transparent)]'>

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -65,10 +65,10 @@ describe('SidebarThreadsSection', () => {
       name: `Chat Actions for ${title}`,
     });
 
-    expect(row).toHaveClass('grid-cols-[22px_minmax(0,1fr)]');
+    expect(row).toHaveClass('grid-cols-[18px_minmax(0,1fr)]');
     expect(row).not.toHaveClass(
-      'grid-cols-[22px_minmax(0,1fr)_20px]',
-      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]',
+      'grid-cols-[18px_minmax(0,1fr)_20px]',
+      'grid-cols-[18px_minmax(0,1fr)_minmax(34px,auto)]',
       'pr-8'
     );
     expect(action).toHaveClass('right-2.5', 'group-hover/thread:bg-surface-0');

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -60,12 +60,14 @@ describe('DashboardNav interactions', () => {
     );
     const inbox = screen.getByRole('link', { name: 'Inbox' });
 
-    expect(newChat).toHaveClass('w-fit', 'rounded-full', 'bg-btn-primary');
-    expect(newChat).not.toHaveClass('bg-sidebar-accent-active', 'w-full');
-    expect(newChat.querySelector('svg')).toHaveClass(
-      'text-btn-primary-foreground'
+    expect(newChat).toHaveClass(
+      'w-fit',
+      'rounded-full',
+      'bg-sidebar-accent/40'
     );
-    expect(searchSlot).toHaveClass('mt-1.5', 'mb-3');
+    expect(newChat).not.toHaveClass('bg-sidebar-accent-active', 'w-full');
+    expect(newChat.querySelector('svg')).toHaveClass('text-accent-teal!');
+    expect(searchSlot).toHaveClass('mt-1.5', 'mb-4');
     expect(screen.getAllByRole('button', { name: 'Search' })).toHaveLength(1);
     expect(
       newChat.compareDocumentPosition(searchSlot!) &

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -813,8 +813,11 @@ describe('UserButton billing actions', () => {
     expect(
       trigger.querySelector('[data-user-button-display-name]')
     ).toHaveClass('group-data-[collapsible=icon]:hidden');
+    expect(trigger).toHaveClass('group/user-button');
     expect(trigger.querySelector('[data-user-button-chevron]')).toHaveClass(
-      'group-data-[collapsible=icon]:hidden'
+      'group-data-[collapsible=icon]:hidden',
+      'opacity-0',
+      'group-hover/user-button:opacity-100'
     );
   });
 

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -268,16 +268,14 @@ describe('DashboardNav', () => {
     const chatLink = getByRole('link', { name: 'New Chat' });
     expect(chatLink).toHaveClass('w-fit');
     expect(chatLink).toHaveClass('rounded-full');
-    expect(chatLink).toHaveClass('bg-btn-primary');
-    expect(chatLink).toHaveClass('text-btn-primary-foreground');
+    expect(chatLink).toHaveClass('bg-sidebar-accent/40');
+    expect(chatLink).toHaveClass('text-sidebar-item-foreground');
     expect(chatLink).toHaveClass('font-medium');
     expect(chatLink).not.toHaveClass('bg-sidebar-accent-active');
     expect(chatLink).not.toHaveClass(
       'shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
     );
-    expect(chatLink.querySelector('svg')).toHaveClass(
-      'text-btn-primary-foreground'
-    );
+    expect(chatLink.querySelector('svg')).toHaveClass('text-accent-teal!');
     expect(chatLink).not.toHaveAttribute('aria-current');
   });
 

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -177,7 +177,7 @@ describe('Sidebar row alignment', () => {
     // icon-column grid template.
     expect(settingsRow).toContain('grid-cols-[minmax(0,1fr)]');
     expect(settingsRow).not.toContain(
-      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
+      'grid-cols-[18px_minmax(0,1fr)_minmax(34px,auto)]'
     );
   });
 
@@ -207,7 +207,7 @@ describe('Sidebar row alignment', () => {
     expect(rowClassName).toContain('px-2.5');
     expect(rowClassName).toContain('gap-x-2.5');
     expect(rowClassName).toContain(
-      'grid-cols-[22px_minmax(0,1fr)_minmax(34px,auto)]'
+      'grid-cols-[18px_minmax(0,1fr)_minmax(34px,auto)]'
     );
     expect(rowClassName).not.toContain('before:');
     expect(rowClassName).not.toContain('after:');


### PR DESCRIPTION
## Summary
- make New Chat a quiet secondary action instead of a selected-looking CTA
- render Search with the canonical sidebar row geometry to prevent layout shift
- tighten the shared 18px icon track and 2px icon weight
- remove the workspace trigger chevron and reveal the user chevron only on hover, focus, or open
- increase spacing between the search utility and primary navigation without adding separators

## Verification
- Biome: 9 changed files
- focused Vitest: 55/55 passing from the canonical workspace dependency tree
- @jovie/web typecheck: passing
- git diff --check: passing

Linear: JOV-4695