### PR TITLE
fix(search): add Connections destination (JOV-4707)

### DIFF
--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -229,6 +229,13 @@ export const COMMANDS: readonly Command[] = [
     APP_ROUTES.CHAT_PROFILE_PANEL
   ),
   nav(
+    'go-connections',
+    'Connections',
+    'Manage artist identities and connected services.',
+    'Waypoints',
+    APP_ROUTES.PROFILES
+  ),
+  nav(
     'go-chats',
     'Chats',
     'Open the chats workspace.',

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -176,6 +176,25 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     );
   });
 
+  it('filters to Connections and opens the canonical workspace on Enter', () => {
+    pushMock.mockClear();
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+
+    const input = screen.getByRole('searchbox', {
+      name: 'Command Palette Search',
+    });
+    fireEvent.change(input, { target: { value: 'Connections' } });
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Connections Manage artist identities and connected services. ⌘1',
+      })
+    ).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(pushMock).toHaveBeenCalledWith(APP_ROUTES.PROFILES);
+  });
+
   it('renders nav, skill, and release sections when open', () => {
     render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
     expect(screen.getByTestId('shared-command-palette')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add Connections to the canonical Go To command registry
- route to the existing `/app/profiles` Connections workspace
- preserve keyboard selection and Enter navigation through the shared command surface

## Verification
- `pnpm --filter web exec vitest run tests/unit/commands/SharedCommandPalette.test.tsx --maxWorkers 1` (18/18)
- `pnpm biome check apps/web/lib/commands/registry.ts apps/web/tests/unit/commands/SharedCommandPalette.test.tsx`
- `git diff --check`

Linear: JOV-4707