### PR TITLE
fix(inbox): route catalog CTA to Connections (JOV-4702)

### DIFF
--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxEmptyState.test.tsx
@@ -12,7 +12,7 @@ describe('OpportunityInboxEmptyState', () => {
             title: 'Connect Spotify',
             body: 'Link your catalog so Jovie can spot releases.',
             actionLabel: 'Connect catalog',
-            href: '/app/settings/artist-profile',
+            href: '/app/profiles',
           },
         ]}
       />
@@ -22,7 +22,7 @@ describe('OpportunityInboxEmptyState', () => {
     expect(emptyState).toHaveClass('flex-1', 'items-center', 'justify-center');
     expect(
       screen.getByRole('link', { name: 'Connect catalog' })
-    ).toHaveAttribute('href', '/app/settings/artist-profile');
+    ).toHaveAttribute('href', '/app/profiles');
   });
 
   it('keeps the chat fallback when no catalog action is available', () => {

--- a/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
+++ b/apps/web/components/features/opportunity-inbox/OpportunityInboxPageClient.test.tsx
@@ -209,7 +209,7 @@ describe('OpportunityInboxPageClient', () => {
               title: 'Connect Spotify',
               body: 'Link your catalog so Jovie can spot releases.',
               actionLabel: 'Connect catalog',
-              href: '/app/settings/artist-profile',
+              href: '/app/profiles',
             },
           ],
         }}
@@ -223,7 +223,7 @@ describe('OpportunityInboxPageClient', () => {
     expect(screen.getByText('Your Inbox Is Clear')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Connect catalog' })
-    ).toHaveAttribute('href', '/app/settings/artist-profile');
+    ).toHaveAttribute('href', '/app/profiles');
   });
 
   it('filters cards by signal type and restores them on All', () => {

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.test.ts
@@ -221,6 +221,7 @@ describe('buildOpportunityInboxData', () => {
     expect(data.cards).toEqual([]);
     expect(data.emptyActionCards).toHaveLength(2);
     expect(data.emptyActionCards[0]?.id).toBe('connect-spotify');
+    expect(data.emptyActionCards[0]?.href).toBe('/app/profiles');
   });
 });
 

--- a/apps/web/lib/connectors/opportunity-inbox-mapper.ts
+++ b/apps/web/lib/connectors/opportunity-inbox-mapper.ts
@@ -124,7 +124,7 @@ export const DEFAULT_OPPORTUNITY_INBOX_EMPTY_ACTION_CARDS: readonly OpportunityI
       title: 'Connect Spotify',
       body: 'Link your catalog so Jovie can spot releases, audience spikes, and pitch windows.',
       actionLabel: 'Connect catalog',
-      href: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
+      href: APP_ROUTES.PROFILES,
     },
     {
       id: 'add-tour-dates',

--- a/apps/web/tests/unit/lib/mobile/action-loop-inbox.test.ts
+++ b/apps/web/tests/unit/lib/mobile/action-loop-inbox.test.ts
@@ -42,7 +42,7 @@ describe('buildMobileInbox', () => {
           title: 'Connect Spotify',
           body: 'Link your catalog so Jovie can spot releases.',
           actionLabel: 'Connect catalog',
-          href: '/app/settings/artist-profile',
+          href: '/app/profiles',
         },
       ],
     });
@@ -66,7 +66,7 @@ describe('buildMobileInbox', () => {
           title: 'Connect Spotify',
           body: 'Link your catalog so Jovie can spot releases.',
           actionLabel: 'Connect catalog',
-          continueOnWebPath: '/app/settings/artist-profile',
+          continueOnWebPath: '/app/profiles',
         },
       ],
       chatPrompt:


### PR DESCRIPTION
## Outcome

Routes the Inbox empty-state **Connect catalog** CTA to the canonical Connections workspace at `/app/profiles`, closing the staging regression left behind after JOV-4512.

## Scope

- Replace the Settings artist-profile destination in the canonical opportunity-inbox mapper.
- Update empty-state, page-client, mapper, and mobile handoff route contracts.
- Preserve the existing centered empty-state geometry and single CTA.

## Verification

- Biome: 5 files clean
- Focused Vitest: 26/26 passing
- `git diff --check`: clean

Taste review is advisory under the current shipping policy; deterministic CI and native queue remain authoritative.