### PR TITLE
refactor(contacts): use canonical entity header [JOV-4698]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { CommonDropdownItem } from '@jovie/ui';
 import { Check, Copy, Trash2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -15,6 +16,7 @@ interface UseContactDetailHeaderProps {
   readonly email?: string | null;
   readonly onDelete: () => void;
   readonly onClose?: () => void;
+  readonly menuItems?: readonly CommonDropdownItem[];
 }
 
 interface UseContactDetailHeaderResult {
@@ -30,6 +32,7 @@ export function useContactDetailHeaderParts({
   email,
   onDelete,
   onClose,
+  menuItems,
 }: UseContactDetailHeaderProps): UseContactDetailHeaderResult {
   const notifications = useNotifications();
   const [isCopied, setIsCopied] = useState(false);
@@ -69,7 +72,7 @@ export function useContactDetailHeaderParts({
   const overflowActions: DrawerHeaderAction[] = [
     {
       id: 'delete',
-      label: 'Delete contact',
+      label: 'Delete Contact',
       icon: Trash2,
       onClick: onDelete,
     },
@@ -84,6 +87,7 @@ export function useContactDetailHeaderParts({
         <DrawerHeaderActions
           primaryActions={primaryActions}
           overflowActions={overflowActions}
+          menuItems={menuItems}
           onClose={onClose}
         />
       ) : undefined,

--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
@@ -13,16 +13,14 @@ import {
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 import {
-  DrawerCardActionBar,
   DrawerEditableTextField,
   DrawerPropertyRow,
-  DrawerSurfaceCard,
   DrawerTabbedCard,
   DrawerTabs,
+  EntityHeaderCard,
   EntitySidebarShell,
 } from '@/components/molecules/drawer';
 import { DrawerSection } from '@/components/molecules/drawer/DrawerSection';
-import { DrawerHero } from '@/components/shell/DrawerHero';
 import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
 import {
   CONTACT_ROLE_OPTIONS,
@@ -168,13 +166,15 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
     [contact, onUpdate, debouncedSave]
   );
 
-  const { title: headerTitle, primaryActions } = useContactDetailHeaderParts({
-    role: contact?.role ?? 'other',
-    customLabel: contact?.customLabel,
-    email: contact?.email,
-    onDelete,
-    onClose: handleClose,
-  });
+  const { title: headerTitle, actions: headerActions } =
+    useContactDetailHeaderParts({
+      role: contact?.role ?? 'other',
+      customLabel: contact?.customLabel,
+      email: contact?.email,
+      onDelete,
+      onClose: handleClose,
+      menuItems: contextMenuItems,
+    });
 
   const hasContact = Boolean(contact);
   const roleLabel = contact
@@ -248,42 +248,31 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
       emptyMessage='Select a contact to view details'
       entityHeader={
         contact ? (
-          <DrawerSurfaceCard variant='card' className='overflow-hidden'>
-            <div className='relative'>
-              <DrawerCardActionBar
-                primaryActions={primaryActions}
-                menuItems={contextMenuItems}
-                onClose={handleClose}
-                overflowTriggerPlacement='card-top-right'
-                className='border-0 bg-transparent px-0 py-0'
-              />
-              <DrawerHero
-                title={contactDisplayName}
-                density='rail'
-                subtitle={roleLabel}
-                stableLayout
-                titleLineClamp={1}
-                subtitleLineClamp={1}
-                reserveSubtitleSlot
-                reserveMetaSlot
-                metaOverflow='scroll'
-                meta={
-                  territorySummary ? (
-                    <div className='flex items-center gap-1.5 text-2xs text-tertiary-token'>
-                      <Badge
-                        size='sm'
-                        className='rounded-md border border-subtle bg-surface-0 px-1.5 text-3xs text-secondary-token'
-                      >
-                        {territorySummary}
-                      </Badge>
-                    </div>
-                  ) : undefined
-                }
-                className='[&_h2]:pr-9'
-                testId='contact-detail-entity-header'
-              />
-            </div>
-          </DrawerSurfaceCard>
+          <EntityHeaderCard
+            title={contactDisplayName}
+            subtitle={roleLabel}
+            stableLayout
+            titleLineClamp={1}
+            subtitleLineClamp={1}
+            reserveSubtitleSlot
+            reserveMetaSlot
+            metaOverflow='scroll'
+            meta={
+              territorySummary ? (
+                <div className='flex items-center gap-1.5 text-2xs text-tertiary-token'>
+                  <Badge
+                    size='sm'
+                    className='rounded-md border border-subtle bg-surface-0 px-1.5 text-3xs text-secondary-token'
+                  >
+                    {territorySummary}
+                  </Badge>
+                </div>
+              ) : undefined
+            }
+            actions={headerActions}
+            bodyClassName='pr-8'
+            data-testid='contact-detail-entity-header'
+          />
         ) : undefined
       }
     >

--- a/apps/web/tests/unit/dashboard/ContactDetailSidebar.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactDetailSidebar.test.tsx
@@ -84,10 +84,15 @@ describe('ContactDetailSidebar', () => {
       'data-workspace-surface',
       'raised'
     );
-    expect(screen.getByTestId('contact-detail-entity-header')).toHaveAttribute(
-      'data-density',
-      'rail'
-    );
+    expect(
+      screen.getByTestId('contact-detail-entity-header')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('entity-header-meta-slot')).toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId('contact-detail-entity-header')
+        .querySelector('[data-testid="drawer-card-action-bar"]')
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('Contact')).not.toBeInTheDocument();
     expect(screen.getByText('Contact Info')).toBeInTheDocument();
     expect(screen.getByText('Role')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- replace the Contacts detail rail's route-local `DrawerHero`/card action composition with the shared `EntityHeaderCard`
- preserve Contact Info and Territories tabs, debounced autosave, shared desktop allocation, mobile behavior, and canonical actions
- keep the rail raised and free of duplicate header/action geometry

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/ContactDetailSidebar.test.tsx tests/unit/dashboard/ContactsTable.test.tsx --maxWorkers 1` (5/5)
- `pnpm biome check apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailHeader.tsx apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx apps/web/tests/unit/dashboard/ContactDetailSidebar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`
- normal hooked push (including component gate and affected verify)

Closes JOV-4698.