### PR TITLE
refactor(release): use canonical entity header [JOV-4703]

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.stories.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ReleaseEntityHeader } from './ReleaseSidebarSections';
+import type { Release } from './types';
+
+const mockRelease = {
+  id: 'rel_1',
+  title: 'Midnight Drive',
+  artistNames: ['Example Artist'],
+  releaseType: 'single',
+  releaseDate: '2026-01-15',
+  totalTracks: 1,
+  artworkUrl: 'https://placehold.co/400x400',
+  links: [],
+} as unknown as Release;
+
+const meta = {
+  title: 'Organisms/ReleaseSidebar/ReleaseSidebarSections',
+  component: ReleaseEntityHeader,
+  parameters: {
+    layout: 'centered',
+    jovie: {
+      uncoveredProps: ['disabled'],
+    },
+  },
+} satisfies Meta<typeof ReleaseEntityHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EntityHeader: Story = {
+  args: {
+    release: mockRelease,
+    artistName: 'Example Artist',
+    providerConfig: {},
+    canUploadArtwork: false,
+    canRevertArtwork: false,
+    allowDownloads: false,
+    previewUrl: null,
+    isPlaying: false,
+    onTogglePreview: () => undefined,
+  },
+};

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.stories.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { ProviderKey } from '@/lib/discography/types';
 import { ReleaseEntityHeader } from './ReleaseSidebarSections';
 import type { Release } from './types';
 
@@ -11,7 +12,13 @@ const mockRelease = {
   totalTracks: 1,
   artworkUrl: 'https://placehold.co/400x400',
   links: [],
+  providers: [],
 } as unknown as Release;
+
+const providerConfig = {} as Record<
+  ProviderKey,
+  { label: string; accent: string }
+>;
 
 const meta = {
   title: 'Organisms/ReleaseSidebar/ReleaseSidebarSections',
@@ -31,9 +38,11 @@ export const EntityHeader: Story = {
   args: {
     release: mockRelease,
     artistName: 'Example Artist',
-    providerConfig: {},
+    providerConfig,
     canUploadArtwork: false,
     canRevertArtwork: false,
+    onArtworkUpload: undefined,
+    onArtworkRevert: undefined,
     allowDownloads: false,
     previewUrl: null,
     isPlaying: false,

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
@@ -35,11 +35,11 @@ vi.mock('@/components/molecules/drawer', () => ({
   EntityHeaderCard: ({
     children,
     title,
-    testId = 'release-header-card',
+    'data-testid': testId,
   }: {
     readonly children?: React.ReactNode;
     readonly title?: React.ReactNode;
-    readonly testId?: string;
+    readonly 'data-testid'?: string;
   }) => (
     <div data-testid={testId}>
       {title}

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import type { ProviderKey } from '@/lib/discography/types';
+import { ReleaseEntityHeader } from './ReleaseSidebarSections';
+import type { Release } from './types';
 
 vi.mock('@/components/atoms/Icon', () => ({
   Icon: ({ name }: { readonly name: string }) => (
@@ -72,9 +75,6 @@ vi.mock('@/features/release/AlbumArtworkContextMenu', () => ({
   buildArtworkSizes: () => ({}),
 }));
 
-import { ReleaseEntityHeader } from './ReleaseSidebarSections';
-import type { Release } from './types';
-
 const mockRelease = {
   id: 'rel_1',
   title: 'Midnight Drive',
@@ -84,7 +84,13 @@ const mockRelease = {
   totalTracks: 1,
   artworkUrl: 'https://placehold.co/400x400',
   links: [],
+  providers: [],
 } as unknown as Release;
+
+const providerConfig = {} as Record<
+  ProviderKey,
+  { label: string; accent: string }
+>;
 
 describe('ReleaseSidebarSections', () => {
   it('renders release entity header title', () => {
@@ -92,9 +98,11 @@ describe('ReleaseSidebarSections', () => {
       <ReleaseEntityHeader
         release={mockRelease}
         artistName='Example Artist'
-        providerConfig={{}}
+        providerConfig={providerConfig}
         canUploadArtwork={false}
         canRevertArtwork={false}
+        onArtworkUpload={undefined}
+        onArtworkRevert={undefined}
         allowDownloads={false}
         previewUrl={null}
         isPlaying={false}

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/atoms/Icon', () => ({
+  Icon: ({ name }: { readonly name: string }) => (
+    <span data-testid={`icon-${name}`} />
+  ),
+}));
+
+vi.mock('@/components/atoms/DspLogo', () => ({
+  DSP_LOGO_CONFIG: {},
+}));
+
+vi.mock('@/components/molecules/drawer', () => ({
+  DrawerAsyncToggle: () => null,
+  DrawerFormGridRow: ({
+    children,
+  }: {
+    readonly children?: React.ReactNode;
+  }) => <div>{children}</div>,
+  DrawerMediaThumb: () => null,
+  DrawerSection: ({ children }: { readonly children?: React.ReactNode }) => (
+    <section>{children}</section>
+  ),
+  DrawerSurfaceCard: ({
+    children,
+    testId,
+  }: {
+    readonly children?: React.ReactNode;
+    readonly testId?: string;
+  }) => <div data-testid={testId}>{children}</div>,
+}));
+
+vi.mock('@/components/organisms/AvatarUploadable', () => ({
+  AvatarUploadable: () => null,
+}));
+
+vi.mock('@/components/shell/DrawerHero', () => ({
+  DrawerHero: ({ children }: { readonly children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('@/components/shell/DropDateChip', () => ({
+  DropDateChip: () => null,
+}));
+
+vi.mock('@/components/shell/DspAvatarStack', () => ({
+  DspAvatarStack: () => null,
+}));
+
+vi.mock('@/components/shell/MetaPill', () => ({
+  MetaPill: ({ children }: { readonly children?: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+vi.mock('@/components/shell/StatusBadge', () => ({
+  StatusBadge: () => null,
+}));
+
+vi.mock('@/components/shell/TypeBadge', () => ({
+  TypeBadge: () => null,
+}));
+
+vi.mock('@/features/release/AlbumArtworkContextMenu', () => ({
+  AlbumArtworkContextMenu: ({
+    children,
+  }: {
+    readonly children?: React.ReactNode;
+  }) => <div>{children}</div>,
+  buildArtworkSizes: () => ({}),
+}));
+
+import { ReleaseEntityHeader } from './ReleaseSidebarSections';
+import type { Release } from './types';
+
+const mockRelease = {
+  id: 'rel_1',
+  title: 'Midnight Drive',
+  artistNames: ['Example Artist'],
+  releaseType: 'single',
+  releaseDate: '2026-01-15',
+  totalTracks: 1,
+  artworkUrl: 'https://placehold.co/400x400',
+  links: [],
+} as unknown as Release;
+
+describe('ReleaseSidebarSections', () => {
+  it('renders release entity header title', () => {
+    render(
+      <ReleaseEntityHeader
+        release={mockRelease}
+        artistName='Example Artist'
+        providerConfig={{}}
+        canUploadArtwork={false}
+        canRevertArtwork={false}
+        allowDownloads={false}
+        previewUrl={null}
+        isPlaying={false}
+        onTogglePreview={() => undefined}
+      />
+    );
+
+    expect(screen.getByTestId('release-header-card')).toBeTruthy();
+    expect(screen.getByText('Midnight Drive')).toBeTruthy();
+  });
+});

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.test.tsx
@@ -32,6 +32,20 @@ vi.mock('@/components/molecules/drawer', () => ({
     readonly children?: React.ReactNode;
     readonly testId?: string;
   }) => <div data-testid={testId}>{children}</div>,
+  EntityHeaderCard: ({
+    children,
+    title,
+    testId = 'release-header-card',
+  }: {
+    readonly children?: React.ReactNode;
+    readonly title?: React.ReactNode;
+    readonly testId?: string;
+  }) => (
+    <div data-testid={testId}>
+      {title}
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock('@/components/organisms/AvatarUploadable', () => ({

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarSections.tsx
@@ -9,10 +9,9 @@ import {
   DrawerFormGridRow,
   DrawerMediaThumb,
   DrawerSection,
-  DrawerSurfaceCard,
+  EntityHeaderCard,
 } from '@/components/molecules/drawer';
 import { AvatarUploadable } from '@/components/organisms/AvatarUploadable';
-import { DrawerHero } from '@/components/shell/DrawerHero';
 import { DropDateChip } from '@/components/shell/DropDateChip';
 import {
   type DspAvatarItem,
@@ -35,8 +34,6 @@ import { cn } from '@/lib/utils';
 import { formatTimeAgo } from '@/lib/utils/date-formatting';
 import type { Release } from './types';
 import { isValidUrl } from './utils';
-
-const RELEASE_SIDEBAR_CARD_CLASSNAME = 'overflow-hidden';
 
 const RELEASE_TYPE_LABELS: Record<string, string> = {
   single: 'Single',
@@ -229,7 +226,6 @@ export function ReleaseEntityHeader({
     artistName,
     onArtistClick
   );
-  const hasActionBar = Boolean(actionBar);
   const releaseTypeLabel = getReleaseTypeLabel(release.releaseType);
   const releaseDate = release.releaseDate
     ? dropDateMeta(release.releaseDate)
@@ -238,113 +234,101 @@ export function ReleaseEntityHeader({
   const trackLabel = formatTrackCount(release.totalTracks);
 
   return (
-    <DrawerSurfaceCard
-      variant='card'
-      className={RELEASE_SIDEBAR_CARD_CLASSNAME}
-      testId='release-header-card'
-    >
-      <div className='relative'>
-        {hasActionBar ? (
-          <div className='absolute right-2.5 top-2.5'>{actionBar}</div>
-        ) : null}
-        <DrawerHero
-          title={release.title}
-          density='rail'
-          stableLayout
-          titleLineClamp={1}
-          subtitleLineClamp={1}
-          reserveSubtitleSlot
-          reserveMetaSlot
-          metaOverflow='scroll'
-          subtitle={
-            artistLine ? (
-              <span className='line-clamp-2 block'>{artistLine}</span>
-            ) : null
-          }
-          artwork={
-            <div className='group/artwork relative shrink-0'>
-              <AlbumArtworkContextMenu
-                title={release.title}
-                sizes={buildArtworkSizes(undefined, release.artworkUrl)}
-                allowDownloads={allowDownloads}
-                releaseId={release.id}
-                canRevert={canRevertArtwork}
-                onRevert={canRevertArtwork ? onArtworkRevert : undefined}
-              >
-                {canUploadArtwork && onArtworkUpload ? (
-                  <AvatarUploadable
-                    src={release.artworkUrl}
-                    alt={artworkAlt}
-                    name={release.title}
-                    size='md'
-                    rounded='md'
-                    uploadable={canUploadArtwork}
-                    onUpload={onArtworkUpload}
-                    showHoverOverlay
-                  />
-                ) : (
-                  <DrawerMediaThumb
-                    src={release.artworkUrl}
-                    alt={artworkAlt}
-                    dimension={48}
-                    sizeClassName='h-12 w-12 rounded-lg'
-                    sizes='48px'
-                    fallback={
-                      <Icon
-                        name='Disc3'
-                        className='h-6 w-6 text-tertiary-token'
-                        aria-hidden='true'
-                      />
-                    }
-                  />
-                )}
-              </AlbumArtworkContextMenu>
-
-              <button
-                type='button'
-                onClick={onTogglePreview}
-                disabled={!previewUrl}
-                aria-pressed={isPlaying}
-                className={cn(
-                  'absolute inset-0 flex items-center justify-center rounded-lg transition-[background-color,opacity] duration-subtle',
-                  'bg-black/0 opacity-0',
-                  'group-hover/artwork:bg-black/40 group-hover/artwork:opacity-100',
-                  'aria-[pressed=true]:bg-black/40 aria-[pressed=true]:opacity-100',
-                  'disabled:pointer-events-none disabled:hidden'
-                )}
-                aria-label={getPreviewAriaLabel(Boolean(previewUrl), isPlaying)}
-              >
-                {isPlaying ? (
-                  <Pause className='h-4 w-4 text-white dark:text-white drop-shadow-sm' />
-                ) : (
-                  <Play className='h-4 w-4 translate-x-px text-white dark:text-white drop-shadow-sm' />
-                )}
-              </button>
-            </div>
-          }
-          meta={
-            <>
-              <StatusBadge status={getShellReleaseStatus(release)} />
-              {releaseTypeLabel ? <TypeBadge label={releaseTypeLabel} /> : null}
-              {releaseDate ? (
-                <DropDateChip
-                  tone={releaseDate.tone}
-                  label={releaseDate.label}
+    <div className='overflow-hidden' data-testid='release-header-card'>
+      <EntityHeaderCard
+        title={release.title}
+        stableLayout
+        titleLineClamp={1}
+        subtitleLineClamp={1}
+        reserveSubtitleSlot
+        reserveMetaSlot
+        metaOverflow='scroll'
+        subtitle={
+          artistLine ? (
+            <span className='line-clamp-2 block'>{artistLine}</span>
+          ) : null
+        }
+        image={
+          <div className='group/artwork relative shrink-0'>
+            <AlbumArtworkContextMenu
+              title={release.title}
+              sizes={buildArtworkSizes(undefined, release.artworkUrl)}
+              allowDownloads={allowDownloads}
+              releaseId={release.id}
+              canRevert={canRevertArtwork}
+              onRevert={canRevertArtwork ? onArtworkRevert : undefined}
+            >
+              {canUploadArtwork && onArtworkUpload ? (
+                <AvatarUploadable
+                  src={release.artworkUrl}
+                  alt={artworkAlt}
+                  name={release.title}
+                  size='md'
+                  rounded='md'
+                  uploadable={canUploadArtwork}
+                  onUpload={onArtworkUpload}
+                  showHoverOverlay
                 />
-              ) : null}
-              {trackLabel ? <MetaPill>{trackLabel}</MetaPill> : null}
-              <DspAvatarStack dsps={dspItems} />
-            </>
-          }
-          className={cn('pb-2.5', hasActionBar && '[&_h2]:pr-9')}
-        />
-      </div>
+              ) : (
+                <DrawerMediaThumb
+                  src={release.artworkUrl}
+                  alt={artworkAlt}
+                  dimension={48}
+                  sizeClassName='h-12 w-12 rounded-lg'
+                  sizes='48px'
+                  fallback={
+                    <Icon
+                      name='Disc3'
+                      className='h-6 w-6 text-tertiary-token'
+                      aria-hidden='true'
+                    />
+                  }
+                />
+              )}
+            </AlbumArtworkContextMenu>
+
+            <button
+              type='button'
+              onClick={onTogglePreview}
+              disabled={!previewUrl}
+              aria-pressed={isPlaying}
+              className={cn(
+                'absolute inset-0 flex items-center justify-center rounded-lg transition-[background-color,opacity] duration-subtle',
+                'bg-black/0 opacity-0',
+                'group-hover/artwork:bg-black/40 group-hover/artwork:opacity-100',
+                'aria-[pressed=true]:bg-black/40 aria-[pressed=true]:opacity-100',
+                'disabled:pointer-events-none disabled:hidden'
+              )}
+              aria-label={getPreviewAriaLabel(Boolean(previewUrl), isPlaying)}
+            >
+              {isPlaying ? (
+                <Pause className='h-4 w-4 text-white dark:text-white drop-shadow-sm' />
+              ) : (
+                <Play className='h-4 w-4 translate-x-px text-white dark:text-white drop-shadow-sm' />
+              )}
+            </button>
+          </div>
+        }
+        meta={
+          <>
+            <StatusBadge status={getShellReleaseStatus(release)} />
+            {releaseTypeLabel ? <TypeBadge label={releaseTypeLabel} /> : null}
+            {releaseDate ? (
+              <DropDateChip tone={releaseDate.tone} label={releaseDate.label} />
+            ) : null}
+            {trackLabel ? <MetaPill>{trackLabel}</MetaPill> : null}
+            <DspAvatarStack dsps={dspItems} />
+          </>
+        }
+        actions={actionBar}
+        bodyClassName={cn('pb-2.5', actionBar && 'pr-9')}
+      />
       {footer ? (
         <div className='border-t border-(--app-shell-frame-seam) px-3 py-2.5'>
           {footer}
         </div>
       ) : null}
-    </DrawerSurfaceCard>
+    </div>
   );
 }
 

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -115,8 +115,25 @@ vi.mock('@/components/molecules/drawer', () => ({
         {footer}
       </div>
     ),
-  EntityHeaderCard: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
+  EntityHeaderCard: ({
+    title,
+    subtitle,
+    meta,
+    actions,
+    stableLayout,
+  }: {
+    title: string;
+    subtitle?: React.ReactNode;
+    meta?: React.ReactNode;
+    actions?: React.ReactNode;
+    stableLayout?: boolean;
+  }) => (
+    <div data-testid='entity-header-card' data-stable-layout={stableLayout}>
+      <h2 className='text-sm line-clamp-1 min-h-6'>{title}</h2>
+      {subtitle}
+      <div data-testid='entity-header-meta-slot'>{meta}</div>
+      {actions}
+    </div>
   ),
   DrawerEmptyState: ({ message }: { message: string }) => (
     <p data-testid='empty-state'>{message}</p>
@@ -596,12 +613,14 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(screen.getByTestId('release-header-card')).toBeInTheDocument();
   });
 
-  it('opts into the card surface variant contract', () => {
+  it('uses the canonical entity header without a nested card surface', () => {
     render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
 
-    expect(screen.getByTestId('release-header-card')).toHaveAttribute(
-      'data-surface-variant',
-      'card'
+    const header = screen.getByTestId('release-header-card');
+    expect(header).not.toHaveAttribute('data-surface-variant');
+    expect(within(header).getByTestId('entity-header-card')).toHaveAttribute(
+      'data-stable-layout',
+      'true'
     );
     expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
@@ -617,9 +636,7 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(
       within(header).getByRole('heading', { name: mockRelease.title })
     ).toHaveClass('text-sm', 'line-clamp-1', 'min-h-6');
-    expect(
-      screen.getByTestId('drawer-hero-meta-slot').firstElementChild
-    ).toHaveClass('overflow-x-auto', 'whitespace-nowrap');
+    expect(screen.getByTestId('entity-header-meta-slot')).toBeInTheDocument();
   });
 
   it('resets the active tab to Details when the release changes', async () => {


### PR DESCRIPTION
## Summary
- migrate the release right-rail identity header to the shared `EntityHeaderCard` seam
- retain the canonical release action registry, artwork controls, metadata, and analytics footer
- remove the nested route-local header card and `DrawerHero` action wrapper

## Verification
- `pnpm --filter web exec vitest run tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebarHeader.test.tsx --maxWorkers 1` (21/21)
- `biome check` on changed files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

No browser or advisory design-model gate was used; this is an isolated shared-primitive convergence slice.