### PR TITLE
fix(connections): keep toolbar CTA in bounds [JOV-4710]

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -210,7 +210,7 @@ describe('ProfilesWorkspace', () => {
     ).toBeEnabled();
   });
 
-  it('preserves the compact mobile table contract', () => {
+  it('keeps the single Add connection action in bounds at the 670px toolbar contract', () => {
     renderWorkspace(data);
 
     expect(screen.getByRole('columnheader', { name: 'Rank' })).toHaveClass(
@@ -224,14 +224,17 @@ describe('ProfilesWorkspace', () => {
     ).toHaveClass('max-xl:hidden');
     expect(screen.getByText('tim@example.com')).toHaveClass('max-sm:hidden');
 
+    const toolbarActions = screen.getByTestId('connections-toolbar-actions');
     const summary = screen.getByTestId('connections-summary');
-    expect(summary.parentElement?.parentElement).toHaveClass('overflow-x-auto');
-    expect(summary).toHaveClass('min-w-0', 'overflow-x-auto');
+    expect(toolbarActions).toHaveClass('w-full', 'min-w-0', 'justify-between');
+    expect(summary).toHaveClass('min-w-0', 'overflow-hidden');
     expect(screen.getByRole('button', { name: 'Add Connection' })).toHaveClass(
       'shrink-0',
       'max-sm:w-7.5'
     );
-    expect(screen.getByText('Best Rank #2')).toHaveClass('max-sm:hidden');
-    expect(screen.getByText('Monitoring Active')).toHaveClass('max-sm:hidden');
+    expect(screen.getByText('Monitored 1/5')).toHaveClass('max-lg:hidden');
+    expect(screen.getByText('Needs Attention 1')).toHaveClass('max-lg:hidden');
+    expect(screen.getByText('Best Rank #2')).toHaveClass('max-lg:hidden');
+    expect(screen.getByText('Monitoring Active')).toHaveClass('max-lg:hidden');
   });
 });

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -631,7 +631,7 @@ export function ProfilesWorkspace({
         <PageToolbar
           className='flex-col items-stretch gap-0 px-0 py-0 lg:flex-row lg:items-center lg:gap-1.5 lg:px-app-header lg:py-1.5'
           startClassName='w-full flex-none px-app-header py-1.5 lg:min-w-0 lg:flex-1 lg:px-0 lg:py-0'
-          endClassName='ml-0 w-full min-w-0 max-w-full shrink justify-start overflow-x-auto border-t border-subtle px-app-header py-1.5 lg:ml-auto lg:w-auto lg:max-w-none lg:shrink-0 lg:justify-end lg:overflow-visible lg:border-t-0 lg:px-0 lg:py-0'
+          endClassName='ml-0 w-full min-w-0 max-w-full shrink justify-start overflow-hidden border-t border-subtle px-app-header py-1.5 lg:ml-auto lg:w-auto lg:max-w-none lg:shrink-0 lg:justify-end lg:overflow-visible lg:border-t-0 lg:px-0 lg:py-0'
           start={FILTERS.map(option => (
             <PageToolbarTabButton
               key={option.id}
@@ -644,27 +644,20 @@ export function ProfilesWorkspace({
             />
           ))}
           end={
-            <div className='flex w-full items-center gap-2 whitespace-nowrap lg:w-auto lg:gap-3'>
+            <div
+              className='flex w-full min-w-0 items-center justify-between gap-2 whitespace-nowrap lg:w-auto lg:justify-end lg:gap-3'
+              data-testid='connections-toolbar-actions'
+            >
               <div
                 data-testid='connections-summary'
-                className='flex min-w-0 flex-1 items-center gap-2 overflow-x-auto text-xs text-tertiary-token tabular-nums lg:flex-none lg:overflow-visible'
+                className='flex min-w-0 items-center gap-2 overflow-hidden text-xs text-tertiary-token tabular-nums lg:flex-none lg:overflow-visible'
               >
                 <span>{summary.connectionCount} Connections</span>
-                <span aria-hidden className='text-quaternary-token'>
-                  ·
+                <span className='max-lg:hidden'>{limitLabel}</span>
+                <span className='max-lg:hidden'>
+                  Needs Attention {summary.needsAttentionCount}
                 </span>
-                <span>{limitLabel}</span>
-                <span aria-hidden className='text-quaternary-token'>
-                  ·
-                </span>
-                <span>Needs Attention {summary.needsAttentionCount}</span>
-                <span
-                  aria-hidden
-                  className='max-sm:hidden text-quaternary-token'
-                >
-                  ·
-                </span>
-                <span className='max-sm:hidden'>
+                <span className='max-lg:hidden'>
                   Best Rank{' '}
                   {summary.bestRank === null ? (
                     <SimpleTooltip content='No search rank has been measured yet.'>
@@ -676,13 +669,7 @@ export function ProfilesWorkspace({
                     `#${summary.bestRank}`
                   )}
                 </span>
-                <span
-                  aria-hidden
-                  className='max-sm:hidden text-quaternary-token'
-                >
-                  ·
-                </span>
-                <span className='max-sm:hidden'>
+                <span className='max-lg:hidden'>
                   Monitoring {summary.monitoringLabel}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- keep the Connections toolbar Add connection CTA inside the 670px authenticated viewport
- preserve the single canonical add action and existing filter hierarchy
- compress secondary metrics below desktop without introducing interaction-driven layout shift

## Verification
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1` (6/6)
- `biome check` on changed files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`

No browser or design-model gate was used; this is a bounded responsive contract fix.