### PR TITLE
refactor(tour): use canonical entity header [JOV-4697]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
@@ -29,9 +29,9 @@ import {
   EntitySidebarShell,
   ShareableLinkRow,
 } from '@/components/molecules/drawer';
+import { EntityHeaderCard } from '@/components/molecules/drawer/EntityHeaderCard';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 import { convertToCommonDropdownItems } from '@/components/organisms/table';
-import { DrawerHero } from '@/components/shell/DrawerHero';
 import { CANONICAL_METRICS } from '@/lib/analytics/metrics';
 import {
   useDeleteTourDateMutation,
@@ -264,24 +264,16 @@ export function TourDateSidebar({
         entityHeader={
           tourDate ? (
             <>
-              <DrawerSurfaceCard
-                variant='card'
-                className='relative overflow-hidden'
-              >
-                <div className='absolute right-2 top-2 z-10'>
-                  <DrawerCardActionBar
-                    primaryActions={[]}
-                    menuItems={contextMenuItems}
-                    onClose={onClose}
-                    overflowTriggerPlacement='card-top-right'
-                    overflowTriggerIcon='vertical'
-                    className='border-0 bg-transparent px-0 py-0'
-                  />
-                </div>
-                <DrawerHero
+              <DrawerSurfaceCard variant='card' className='overflow-hidden p-3'>
+                <EntityHeaderCard
                   title={tourDate.title?.trim() || tourDate.venueName}
-                  density='rail'
-                  artwork={
+                  stableLayout
+                  titleLineClamp={1}
+                  subtitleLineClamp={1}
+                  reserveSubtitleSlot
+                  reserveMetaSlot
+                  metaOverflow='scroll'
+                  image={
                     <DrawerMediaThumb
                       alt=''
                       fallback={
@@ -303,12 +295,6 @@ export function TourDateSidebar({
                       {tourDate.country}
                     </>
                   }
-                  stableLayout
-                  titleLineClamp={1}
-                  subtitleLineClamp={1}
-                  reserveSubtitleSlot
-                  reserveMetaSlot
-                  metaOverflow='scroll'
                   meta={
                     tourDate.provider === 'bandsintown' ? (
                       <span className='inline-flex items-center gap-1.5 text-2xs text-secondary-token'>
@@ -317,8 +303,18 @@ export function TourDateSidebar({
                       </span>
                     ) : null
                   }
-                  className='[&_h2]:pr-9'
-                  testId='tour-date-entity-header'
+                  actions={
+                    <DrawerCardActionBar
+                      primaryActions={[]}
+                      menuItems={contextMenuItems}
+                      onClose={onClose}
+                      overflowTriggerPlacement='card-top-right'
+                      overflowTriggerIcon='vertical'
+                      className='border-0 bg-transparent px-0 py-0'
+                    />
+                  }
+                  bodyClassName='pr-9'
+                  data-testid='tour-date-entity-header'
                 />
               </DrawerSurfaceCard>
               <DrawerAnalyticsSummaryCard

--- a/apps/web/tests/unit/tour-date-sidebar-analytics.test.tsx
+++ b/apps/web/tests/unit/tour-date-sidebar-analytics.test.tsx
@@ -131,6 +131,31 @@ vi.mock('@/components/molecules/drawer', () => ({
   DrawerCardActionBar: () => <div data-testid='drawer-card-action-bar' />,
 }));
 
+vi.mock('@/components/molecules/drawer/EntityHeaderCard', () => ({
+  EntityHeaderCard: ({
+    title,
+    subtitle,
+    meta,
+    actions,
+    stableLayout,
+    'data-testid': testId,
+  }: {
+    title: React.ReactNode;
+    subtitle?: React.ReactNode;
+    meta?: React.ReactNode;
+    actions?: React.ReactNode;
+    stableLayout?: boolean;
+    'data-testid'?: string;
+  }) => (
+    <div data-testid={testId} data-stable-layout={stableLayout}>
+      <div>{title}</div>
+      {subtitle}
+      {meta}
+      {actions}
+    </div>
+  ),
+}));
+
 vi.mock('@/components/molecules/LoadingSkeleton', () => ({
   LoadingSkeleton: () => <div data-testid='loading-skeleton' />,
 }));
@@ -226,6 +251,25 @@ describe('TourDateSidebar analytics section', () => {
     expect(screen.getAllByTestId('loading-skeleton').length).toBeGreaterThan(0);
   });
 
+  it('uses the canonical entity header for identity and overflow actions', () => {
+    mockUseTourDateAnalyticsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+
+    renderSidebar();
+
+    expect(screen.getByTestId('tour-date-entity-header')).toHaveTextContent(
+      'Summer Tour 2026'
+    );
+    expect(screen.getByTestId('tour-date-entity-header')).toHaveAttribute(
+      'data-stable-layout',
+      'true'
+    );
+    expect(screen.getByTestId('drawer-card-action-bar')).toBeInTheDocument();
+  });
+
   it('shows error message when analytics fail to load', () => {
     mockUseTourDateAnalyticsQuery.mockReturnValue({
       data: undefined,
@@ -276,11 +320,6 @@ describe('TourDateSidebar analytics section', () => {
       'data-workspace-surface',
       'raised'
     );
-    expect(screen.getByTestId('tour-date-entity-header')).toHaveAttribute(
-      'data-density',
-      'rail'
-    );
-
     // Check stat tiles
     const ticketStat = screen.getByTestId('stat-Ticket Clicks');
     expect(ticketStat).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- replaces the Tour Date rail's bespoke DrawerHero and absolute action bar with the shared EntityHeaderCard
- preserves shared raised rail allocation, analytics, ticket links, and edit/action semantics
- adds focused coverage for canonical header composition

## Verification
- `pnpm --filter web exec vitest run tests/unit/tour-date-sidebar-analytics.test.tsx --maxWorkers 1` (6/6)
- `pnpm biome check apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx apps/web/tests/unit/tour-date-sidebar-analytics.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

Closes JOV-4697