### PR TITLE
fix(chat): unify release rail actions

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -34,7 +34,6 @@ import {
   EntityHeaderCard,
   EntitySidebarShell,
 } from '@/components/molecules/drawer';
-import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import type { EntityCardModel } from '@/components/organisms/entity-card';
 import {
@@ -46,6 +45,7 @@ import {
 } from '@/components/organisms/entity-card';
 import {
   type ContextMenuItemType,
+  convertToCommonDropdownItems,
   TableContextMenu,
 } from '@/components/organisms/table';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
@@ -574,31 +574,10 @@ function ChatReleaseEntityPanel({
       }),
     [panelTitle, smartLinkPath]
   );
-  const headerOverflowActions = useMemo<DrawerHeaderAction[]>(() => {
-    const actions: DrawerHeaderAction[] = [];
-
-    if (smartLinkPath) {
-      actions.push({
-        id: 'open-smart-link',
-        label: 'Open Smart Link',
-        icon: ExternalLink,
-        onClick: () => {
-          globalThis.open(smartLinkPath, '_blank', 'noopener,noreferrer');
-        },
-      });
-    }
-
-    actions.push({
-      id: 'copy-title',
-      label: 'Copy Title',
-      icon: Copy,
-      onClick: () => {
-        void globalThis.navigator?.clipboard?.writeText(panelTitle);
-      },
-    });
-
-    return actions;
-  }, [panelTitle, smartLinkPath]);
+  const railActionItems = useMemo(
+    () => convertToCommonDropdownItems(contextMenuItems),
+    [contextMenuItems]
+  );
 
   useEffect(() => {
     setShowTasksUpgrade(true);
@@ -611,6 +590,7 @@ function ChatReleaseEntityPanel({
         ariaLabel='Release details'
         scrollStrategy='shell'
         workspaceSurface='raised'
+        contextMenuItems={railActionItems}
         headerMode='minimal'
         hideMinimalHeaderBar
         data-testid='chat-release-entity-panel'
@@ -664,7 +644,7 @@ function ChatReleaseEntityPanel({
             actions={
               <DrawerHeaderActions
                 primaryActions={[]}
-                overflowActions={headerOverflowActions}
+                menuItems={railActionItems}
                 onClose={onClose}
               />
             }

--- a/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
+++ b/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, { useCallback, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -846,6 +853,52 @@ describe('ChatEntityRightPanelHost', () => {
     expect(screen.getByTestId('chat-release-entity-panel')).toHaveTextContent(
       'Release'
     );
+  });
+
+  it('mirrors canonical release actions in the compact header overflow', async () => {
+    const user = userEvent.setup();
+    mockPreviewPanelOpen = false;
+    mockUseRegisterRightPanel.mockClear();
+    mockUseReleaseEntityQuery.mockReturnValue({
+      data: {
+        id: 'release-1',
+        title: 'Lost In The Light',
+        releaseType: 'single',
+        status: 'released',
+        slug: 'lost-in-the-light',
+        smartLinkPath: '/r/lost-in-the-light',
+        profileId: 'profile-1',
+        totalTracks: 1,
+        providers: [],
+      },
+      isLoading: false,
+    });
+
+    render(
+      <ChatEntityPanelProvider>
+        <OpenReleaseTarget />
+        <ChatEntityRightPanelHost
+          enablePreviewPanel={false}
+          enableChatEntityPanels
+          profileId='profile-1'
+        />
+      </ChatEntityPanelProvider>
+    );
+
+    const registeredPanel = mockUseRegisterRightPanel.mock.calls.at(-1)?.[0];
+    expect(registeredPanel).not.toBeNull();
+    render(registeredPanel as React.ReactElement);
+
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
+
+    const menu = await screen.findByRole('menu');
+    expect(
+      within(menu).getByRole('menuitem', { name: 'Open Smart Link' })
+    ).toBeVisible();
+    expect(
+      within(menu).getByRole('menuitem', { name: 'Copy Title' })
+    ).toBeVisible();
+    expect(within(menu).getByRole('menuitem', { name: 'Close' })).toBeVisible();
   });
 
   it('renders the canonical entity header for contact panels', () => {


### PR DESCRIPTION
## Summary
- derive release rail context and compact-header overflow actions from one typed canonical action source
- preserve Smart Link, copy-title, close, and static rail behavior
- add compact-header action parity coverage

## Verification
- `pnpm --filter web exec vitest run tests/unit/chat/ChatEntityRightPanelHost.test.tsx tests/unit/chat/chat-entity-right-panel-system-b-style-guard.test.ts --maxWorkers 1`
- `pnpm biome check --write apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

JOV-4711