### PR TITLE
fix(evals): Promptfoo presence-build + channelIntelligence inventory

### DIFF
--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -339,6 +339,39 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Ready to record',
     errorTitle: "Couldn't prepare your recording",
   },
+  // JOV-3988 onboarding presence-build wow-moment artifacts
+  researchArtistPresence: {
+    label: 'Artist research',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Researching your artist presence…',
+    successTitle: 'Artist research ready',
+    errorTitle: "Couldn't research this artist",
+  },
+  assembleArtistProfile: {
+    label: 'Profile assembly',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Assembling your profile…',
+    successTitle: 'Profile sections ready',
+    errorTitle: "Couldn't assemble your profile",
+  },
+  generateSmartLink: {
+    label: 'Smart link',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Generating your smart link…',
+    successTitle: 'Smart link ready',
+    errorTitle: "Couldn't generate your smart link",
+  },
+  draftWelcomePost: {
+    label: 'Welcome post',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Drafting your first post…',
+    successTitle: 'Welcome draft ready',
+    errorTitle: "Couldn't draft a welcome post",
+  },
 } as const satisfies Record<string, ToolUiConfig>;
 
 function startCaseFromCamelCase(value: string): string {

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -88,6 +88,14 @@ export const HIDDEN_TOOLS: Readonly<Record<string, string>> = {
     'Merch lifecycle action shown from merch cards, not the root slash menu.',
   writeWorldClassBio:
     'Pro-only; chat surfaces it conversationally rather than via slash.',
+  researchArtistPresence:
+    'Onboarding presence-build system event; not a model-invoked or slash tool.',
+  assembleArtistProfile:
+    'Onboarding presence-build system event; not a model-invoked or slash tool.',
+  generateSmartLink:
+    'Onboarding presence-build system event; not a model-invoked or slash tool.',
+  draftWelcomePost:
+    'Onboarding presence-build system event; not a model-invoked or slash tool.',
 } as const;
 
 export type CommandSurface = 'chat-slash' | 'cmdk';

--- a/apps/web/scripts/run-deterministic-promptfoo-evals.sh
+++ b/apps/web/scripts/run-deterministic-promptfoo-evals.sh
@@ -51,13 +51,36 @@ case "$mode" in
     promptfoo validate -c "$config_path"
     ;;
   eval)
+    # Capture full output (no interactive TTY). Promptfoo's winston File transport
+    # can throw ERR_STREAM_WRITE_AFTER_END during teardown after all cases pass,
+    # which would otherwise fail merge_group with exit 1 (seen on #15334).
+    tmp_log="$(mktemp -t jovie-pf-eval.XXXXXX)"
+    set +e
+    set +o pipefail
     promptfoo eval \
       -c "$config_path" \
       --filter-metadata cost=deterministic \
       --no-cache \
       --no-share \
       --no-write \
-      --no-table 2>&1 | cat
+      --no-table >"$tmp_log" 2>&1
+    pf_rc=$?
+    set -e
+    set -o pipefail
+    cat "$tmp_log"
+    if [ "$pf_rc" -eq 0 ]; then
+      rm -f "$tmp_log"
+      exit 0
+    fi
+    if grep -q 'Error: write after end' "$tmp_log" \
+      && grep -Eq '0 failed|passed \(100%\)|✓ Complete!' "$tmp_log" \
+      && ! grep -Eq '[1-9][0-9]* failed' "$tmp_log"; then
+      echo "promptfoo teardown write-after-end ignored (all deterministic cases passed)" >&2
+      rm -f "$tmp_log"
+      exit 0
+    fi
+    rm -f "$tmp_log"
+    exit "$pf_rc"
     ;;
   *)
     echo "Usage: $0 [validate|eval]" >&2

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -454,6 +454,35 @@ const ADVANCED_TOOL_SCHEMAS = {
       script: z.string().min(12).max(1200),
     }),
   },
+  // JOV-3988 onboarding presence-build wow-moment artifacts (UI event names; not chat-model tools)
+  researchArtistPresence: {
+    description:
+      'Onboarding presence-build research step artifact. System-emitted tool event, not a model-invoked chat tool.',
+    inputSchema: z.object({
+      stepId: z.string().optional(),
+    }),
+  },
+  assembleArtistProfile: {
+    description:
+      'Onboarding presence-build profile assembly artifact. System-emitted tool event, not a model-invoked chat tool.',
+    inputSchema: z.object({
+      stepId: z.string().optional(),
+    }),
+  },
+  generateSmartLink: {
+    description:
+      'Onboarding presence-build smart link artifact. System-emitted tool event, not a model-invoked chat tool.',
+    inputSchema: z.object({
+      stepId: z.string().optional(),
+    }),
+  },
+  draftWelcomePost: {
+    description:
+      'Onboarding presence-build welcome draft artifact. System-emitted tool event, not a model-invoked chat tool.',
+    inputSchema: z.object({
+      stepId: z.string().optional(),
+    }),
+  },
 } as const;
 
 const ALL_EVAL_TOOL_SCHEMAS = {
@@ -501,6 +530,10 @@ const ALWAYS_PAID_TOOL_NAMES = [
   'markCanvasUploaded',
   'formatLyrics',
   'proposeVideoRecording',
+  'researchArtistPresence',
+  'assembleArtistProfile',
+  'generateSmartLink',
+  'draftWelcomePost',
 ] as const;
 
 const PAID_TOOL_NAMES = [
@@ -721,6 +754,10 @@ const TOOL_RESULT_REQUIRED_KEYS: Record<string, readonly string[]> = {
   suggestRelatedArtists: ['success', 'action', 'artists', 'summary'],
   unpauseMerchCard: ['success', 'action', 'merchCardId'],
   writeWorldClassBio: ['success', 'action', 'bio', 'summary'],
+  researchArtistPresence: ['action', 'stepId', 'title', 'summary'],
+  assembleArtistProfile: ['action', 'stepId', 'title', 'summary'],
+  generateSmartLink: ['action', 'stepId', 'title', 'summary'],
+  draftWelcomePost: ['action', 'stepId', 'title', 'summary'],
 };
 const SENSITIVE_RESULT_KEY_PATTERN =
   /(?:api[_-]?key|authorization|cookie|password|secret|session|token)/i;
@@ -4284,6 +4321,17 @@ function defaultToolResult(toolName: string, input: unknown): unknown {
           'Luna Waves pairs ambient textures with a concise release story for editorial pitching.',
         summary: 'Pitch ready.',
       };
+    case 'researchArtistPresence':
+    case 'assembleArtistProfile':
+    case 'generateSmartLink':
+    case 'draftWelcomePost':
+      return {
+        action: 'presence_build_artifact',
+        stepId:
+          typeof args.stepId === 'string' ? args.stepId : 'research_artist',
+        title: 'Presence build artifact',
+        summary: 'Synthetic presence-build artifact for evals.',
+      };
     default:
       return { success: true, action: toolName, input: args };
   }
@@ -4910,6 +4958,11 @@ function sampleToolInput(toolName: string): Record<string, unknown> {
         script:
           'Hey everyone, Neon Reef is out now. Thank you so much for listening.',
       };
+    case 'researchArtistPresence':
+    case 'assembleArtistProfile':
+    case 'generateSmartLink':
+    case 'draftWelcomePost':
+      return { stepId: 'research_artist' };
     default:
       return {};
   }

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1576,6 +1576,10 @@ tests:
           - suggestRelatedArtists
           - unpauseMerchCard
           - writeWorldClassBio
+          - researchArtistPresence
+          - assembleArtistProfile
+          - generateSmartLink
+          - draftWelcomePost
     assert:
       - type: javascript
         value: file://assertions.cjs:assertDeterministicNoSpend
@@ -1596,6 +1600,7 @@ tests:
       coverage:
         expectedSkillIds:
           - analyzePackaging
+          - channelIntelligenceReport
           - fan_email_send
           - generateReleasePitch
           - retouch
@@ -1616,6 +1621,7 @@ tests:
       coverage:
         expectedSkillIds:
           - analyzePackaging
+          - channelIntelligenceReport
           - fan_email_send
           - generateReleasePitch
           - retouch
@@ -1643,6 +1649,7 @@ tests:
       coverage:
         expectedSkillIds:
           - analyzePackaging
+          - channelIntelligenceReport
           - fan_email_send
           - generateReleasePitch
           - retouch
@@ -1684,6 +1691,7 @@ tests:
       coverage:
         expectedSkillIds:
           - analyzePackaging
+          - channelIntelligenceReport
           - fan_email_send
           - generateReleasePitch
           - retouch
@@ -2884,6 +2892,90 @@ tests:
         kind: promo
         title: "Release day shout-out"
         script: "Hey everyone, Neon Reef is out now. Thank you so much for listening."
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts presence-build research artifact event
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Presence-build research artifact."
+      target: tool-contract
+      toolName: researchArtistPresence
+      mode: app
+      plan: pro
+      toolInput:
+        stepId: research_artist
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts presence-build profile assembly artifact event
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Presence-build profile assembly artifact."
+      target: tool-contract
+      toolName: assembleArtistProfile
+      mode: app
+      plan: pro
+      toolInput:
+        stepId: assemble_profile
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts presence-build smart link artifact event
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Presence-build smart link artifact."
+      target: tool-contract
+      toolName: generateSmartLink
+      mode: app
+      plan: pro
+      toolInput:
+        stepId: generate_smart_link
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts presence-build welcome draft artifact event
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Presence-build welcome draft artifact."
+      target: tool-contract
+      toolName: draftWelcomePost
+      mode: app
+      plan: pro
+      toolInput:
+        stepId: draft_welcome_post
     assert:
       - type: javascript
         value: file://assertions.cjs:assertDeterministicNoSpend


### PR DESCRIPTION
## Summary
Unblock merge_group Promptfoo after presence-build TOOL_UI entries and channelIntelligenceReport skill drift.

## Changes
- TOOL_UI_REGISTRY labels for presence-build artifact events
- deterministic schemas/contracts + HIDDEN_TOOLS
- expectedSkillIds includes channelIntelligenceReport
- Local Promptfoo 205/205

## Test plan
- [x] deterministic promptfoo eval 205/205
- [ ] CI green + native MQ
