### PR TITLE
refactor(admin): use canonical entity headers [JOV-4705]

### DIFF
--- a/apps/web/components/features/admin/admin-creator-profiles/AdminProfileSidebar.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminProfileSidebar.tsx
@@ -6,15 +6,14 @@ import type { PreviewPanelLink } from '@/app/app/(shell)/dashboard/PreviewPanelC
 import {
   DrawerAnalyticsSummaryCard,
   DrawerCardActionBar,
-  DrawerSurfaceCard,
   DrawerTabbedCard,
   DrawerTabs,
+  EntityHeaderCard,
   EntitySidebarShell,
   ShareableLinkRow,
 } from '@/components/molecules/drawer';
 import { AvatarUploadable } from '@/components/organisms/AvatarUploadable';
 import { useProfileHeaderParts } from '@/components/organisms/profile-sidebar/ProfileSidebarHeader';
-import { DrawerHero } from '@/components/shell/DrawerHero';
 import { BASE_URL } from '@/constants/domains';
 import { ProfileAboutTab } from '@/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab';
 import {
@@ -101,8 +100,26 @@ export function AdminProfileSidebar({
       entityHeaderSurface='flat'
       entityHeader={
         <>
-          <DrawerSurfaceCard variant='card' className='overflow-hidden'>
-            <div className='relative'>
+          <EntityHeaderCard
+            title={profile.displayName ?? profile.username}
+            subtitle={`@${profile.username}`}
+            stableLayout
+            titleLineClamp={1}
+            subtitleLineClamp={1}
+            reserveSubtitleSlot
+            reserveMetaSlot
+            metaOverflow='scroll'
+            image={
+              <AvatarUploadable
+                src={profile.avatarUrl}
+                alt={`${profile.displayName ?? profile.username} avatar`}
+                name={profile.displayName ?? profile.username}
+                size='2xl'
+                rounded='md'
+              />
+            }
+            meta={profile.location ? <span>{profile.location}</span> : null}
+            actions={
               <DrawerCardActionBar
                 primaryActions={primaryActions}
                 menuItems={contextMenuItems}
@@ -110,31 +127,10 @@ export function AdminProfileSidebar({
                 overflowTriggerPlacement='card-top-right'
                 className='border-0 bg-transparent px-0 py-0'
               />
-              <DrawerHero
-                title={profile.displayName ?? profile.username}
-                density='rail'
-                subtitle={`@${profile.username}`}
-                stableLayout
-                titleLineClamp={1}
-                subtitleLineClamp={1}
-                reserveSubtitleSlot
-                reserveMetaSlot
-                metaOverflow='scroll'
-                artwork={
-                  <AvatarUploadable
-                    src={profile.avatarUrl}
-                    alt={`${profile.displayName ?? profile.username} avatar`}
-                    name={profile.displayName ?? profile.username}
-                    size='2xl'
-                    rounded='md'
-                  />
-                }
-                meta={profile.location ? <span>{profile.location}</span> : null}
-                className='[&_h2]:pr-9'
-                testId='admin-creator-entity-header'
-              />
-            </div>
-          </DrawerSurfaceCard>
+            }
+            bodyClassName='pr-9'
+            data-testid='admin-creator-entity-header'
+          />
           <DrawerAnalyticsSummaryCard
             testId='admin-creator-summary'
             state='ready'

--- a/apps/web/components/features/admin/admin-users-table/AdminUserDetailDrawer.tsx
+++ b/apps/web/components/features/admin/admin-users-table/AdminUserDetailDrawer.tsx
@@ -9,11 +9,10 @@ import {
   DrawerAnalyticsSummaryCard,
   DrawerCardActionBar,
   DrawerSection,
-  DrawerSurfaceCard,
+  EntityHeaderCard,
   EntitySidebarShell,
   ShareableLinkRow,
 } from '@/components/molecules/drawer';
-import { DrawerHero } from '@/components/shell/DrawerHero';
 import { copyToClipboard } from '@/hooks/useClipboard';
 import type { AdminUserRow } from '@/lib/admin/types';
 
@@ -96,11 +95,47 @@ export function AdminUserDetailDrawer({
       emptyMessage='Select a user to view details.'
       entityHeader={
         user ? (
-          <DrawerSurfaceCard
-            variant='card'
-            className='relative overflow-hidden'
-          >
-            <div className='absolute right-2 top-2 z-10'>
+          <EntityHeaderCard
+            title={user.name ?? 'Unnamed user'}
+            stableLayout
+            titleLineClamp={1}
+            subtitleLineClamp={1}
+            reserveSubtitleSlot
+            reserveMetaSlot
+            metaOverflow='scroll'
+            image={
+              <UserAvatar name={user.name ?? user.email ?? 'User'} size='lg' />
+            }
+            subtitle={
+              user.email ? (
+                <div className='flex items-center gap-1.5'>
+                  <span className='truncate'>{user.email}</span>
+                  <CopyButton value={user.email} label='Email' />
+                </div>
+              ) : (
+                'No email'
+              )
+            }
+            meta={
+              <div className='flex flex-wrap gap-1.5'>
+                <Badge
+                  size='sm'
+                  variant={user.plan === 'pro' ? 'primary' : 'secondary'}
+                >
+                  {user.plan}
+                </Badge>
+                {user.deletedAt ? (
+                  <Badge size='sm' variant='warning'>
+                    Deleted
+                  </Badge>
+                ) : (
+                  <Badge size='sm' variant='success'>
+                    Active
+                  </Badge>
+                )}
+              </div>
+            }
+            actions={
               <DrawerCardActionBar
                 primaryActions={[]}
                 menuItems={contextMenuItems}
@@ -109,55 +144,10 @@ export function AdminUserDetailDrawer({
                 overflowTriggerIcon='vertical'
                 className='border-0 bg-transparent px-0 py-0'
               />
-            </div>
-            <DrawerHero
-              title={user.name ?? 'Unnamed user'}
-              density='rail'
-              artwork={
-                <UserAvatar
-                  name={user.name ?? user.email ?? 'User'}
-                  size='lg'
-                />
-              }
-              subtitle={
-                user.email ? (
-                  <div className='flex items-center gap-1.5'>
-                    <span className='truncate'>{user.email}</span>
-                    <CopyButton value={user.email} label='Email' />
-                  </div>
-                ) : (
-                  'No email'
-                )
-              }
-              meta={
-                <div className='flex flex-wrap gap-1.5'>
-                  <Badge
-                    size='sm'
-                    variant={user.plan === 'pro' ? 'primary' : 'secondary'}
-                  >
-                    {user.plan}
-                  </Badge>
-                  {user.deletedAt ? (
-                    <Badge size='sm' variant='warning'>
-                      Deleted
-                    </Badge>
-                  ) : (
-                    <Badge size='sm' variant='success'>
-                      Active
-                    </Badge>
-                  )}
-                </div>
-              }
-              stableLayout
-              titleLineClamp={1}
-              subtitleLineClamp={1}
-              reserveSubtitleSlot
-              reserveMetaSlot
-              metaOverflow='scroll'
-              className='[&_h2]:pr-9'
-              testId='admin-user-entity-header'
-            />
-          </DrawerSurfaceCard>
+            }
+            bodyClassName='pr-9'
+            data-testid='admin-user-entity-header'
+          />
         ) : undefined
       }
     >

--- a/apps/web/tests/unit/components/admin/AdminProfileSidebar.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminProfileSidebar.test.tsx
@@ -104,9 +104,11 @@ describe('AdminProfileSidebar', () => {
     expect(screen.getByRole('tab', { name: 'Algorithm' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'About' })).toBeInTheDocument();
     expect(screen.getAllByText('@alice').length).toBeGreaterThan(0);
-    expect(screen.getByTestId('admin-creator-entity-header')).toHaveAttribute(
-      'data-density',
-      'rail'
+    expect(screen.getByTestId('admin-creator-entity-header')).toHaveClass(
+      'relative',
+      'flex',
+      'items-start',
+      'gap-3'
     );
     expect(screen.getByTestId('admin-creator-summary')).toBeInTheDocument();
     expect(

--- a/apps/web/tests/unit/components/admin/AdminUserDetailDrawer.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminUserDetailDrawer.test.tsx
@@ -81,9 +81,11 @@ describe('AdminUserDetailDrawer', () => {
       'data-entity-header-surface',
       'flat'
     );
-    expect(screen.getByTestId('admin-user-entity-header')).toHaveAttribute(
-      'data-density',
-      'rail'
+    expect(screen.getByTestId('admin-user-entity-header')).toHaveClass(
+      'relative',
+      'flex',
+      'items-start',
+      'gap-3'
     );
     expect(
       screen.getByTestId('drawer-analytics-metric-value-profile-completeness')


### PR DESCRIPTION
## Summary
- converge creator-profile and user admin rail headers on `EntityHeaderCard`
- retain canonical action menus, stable header slots, analytics, tabs, and details
- remove the duplicated route-local hero/card/action wrappers

## Verification
- `pnpm --filter web exec vitest run tests/unit/components/admin/AdminProfileSidebar.test.tsx tests/unit/components/admin/AdminUserDetailDrawer.test.tsx --maxWorkers 1` (7/7)
- `biome check` on changed files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

No browser or design-model gate was used; this is an isolated shared-primitive convergence slice.