### PR TITLE
refactor(track): unify rail header actions [JOV-4704]

### DIFF
--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.stories.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { TrackSidebar, type TrackSidebarData } from './TrackSidebar';
+
+const mockTrack = {
+  id: 'track-1',
+  title: 'Midnight Echo',
+  slug: 'midnight-echo',
+  smartLinkPath: '/r/midnight-echo/track-1',
+  trackNumber: 1,
+  discNumber: 1,
+  durationMs: 181000,
+  isrc: 'USRC17607839',
+  isExplicit: false,
+  previewUrl: null,
+  audioUrl: null,
+  audioFormat: null,
+  previewSource: null,
+  previewVerification: 'unknown',
+  providerConfidenceSummary: {
+    canonical: 1,
+    searchFallback: 0,
+    unknown: 3,
+    unresolvedProviders: ['apple_music', 'youtube', 'soundcloud'],
+  },
+  providers: [
+    {
+      key: 'spotify',
+      label: 'Spotify',
+      url: 'https://open.spotify.com/track/123',
+      confidence: 'canonical',
+    },
+  ],
+  releaseTitle: 'Midnight Echo (EP)',
+  releaseArtworkUrl: null,
+  releaseId: 'release-1',
+} as TrackSidebarData;
+
+const meta = {
+  title: 'Organisms/ReleaseSidebar/TrackSidebar',
+  component: TrackSidebar,
+  parameters: {
+    layout: 'centered',
+    jovie: {
+      uncoveredProps: ['disabled'],
+    },
+  },
+} satisfies Meta<typeof TrackSidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    track: mockTrack,
+    isOpen: true,
+    onClose: () => undefined,
+    onBackToRelease: () => undefined,
+  },
+};

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+// @coverage-via apps/web/tests/components/organisms/release-sidebar/TrackSidebar.test.tsx
 import type { CommonDropdownItem } from '@jovie/ui';
 import { Check, Copy, ExternalLink, Pause, Play, VolumeX } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import type { CommonDropdownItem } from '@jovie/ui';
 import { Check, Copy, ExternalLink, Pause, Play, VolumeX } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SeekBar } from '@/components/atoms/SeekBar';
 import { toast } from '@/components/feedback';
 import {
   DrawerBackButton,
-  DrawerCardActionBar,
   DrawerMediaThumb,
   DrawerSurfaceCard,
   DrawerTabbedCard,
@@ -15,7 +15,7 @@ import {
   ShareableLinkRow,
 } from '@/components/molecules/drawer';
 import { EntityHeaderCard } from '@/components/molecules/drawer/EntityHeaderCard';
-import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
+import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { PROVIDER_LABELS } from '@/lib/discography/provider-labels';
 import type {
   PreviewSource,
@@ -227,21 +227,25 @@ export function TrackSidebar({
   const unresolvedProviders =
     track?.providerConfidenceSummary?.unresolvedProviders ?? [];
 
-  const overflowActions = useMemo<DrawerHeaderAction[]>(() => {
+  const trackActionItems = useMemo<CommonDropdownItem[]>(() => {
     if (!track) return [];
     return [
       {
-        id: 'refresh-copy',
+        type: 'action',
+        id: 'copy-track-link',
         label: isSmartLinkCopied ? 'Copied!' : 'Copy Track Link',
-        icon: Copy,
-        activeIcon: Check,
-        isActive: isSmartLinkCopied,
+        icon: isSmartLinkCopied ? (
+          <Check className='h-4 w-4' />
+        ) : (
+          <Copy className='h-4 w-4' />
+        ),
         onClick: handleCopySmartLink,
       },
       {
-        id: 'open',
+        type: 'action',
+        id: 'open-track-link',
         label: 'Open Track Link',
-        icon: ExternalLink,
+        icon: <ExternalLink className='h-4 w-4' />,
         onClick: () => {
           if (track.smartLinkPath) {
             globalThis.open(smartLinkUrl, '_blank', 'noopener,noreferrer');
@@ -303,6 +307,7 @@ export function TrackSidebar({
       isOpen={isOpen}
       width={width}
       ariaLabel='Track details'
+      contextMenuItems={trackActionItems}
       data-testid='track-sidebar'
       workspaceSurface='raised'
       onClose={onClose}
@@ -323,87 +328,81 @@ export function TrackSidebar({
                 onClick={handleBackToRelease}
               />
             ) : null}
-            <DrawerSurfaceCard
-              variant='card'
-              className='overflow-hidden p-3'
-              testId='track-header-card'
-            >
-              <EntityHeaderCard
-                title={track.title}
-                stableLayout
-                titleLineClamp={1}
-                subtitleLineClamp={1}
-                reserveSubtitleSlot
-                reserveMetaSlot
-                reserveFooterSlot
-                metaOverflow='scroll'
-                subtitle={
-                  <span className='flex items-center gap-1.5'>
-                    <span className='tabular-nums'>{trackLabel}.</span>
-                    {track.releaseTitle}
-                    {track.isExplicit ? (
-                      <span className='rounded bg-surface-1 px-1 text-3xs font-caption text-tertiary-token'>
-                        E
-                      </span>
-                    ) : null}
-                  </span>
-                }
-                image={
-                  <DrawerMediaThumb
-                    src={track.releaseArtworkUrl}
-                    alt={`${track.releaseTitle} artwork`}
-                    dimension={44}
-                    sizeClassName='h-11 w-11 rounded-lg'
-                    sizes='44px'
-                    fallback={
-                      <div className='h-11 w-11 rounded-lg bg-surface-0' />
-                    }
+            <EntityHeaderCard
+              data-testid='track-entity-header'
+              className='px-3 pt-3'
+              title={track.title}
+              stableLayout
+              titleLineClamp={1}
+              subtitleLineClamp={1}
+              reserveSubtitleSlot
+              reserveMetaSlot
+              reserveFooterSlot
+              metaOverflow='scroll'
+              subtitle={
+                <span className='flex items-center gap-1.5'>
+                  <span className='tabular-nums'>{trackLabel}.</span>
+                  {track.releaseTitle}
+                  {track.isExplicit ? (
+                    <span className='rounded bg-surface-1 px-1 text-3xs font-caption text-tertiary-token'>
+                      E
+                    </span>
+                  ) : null}
+                </span>
+              }
+              image={
+                <DrawerMediaThumb
+                  src={track.releaseArtworkUrl}
+                  alt={`${track.releaseTitle} artwork`}
+                  dimension={44}
+                  sizeClassName='h-11 w-11 rounded-lg'
+                  sizes='44px'
+                  fallback={
+                    <div className='h-11 w-11 rounded-lg bg-surface-0' />
+                  }
+                />
+              }
+              meta={
+                <div className='flex items-center gap-2 text-3xs text-tertiary-token'>
+                  {track.durationMs == null ? null : (
+                    <span className='tabular-nums'>
+                      {formatDuration(track.durationMs)}
+                    </span>
+                  )}
+                  {track.isrc ? (
+                    <span className='font-mono text-3xs tracking-wider'>
+                      {track.isrc}
+                    </span>
+                  ) : null}
+                </div>
+              }
+              actions={
+                <DrawerHeaderActions
+                  primaryActions={[]}
+                  menuItems={trackActionItems}
+                  onClose={onClose}
+                />
+              }
+              footer={
+                smartLinkUrl ? (
+                  <ShareableLinkRow
+                    url={smartLinkUrl}
+                    density='compact'
+                    surface='boxed'
+                    copyButtonTitle='Copy Track Link'
+                    openButtonTitle='Open Track Link'
+                    onCopySuccess={() => {
+                      showSmartLinkCopied();
+                    }}
+                    onCopyError={() => {
+                      toast.error('Failed to copy link');
+                    }}
                   />
-                }
-                meta={
-                  <div className='flex items-center gap-2 text-3xs text-tertiary-token'>
-                    {track.durationMs == null ? null : (
-                      <span className='tabular-nums'>
-                        {formatDuration(track.durationMs)}
-                      </span>
-                    )}
-                    {track.isrc ? (
-                      <span className='font-mono text-3xs tracking-wider'>
-                        {track.isrc}
-                      </span>
-                    ) : null}
-                  </div>
-                }
-                actions={
-                  <DrawerCardActionBar
-                    primaryActions={[]}
-                    overflowActions={overflowActions}
-                    onClose={onClose}
-                    overflowTriggerPlacement='card-top-right'
-                    overflowTriggerIcon='vertical'
-                    className='border-0 bg-transparent px-0 py-0'
-                  />
-                }
-                footer={
-                  smartLinkUrl ? (
-                    <ShareableLinkRow
-                      url={smartLinkUrl}
-                      density='compact'
-                      surface='boxed'
-                      copyButtonTitle='Copy Track Link'
-                      openButtonTitle='Open Track Link'
-                      onCopySuccess={() => {
-                        showSmartLinkCopied();
-                      }}
-                      onCopyError={() => {
-                        toast.error('Failed to copy link');
-                      }}
-                    />
-                  ) : null
-                }
-                bodyClassName='pr-9'
-              />
-            </DrawerSurfaceCard>
+                ) : null
+              }
+              bodyClassName='pr-9'
+              footerClassName='pb-3'
+            />
           </div>
         ) : undefined
       }

--- a/apps/web/tests/components/organisms/release-sidebar/TrackSidebar.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/TrackSidebar.test.tsx
@@ -85,7 +85,9 @@ describe('TrackSidebar', () => {
     expect(screen.getByTestId('track-platforms-empty')).toBeInTheDocument();
   });
 
-  it('keeps the playback card visible in the default view', () => {
+  it('uses one compact entity header and shares actions with the rail context menu', async () => {
+    const user = userEvent.setup();
+
     render(
       <TrackSidebar
         track={buildTrack()}
@@ -98,12 +100,24 @@ describe('TrackSidebar', () => {
     expect(screen.getAllByText('Midnight Echo').length).toBeGreaterThan(0);
     expect(screen.getByTitle('Copy Track Link')).toBeInTheDocument();
     expect(screen.getByText(/Preview Unverified/i)).toBeInTheDocument();
-    const header = screen.getByTestId('track-header-card');
+    const header = screen.getByTestId('track-entity-header');
     const details = screen.getByTestId('track-tabbed-card');
     expect(header).toContainElement(screen.getByTitle('Copy Track Link'));
     expect(
       header.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+    expect(
+      screen.queryByTestId('drawer-card-action-bar')
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Copy Track Link' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Open Track Link' })
+    ).toBeInTheDocument();
     expect(screen.getByTestId('track-tabbed-card')).toHaveAttribute(
       'data-surface-variant',
       'card'


### PR DESCRIPTION
## Summary
- remove the nested Track rail header card and its parallel action bar
- use `EntityHeaderCard` as the single compact entity header
- drive header overflow and rail context actions from one track action source

## Verification
- `pnpm exec biome check --write apps/web/components/organisms/release-sidebar/TrackSidebar.tsx apps/web/tests/components/organisms/release-sidebar/TrackSidebar.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/components/organisms/release-sidebar/TrackSidebar.test.tsx --maxWorkers 1` (5/5)
- `pnpm --filter @jovie/web run typecheck -- --pretty false` (`JOV4704_TYPECHECK_EXIT=0`)
- `git diff --check origin/main...HEAD`

No browser, Kimi, or Grok review run: this is an isolated source/UI consolidation slice and those are advisory, not admission gates.

Closes JOV-4704