### PR TITLE
fix(tasks): raise linked release recovery rail [JOV-4699]

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -282,7 +282,7 @@ function TaskReleasePanelStatus({
       title='Release'
       onClose={onClose}
       scrollStrategy='shell'
-      workspaceSurface='flat'
+      workspaceSurface='raised'
       data-testid='task-release-panel-status'
     >
       <div

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -12,6 +12,7 @@ const {
   mockUseReleaseEntityQuery,
   mockUseTaskBoardQuery,
   mockUseTasksQuery,
+  mockEntitySidebarShell,
 } = vi.hoisted(() => ({
   mockRouterPush: vi.fn(),
   mockRegisterRightPanel: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockUseReleaseEntityQuery: vi.fn(),
   mockUseTaskBoardQuery: vi.fn(),
   mockUseTasksQuery: vi.fn(),
+  mockEntitySidebarShell: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -207,6 +209,12 @@ let mockBoardQueryIsError = false;
 let mockViewMode: 'board' | 'list' = 'list';
 let mockViewModeHydrated = true;
 let mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
+let mockReleaseEntityData: {
+  readonly id: string;
+  readonly title: string;
+} | null = null;
+let mockReleaseEntityIsError = false;
+let mockReleaseEntityIsLoading = false;
 const mockUnifiedTable = vi.fn();
 const mockSetViewMode = vi.fn((viewMode: 'board' | 'list') => {
   mockViewMode = viewMode;
@@ -301,11 +309,23 @@ vi.mock('@/lib/queries/useReleaseEntityQuery', () => ({
     mockUseReleaseEntityQuery(profileId, releaseId);
 
     return {
-      data: releaseId ? { id: releaseId, title: 'QA Release' } : null,
-      isError: false,
-      isLoading: false,
+      data: releaseId ? mockReleaseEntityData : null,
+      isError: mockReleaseEntityIsError,
+      isLoading: mockReleaseEntityIsLoading,
       refetch: vi.fn(),
     };
+  },
+}));
+
+vi.mock('@/components/molecules/drawer/EntitySidebarShell', () => ({
+  EntitySidebarShell: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+  }) => {
+    mockEntitySidebarShell(props);
+    return <div data-testid={props['data-testid']}>{children}</div>;
   },
 }));
 
@@ -637,6 +657,7 @@ describe('TasksPageClient', () => {
     mockRegisterRightPanel.mockReset();
     mockRouterPush.mockReset();
     mockUseReleaseEntityQuery.mockClear();
+    mockEntitySidebarShell.mockClear();
     mockUseTaskBoardQuery.mockClear();
     mockUseTasksQuery.mockClear();
     mockRefetchTasks.mockReset();
@@ -654,6 +675,9 @@ describe('TasksPageClient', () => {
     mockViewMode = 'list';
     mockViewModeHydrated = true;
     mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
+    mockReleaseEntityData = { id: 'release-1', title: 'QA Release' };
+    mockReleaseEntityIsError = false;
+    mockReleaseEntityIsLoading = false;
   });
 
   afterEach(() => {
@@ -1055,6 +1079,28 @@ describe('TasksPageClient', () => {
     expect(mockRegisterRightPanel).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: expect.any(Function),
+      })
+    );
+  });
+
+  it.each([
+    ['loading', { isLoading: true }],
+    ['error', { isError: true }],
+    ['empty', {}],
+  ] as const)('uses the raised release recovery rail for the %s state', (_status, queryState) => {
+    mockReleaseEntityData = null;
+    mockReleaseEntityIsError = queryState.isError ?? false;
+    mockReleaseEntityIsLoading = queryState.isLoading ?? false;
+
+    renderPage();
+    openTask();
+    fireEvent.click(screen.getByRole('button', { name: 'QA Release' }));
+    const rightPanel = mockRegisterRightPanel.mock.calls.at(-1)?.[0];
+    render(rightPanel as React.ReactElement);
+
+    expect(mockEntitySidebarShell).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        workspaceSurface: 'raised',
       })
     );
   });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4699 -->

## Summary
- Use the canonical raised workspace surface for task linked-release loading, error, and empty recovery.
- Add focused regression coverage for all three recovery states.

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/TasksPageClient.test.tsx` (58 passed)
- `pnpm biome check --write apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `git diff --check`

## Risk
One shared-shell surface prop only; recovery copy, behavior, geometry, focus, mobile sheet, and reduced motion are unchanged.