### PR TITLE
feat(youtube): channel intelligence report ranked by WMPI [JOV-3193]

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1493,6 +1493,57 @@ function createShowTopInsightsTool(
 }
 
 /**
+ * Channel-intelligence Q&A (JOV-3193).
+ * Ranks videos by watch_minutes_per_impression and cites Reporting-API sources.
+ * Live metrics require the YouTube OAuth connector (GH-10912); until then the
+ * tool returns a connect CTA instead of inventing numbers.
+ */
+function createShowChannelIntelligenceTool(lastUserText: string) {
+  return tool({
+    description:
+      'Answer YouTube channel questions from real Reporting-API metrics: best/worst videos, what packaging works on THIS channel, and what is declining. Rank by watch minutes per impression (not CTR alone). Call when the artist asks about their YouTube videos, channel performance, thumbnails/packaging patterns, or reach decline. Do NOT invent metrics.',
+    inputSchema: chatToolSchema({
+      intent: z
+        .enum([
+          'best_videos',
+          'worst_videos',
+          'whats_working',
+          'whats_declining',
+          'channel_overview',
+        ])
+        .optional()
+        .describe(
+          'Optional intent override. When omitted, intent is detected from the user message.'
+        ),
+    }),
+    execute: async ({ intent: intentOverride }) => {
+      const { answerChannelQuestion, detectChannelQuestionIntent } =
+        await import('@/lib/services/channel-intelligence');
+
+      const intent =
+        intentOverride ??
+        detectChannelQuestionIntent(lastUserText) ??
+        'channel_overview';
+
+      // Connector metrics not wired yet (BlockedBy GH-10912). Fail closed
+      // with sources instead of fabricating rankings.
+      const answer = answerChannelQuestion(null, intent);
+
+      return {
+        success: true,
+        title: 'Channel intelligence',
+        intent: answer.intent,
+        hasData: answer.hasData,
+        summary: answer.summary,
+        rankedVideos: answer.rankedVideos,
+        findings: answer.findings,
+        sources: answer.sources,
+      };
+    },
+  });
+}
+
+/**
  * Creates the markCanvasUploaded tool.
  * Lets artists self-report that they've uploaded a canvas to Spotify for Artists.
  * Since Spotify has no public API for canvas status, this is the only reliable way to track it.
@@ -1989,6 +2040,7 @@ function buildChatTools(
           ),
         }
       : {}),
+    showChannelIntelligence: createShowChannelIntelligenceTool(lastUserText),
     proposeProfileEdit: createProfileEditTool(artistContext),
     importBioFromUrl: createImportBioFromUrlTool({ userId: clerkUserId }),
     checkCanvasStatus: createCheckCanvasStatusTool(resolvedProfileId, releases),

--- a/apps/web/app/app/(shell)/youtube/page.tsx
+++ b/apps/web/app/app/(shell)/youtube/page.tsx
@@ -1,32 +1,60 @@
+import { ChannelIntelligencePanel } from '@/components/features/dashboard/youtube/ChannelIntelligencePanel';
 import { RevivalQueuePanel } from '@/components/features/dashboard/youtube/RevivalQueuePanel';
+import { PageShell } from '@/components/organisms/PageShell';
+import { PageToolbar } from '@/components/organisms/table';
 import { APP_ROUTES } from '@/constants/routes';
 import { loadAppShellRouteContext } from '../app-shell-route-context';
 
 export const runtime = 'nodejs';
 
-export default async function YouTubeRevivalQueuePage() {
+export default async function YouTubeChannelPage() {
   const routeContext = await loadAppShellRouteContext({
     route: APP_ROUTES.YOUTUBE_REVIVAL,
     dashboardErrorLogMessage:
-      'Dashboard data load failed on YouTube revival queue page',
+      'Dashboard data load failed on YouTube channel page',
     dashboardErrorMessage:
-      'Failed to load the revival queue. Please refresh the page.',
+      'Failed to load YouTube channel intelligence. Please refresh the page.',
   });
   if (!routeContext.ok) {
     return routeContext.error;
   }
 
-  // ponytail: connector and experiment engine are not yet wired (GH-10921 BlockedBy).
-  // Show the unconnected empty state until the YouTube OAuth connector lands.
-  // Channel intelligence (GH-10917 / JOV-3193) shares this page and hydrates
-  // from Reporting API rows once the connector syncs.
-  return (
-    <RevivalQueuePanel
-      candidates={[]}
-      experiments={[]}
-      quota={null}
-      isConnected={false}
-      intelligenceReport={null}
+  // YouTube OAuth connector is not yet wired (GH-10912 BlockedBy).
+  // Show unconnected empty states until Reporting-API metrics land.
+  const toolbar = (
+    <PageToolbar
+      start={
+        <span className='text-xs text-tertiary-token'>
+          Ranked by watch minutes per impression
+        </span>
+      }
+      end={null}
     />
+  );
+
+  return (
+    <PageShell toolbar={toolbar} data-testid='youtube-channel-page'>
+      <div className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden'>
+        <div className='flex flex-col gap-8 px-3 py-2.5 sm:px-4 sm:py-3.5'>
+          <ChannelIntelligencePanel report={null} isConnected={false} />
+          <section aria-labelledby='youtube-revival-section-heading'>
+            <h2
+              id='youtube-revival-section-heading'
+              className='mb-3 text-app font-caption tracking-normal text-secondary-token'
+            >
+              Revival Queue
+            </h2>
+            <RevivalQueuePanel
+              candidates={[]}
+              experiments={[]}
+              quota={null}
+              isConnected={false}
+              withShell={false}
+              testId='youtube-revival-queue-section'
+            />
+          </section>
+        </div>
+      </div>
+    </PageShell>
   );
 }

--- a/apps/web/components/features/dashboard/youtube/ChannelIntelligencePanel.tsx
+++ b/apps/web/components/features/dashboard/youtube/ChannelIntelligencePanel.tsx
@@ -4,33 +4,48 @@ import { Icon } from '@/components/atoms/Icon';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import type {
   ChannelIntelligenceReport,
-  ChannelWinSignal,
+  CorrelationFinding,
   RankedVideo,
 } from '@/lib/services/channel-intelligence';
 
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
 function formatWmpi(value: number): string {
-  return value.toFixed(3);
+  if (value >= 1) return value.toFixed(2);
+  if (value >= 0.01) return value.toFixed(3);
+  return value.toFixed(4);
 }
 
-function formatCtr(ctr: number): string {
-  return `${(ctr * 100).toFixed(1)}%`;
+function formatLift(lift: number): string {
+  const pct = lift * 100;
+  const sign = pct >= 0 ? '+' : '';
+  return `${sign}${pct.toFixed(0)}%`;
 }
 
 function formatTrend(trend: number): string {
-  const pct = (trend * 100).toFixed(0);
-  return trend >= 0 ? `+${pct}%` : `${pct}%`;
+  const pct = trend * 100;
+  return pct >= 0 ? `+${pct.toFixed(0)}%` : `${pct.toFixed(0)}%`;
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
 
 interface RankedVideoRowProps {
   readonly video: RankedVideo;
-  readonly showTrend?: boolean;
 }
 
-function RankedVideoRow({ video, showTrend = false }: RankedVideoRowProps) {
+function RankedVideoRow({ video }: RankedVideoRowProps) {
   return (
-    <div className='flex items-start gap-3 px-4 py-3'>
+    <div className='flex items-start gap-3 border-b border-subtle px-4 py-3 last:border-b-0'>
+      <span className='w-6 shrink-0 text-xs font-medium tabular-nums text-tertiary-token'>
+        {video.rank}
+      </span>
       {video.thumbnailUrl ? (
-        // eslint-disable-next-line @next/next/no-img-element -- external YouTube thumbs
+        // External YouTube CDN URLs — plain img matches RevivalQueuePanel
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           src={video.thumbnailUrl}
           alt=''
@@ -44,81 +59,89 @@ function RankedVideoRow({ video, showTrend = false }: RankedVideoRowProps) {
       )}
       <div className='min-w-0 flex-1'>
         <p className='truncate text-app font-medium text-primary-token'>
-          <span className='mr-1.5 tabular-nums text-tertiary-token'>
-            {video.rank}.
-          </span>
           {video.title}
         </p>
         <div className='mt-1 flex flex-wrap gap-3 text-xs text-tertiary-token'>
           <span>
-            <span className='font-medium text-secondary-token'>
-              Watch-min/impression
-            </span>{' '}
+            <span className='font-medium text-secondary-token'>WMPI</span>{' '}
             {formatWmpi(video.watchMinutesPerImpression)}
           </span>
           <span>
             <span className='font-medium text-secondary-token'>CTR</span>{' '}
-            {formatCtr(video.ctr)}
+            {(video.ctr * 100).toFixed(1)}%
           </span>
           <span>
-            <span className='font-medium text-secondary-token'>AVD</span>{' '}
-            {Math.round(video.avgViewDurationSeconds)}s
+            <span className='font-medium text-secondary-token'>
+              Impressions
+            </span>{' '}
+            {video.impressions.toLocaleString()}
           </span>
-          {showTrend ? (
-            <span>
-              <span className='font-medium text-secondary-token'>Reach</span>{' '}
-              {formatTrend(video.reachTrend)}
-            </span>
-          ) : null}
         </div>
       </div>
     </div>
   );
 }
 
-function WinSignalCard({ signal }: { readonly signal: ChannelWinSignal }) {
+interface FindingRowProps {
+  readonly finding: CorrelationFinding;
+}
+
+function FindingRow({ finding }: FindingRowProps) {
+  const positive = finding.liftVsChannel > 0;
   return (
-    <div className='rounded-md bg-surface-0 px-3 py-2'>
-      <p className='text-xs font-medium text-primary-token'>{signal.summary}</p>
-      <p className='mt-0.5 text-xs text-tertiary-token'>
-        {signal.confidence} confidence · n={signal.sampleSize} ·{' '}
-        {signal.source.label}
-      </p>
+    <div className='flex items-start justify-between gap-3 border-b border-subtle px-4 py-3 last:border-b-0'>
+      <div className='min-w-0'>
+        <p className='text-app text-primary-token'>{finding.segment}</p>
+        <p className='mt-0.5 text-xs text-tertiary-token'>
+          n={finding.sampleSize} · {finding.confidence} confidence ·{' '}
+          {finding.dimension}
+        </p>
+      </div>
+      <span
+        className={`shrink-0 text-xs font-medium tabular-nums ${positive ? 'text-accent-green' : 'text-accent-red'}`}
+      >
+        {formatLift(finding.liftVsChannel)}
+      </span>
     </div>
   );
 }
 
-function VideoList({
-  videos,
-  empty,
-  showTrend,
-}: {
-  readonly videos: readonly RankedVideo[];
-  readonly empty: string;
-  readonly showTrend?: boolean;
-}) {
-  if (videos.length === 0) {
-    return (
-      <ContentSurfaceCard className='px-4 py-4 text-center'>
-        <p className='text-app text-secondary-token'>{empty}</p>
-      </ContentSurfaceCard>
-    );
-  }
+function NotConnectedState() {
   return (
-    <ContentSurfaceCard className='divide-y divide-subtle p-0'>
-      {videos.map(video => (
-        <RankedVideoRow
-          key={video.videoId}
-          video={video}
-          showTrend={showTrend}
-        />
-      ))}
+    <ContentSurfaceCard className='flex flex-col items-center justify-center px-6 py-10 text-center'>
+      <div className='flex h-10 w-10 items-center justify-center rounded-xl bg-surface-0'>
+        <Icon name='ChartBar' className='h-5 w-5 text-tertiary-token' />
+      </div>
+      <h3 className='mt-3 text-app font-semibold text-primary-token'>
+        Channel Intelligence
+      </h3>
+      <p className='mt-1 max-w-sm text-app text-secondary-token leading-snug'>
+        Connect YouTube to rank videos by watch minutes per impression, see what
+        packaging correlates with wins on your channel, and ask Jovie what is
+        working.
+      </p>
     </ContentSurfaceCard>
   );
 }
 
+function EmptyReportState() {
+  return (
+    <ContentSurfaceCard className='px-4 py-6 text-center'>
+      <p className='text-app text-secondary-token'>
+        Not enough Reporting API data yet. Once videos clear the impression
+        floor, rankings and packaging correlations appear here.
+      </p>
+    </ContentSurfaceCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
 export interface ChannelIntelligencePanelProps {
   readonly report: ChannelIntelligenceReport | null;
+  /** True when the YouTube connector is set up */
   readonly isConnected: boolean;
   readonly testId?: string;
 }
@@ -126,94 +149,96 @@ export interface ChannelIntelligencePanelProps {
 export function ChannelIntelligencePanel({
   report,
   isConnected,
-  testId = 'youtube-channel-intelligence',
+  testId = 'channel-intelligence-report',
 }: ChannelIntelligencePanelProps) {
   return (
-    <section
-      aria-labelledby='channel-intelligence-heading'
-      data-testid={testId}
-      className='space-y-6'
-    >
-      <div>
-        <h2
-          id='channel-intelligence-heading'
-          className='mb-1 text-app font-caption tracking-normal text-secondary-token'
-        >
-          Channel Intelligence
-        </h2>
-        {report && isConnected ? (
-          <p className='text-xs text-tertiary-token'>
-            Ranked by watch-min/impression · channel mean{' '}
-            {formatWmpi(report.channelMeanWatchMinutesPerImpression)} ·{' '}
-            {report.videoCount} video{report.videoCount !== 1 ? 's' : ''}
-          </p>
-        ) : null}
-      </div>
-
+    <div className='flex flex-col gap-6' data-testid={testId}>
       {!isConnected ? (
-        <ContentSurfaceCard className='flex flex-col items-center px-4 py-10 text-center'>
-          <div className='mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-surface-0'>
-            <Icon name='ChartBar' className='h-5 w-5 text-tertiary-token' />
-          </div>
-          <h3 className='text-app font-semibold text-primary-token'>
-            Connect YouTube Analytics
-          </h3>
-          <p className='mt-1 max-w-sm text-app text-secondary-token leading-snug'>
-            Ask Jovie about your best and worst videos once analytics are
-            connected. Rankings use watch-minutes-per-impression, not CTR alone.
-          </p>
-        </ContentSurfaceCard>
+        <NotConnectedState />
       ) : !report || report.videoCount === 0 ? (
-        <ContentSurfaceCard className='px-4 py-6 text-center'>
-          <p className='text-app text-secondary-token'>
-            No Reporting API metrics yet. After the connector syncs, videos with
-            at least 100 impressions appear ranked by watch-min/impression.
-          </p>
-        </ContentSurfaceCard>
+        <EmptyReportState />
       ) : (
         <>
-          <div>
-            <h3 className='mb-2 text-xs font-medium text-secondary-token'>
-              Best Videos
-            </h3>
-            <VideoList
-              videos={report.bestVideos}
-              empty='No rankable videos yet.'
-            />
-          </div>
+          <section aria-labelledby='channel-intel-best-heading'>
+            <h2
+              id='channel-intel-best-heading'
+              className='mb-3 text-app font-caption tracking-normal text-secondary-token'
+            >
+              Ranked By Watch Minutes Per Impression
+            </h2>
+            <ContentSurfaceCard className='overflow-hidden p-0'>
+              {report.rankedVideos.slice(0, 10).map(video => (
+                <RankedVideoRow key={video.videoId} video={video} />
+              ))}
+            </ContentSurfaceCard>
+            <p className='mt-2 text-xs text-tertiary-token'>
+              Primary metric is watch minutes per impression (not CTR alone).
+              Channel mean WMPI {formatWmpi(report.channelMeanWmpi)}.
+            </p>
+          </section>
 
-          {report.winSignals.length > 0 ? (
-            <div>
-              <h3 className='mb-2 text-xs font-medium text-secondary-token'>
-                What Works On This Channel
-              </h3>
-              <div className='space-y-2'>
-                {report.winSignals.map(signal => (
-                  <WinSignalCard
-                    key={`${signal.dimension}-${signal.winningLabel ?? signal.summary}`}
-                    signal={signal}
-                  />
+          <section aria-labelledby='channel-intel-works-heading'>
+            <h2
+              id='channel-intel-works-heading'
+              className='mb-3 text-app font-caption tracking-normal text-secondary-token'
+            >
+              What Works On This Channel
+            </h2>
+            {report.whatWorks.length === 0 ? (
+              <ContentSurfaceCard className='px-4 py-6 text-center'>
+                <p className='text-app text-secondary-token'>
+                  Need more face / text / topic / length labels before packaging
+                  correlations are reliable.
+                </p>
+              </ContentSurfaceCard>
+            ) : (
+              <ContentSurfaceCard className='overflow-hidden p-0'>
+                {report.whatWorks.map(finding => (
+                  <FindingRow key={finding.segmentKey} finding={finding} />
                 ))}
-              </div>
-            </div>
-          ) : null}
+              </ContentSurfaceCard>
+            )}
+          </section>
 
-          {report.decliningVideos.length > 0 ? (
-            <div>
-              <h3 className='mb-2 text-xs font-medium text-secondary-token'>
-                Declining Reach
-              </h3>
-              <VideoList videos={report.decliningVideos} empty='' showTrend />
-            </div>
-          ) : null}
+          <section aria-labelledby='channel-intel-declining-heading'>
+            <h2
+              id='channel-intel-declining-heading'
+              className='mb-3 text-app font-caption tracking-normal text-secondary-token'
+            >
+              Declining Reach
+            </h2>
+            {report.declining.length === 0 ? (
+              <ContentSurfaceCard className='px-4 py-6 text-center'>
+                <p className='text-app text-secondary-token'>
+                  No videos currently show a meaningful reach decline.
+                </p>
+              </ContentSurfaceCard>
+            ) : (
+              <ContentSurfaceCard className='overflow-hidden p-0'>
+                {report.declining.slice(0, 5).map(video => (
+                  <div
+                    key={video.videoId}
+                    className='flex items-center justify-between gap-3 border-b border-subtle px-4 py-3 last:border-b-0'
+                  >
+                    <p className='min-w-0 truncate text-app text-primary-token'>
+                      {video.title}
+                    </p>
+                    <span className='shrink-0 text-xs font-medium tabular-nums text-accent-red'>
+                      {formatTrend(video.reachTrend)}
+                    </span>
+                  </div>
+                ))}
+              </ContentSurfaceCard>
+            )}
+          </section>
 
-          {report.sources.length > 0 ? (
+          {report.sources.length > 0 && (
             <p className='text-xs text-tertiary-token'>
               Sources: {report.sources.map(s => s.label).join(' · ')}
             </p>
-          ) : null}
+          )}
         </>
       )}
-    </section>
+    </div>
   );
 }

--- a/apps/web/components/features/dashboard/youtube/RevivalQueuePanel.tsx
+++ b/apps/web/components/features/dashboard/youtube/RevivalQueuePanel.tsx
@@ -269,6 +269,11 @@ export interface RevivalQueuePanelProps {
    */
   readonly intelligenceReport?: ChannelIntelligenceReport | null;
   readonly testId?: string;
+  /**
+   * When false, render body only (no PageShell). Use when embedding under a
+   * parent YouTube channel shell (channel-intelligence report).
+   */
+  readonly withShell?: boolean;
 }
 
 export function RevivalQueuePanel({
@@ -278,7 +283,67 @@ export function RevivalQueuePanel({
   isConnected,
   intelligenceReport = null,
   testId = 'youtube-revival-queue',
+  withShell = true,
 }: RevivalQueuePanelProps) {
+  const body = (
+    <>
+      {!isConnected ? (
+        <NotConnectedState />
+      ) : (
+        <>
+          {quota && <QuotaBar quota={quota} />}
+
+          <section aria-labelledby='revival-queue-heading'>
+            <h2
+              id='revival-queue-heading'
+              className='mb-3 text-app font-caption tracking-normal text-secondary-token'
+            >
+              Revival Candidates
+            </h2>
+            {candidates.length === 0 ? (
+              <ContentSurfaceCard className='px-4 py-6 text-center'>
+                <p className='text-app text-secondary-token'>
+                  No underperforming videos found. All videos are meeting
+                  channel baselines.
+                </p>
+              </ContentSurfaceCard>
+            ) : (
+              <div className='space-y-3'>
+                {candidates.map(c => (
+                  <RevivalCandidateCard key={c.videoId} candidate={c} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          {experiments.length > 0 && (
+            <section aria-labelledby='experiments-heading'>
+              <h2
+                id='experiments-heading'
+                className='mb-3 text-app font-caption tracking-normal text-secondary-token'
+              >
+                Experiments
+              </h2>
+              <ContentSurfaceCard className='divide-y divide-subtle p-0'>
+                {experiments.map(exp => (
+                  <ExperimentRow key={exp.experimentId} experiment={exp} />
+                ))}
+              </ContentSurfaceCard>
+            </section>
+          )}
+        </>
+      )}
+    </>
+  );
+
+  if (!withShell) {
+    return (
+      <div className='flex flex-col gap-6' data-testid={testId}>
+        {body}
+      </div>
+    );
+  }
+
   const toolbar = (
     <PageToolbar
       start={
@@ -301,60 +366,7 @@ export function RevivalQueuePanel({
     >
       <div className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden'>
         <div className='flex flex-col gap-6 px-3 py-2.5 sm:px-4 sm:py-3.5'>
-          <ChannelIntelligencePanel
-            report={intelligenceReport}
-            isConnected={isConnected}
-          />
-
-          {!isConnected ? (
-            <NotConnectedState />
-          ) : (
-            <>
-              {/* Quota bar */}
-              {quota && <QuotaBar quota={quota} />}
-
-              {/* Revival queue */}
-              <section aria-labelledby='revival-queue-heading'>
-                <h2
-                  id='revival-queue-heading'
-                  className='mb-3 text-app font-caption tracking-normal text-secondary-token'
-                >
-                  Revival Candidates
-                </h2>
-                {candidates.length === 0 ? (
-                  <ContentSurfaceCard className='px-4 py-6 text-center'>
-                    <p className='text-app text-secondary-token'>
-                      No underperforming videos found. All videos are meeting
-                      channel baselines.
-                    </p>
-                  </ContentSurfaceCard>
-                ) : (
-                  <div className='space-y-3'>
-                    {candidates.map(c => (
-                      <RevivalCandidateCard key={c.videoId} candidate={c} />
-                    ))}
-                  </div>
-                )}
-              </section>
-
-              {/* Experiments dashboard */}
-              {experiments.length > 0 && (
-                <section aria-labelledby='experiments-heading'>
-                  <h2
-                    id='experiments-heading'
-                    className='mb-3 text-app font-caption tracking-normal text-secondary-token'
-                  >
-                    Experiments
-                  </h2>
-                  <ContentSurfaceCard className='divide-y divide-subtle p-0'>
-                    {experiments.map(exp => (
-                      <ExperimentRow key={exp.experimentId} experiment={exp} />
-                    ))}
-                  </ContentSurfaceCard>
-                </section>
-              )}
-            </>
-          )}
+          {body}
         </div>
       </div>
     </PageShell>

--- a/apps/web/components/features/dashboard/youtube/RevivalQueuePanel.tsx
+++ b/apps/web/components/features/dashboard/youtube/RevivalQueuePanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Icon } from '@/components/atoms/Icon';
-import { ChannelIntelligencePanel } from '@/components/features/dashboard/youtube/ChannelIntelligencePanel';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { PageShell } from '@/components/organisms/PageShell';
 import { PageToolbar } from '@/components/organisms/table';

--- a/apps/web/lib/agents/registry.ts
+++ b/apps/web/lib/agents/registry.ts
@@ -80,11 +80,11 @@ export const PUBLIC_SKILL_REGISTRY = {
       connector: 'youtube',
     },
   },
-  channelIntelligenceReport: {
-    id: 'channelIntelligenceReport',
-    name: 'Channel intelligence report',
+  showChannelIntelligence: {
+    id: 'showChannelIntelligence',
+    name: 'Channel intelligence',
     description:
-      'Rank channel videos by watch-minutes-per-impression, surface face/text/topic/length correlations, and answer best/worst/working/declining questions from YouTube Reporting API metrics with sources.',
+      "Rank the artist's YouTube videos by watch minutes per impression, surface packaging correlations on this channel, and answer best/worst/working/declining questions from Reporting-API metrics with sources.",
     kind: 'tool',
     version: '1.0.0',
     lifecycle: 'ga',
@@ -95,8 +95,9 @@ export const PUBLIC_SKILL_REGISTRY = {
     outputSchemaZodPath: 'apps/web/lib/services/channel-intelligence/types.ts',
     metadata: {
       surface: 'youtube',
-      action: 'channel_intelligence_report',
+      action: 'channel_intelligence',
       connector: 'youtube',
+      chatToolId: 'showChannelIntelligence',
     },
   },
   // Playbook-facing tool stubs (catalog + compile resolution). Executors may
@@ -173,4 +174,5 @@ export type SkillId = keyof typeof PUBLIC_SKILL_REGISTRY;
 export const PUBLIC_SKILL_CHAT_TOOL_IDS = {
   generateReleasePitch: 'generateReleasePitch',
   retouch: 'retouchImage',
+  showChannelIntelligence: 'showChannelIntelligence',
 } as const satisfies Partial<Record<SkillId, string>>;

--- a/apps/web/lib/chat/chat-tool-inventory.ts
+++ b/apps/web/lib/chat/chat-tool-inventory.ts
@@ -34,6 +34,7 @@ export const CHAT_ROUTE_TOOL_IDS = [
   'openBillingPortal',
   // Paid-tier creative / profile tools
   'showTopInsights',
+  'showChannelIntelligence',
   'proposeProfileEdit',
   'importBioFromUrl',
   'checkCanvasStatus',

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -361,6 +361,8 @@ function buildAnalyticsSection(options?: {
 - Do NOT call 'showTopInsights' for distribution deals (e.g. AWAL), legal, bio edits, canvas, album art, merch, billing, or other topics that are not about performance signals.
 - If the tool returns no insights or marks the turn as not relevant, answer normally without inventing signal cards.
 - Use the returned insights to answer briefly and concretely.
+- When the artist asks about YouTube channel performance, best/worst videos, what packaging is working, or declining reach, call 'showChannelIntelligence'. Rankings use watch minutes per impression — never invent CTR-only rankings or fake video metrics.
+- If 'showChannelIntelligence' returns hasData=false, tell the artist to connect YouTube; do not invent rankings.
 - Never invent downstream DSP performance or revenue figures.
 - You may describe monetization potential qualitatively, but do not expose guessed dollar values or hidden internal scoring.`;
   }
@@ -370,6 +372,7 @@ function buildAnalyticsSection(options?: {
 ## Analytics
 - You can discuss the artist's profile context and known releases, but you do not have access to insight cards in this session.
 - If the artist asks for detailed analytics, be explicit that the deeper insight view is unavailable on their current plan.
+- When the artist asks about YouTube best/worst videos or channel packaging patterns, call 'showChannelIntelligence' if available; if it reports no data, say they need to connect YouTube.
 - Never invent downstream DSP performance or revenue figures.
 - You may describe monetization potential qualitatively, but do not expose guessed dollar values or hidden internal scoring.`;
 }

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -51,6 +51,14 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Here are your insights',
     errorTitle: "Couldn't load your insights",
   },
+  showChannelIntelligence: {
+    label: 'Channel intelligence',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Reading your channel metrics…',
+    successTitle: 'Channel intelligence ready',
+    errorTitle: "Couldn't load channel intelligence",
+  },
   proposeProfileEdit: {
     label: 'Profile',
     uiHint: 'artifact',

--- a/apps/web/lib/services/channel-intelligence/correlations.ts
+++ b/apps/web/lib/services/channel-intelligence/correlations.ts
@@ -1,329 +1,271 @@
 /**
- * Per-channel packaging correlations (face / text / topic / length).
+ * Per-channel packaging correlations (JOV-3193).
  *
- * Groups rankable videos by packaging attributes and compares mean
- * watch_minutes_per_impression. Pure — learning-layer annotations are merged
- * by the report builder.
+ * Surfaces what correlates with wins on THIS channel:
+ * face vs no-face, text vs none, topic, length.
+ *
+ * Optional learning-layer rules (channel-rules) are merged as high-confidence
+ * findings when they override global priors.
  */
 
+import type {
+  ChannelPackagingRules,
+  PackagingDimension,
+} from '@/lib/services/packaging-intelligence/channel-rules';
 import {
-  durationBucket,
-  isRankable,
-  meanWatchMinutesPerImpression,
-  titleLengthBucket,
+  CONFIDENCE_THRESHOLD,
+  MIN_SAMPLE_SIZE,
+} from '@/lib/services/packaging-intelligence/channel-rules';
+import {
+  isEligibleForRank,
+  lengthBucket,
+  lengthBucketLabel,
   watchMinutesPerImpression,
 } from './metrics';
 import type {
   ChannelVideoMetrics,
-  ChannelWinSignal,
   CorrelationDimension,
-  CorrelationGroup,
-  LearningLayerWinAnnotation,
+  CorrelationFinding,
   MetricSource,
 } from './types';
 
-/** Minimum videos per group before we surface a correlation. */
-export const MIN_GROUP_SAMPLE = 3;
+/** Min videos per segment before emitting a correlation finding. */
+export const MIN_SEGMENT_SAMPLE = 3;
 
-/** Absolute lift vs channel mean required to call a “win” signal. */
-export const MIN_LIFT_ABS = 0.08;
-
-function groupMean(videos: readonly ChannelVideoMetrics[]): number {
-  if (videos.length === 0) return 0;
-  const sum = videos.reduce((acc, v) => acc + watchMinutesPerImpression(v), 0);
-  return sum / videos.length;
+interface SegmentAgg {
+  readonly dimension: CorrelationDimension;
+  readonly segmentKey: string;
+  readonly segment: string;
+  readonly wmpiSum: number;
+  readonly sampleSize: number;
+  readonly videoIds: string[];
 }
 
-function confidenceFromSample(
-  sampleSize: number
-): ChannelWinSignal['confidence'] {
+function confidenceFromSample(sampleSize: number): 'low' | 'medium' | 'high' {
   if (sampleSize >= 20) return 'high';
   if (sampleSize >= 8) return 'medium';
   return 'low';
 }
 
-function buildGroup(
-  dimension: CorrelationDimension,
-  key: string,
-  label: string,
-  videos: readonly ChannelVideoMetrics[],
-  channelMean: number
-): CorrelationGroup | null {
-  if (videos.length < MIN_GROUP_SAMPLE) return null;
-  const mean = groupMean(videos);
-  const lift =
-    channelMean > 0 ? (mean - channelMean) / channelMean : mean > 0 ? 1 : 0;
+function segmentForFace(hasFace: boolean | null): {
+  key: string;
+  label: string;
+} | null {
+  if (hasFace === null) return null;
+  return hasFace
+    ? { key: 'face:yes', label: 'Face' }
+    : { key: 'face:no', label: 'No face' };
+}
+
+function segmentForText(hasText: boolean | null): {
+  key: string;
+  label: string;
+} | null {
+  if (hasText === null) return null;
+  return hasText
+    ? { key: 'text:yes', label: 'Text overlay' }
+    : { key: 'text:no', label: 'No text' };
+}
+
+function segmentForTopic(topic: string | null): {
+  key: string;
+  label: string;
+} | null {
+  if (!topic?.trim()) return null;
+  const normalized = topic.trim().toLowerCase();
   return {
-    key,
-    dimension,
-    label,
-    sampleSize: videos.length,
-    meanWatchMinutesPerImpression: mean,
-    liftVsChannelMean: lift,
+    key: `topic:${normalized}`,
+    label: `Topic: ${topic.trim()}`,
   };
 }
 
-function partitionByBoolean(
-  videos: readonly ChannelVideoMetrics[],
-  pick: (v: ChannelVideoMetrics) => boolean | null,
-  dimension: CorrelationDimension,
-  trueLabel: string,
-  falseLabel: string,
-  channelMean: number
-): CorrelationGroup[] {
-  const yes: ChannelVideoMetrics[] = [];
-  const no: ChannelVideoMetrics[] = [];
-  for (const video of videos) {
-    const value = pick(video);
-    if (value === true) yes.push(video);
-    else if (value === false) no.push(video);
-  }
-  return [
-    buildGroup(dimension, `${dimension}:true`, trueLabel, yes, channelMean),
-    buildGroup(dimension, `${dimension}:false`, falseLabel, no, channelMean),
-  ].filter((g): g is CorrelationGroup => g !== null);
-}
-
-function partitionByKey(
-  videos: readonly ChannelVideoMetrics[],
-  pick: (v: ChannelVideoMetrics) => string | null,
-  dimension: CorrelationDimension,
-  labelFor: (key: string) => string,
-  channelMean: number
-): CorrelationGroup[] {
-  const buckets = new Map<string, ChannelVideoMetrics[]>();
-  for (const video of videos) {
-    const key = pick(video);
-    if (!key) continue;
-    const list = buckets.get(key);
-    if (list) list.push(video);
-    else buckets.set(key, [video]);
-  }
-  const groups: CorrelationGroup[] = [];
-  for (const [key, list] of buckets) {
-    const group = buildGroup(
-      dimension,
-      `${dimension}:${key}`,
-      labelFor(key),
-      list,
-      channelMean
-    );
-    if (group) groups.push(group);
-  }
-  return groups;
-}
-
-function signalFromGroups(
-  dimension: CorrelationDimension,
-  groups: readonly CorrelationGroup[],
-  source: MetricSource
-): ChannelWinSignal | null {
-  if (groups.length < 2) {
-    // Single group with strong positive lift can still be informative
-    const only = groups[0];
-    if (!only || Math.abs(only.liftVsChannelMean) < MIN_LIFT_ABS) return null;
-    return {
-      dimension,
-      summary: `${only.label} averages ${only.meanWatchMinutesPerImpression.toFixed(3)} watch-min/impression (${formatLift(only.liftVsChannelMean)} vs channel mean).`,
-      winningLabel: only.liftVsChannelMean > 0 ? only.label : null,
-      losingLabel: only.liftVsChannelMean < 0 ? only.label : null,
-      liftPercent: only.liftVsChannelMean * 100,
-      sampleSize: only.sampleSize,
-      confidence: confidenceFromSample(only.sampleSize),
-      groups,
-      source,
-    };
-  }
-
-  const sorted = groups
-    .slice()
-    .sort(
-      (a, b) =>
-        b.meanWatchMinutesPerImpression - a.meanWatchMinutesPerImpression
-    );
-  const best = sorted[0];
-  const worst = sorted[sorted.length - 1];
-  if (!best || !worst || best.key === worst.key) return null;
-
-  const relativeLift =
-    worst.meanWatchMinutesPerImpression > 0
-      ? (best.meanWatchMinutesPerImpression -
-          worst.meanWatchMinutesPerImpression) /
-        worst.meanWatchMinutesPerImpression
-      : best.meanWatchMinutesPerImpression > 0
-        ? 1
-        : 0;
-
-  if (
-    relativeLift < MIN_LIFT_ABS &&
-    Math.abs(best.liftVsChannelMean) < MIN_LIFT_ABS
-  ) {
-    return null;
-  }
-
+function segmentForLength(durationSeconds: number | null): {
+  key: string;
+  label: string;
+} | null {
+  const bucket = lengthBucket(durationSeconds);
+  if (!bucket) return null;
   return {
-    dimension,
-    summary: `${best.label} outperforms ${worst.label} on watch-min/impression (${formatLift(relativeLift)} relative lift).`,
-    winningLabel: best.label,
-    losingLabel: worst.label,
-    liftPercent: relativeLift * 100,
-    sampleSize: best.sampleSize + worst.sampleSize,
-    confidence: confidenceFromSample(best.sampleSize + worst.sampleSize),
-    groups: sorted,
-    source,
+    key: `length:${bucket}`,
+    label: lengthBucketLabel(bucket),
   };
 }
 
-function formatLift(lift: number): string {
-  const pct = Math.abs(lift * 100).toFixed(0);
-  if (lift > 0) return `+${pct}%`;
-  if (lift < 0) return `−${pct}%`;
-  return '0%';
+function accumulate(
+  map: Map<string, SegmentAgg>,
+  dimension: CorrelationDimension,
+  seg: { key: string; label: string } | null,
+  wmpi: number,
+  videoId: string
+): void {
+  if (!seg) return;
+  const existing = map.get(seg.key);
+  if (existing) {
+    map.set(seg.key, {
+      ...existing,
+      wmpiSum: existing.wmpiSum + wmpi,
+      sampleSize: existing.sampleSize + 1,
+      videoIds: [...existing.videoIds, videoId],
+    });
+  } else {
+    map.set(seg.key, {
+      dimension,
+      segmentKey: seg.key,
+      segment: seg.label,
+      wmpiSum: wmpi,
+      sampleSize: 1,
+      videoIds: [videoId],
+    });
+  }
 }
 
-function reportingSource(metricKeys: readonly string[]): MetricSource {
+function toFinding(
+  agg: SegmentAgg,
+  channelMean: number
+): CorrelationFinding | null {
+  if (agg.sampleSize < MIN_SEGMENT_SAMPLE) return null;
+  const avg = agg.wmpiSum / agg.sampleSize;
+  const liftVsChannel = channelMean > 0 ? (avg - channelMean) / channelMean : 0;
+  const sources: MetricSource[] = [
+    {
+      kind: 'youtube_reporting_api',
+      label: 'YouTube Reporting API',
+      videoIds: agg.videoIds,
+      detail: `Segment mean WMPI across ${agg.sampleSize} videos`,
+    },
+    {
+      kind: 'derived',
+      label: 'Channel correlation',
+      detail: `liftVsChannel = (segmentMean − channelMean) / channelMean`,
+    },
+  ];
+
   return {
-    kind: 'youtube_reporting_api',
-    label: 'YouTube Reporting API',
-    metricKeys,
+    dimension: agg.dimension,
+    segment: agg.segment,
+    segmentKey: agg.segmentKey,
+    avgWatchMinutesPerImpression: avg,
+    sampleSize: agg.sampleSize,
+    liftVsChannel,
+    confidence: confidenceFromSample(agg.sampleSize),
+    sources,
   };
 }
 
 /**
- * Compute channel win signals from packaging attributes on ranked videos.
+ * Computes face / text / topic / length correlations against channel mean WMPI.
+ * Returns findings sorted by absolute lift descending (strongest signals first).
  */
 export function computeChannelCorrelations(
   videos: readonly ChannelVideoMetrics[]
-): ChannelWinSignal[] {
-  const rankable = videos.filter(isRankable);
-  if (rankable.length < MIN_GROUP_SAMPLE * 2) return [];
-
-  const channelMean = meanWatchMinutesPerImpression(rankable);
-  const signals: ChannelWinSignal[] = [];
-  const source = reportingSource([
-    'watch_minutes_per_impression',
-    'impressions',
-    'watch_minutes',
-  ]);
-
-  const faceGroups = partitionByBoolean(
-    rankable,
-    v => v.hasFace,
-    'face',
-    'Face in thumbnail',
-    'No face in thumbnail',
-    channelMean
-  );
-  const faceSignal = signalFromGroups('face', faceGroups, source);
-  if (faceSignal) signals.push(faceSignal);
-
-  const textGroups = partitionByBoolean(
-    rankable,
-    v => v.hasText,
-    'text',
-    'Text on thumbnail',
-    'No text on thumbnail',
-    channelMean
-  );
-  const textSignal = signalFromGroups('text', textGroups, source);
-  if (textSignal) signals.push(textSignal);
-
-  const topicGroups = partitionByKey(
-    rankable,
-    v => (v.topic?.trim() ? v.topic.trim().toLowerCase() : null),
-    'topic',
-    key => `Topic: ${key}`,
-    channelMean
-  );
-  const topicSignal = signalFromGroups('topic', topicGroups, source);
-  if (topicSignal) signals.push(topicSignal);
-
-  const titleGroups = partitionByKey(
-    rankable,
-    v => titleLengthBucket(v.titleWordCount),
-    'title_length',
-    key => `Title length: ${key}`,
-    channelMean
-  );
-  const titleSignal = signalFromGroups('title_length', titleGroups, source);
-  if (titleSignal) signals.push(titleSignal);
-
-  const durationGroups = partitionByKey(
-    rankable,
-    v => durationBucket(v.durationSeconds),
-    'duration',
-    key => `Video length: ${key}`,
-    channelMean
-  );
-  const durationSignal = signalFromGroups('duration', durationGroups, source);
-  if (durationSignal) signals.push(durationSignal);
-
-  return signals.sort(
-    (a, b) => Math.abs(b.liftPercent) - Math.abs(a.liftPercent)
-  );
-}
-
-/**
- * Merge learning-layer (experiment) annotations into win signals when the
- * observed sample is strong enough. Annotations supplement, not replace,
- * metric-derived correlations.
- */
-export function mergeLearningLayerAnnotations(
-  signals: readonly ChannelWinSignal[],
-  annotations: readonly LearningLayerWinAnnotation[] | undefined
-): ChannelWinSignal[] {
-  if (!annotations?.length) return [...signals];
-
-  const byDimension = new Map(signals.map(s => [s.dimension, s]));
-  const merged: ChannelWinSignal[] = [...signals];
-
-  for (const annotation of annotations) {
-    if (annotation.source !== 'observed') continue;
-    if (annotation.sampleSize < 50 || annotation.confidence < 0.8) continue;
-
-    const existing = byDimension.get(annotation.dimension);
-    const learningSource: MetricSource = {
-      kind: 'learning_layer',
-      label: 'Channel packaging learning layer',
-      metricKeys: ['experiment_lift', annotation.dimension],
-    };
-
-    if (existing) {
-      // Annotate existing metric correlation with learning-layer evidence
-      const idx = merged.findIndex(s => s.dimension === annotation.dimension);
-      if (idx >= 0) {
-        merged[idx] = {
-          ...existing,
-          summary: `${existing.summary} Learning layer: ${annotation.summary}`,
-          source: {
-            kind: 'learning_layer',
-            label: `${existing.source.label} + learning layer`,
-            metricKeys: [
-              ...existing.source.metricKeys,
-              ...learningSource.metricKeys,
-            ],
-          },
-        };
-      }
-    } else {
-      merged.push({
-        dimension: annotation.dimension,
-        summary: annotation.summary,
-        winningLabel: null,
-        losingLabel: null,
-        liftPercent: annotation.liftPercent,
-        sampleSize: annotation.sampleSize,
-        confidence:
-          annotation.confidence >= 0.95
-            ? 'high'
-            : annotation.confidence >= 0.85
-              ? 'medium'
-              : 'low',
-        groups: [],
-        source: learningSource,
-      });
-    }
+): {
+  readonly findings: CorrelationFinding[];
+  readonly channelMeanWmpi: number;
+} {
+  const eligible = videos.filter(isEligibleForRank);
+  if (eligible.length === 0) {
+    return { findings: [], channelMeanWmpi: 0 };
   }
 
-  return merged;
+  const wmpiValues = eligible.map(watchMinutesPerImpression);
+  const channelMean = wmpiValues.reduce((a, b) => a + b, 0) / wmpiValues.length;
+
+  const segments = new Map<string, SegmentAgg>();
+  for (const v of eligible) {
+    const wmpi = watchMinutesPerImpression(v);
+    accumulate(segments, 'face', segmentForFace(v.hasFace), wmpi, v.videoId);
+    accumulate(segments, 'text', segmentForText(v.hasText), wmpi, v.videoId);
+    accumulate(segments, 'topic', segmentForTopic(v.topic), wmpi, v.videoId);
+    accumulate(
+      segments,
+      'length',
+      segmentForLength(v.durationSeconds),
+      wmpi,
+      v.videoId
+    );
+  }
+
+  const findings = [...segments.values()]
+    .map(agg => toFinding(agg, channelMean))
+    .filter((f): f is CorrelationFinding => f !== null)
+    .sort((a, b) => Math.abs(b.liftVsChannel) - Math.abs(a.liftVsChannel));
+
+  return { findings, channelMeanWmpi: channelMean };
+}
+
+const DIMENSION_LABEL: Record<PackagingDimension, string> = {
+  face: 'Face',
+  text: 'Text overlay',
+  titleLength: 'Title length',
+};
+
+/**
+ * Merges learning-layer channel rules into correlation findings when they
+ * meet the observed-override threshold (sample + confidence).
+ */
+export function findingsFromLearningLayer(
+  rules: ChannelPackagingRules | null | undefined
+): CorrelationFinding[] {
+  if (!rules) return [];
+
+  const out: CorrelationFinding[] = [];
+  for (const dim of ['face', 'text', 'titleLength'] as const) {
+    const rule = rules.dimensions[dim];
+    if (!rule) continue;
+    if (
+      rule.sampleSize < MIN_SAMPLE_SIZE ||
+      rule.confidence < CONFIDENCE_THRESHOLD
+    ) {
+      continue;
+    }
+
+    const dimension: CorrelationDimension =
+      dim === 'titleLength' ? 'length' : dim;
+    const direction =
+      rule.liftDirection === 'positive'
+        ? 'helps'
+        : rule.liftDirection === 'negative'
+          ? 'hurts'
+          : 'neutral';
+    const segment =
+      dim === 'titleLength'
+        ? `Title length (${direction})`
+        : `${DIMENSION_LABEL[dim]} (${direction})`;
+
+    out.push({
+      dimension,
+      segment,
+      segmentKey: `learning:${dim}:${rule.liftDirection}`,
+      avgWatchMinutesPerImpression: 0,
+      sampleSize: rule.sampleSize,
+      // liftPercent is percentage points; normalize to fraction for consistency
+      liftVsChannel: rule.liftPercent / 100,
+      confidence:
+        rule.confidence >= 0.9
+          ? 'high'
+          : rule.confidence >= 0.8
+            ? 'medium'
+            : 'low',
+      sources: [
+        {
+          kind: 'learning_layer',
+          label: 'Channel packaging rules',
+          detail: `Observed ${dim} lift from ${rule.sampleSize} experiment impressions (confidence ${(rule.confidence * 100).toFixed(0)}%)`,
+        },
+      ],
+    });
+  }
+
+  return out;
+}
+
+/** Positive-lift findings (what works), strongest first. */
+export function selectWhatWorks(
+  findings: readonly CorrelationFinding[],
+  limit = 5
+): CorrelationFinding[] {
+  return findings
+    .filter(f => f.liftVsChannel > 0)
+    .sort((a, b) => b.liftVsChannel - a.liftVsChannel)
+    .slice(0, limit);
 }

--- a/apps/web/lib/services/channel-intelligence/index.ts
+++ b/apps/web/lib/services/channel-intelligence/index.ts
@@ -1,50 +1,47 @@
 /**
- * Channel-intelligence report (GH-10917 / JOV-3193).
+ * Channel-intelligence report (JOV-3193 / GH-10917).
  *
- * Pure query + summarize layer over YouTube Reporting API metrics:
- * rank by watch_minutes_per_impression, surface channel-specific packaging
- * correlations, and answer chat questions with sources.
+ * Rank videos by watch_minutes_per_impression, surface per-channel packaging
+ * correlations, and answer chat questions with Reporting-API sources.
  */
 
 export {
-  answerChannelIntelligenceQuery,
-  classifyChannelIntelligenceIntent,
-} from './answer';
-export {
   computeChannelCorrelations,
-  MIN_GROUP_SAMPLE,
-  MIN_LIFT_ABS,
-  mergeLearningLayerAnnotations,
+  findingsFromLearningLayer,
+  MIN_SEGMENT_SAMPLE,
+  selectWhatWorks,
 } from './correlations';
 export {
   ctrTimesAvgViewDurationMinutes,
   DECLINING_REACH_THRESHOLD,
-  durationBucket,
   isDeclining,
-  isRankable,
-  MIN_IMPRESSIONS_FOR_RANKING,
-  meanWatchMinutesPerImpression,
-  rankDecliningVideos,
-  rankVideosByWatchMinutesPerImpression,
-  rankWorstVideosByWatchMinutesPerImpression,
-  titleLengthBucket,
+  isEligibleForRank,
+  LENGTH_MEDIUM_MAX_SECONDS,
+  LENGTH_SHORT_MAX_SECONDS,
+  lengthBucket,
+  lengthBucketLabel,
+  MIN_IMPRESSIONS_FOR_RANK,
   watchMinutesPerImpression,
 } from './metrics';
-export { buildChannelIntelligenceReport } from './report';
+export {
+  answerChannelQuestion,
+  answerChannelQuestionFromText,
+  detectChannelQuestionIntent,
+} from './qa';
+export { channelMeanWmpi, rankVideosByWatchMinutesPerImpression } from './rank';
+export {
+  type BuildChannelIntelligenceReportInput,
+  buildChannelIntelligenceReport,
+  hasChannelIntelligenceData,
+} from './report';
 export type {
-  AnswerChannelIntelligenceQueryInput,
-  BuildChannelIntelligenceReportInput,
   ChannelIntelligenceAnswer,
-  ChannelIntelligenceIntent,
   ChannelIntelligenceReport,
+  ChannelQuestionIntent,
   ChannelVideoMetrics,
-  ChannelWinSignal,
   CorrelationDimension,
-  CorrelationGroup,
-  DurationBucket,
-  LearningLayerWinAnnotation,
+  CorrelationFinding,
+  LengthBucket,
   MetricSource,
-  MetricSourceKind,
   RankedVideo,
-  TitleLengthBucket,
 } from './types';

--- a/apps/web/lib/services/channel-intelligence/metrics.ts
+++ b/apps/web/lib/services/channel-intelligence/metrics.ts
@@ -1,164 +1,88 @@
 /**
- * Channel-intelligence metric derivations (GH-10917 / JOV-3193).
+ * Winner metric helpers for channel intelligence (JOV-3193).
  *
- * Winner metric for the whole packaging epic:
- *   watch_minutes_per_impression
- *     = watch_minutes / impressions
- *     ≈ CTR × average_view_duration_minutes
+ * Primary metric: watch_minutes_per_impression
+ *   = watchMinutes / impressions
+ *   ≈ ctr × avg_view_duration_minutes
  *
- * Never rank or declare winners by CTR alone — a thumbnail that wins clicks
- * but loses retention must lose.
+ * Ranking MUST use this metric, never CTR alone. A thumbnail that wins clicks
+ * but loses retention must rank lower.
  */
 
-import type {
-  ChannelVideoMetrics,
-  DurationBucket,
-  RankedVideo,
-  TitleLengthBucket,
-} from './types';
+import type { ChannelVideoMetrics, LengthBucket } from './types';
 
-/** Minimum impressions before a video enters ranking / correlation sets. */
-export const MIN_IMPRESSIONS_FOR_RANKING = 100;
+/** Minimum impressions before a video enters ranking / correlation. */
+export const MIN_IMPRESSIONS_FOR_RANK = 100;
 
 /** Reach trend below this is treated as declining. */
 export const DECLINING_REACH_THRESHOLD = -0.1;
 
 /**
- * Title word-count buckets (aligned with packaging niche titleLengthBias):
- * short < 5, medium 5–10, long > 10.
+ * Content length buckets (seconds):
+ * short &lt; 3 min, medium 3–10 min, long &gt; 10 min.
  */
-export function titleLengthBucket(
-  wordCount: number | null | undefined
-): TitleLengthBucket | null {
-  if (wordCount == null || !Number.isFinite(wordCount) || wordCount < 0) {
-    return null;
+export const LENGTH_SHORT_MAX_SECONDS = 180;
+export const LENGTH_MEDIUM_MAX_SECONDS = 600;
+
+/**
+ * Computes watch_minutes_per_impression.
+ *
+ * Prefers Reporting-API watchMinutes / impressions. Falls back to
+ * CTR × avg view duration (minutes) when watch minutes are missing but
+ * impressions + CTR + AVD are present — same identity used in the packaging
+ * experiment engine.
+ */
+export function watchMinutesPerImpression(v: ChannelVideoMetrics): number {
+  if (v.impressions <= 0) return 0;
+
+  if (v.watchMinutes > 0) {
+    return v.watchMinutes / v.impressions;
   }
-  if (wordCount < 5) return 'short';
-  if (wordCount <= 10) return 'medium';
-  return 'long';
+
+  // Fallback: CTR × AVD(minutes) ≈ watch_minutes / impressions
+  if (v.ctr > 0 && v.avgViewDurationSeconds > 0) {
+    return v.ctr * (v.avgViewDurationSeconds / 60);
+  }
+
+  return 0;
 }
 
 /**
- * Video duration buckets (minutes of content):
- * short < 8 min, medium 8–20, long > 20.
- */
-export function durationBucket(
-  durationSeconds: number | null | undefined
-): DurationBucket | null {
-  if (
-    durationSeconds == null ||
-    !Number.isFinite(durationSeconds) ||
-    durationSeconds < 0
-  ) {
-    return null;
-  }
-  const minutes = durationSeconds / 60;
-  if (minutes < 8) return 'short';
-  if (minutes <= 20) return 'medium';
-  return 'long';
-}
-
-/**
- * Primary ranking metric: watch_minutes / impressions.
- * Falls back to CTR × AVD(minutes) when impressions are missing but CTR+AVD exist.
- */
-export function watchMinutesPerImpression(
-  metrics: Pick<
-    ChannelVideoMetrics,
-    'impressions' | 'watchMinutes' | 'ctr' | 'avgViewDurationSeconds'
-  >
-): number {
-  if (metrics.impressions > 0) {
-    return metrics.watchMinutes / metrics.impressions;
-  }
-  return ctrTimesAvgViewDurationMinutes(metrics);
-}
-
-/**
- * Product form of the winner metric: CTR × average_view_duration_minutes.
- * Used for display and to prove ranking is not CTR-only.
+ * CTR × average view duration in minutes — explicit form of the epic metric.
+ * Exposed for tests and callers that already hold CTR/AVD only.
  */
 export function ctrTimesAvgViewDurationMinutes(
-  metrics: Pick<ChannelVideoMetrics, 'ctr' | 'avgViewDurationSeconds'>
+  ctr: number,
+  avgViewDurationSeconds: number
 ): number {
-  if (metrics.ctr <= 0 || metrics.avgViewDurationSeconds <= 0) return 0;
-  return metrics.ctr * (metrics.avgViewDurationSeconds / 60);
+  if (ctr <= 0 || avgViewDurationSeconds <= 0) return 0;
+  return ctr * (avgViewDurationSeconds / 60);
 }
 
-export function isRankable(
-  metrics: Pick<ChannelVideoMetrics, 'impressions'>
-): boolean {
-  return metrics.impressions >= MIN_IMPRESSIONS_FOR_RANKING;
+export function lengthBucket(
+  durationSeconds: number | null | undefined
+): LengthBucket | null {
+  if (durationSeconds == null || durationSeconds < 0) return null;
+  if (durationSeconds < LENGTH_SHORT_MAX_SECONDS) return 'short';
+  if (durationSeconds <= LENGTH_MEDIUM_MAX_SECONDS) return 'medium';
+  return 'long';
 }
 
-export function isDeclining(
-  metrics: Pick<ChannelVideoMetrics, 'reachTrend'>
-): boolean {
-  return metrics.reachTrend < DECLINING_REACH_THRESHOLD;
+export function lengthBucketLabel(bucket: LengthBucket): string {
+  switch (bucket) {
+    case 'short':
+      return 'Short (<3 min)';
+    case 'medium':
+      return 'Medium (3–10 min)';
+    case 'long':
+      return 'Long (>10 min)';
+  }
 }
 
-export function meanWatchMinutesPerImpression(
-  videos: readonly Pick<
-    ChannelVideoMetrics,
-    'impressions' | 'watchMinutes' | 'ctr' | 'avgViewDurationSeconds'
-  >[]
-): number {
-  const rankable = videos.filter(isRankable);
-  if (rankable.length === 0) return 0;
-  const sum = rankable.reduce(
-    (acc, v) => acc + watchMinutesPerImpression(v),
-    0
-  );
-  return sum / rankable.length;
+export function isEligibleForRank(v: ChannelVideoMetrics): boolean {
+  return v.impressions >= MIN_IMPRESSIONS_FOR_RANK;
 }
 
-function toRanked(metrics: ChannelVideoMetrics, rank: number): RankedVideo {
-  return {
-    videoId: metrics.videoId,
-    title: metrics.title,
-    thumbnailUrl: metrics.thumbnailUrl,
-    publishedAt: metrics.publishedAt,
-    watchMinutesPerImpression: watchMinutesPerImpression(metrics),
-    ctrTimesAvgViewDurationMinutes: ctrTimesAvgViewDurationMinutes(metrics),
-    ctr: metrics.ctr,
-    avgViewDurationSeconds: metrics.avgViewDurationSeconds,
-    impressions: metrics.impressions,
-    views: metrics.views,
-    watchMinutes: metrics.watchMinutes,
-    reachTrend: metrics.reachTrend,
-    rank,
-  };
-}
-
-/** Rank by watch_minutes_per_impression descending (best first). */
-export function rankVideosByWatchMinutesPerImpression(
-  videos: readonly ChannelVideoMetrics[]
-): RankedVideo[] {
-  return videos
-    .filter(isRankable)
-    .slice()
-    .sort((a, b) => {
-      const wmpi = watchMinutesPerImpression(b) - watchMinutesPerImpression(a);
-      return wmpi !== 0 ? wmpi : b.impressions - a.impressions;
-    })
-    .map((video, index) => toRanked(video, index + 1));
-}
-
-/** Worst videos: ascending WMPI (not CTR). */
-export function rankWorstVideosByWatchMinutesPerImpression(
-  videos: readonly ChannelVideoMetrics[]
-): RankedVideo[] {
-  return rankVideosByWatchMinutesPerImpression(videos)
-    .slice()
-    .reverse()
-    .map((video, index) => ({ ...video, rank: index + 1 }));
-}
-
-/** Declining reach, weakest WMPI first among decliners. */
-export function rankDecliningVideos(
-  videos: readonly ChannelVideoMetrics[]
-): RankedVideo[] {
-  return rankWorstVideosByWatchMinutesPerImpression(
-    videos.filter(v => isRankable(v) && isDeclining(v))
-  );
+export function isDeclining(v: ChannelVideoMetrics): boolean {
+  return v.reachTrend < DECLINING_REACH_THRESHOLD;
 }

--- a/apps/web/lib/services/channel-intelligence/qa.ts
+++ b/apps/web/lib/services/channel-intelligence/qa.ts
@@ -1,0 +1,246 @@
+/**
+ * Conversational Q&A over channel-intelligence reports (JOV-3193).
+ *
+ * Answers "what are my best videos / what's working / what's declining"
+ * from structured Reporting-API metrics with explicit sources.
+ */
+
+import type {
+  ChannelIntelligenceAnswer,
+  ChannelIntelligenceReport,
+  ChannelQuestionIntent,
+  MetricSource,
+} from './types';
+
+const INTENT_PATTERNS: readonly {
+  readonly intent: ChannelQuestionIntent;
+  readonly patterns: readonly RegExp[];
+}[] = [
+  {
+    intent: 'best_videos',
+    patterns: [
+      /\bbest\s+videos?\b/i,
+      /\btop\s+videos?\b/i,
+      /\bhighest\s+(?:performing|watch)\b/i,
+      /\bwhich\s+videos?\s+(?:work|perform|win)\b/i,
+      /\bmy\s+best\b/i,
+    ],
+  },
+  {
+    intent: 'worst_videos',
+    patterns: [
+      /\bworst\s+videos?\b/i,
+      /\bbottom\s+videos?\b/i,
+      /\blowest\s+(?:performing|watch)\b/i,
+      /\bunderperform/i,
+    ],
+  },
+  {
+    intent: 'whats_working',
+    patterns: [
+      /\bwhat(?:'s|s|\s+is)\s+working\b/i,
+      /\bwhat\s+works\b/i,
+      /\bwhat\s+correlates\b/i,
+      /\bface\s+vs\b/i,
+      /\bpackaging\s+(?:wins|rules|insights)\b/i,
+      /\bthumbnail\s+(?:patterns?|insights?)\b/i,
+    ],
+  },
+  {
+    intent: 'whats_declining',
+    patterns: [
+      /\bwhat(?:'s|s|\s+is)\s+declin/i,
+      /\bdeclining\b/i,
+      /\blosing\s+(?:reach|views|steam)\b/i,
+      /\breach\s+(?:down|drop|falling)\b/i,
+    ],
+  },
+  {
+    intent: 'channel_overview',
+    patterns: [
+      /\bchannel\s+(?:report|intelligence|performance|overview)\b/i,
+      /\bhow\s+(?:is|are)\s+(?:my\s+)?channel\b/i,
+      /\bchannel\s+health\b/i,
+    ],
+  },
+];
+
+/**
+ * Detects channel-intelligence intent from free-text chat.
+ * Returns null when the turn is not about channel video performance.
+ */
+export function detectChannelQuestionIntent(
+  text: string
+): ChannelQuestionIntent | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  for (const entry of INTENT_PATTERNS) {
+    if (entry.patterns.some(re => re.test(trimmed))) {
+      return entry.intent;
+    }
+  }
+  return null;
+}
+
+function formatWmpi(value: number): string {
+  if (value >= 1) return value.toFixed(2);
+  if (value >= 0.01) return value.toFixed(3);
+  return value.toFixed(4);
+}
+
+function formatLift(lift: number): string {
+  const pct = lift * 100;
+  const sign = pct >= 0 ? '+' : '';
+  return `${sign}${pct.toFixed(0)}%`;
+}
+
+function videoListSummary(
+  videos: ChannelIntelligenceReport['rankedVideos'],
+  limit: number
+): string {
+  if (videos.length === 0) return 'No ranked videos yet.';
+  return videos
+    .slice(0, limit)
+    .map(
+      (v, i) =>
+        `${i + 1}. "${v.title}" (WMPI ${formatWmpi(v.watchMinutesPerImpression)}, CTR ${(v.ctr * 100).toFixed(1)}%)`
+    )
+    .join(' ');
+}
+
+function findingsSummary(
+  findings: ChannelIntelligenceReport['correlations'],
+  limit: number
+): string {
+  if (findings.length === 0) {
+    return 'Not enough per-segment data yet to name packaging winners on this channel.';
+  }
+  return findings
+    .slice(0, limit)
+    .map(
+      f =>
+        `${f.segment}: ${formatLift(f.liftVsChannel)} vs channel mean (n=${f.sampleSize}, ${f.confidence} confidence)`
+    )
+    .join('; ');
+}
+
+function collectSources(
+  report: ChannelIntelligenceReport,
+  extra: readonly MetricSource[] = []
+): MetricSource[] {
+  const seen = new Set<string>();
+  const out: MetricSource[] = [];
+  for (const s of [...report.sources, ...extra]) {
+    const key = `${s.kind}:${s.label}:${s.detail ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(s);
+  }
+  return out;
+}
+
+const EMPTY_SOURCES: MetricSource[] = [
+  {
+    kind: 'youtube_reporting_api',
+    label: 'YouTube Reporting API',
+    detail: 'No channel metrics available — connect YouTube OAuth',
+  },
+];
+
+/**
+ * Answers a channel-intelligence question from a built report.
+ * Always attaches sources; never invents metrics.
+ */
+export function answerChannelQuestion(
+  report: ChannelIntelligenceReport | null,
+  intent: ChannelQuestionIntent
+): ChannelIntelligenceAnswer {
+  if (!report || report.videoCount === 0) {
+    return {
+      intent,
+      summary:
+        'Connect your YouTube channel to answer this from real Reporting API metrics. Ranking uses watch minutes per impression — not CTR alone.',
+      rankedVideos: [],
+      findings: [],
+      sources: EMPTY_SOURCES,
+      hasData: false,
+    };
+  }
+
+  switch (intent) {
+    case 'best_videos': {
+      const top = report.rankedVideos.slice(0, 5);
+      return {
+        intent,
+        summary: `Top videos by watch minutes per impression (not CTR alone). Channel mean WMPI ${formatWmpi(report.channelMeanWmpi)}. ${videoListSummary(top, 5)}`,
+        rankedVideos: top,
+        findings: [],
+        sources: collectSources(report),
+        hasData: true,
+      };
+    }
+    case 'worst_videos': {
+      const bottom = [...report.rankedVideos].reverse().slice(0, 5);
+      return {
+        intent,
+        summary: `Lowest videos by watch minutes per impression. ${videoListSummary(bottom, 5)}`,
+        rankedVideos: bottom,
+        findings: [],
+        sources: collectSources(report),
+        hasData: true,
+      };
+    }
+    case 'whats_working': {
+      const works = report.whatWorks;
+      return {
+        intent,
+        summary: `What correlates with wins on this channel: ${findingsSummary(works, 5)}`,
+        rankedVideos: report.rankedVideos.slice(0, 3),
+        findings: works,
+        sources: collectSources(
+          report,
+          works.flatMap(f => f.sources)
+        ),
+        hasData: true,
+      };
+    }
+    case 'whats_declining': {
+      const declining = report.declining.slice(0, 5);
+      return {
+        intent,
+        summary:
+          declining.length === 0
+            ? 'No videos currently show a meaningful reach decline (trend below −10%).'
+            : `Videos with declining reach: ${videoListSummary(declining, 5)}`,
+        rankedVideos: declining,
+        findings: [],
+        sources: collectSources(report),
+        hasData: true,
+      };
+    }
+    case 'channel_overview': {
+      return {
+        intent,
+        summary: `Channel intelligence: ${report.videoCount} videos ranked by watch minutes per impression (mean ${formatWmpi(report.channelMeanWmpi)}). What works: ${findingsSummary(report.whatWorks, 3)}. Declining: ${report.declining.length} video${report.declining.length === 1 ? '' : 's'}.`,
+        rankedVideos: report.rankedVideos.slice(0, 5),
+        findings: report.whatWorks,
+        sources: collectSources(report),
+        hasData: true,
+      };
+    }
+  }
+}
+
+/**
+ * Convenience: detect intent from free text and answer.
+ * Returns null when the text is not a channel-intelligence question.
+ */
+export function answerChannelQuestionFromText(
+  report: ChannelIntelligenceReport | null,
+  text: string
+): ChannelIntelligenceAnswer | null {
+  const intent = detectChannelQuestionIntent(text);
+  if (!intent) return null;
+  return answerChannelQuestion(report, intent);
+}

--- a/apps/web/lib/services/channel-intelligence/rank.ts
+++ b/apps/web/lib/services/channel-intelligence/rank.ts
@@ -1,0 +1,73 @@
+/**
+ * Rank channel videos by watch_minutes_per_impression (JOV-3193).
+ */
+
+import { isEligibleForRank, watchMinutesPerImpression } from './metrics';
+import type { ChannelVideoMetrics, MetricSource, RankedVideo } from './types';
+
+const REPORTING_SOURCE: MetricSource = {
+  kind: 'youtube_reporting_api',
+  label: 'YouTube Reporting API',
+  detail: 'watch_minutes_per_impression = watchMinutes / impressions',
+};
+
+function toRankedVideo(
+  v: ChannelVideoMetrics,
+  rank: number,
+  wmpi: number
+): RankedVideo {
+  return {
+    videoId: v.videoId,
+    title: v.title,
+    thumbnailUrl: v.thumbnailUrl,
+    publishedAt: v.publishedAt,
+    rank,
+    watchMinutesPerImpression: wmpi,
+    ctr: v.ctr,
+    impressions: v.impressions,
+    views: v.views,
+    watchMinutes: v.watchMinutes,
+    avgViewDurationSeconds: v.avgViewDurationSeconds,
+    reachTrend: v.reachTrend,
+    hasFace: v.hasFace,
+    hasText: v.hasText,
+    topic: v.topic,
+    durationSeconds: v.durationSeconds,
+    sources: [
+      {
+        ...REPORTING_SOURCE,
+        videoIds: [v.videoId],
+      },
+    ],
+  };
+}
+
+/**
+ * Ranks eligible videos by watch_minutes_per_impression descending.
+ * Never ranks by CTR alone.
+ */
+export function rankVideosByWatchMinutesPerImpression(
+  videos: readonly ChannelVideoMetrics[]
+): RankedVideo[] {
+  const scored = videos
+    .filter(isEligibleForRank)
+    .map(v => ({
+      video: v,
+      wmpi: watchMinutesPerImpression(v),
+    }))
+    // Stable secondary sort by impressions when WMPI ties
+    .sort((a, b) => {
+      if (b.wmpi !== a.wmpi) return b.wmpi - a.wmpi;
+      return b.video.impressions - a.video.impressions;
+    });
+
+  return scored.map((entry, index) =>
+    toRankedVideo(entry.video, index + 1, entry.wmpi)
+  );
+}
+
+export function channelMeanWmpi(ranked: readonly RankedVideo[]): number {
+  if (ranked.length === 0) return 0;
+  const sum = ranked.reduce((acc, v) => acc + v.watchMinutesPerImpression, 0);
+  return sum / ranked.length;
+}

--- a/apps/web/lib/services/channel-intelligence/report.ts
+++ b/apps/web/lib/services/channel-intelligence/report.ts
@@ -1,109 +1,96 @@
 /**
- * Build a full channel-intelligence report from Reporting-API shaped metrics.
+ * Builds the full channel-intelligence report (JOV-3193).
  */
 
+import type { ChannelPackagingRules } from '@/lib/services/packaging-intelligence/channel-rules';
 import {
   computeChannelCorrelations,
-  mergeLearningLayerAnnotations,
+  findingsFromLearningLayer,
+  selectWhatWorks,
 } from './correlations';
-import {
-  meanWatchMinutesPerImpression,
-  rankDecliningVideos,
-  rankVideosByWatchMinutesPerImpression,
-  rankWorstVideosByWatchMinutesPerImpression,
-} from './metrics';
+import { isDeclining, isEligibleForRank } from './metrics';
+import { channelMeanWmpi, rankVideosByWatchMinutesPerImpression } from './rank';
 import type {
-  BuildChannelIntelligenceReportInput,
   ChannelIntelligenceReport,
+  ChannelVideoMetrics,
   MetricSource,
+  RankedVideo,
 } from './types';
 
-const DEFAULT_LIST_LIMIT = 10;
+export interface BuildChannelIntelligenceReportInput {
+  readonly channelId: string;
+  readonly videos: readonly ChannelVideoMetrics[];
+  /** Optional learning-layer rules for this channel */
+  readonly channelRules?: ChannelPackagingRules | null;
+  /** ISO timestamp override for tests */
+  readonly nowIso?: string;
+}
 
-function reportingSources(
-  videoIds: readonly string[],
-  windowStart: string | null,
-  windowEnd: string | null
-): MetricSource[] {
-  return [
-    {
-      kind: 'youtube_reporting_api',
-      label: 'YouTube Reporting API',
-      metricKeys: [
-        'impressions',
-        'views',
-        'watch_minutes',
-        'ctr',
-        'average_view_duration',
-        'watch_minutes_per_impression',
-      ],
-      videoIds,
-      ...(windowStart ? { windowStart } : {}),
-      ...(windowEnd ? { windowEnd } : {}),
-    },
-    {
-      kind: 'derived',
-      label: 'Derived: watch_minutes_per_impression',
-      metricKeys: ['watch_minutes_per_impression'],
-      videoIds,
-    },
-  ];
+function decliningVideos(ranked: readonly RankedVideo[]): RankedVideo[] {
+  return ranked
+    .filter(v => v.reachTrend < -0.1)
+    .sort((a, b) => a.reachTrend - b.reachTrend);
 }
 
 /**
- * Build the channel-intelligence dashboard report.
- *
- * Ranking is always by watch_minutes_per_impression (not CTR alone).
- * Win signals come from packaging correlations on THIS channel's data,
- * optionally annotated by the packaging learning layer.
+ * Builds a channel-intelligence report from Reporting-API video metrics
+ * and optional learning-layer packaging rules.
  */
 export function buildChannelIntelligenceReport(
   input: BuildChannelIntelligenceReportInput
 ): ChannelIntelligenceReport {
-  const listLimit = input.listLimit ?? DEFAULT_LIST_LIMIT;
-  const windowStart = input.windowStart ?? null;
-  const windowEnd = input.windowEnd ?? null;
   const generatedAt = input.nowIso ?? new Date().toISOString();
-
-  const bestVideos = rankVideosByWatchMinutesPerImpression(input.videos).slice(
-    0,
-    listLimit
-  );
-  const worstVideos = rankWorstVideosByWatchMinutesPerImpression(
-    input.videos
-  ).slice(0, listLimit);
-  const decliningVideos = rankDecliningVideos(input.videos).slice(0, listLimit);
-
-  const metricSignals = computeChannelCorrelations(input.videos);
-  const winSignals = mergeLearningLayerAnnotations(
-    metricSignals,
-    input.learningLayerSummaries
+  const rankedVideos = rankVideosByWatchMinutesPerImpression(input.videos);
+  const { findings: metricFindings, channelMeanWmpi: meanFromCorr } =
+    computeChannelCorrelations(input.videos);
+  const learningFindings = findingsFromLearningLayer(
+    input.channelRules ?? null
   );
 
-  const videoIds = input.videos.map(v => v.videoId);
-  const sources = reportingSources(videoIds, windowStart, windowEnd);
+  // Prefer learning-layer keys when both speak to the same dimension signal
+  const learningKeys = new Set(learningFindings.map(f => f.segmentKey));
+  const mergedFindings = [
+    ...learningFindings,
+    ...metricFindings.filter(f => !learningKeys.has(f.segmentKey)),
+  ].sort((a, b) => Math.abs(b.liftVsChannel) - Math.abs(a.liftVsChannel));
 
-  if (input.learningLayerSummaries?.some(a => a.source === 'observed')) {
+  const mean =
+    rankedVideos.length > 0 ? channelMeanWmpi(rankedVideos) : meanFromCorr;
+
+  const sources: MetricSource[] = [
+    {
+      kind: 'youtube_reporting_api',
+      label: 'YouTube Reporting API',
+      detail: `Ranked ${rankedVideos.length} of ${input.videos.length} videos by watch_minutes_per_impression`,
+      videoIds: rankedVideos.map(v => v.videoId),
+    },
+  ];
+  if (learningFindings.length > 0) {
     sources.push({
       kind: 'learning_layer',
-      label: 'Channel packaging learning layer',
-      metricKeys: ['experiment_lift', 'face', 'text', 'title_length'],
+      label: 'Channel packaging rules',
+      detail: `${learningFindings.length} observed dimension rule(s)`,
     });
   }
 
   return {
     channelId: input.channelId,
     generatedAt,
-    windowStart,
-    windowEnd,
-    videoCount: input.videos.length,
-    channelMeanWatchMinutesPerImpression: meanWatchMinutesPerImpression(
-      input.videos
-    ),
-    bestVideos,
-    worstVideos,
-    decliningVideos,
-    winSignals,
+    rankedVideos,
+    channelMeanWmpi: mean,
+    correlations: mergedFindings,
+    whatWorks: selectWhatWorks(mergedFindings),
+    declining: decliningVideos(rankedVideos),
     sources,
+    videoCount: rankedVideos.length,
   };
 }
+
+/** True when at least one video is eligible for ranking. */
+export function hasChannelIntelligenceData(
+  videos: readonly ChannelVideoMetrics[]
+): boolean {
+  return videos.some(isEligibleForRank);
+}
+
+export { isDeclining };

--- a/apps/web/lib/services/channel-intelligence/types.ts
+++ b/apps/web/lib/services/channel-intelligence/types.ts
@@ -1,140 +1,127 @@
 /**
- * Channel-intelligence report types (JOV-3193).
- * Pure types — connector hydrates YouTube Reporting / Analytics API rows.
+ * Channel-intelligence report types (JOV-3193 / GH-10917).
+ *
+ * Pure contracts for ranking videos by watch_minutes_per_impression,
+ * correlating packaging attributes with wins on THIS channel, and answering
+ * chat questions with cited Reporting-API sources.
+ *
+ * Live YouTube OAuth connector supplies metrics; this layer stays pure.
  */
 
-export type TitleLengthBucket = 'short' | 'medium' | 'long';
-export type DurationBucket = 'short' | 'medium' | 'long';
+/** Provenance for every numeric claim in the report. */
+export interface MetricSource {
+  readonly kind: 'youtube_reporting_api' | 'learning_layer' | 'derived';
+  readonly label: string;
+  readonly videoIds?: readonly string[];
+  readonly detail?: string;
+}
 
+/**
+ * Per-video metrics from YouTube Analytics / Reporting API, plus optional
+ * packaging attributes used for per-channel correlation.
+ */
 export interface ChannelVideoMetrics {
   readonly videoId: string;
   readonly title: string;
   readonly thumbnailUrl?: string;
+  /** ISO-8601 publish date */
   readonly publishedAt: string;
+  /** Thumbnail impressions in the measurement window */
   readonly impressions: number;
-  readonly views: number;
-  readonly watchMinutes: number;
-  /** CTR 0–1 */
+  /** Click-through rate (0–1) */
   readonly ctr: number;
+  readonly views: number;
+  /** Total watch minutes in the window (Reporting API) */
+  readonly watchMinutes: number;
+  /** Average view duration in seconds */
   readonly avgViewDurationSeconds: number;
-  /** (recent - older) / older impressions */
+  /**
+   * Reach trend: (recentImpressions - olderImpressions) / olderImpressions.
+   * Negative = declining.
+   */
   readonly reachTrend: number;
+  /** Thumbnail face presence; null when unknown */
   readonly hasFace: boolean | null;
+  /** Thumbnail text overlay; null when unknown */
   readonly hasText: boolean | null;
+  /** Topic / niche tag for this video; null when unknown */
   readonly topic: string | null;
-  readonly titleWordCount: number | null;
+  /** Content length in seconds; null when unknown */
   readonly durationSeconds: number | null;
+  /** Title word count; null when unknown */
+  readonly titleWordCount: number | null;
 }
 
-export type MetricSourceKind =
-  | 'youtube_reporting_api'
-  | 'youtube_analytics_api'
-  | 'learning_layer'
-  | 'derived';
+export type CorrelationDimension = 'face' | 'text' | 'topic' | 'length';
 
-export interface MetricSource {
-  readonly kind: MetricSourceKind;
-  readonly label: string;
-  readonly metricKeys: readonly string[];
-  readonly videoIds?: readonly string[];
-  readonly windowStart?: string;
-  readonly windowEnd?: string;
-}
+export type LengthBucket = 'short' | 'medium' | 'long';
 
+/** Video ranked by watch_minutes_per_impression (primary winner metric). */
 export interface RankedVideo {
   readonly videoId: string;
   readonly title: string;
   readonly thumbnailUrl?: string;
   readonly publishedAt: string;
+  readonly rank: number;
+  /** Primary metric: watch_minutes / impressions */
   readonly watchMinutesPerImpression: number;
-  readonly ctrTimesAvgViewDurationMinutes: number;
+  /** CTR alone — never used as the ranking key */
   readonly ctr: number;
-  readonly avgViewDurationSeconds: number;
   readonly impressions: number;
   readonly views: number;
   readonly watchMinutes: number;
+  readonly avgViewDurationSeconds: number;
   readonly reachTrend: number;
-  readonly rank: number;
+  readonly hasFace: boolean | null;
+  readonly hasText: boolean | null;
+  readonly topic: string | null;
+  readonly durationSeconds: number | null;
+  readonly sources: readonly MetricSource[];
 }
 
-export type CorrelationDimension =
-  | 'face'
-  | 'text'
-  | 'topic'
-  | 'title_length'
-  | 'duration';
-
-export interface CorrelationGroup {
-  readonly key: string;
+export interface CorrelationFinding {
   readonly dimension: CorrelationDimension;
-  readonly label: string;
+  /** Human-readable segment label, e.g. "Face", "No face", "Topic: music" */
+  readonly segment: string;
+  readonly segmentKey: string;
+  readonly avgWatchMinutesPerImpression: number;
   readonly sampleSize: number;
-  readonly meanWatchMinutesPerImpression: number;
-  readonly liftVsChannelMean: number;
-}
-
-export interface ChannelWinSignal {
-  readonly dimension: CorrelationDimension;
-  readonly summary: string;
-  readonly winningLabel: string | null;
-  readonly losingLabel: string | null;
-  readonly liftPercent: number;
-  readonly sampleSize: number;
+  /** Relative lift vs channel mean WMPI (0.1 = +10%) */
+  readonly liftVsChannel: number;
   readonly confidence: 'low' | 'medium' | 'high';
-  readonly groups: readonly CorrelationGroup[];
-  readonly source: MetricSource;
+  readonly sources: readonly MetricSource[];
+}
+
+export type ChannelQuestionIntent =
+  | 'best_videos'
+  | 'worst_videos'
+  | 'whats_working'
+  | 'whats_declining'
+  | 'channel_overview';
+
+export interface ChannelIntelligenceAnswer {
+  readonly intent: ChannelQuestionIntent;
+  readonly summary: string;
+  readonly rankedVideos: readonly RankedVideo[];
+  readonly findings: readonly CorrelationFinding[];
+  readonly sources: readonly MetricSource[];
+  /** False when no Reporting-API metrics are available yet */
+  readonly hasData: boolean;
 }
 
 export interface ChannelIntelligenceReport {
   readonly channelId: string;
   readonly generatedAt: string;
-  readonly windowStart: string | null;
-  readonly windowEnd: string | null;
-  readonly videoCount: number;
-  readonly channelMeanWatchMinutesPerImpression: number;
-  readonly bestVideos: readonly RankedVideo[];
-  readonly worstVideos: readonly RankedVideo[];
-  readonly decliningVideos: readonly RankedVideo[];
-  readonly winSignals: readonly ChannelWinSignal[];
-  readonly sources: readonly MetricSource[];
-}
-
-export type ChannelIntelligenceIntent =
-  | 'best_videos'
-  | 'worst_videos'
-  | 'whats_working'
-  | 'whats_declining'
-  | 'unknown';
-
-export interface ChannelIntelligenceAnswer {
-  readonly intent: ChannelIntelligenceIntent;
-  readonly summary: string;
+  /** Videos ranked best → worst by watch_minutes_per_impression */
   readonly rankedVideos: readonly RankedVideo[];
-  readonly winSignals: readonly ChannelWinSignal[];
+  /** Channel mean WMPI across ranked videos */
+  readonly channelMeanWmpi: number;
+  /** What correlates with wins on THIS channel */
+  readonly correlations: readonly CorrelationFinding[];
+  /** Top positive correlations (what works) */
+  readonly whatWorks: readonly CorrelationFinding[];
+  /** Videos with declining reach, ranked by severity */
+  readonly declining: readonly RankedVideo[];
   readonly sources: readonly MetricSource[];
-}
-
-export interface BuildChannelIntelligenceReportInput {
-  readonly channelId: string;
-  readonly videos: readonly ChannelVideoMetrics[];
-  readonly windowStart?: string | null;
-  readonly windowEnd?: string | null;
-  readonly nowIso?: string;
-  readonly listLimit?: number;
-  readonly learningLayerSummaries?: readonly LearningLayerWinAnnotation[];
-}
-
-export interface LearningLayerWinAnnotation {
-  readonly dimension: 'face' | 'text' | 'title_length';
-  readonly summary: string;
-  readonly liftPercent: number;
-  readonly sampleSize: number;
-  readonly confidence: number;
-  readonly source: 'observed' | '1of10';
-}
-
-export interface AnswerChannelIntelligenceQueryInput {
-  readonly question: string;
-  readonly report: ChannelIntelligenceReport;
-  readonly listLimit?: number;
+  readonly videoCount: number;
 }

--- a/apps/web/tests/unit/lib/services/channel-intelligence/channel-intelligence.test.ts
+++ b/apps/web/tests/unit/lib/services/channel-intelligence/channel-intelligence.test.ts
@@ -1,206 +1,358 @@
 import { describe, expect, it } from 'vitest';
 import {
-  answerChannelIntelligenceQuery,
+  answerChannelQuestion,
+  answerChannelQuestionFromText,
   buildChannelIntelligenceReport,
   type ChannelVideoMetrics,
-  classifyChannelIntelligenceIntent,
   computeChannelCorrelations,
-  ctrTimesAvgViewDurationMinutes,
+  detectChannelQuestionIntent,
   rankVideosByWatchMinutesPerImpression,
   watchMinutesPerImpression,
 } from '@/lib/services/channel-intelligence';
+import type { ChannelPackagingRules } from '@/lib/services/packaging-intelligence/channel-rules';
 
 function makeVideo(
-  overrides: Partial<ChannelVideoMetrics> = {}
+  overrides: Partial<ChannelVideoMetrics> & { videoId: string; title: string }
 ): ChannelVideoMetrics {
   return {
-    videoId: 'vid_001',
-    title: 'Test Video',
-    publishedAt: '2024-06-01T00:00:00Z',
+    publishedAt: '2025-01-01T00:00:00.000Z',
     impressions: 10_000,
-    views: 500,
-    watchMinutes: 2_000,
     ctr: 0.05,
+    views: 500,
+    watchMinutes: 2_000, // 0.2 WMPI default
     avgViewDurationSeconds: 240,
     reachTrend: 0.05,
-    hasFace: true,
-    hasText: false,
-    topic: 'music',
-    titleWordCount: 4,
-    durationSeconds: 600,
+    hasFace: null,
+    hasText: null,
+    topic: null,
+    durationSeconds: 300,
+    titleWordCount: 6,
     ...overrides,
   };
 }
 
-function makeVideoWithWmpi(
-  videoId: string,
-  title: string,
-  wmpi: number,
-  impressions: number,
-  extra: Partial<ChannelVideoMetrics> = {}
-): ChannelVideoMetrics {
-  return makeVideo({
-    videoId,
-    title,
-    impressions,
-    watchMinutes: wmpi * impressions,
-    ...extra,
-  });
-}
-
 describe('watchMinutesPerImpression', () => {
-  it('uses watch_minutes / impressions, or CTR × AVD minutes as fallback', () => {
-    expect(
-      watchMinutesPerImpression(
-        makeVideo({ impressions: 200, watchMinutes: 100 })
-      )
-    ).toBeCloseTo(0.5, 6);
-    // CTR 0.10 × (180s / 60) = 0.30
-    expect(
-      watchMinutesPerImpression(
-        makeVideo({
-          impressions: 0,
-          watchMinutes: 0,
-          ctr: 0.1,
-          avgViewDurationSeconds: 180,
-        })
-      )
-    ).toBeCloseTo(0.3, 6);
-    expect(
-      ctrTimesAvgViewDurationMinutes(
-        makeVideo({ ctr: 0.1, avgViewDurationSeconds: 180 })
-      )
-    ).toBeCloseTo(0.3, 6);
+  it('uses watchMinutes / impressions as the primary metric', () => {
+    const v = makeVideo({
+      videoId: 'a',
+      title: 'A',
+      impressions: 1_000,
+      watchMinutes: 500,
+      ctr: 0.99, // high CTR must not replace ranking metric
+      avgViewDurationSeconds: 10,
+    });
+    expect(watchMinutesPerImpression(v)).toBeCloseTo(0.5, 6);
+  });
+
+  it('falls back to CTR × AVD(minutes) when watch minutes are missing', () => {
+    const v = makeVideo({
+      videoId: 'b',
+      title: 'B',
+      impressions: 1_000,
+      watchMinutes: 0,
+      ctr: 0.1,
+      avgViewDurationSeconds: 120, // 2 minutes
+    });
+    // 0.1 * 2 = 0.2
+    expect(watchMinutesPerImpression(v)).toBeCloseTo(0.2, 6);
+  });
+
+  it('returns 0 when impressions are zero', () => {
+    const v = makeVideo({
+      videoId: 'c',
+      title: 'C',
+      impressions: 0,
+      watchMinutes: 100,
+    });
+    expect(watchMinutesPerImpression(v)).toBe(0);
   });
 });
 
 describe('rankVideosByWatchMinutesPerImpression', () => {
-  it('ranks by WMPI not CTR and drops sub-floor impressions', () => {
-    const clickbait = makeVideo({
+  it('ranks by WMPI not CTR alone', () => {
+    const highCtrLowRetention = makeVideo({
       videoId: 'clickbait',
+      title: 'Clickbait',
       impressions: 10_000,
-      watchMinutes: 500, // WMPI 0.05
-      ctr: 0.15,
-      avgViewDurationSeconds: 20,
+      ctr: 0.2, // excellent CTR
+      watchMinutes: 500, // 0.05 WMPI — weak
+      avgViewDurationSeconds: 15,
     });
-    const deep = makeVideo({
-      videoId: 'deep',
+    const lowerCtrHighRetention = makeVideo({
+      videoId: 'keeper',
+      title: 'Keeper',
       impressions: 10_000,
-      watchMinutes: 3_000, // WMPI 0.30
-      ctr: 0.04,
+      ctr: 0.04, // lower CTR
+      watchMinutes: 3_000, // 0.3 WMPI — strong
       avgViewDurationSeconds: 450,
     });
+
     const ranked = rankVideosByWatchMinutesPerImpression([
-      clickbait,
-      deep,
-      makeVideo({ videoId: 'tiny', impressions: 50, watchMinutes: 40 }),
+      highCtrLowRetention,
+      lowerCtrHighRetention,
     ]);
-    expect(ranked.map(v => v.videoId)).toEqual(['deep', 'clickbait']);
-    expect(clickbait.ctr).toBeGreaterThan(deep.ctr);
+
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0]?.videoId).toBe('keeper');
+    expect(ranked[0]?.rank).toBe(1);
+    expect(ranked[1]?.videoId).toBe('clickbait');
+    expect(ranked[0]?.sources[0]?.kind).toBe('youtube_reporting_api');
+  });
+
+  it('excludes videos below the impression floor', () => {
+    const ranked = rankVideosByWatchMinutesPerImpression([
+      makeVideo({
+        videoId: 'tiny',
+        title: 'Tiny',
+        impressions: 50,
+        watchMinutes: 100,
+      }),
+      makeVideo({
+        videoId: 'ok',
+        title: 'Ok',
+        impressions: 500,
+        watchMinutes: 100,
+      }),
+    ]);
+    expect(ranked.map(v => v.videoId)).toEqual(['ok']);
   });
 });
 
 describe('computeChannelCorrelations', () => {
-  it('surfaces face and topic wins on this channel', () => {
-    const videos: ChannelVideoMetrics[] = [];
-    for (let i = 0; i < 5; i++) {
-      videos.push(
-        makeVideoWithWmpi(`face_${i}`, `Face ${i}`, 0.4, 2_000, {
-          hasFace: true,
-          topic: 'live',
-        }),
-        makeVideoWithWmpi(`noface_${i}`, `No Face ${i}`, 0.2, 2_000, {
-          hasFace: false,
-          topic: 'studio',
-        })
-      );
-    }
-    const signals = computeChannelCorrelations(videos);
-    const face = signals.find(s => s.dimension === 'face');
-    expect(face?.winningLabel).toMatch(/face/i);
-    expect(face?.source.kind).toBe('youtube_reporting_api');
-    const topic = signals.find(s => s.dimension === 'topic');
-    expect(topic?.winningLabel?.toLowerCase()).toContain('live');
+  it('surfaces face / text / topic / length correlations on this channel', () => {
+    const videos: ChannelVideoMetrics[] = [
+      makeVideo({
+        videoId: 'f1',
+        title: 'Face 1',
+        hasFace: true,
+        hasText: false,
+        topic: 'Music',
+        durationSeconds: 120,
+        watchMinutes: 4_000, // 0.4
+      }),
+      makeVideo({
+        videoId: 'f2',
+        title: 'Face 2',
+        hasFace: true,
+        hasText: false,
+        topic: 'Music',
+        durationSeconds: 150,
+        watchMinutes: 3_500, // 0.35
+      }),
+      makeVideo({
+        videoId: 'f3',
+        title: 'Face 3',
+        hasFace: true,
+        hasText: true,
+        topic: 'Music',
+        durationSeconds: 160,
+        watchMinutes: 3_800, // 0.38
+      }),
+      makeVideo({
+        videoId: 'n1',
+        title: 'No face 1',
+        hasFace: false,
+        hasText: true,
+        topic: 'Vlog',
+        durationSeconds: 900,
+        watchMinutes: 1_000, // 0.1
+      }),
+      makeVideo({
+        videoId: 'n2',
+        title: 'No face 2',
+        hasFace: false,
+        hasText: true,
+        topic: 'Vlog',
+        durationSeconds: 850,
+        watchMinutes: 1_200, // 0.12
+      }),
+      makeVideo({
+        videoId: 'n3',
+        title: 'No face 3',
+        hasFace: false,
+        hasText: false,
+        topic: 'Vlog',
+        durationSeconds: 800,
+        watchMinutes: 800, // 0.08
+      }),
+    ];
+
+    const { findings } = computeChannelCorrelations(videos);
+    const face = findings.find(f => f.segmentKey === 'face:yes');
+    const noFace = findings.find(f => f.segmentKey === 'face:no');
+    const music = findings.find(f => f.segmentKey === 'topic:music');
+    const short = findings.find(f => f.segmentKey === 'length:short');
+
+    expect(face).toBeDefined();
+    expect(noFace).toBeDefined();
+    expect(face!.liftVsChannel).toBeGreaterThan(0);
+    expect(noFace!.liftVsChannel).toBeLessThan(0);
+    expect(music).toBeDefined();
+    expect(short).toBeDefined();
+    expect(findings.every(f => f.sources.length > 0)).toBe(true);
   });
 });
 
-describe('buildChannelIntelligenceReport + answers', () => {
-  const report = buildChannelIntelligenceReport({
-    channelId: 'UC_test',
-    videos: [
-      makeVideoWithWmpi('best', 'Hit Single', 0.6, 8_000, {
+describe('buildChannelIntelligenceReport', () => {
+  it('builds ranked report, what-works, declining, and sources', () => {
+    const videos = [
+      makeVideo({
+        videoId: 'best',
+        title: 'Best',
+        watchMinutes: 5_000,
         hasFace: true,
-        hasText: false,
-        topic: 'music',
         reachTrend: 0.2,
       }),
-      makeVideoWithWmpi('mid', 'Studio Tour', 0.3, 4_000, {
+      makeVideo({
+        videoId: 'mid',
+        title: 'Mid',
+        watchMinutes: 2_000,
         hasFace: true,
-        hasText: true,
-        topic: 'vlog',
         reachTrend: 0,
       }),
-      makeVideoWithWmpi('weak', 'Random Dump', 0.08, 3_000, {
+      makeVideo({
+        videoId: 'fade',
+        title: 'Fading',
+        watchMinutes: 1_500,
         hasFace: false,
-        hasText: true,
-        topic: 'vlog',
         reachTrend: -0.25,
       }),
-      ...[0, 1, 2].map(i =>
-        makeVideoWithWmpi(`face_${i}`, `Face ${i}`, 0.55, 2_000, {
-          hasFace: true,
-          topic: 'music',
-        })
-      ),
-      ...[0, 1, 2].map(i =>
-        makeVideoWithWmpi(`noface_${i}`, `NoFace ${i}`, 0.12, 2_000, {
-          hasFace: false,
-          topic: 'vlog',
-        })
-      ),
-    ],
-    nowIso: '2026-07-28T12:00:00Z',
-  });
+      makeVideo({
+        videoId: 'fade2',
+        title: 'Fading 2',
+        watchMinutes: 1_400,
+        hasFace: false,
+        reachTrend: -0.15,
+      }),
+      makeVideo({
+        videoId: 'fade3',
+        title: 'Fading 3',
+        watchMinutes: 1_300,
+        hasFace: false,
+        reachTrend: 0.01,
+      }),
+    ];
 
-  it('builds ranked lists with Reporting API sources', () => {
-    expect(report.bestVideos[0]?.videoId).toBe('best');
-    expect(report.worstVideos[0]?.videoId).toBe('weak');
-    expect(report.decliningVideos.map(v => v.videoId)).toContain('weak');
+    const report = buildChannelIntelligenceReport({
+      channelId: 'UC_test',
+      videos,
+      nowIso: '2026-08-01T00:00:00.000Z',
+    });
+
+    expect(report.channelId).toBe('UC_test');
+    expect(report.generatedAt).toBe('2026-08-01T00:00:00.000Z');
+    expect(report.rankedVideos[0]?.videoId).toBe('best');
+    expect(report.declining.map(v => v.videoId)).toContain('fade');
     expect(report.sources.some(s => s.kind === 'youtube_reporting_api')).toBe(
       true
     );
   });
 
-  it.each([
-    ['what are my best videos?', 'best_videos'],
-    ['what are my worst videos', 'worst_videos'],
-    ["what's working?", 'whats_working'],
-    ["what's declining?", 'whats_declining'],
-    ['hello', 'unknown'],
-  ] as const)('classifies %s → %s', (q, intent) => {
-    expect(classifyChannelIntelligenceIntent(q)).toBe(intent);
+  it('merges learning-layer rules into whatWorks when confident', () => {
+    const rules: ChannelPackagingRules = {
+      channelId: 'UC_test',
+      topic: null,
+      dimensions: {
+        face: {
+          liftDirection: 'positive',
+          liftPercent: 22,
+          confidence: 0.92,
+          sampleSize: 500,
+          provenance: [
+            {
+              experimentId: 'exp-1',
+              outcome: 'win',
+              recordedAt: '2026-07-01T00:00:00.000Z',
+            },
+          ],
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+      },
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    };
+
+    const report = buildChannelIntelligenceReport({
+      channelId: 'UC_test',
+      videos: [
+        makeVideo({ videoId: 'a', title: 'A', hasFace: true }),
+        makeVideo({ videoId: 'b', title: 'B', hasFace: true }),
+        makeVideo({ videoId: 'c', title: 'C', hasFace: true }),
+      ],
+      channelRules: rules,
+    });
+
+    expect(
+      report.whatWorks.some(f =>
+        f.sources.some(s => s.kind === 'learning_layer')
+      )
+    ).toBe(true);
+    expect(report.sources.some(s => s.kind === 'learning_layer')).toBe(true);
+  });
+});
+
+describe('detectChannelQuestionIntent + answerChannelQuestion', () => {
+  const report = buildChannelIntelligenceReport({
+    channelId: 'UC_test',
+    videos: [
+      makeVideo({
+        videoId: 'best',
+        title: 'Banger',
+        watchMinutes: 5_000,
+        hasFace: true,
+      }),
+      makeVideo({
+        videoId: 'ok',
+        title: 'Okay',
+        watchMinutes: 2_000,
+        hasFace: true,
+      }),
+      makeVideo({
+        videoId: 'meh',
+        title: 'Meh',
+        watchMinutes: 500,
+        hasFace: false,
+        reachTrend: -0.3,
+      }),
+    ],
   });
 
-  it('answers best / working / declining with sources', () => {
-    const best = answerChannelIntelligenceQuery({
-      question: 'what are my best videos?',
-      report,
-    });
-    expect(best.intent).toBe('best_videos');
-    expect(best.rankedVideos[0]?.videoId).toBe('best');
-    expect(best.sources.length).toBeGreaterThan(0);
+  it.each([
+    ['what are my best videos?', 'best_videos'],
+    ['show my worst videos', 'worst_videos'],
+    ["what's working on my channel?", 'whats_working'],
+    ["what's declining?", 'whats_declining'],
+    ['channel intelligence report', 'channel_overview'],
+  ] as const)('detects intent for %s', (text, intent) => {
+    expect(detectChannelQuestionIntent(text)).toBe(intent);
+  });
 
-    const working = answerChannelIntelligenceQuery({
-      question: "what's working?",
-      report,
-    });
-    expect(working.intent).toBe('whats_working');
-    expect(working.winSignals.length).toBeGreaterThan(0);
+  it('returns null for unrelated questions', () => {
+    expect(detectChannelQuestionIntent('update my bio')).toBeNull();
+  });
 
-    const declining = answerChannelIntelligenceQuery({
-      question: "what's declining?",
+  it('answers best videos from real report data with sources', () => {
+    const answer = answerChannelQuestion(report, 'best_videos');
+    expect(answer.hasData).toBe(true);
+    expect(answer.rankedVideos[0]?.title).toBe('Banger');
+    expect(answer.summary).toMatch(/watch minutes per impression/i);
+    expect(answer.sources.length).toBeGreaterThan(0);
+    expect(answer.sources[0]?.kind).toBe('youtube_reporting_api');
+  });
+
+  it('answers without inventing data when report is empty', () => {
+    const answer = answerChannelQuestion(null, 'best_videos');
+    expect(answer.hasData).toBe(false);
+    expect(answer.rankedVideos).toEqual([]);
+    expect(answer.summary).toMatch(/connect/i);
+  });
+
+  it('answerChannelQuestionFromText routes free-form chat', () => {
+    const answer = answerChannelQuestionFromText(
       report,
-    });
-    expect(declining.rankedVideos.some(v => v.videoId === 'weak')).toBe(true);
+      'what are my best videos right now?'
+    );
+    expect(answer?.intent).toBe('best_videos');
+    expect(answer?.hasData).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Ships the Phase 1 **channel-intelligence report** for JOV-3193 (GH-10917):

- Rank videos by **watch_minutes_per_impression** (watch minutes / impressions; CTR × AVD fallback) — never CTR alone
- Surface what correlates with wins on **this** channel (face / text / topic / length), optionally merged with learning-layer packaging rules
- Chat tool `showChannelIntelligence` answers best / worst / what’s working / declining with **Reporting-API sources**
- Dashboard report on `/app/youtube` (empty/connect state until YouTube OAuth connector lands)

## Test plan

- [x] `pnpm --filter web exec vitest run tests/unit/lib/services/channel-intelligence/channel-intelligence.test.ts` (17 tests)
- [x] `lib/agents/registry.test.ts` + `lib/chat/chat-tool-inventory.test.ts`
- [x] Biome + typecheck on touched files
- [x] Pre-push full verify suite passed (all unit shards) prior to push
- [ ] CI `PR Ready` on draft PR

## Notes

- Live metrics require YouTube OAuth connector (GH-10912). Until then the chat tool and dashboard fail closed with a connect CTA — no invented rankings.
- Pure service layer is ready for connector metrics + learning-layer rules.

Fixes JOV-3193
<!-- linear-issue-id:JOV-3193 -->