### PR TITLE
refactor(admin): unify feedback entity actions

### DIFF
--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { ClipboardCopy, MessageSquareText, XCircle } from 'lucide-react';
+import { ClipboardCopy, MessageSquareText } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { TruncatedText } from '@/components/atoms/TruncatedText';
 import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
@@ -15,7 +15,6 @@ import {
   EntityHeaderCard,
   EntitySidebarShell,
 } from '@/components/molecules/drawer';
-import { type DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import {
   type ContextMenuItemType,
   PAGE_TOOLBAR_META_TEXT_CLASS,
@@ -31,6 +30,11 @@ import {
 } from '@/features/admin/table/AdminTableHeader';
 import { AdminTableShell } from '@/features/admin/table/AdminTableShell';
 import { useDismissFeedbackMutation } from '@/lib/queries';
+import {
+  buildFeedbackActions,
+  feedbackActionsToContextMenuItems,
+  feedbackActionsToDropdownItems,
+} from './feedback-actions';
 
 interface FeedbackRow {
   id: string;
@@ -197,6 +201,18 @@ function AdminFeedbackDetailPanel({
   readonly copyRowAsMarkdown: (item: FeedbackRow) => Promise<void>;
   readonly onClose: () => void;
 }) {
+  const selectedActions = selected
+    ? buildFeedbackActions(selected, {
+        onCopyAsMarkdown: item => {
+          void copyRowAsMarkdown(item);
+        },
+        onDismiss: item => {
+          void dismissRow(item);
+        },
+        isDismissPending,
+      })
+    : [];
+
   return (
     <EntitySidebarShell
       isOpen={Boolean(selected)}
@@ -204,6 +220,7 @@ function AdminFeedbackDetailPanel({
       ariaLabel='Feedback details'
       scrollStrategy='shell'
       onClose={onClose}
+      contextMenuItems={feedbackActionsToDropdownItems(selectedActions)}
       headerMode='minimal'
       hideMinimalHeaderBar
       isEmpty={!selected}
@@ -230,31 +247,8 @@ function AdminFeedbackDetailPanel({
               }
               actions={
                 <DrawerCardActionBar
-                  primaryActions={
-                    [
-                      ...(selected.status === 'dismissed'
-                        ? []
-                        : [
-                            {
-                              id: 'dismiss-feedback',
-                              label: 'Dismiss',
-                              icon: XCircle,
-                              disabled: isDismissPending(selected.id),
-                              onClick: () => {
-                                dismissRow(selected);
-                              },
-                            } satisfies DrawerHeaderAction,
-                          ]),
-                      {
-                        id: 'copy-feedback-markdown',
-                        label: 'Copy As Markdown',
-                        icon: ClipboardCopy,
-                        onClick: () => {
-                          copyRowAsMarkdown(selected);
-                        },
-                      } satisfies DrawerHeaderAction,
-                    ] satisfies readonly DrawerHeaderAction[]
-                  }
+                  primaryActions={[]}
+                  overflowActions={selectedActions}
                   onClose={onClose}
                   overflowTriggerPlacement='card-top-right'
                   overflowTriggerIcon='vertical'
@@ -379,22 +373,18 @@ export function AdminFeedbackTable({
   }, []);
 
   const getContextMenuItems = useCallback(
-    (item: FeedbackRow): ContextMenuItemType[] => [
-      {
-        id: 'copy-markdown',
-        label: 'Copy As Markdown',
-        icon: <ClipboardCopy className='h-4 w-4' />,
-        onClick: () => copyRowAsMarkdown(item),
-      },
-      { type: 'separator' },
-      {
-        id: 'dismiss',
-        label: 'Dismiss',
-        icon: <XCircle className='h-4 w-4' />,
-        onClick: () => dismissRow(item),
-        disabled: item.status === 'dismissed' || isDismissPending(item.id),
-      },
-    ],
+    (item: FeedbackRow): ContextMenuItemType[] =>
+      feedbackActionsToContextMenuItems(
+        buildFeedbackActions(item, {
+          onCopyAsMarkdown: feedback => {
+            void copyRowAsMarkdown(feedback);
+          },
+          onDismiss: feedback => {
+            void dismissRow(feedback);
+          },
+          isDismissPending,
+        })
+      ),
     [copyRowAsMarkdown, dismissRow, isDismissPending]
   );
 

--- a/apps/web/components/features/admin/feedback-table/feedback-actions.tsx
+++ b/apps/web/components/features/admin/feedback-table/feedback-actions.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { CommonDropdownItem } from '@jovie/ui';
+import { ClipboardCopy, type LucideIcon, XCircle } from 'lucide-react';
+import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
+import type { ContextMenuItemType } from '@/components/organisms/table';
+
+export interface FeedbackActionTarget {
+  readonly id: string;
+  readonly status: 'pending' | 'dismissed';
+}
+
+export interface FeedbackActionHandlers<T extends FeedbackActionTarget> {
+  readonly onCopyAsMarkdown: (item: T) => void;
+  readonly onDismiss: (item: T) => void;
+  readonly isDismissPending: (id: string) => boolean;
+}
+
+interface FeedbackActionDefinition extends DrawerHeaderAction {
+  readonly destructive?: boolean;
+}
+
+/**
+ * Canonical action source for feedback entities.
+ *
+ * Table overflow, row context menus, and the detail rail all derive from this
+ * registry so an action cannot appear in one surface but disappear from another.
+ */
+export function buildFeedbackActions<T extends FeedbackActionTarget>(
+  item: T,
+  handlers: FeedbackActionHandlers<T>
+): readonly FeedbackActionDefinition[] {
+  return [
+    {
+      id: 'copy-feedback-markdown',
+      label: 'Copy As Markdown',
+      icon: ClipboardCopy,
+      onClick: () => handlers.onCopyAsMarkdown(item),
+    },
+    {
+      id: 'dismiss-feedback',
+      label: 'Dismiss',
+      icon: XCircle,
+      onClick: () => handlers.onDismiss(item),
+      disabled:
+        item.status === 'dismissed' || handlers.isDismissPending(item.id),
+      destructive: true,
+    },
+  ];
+}
+
+function toContextIcon(Icon: LucideIcon) {
+  return <Icon className='h-4 w-4' aria-hidden='true' />;
+}
+
+export function feedbackActionsToContextMenuItems(
+  actions: readonly FeedbackActionDefinition[]
+): ContextMenuItemType[] {
+  return actions.flatMap((action, index): ContextMenuItemType[] => [
+    ...(index > 0 ? [{ type: 'separator' } as const] : []),
+    {
+      id: action.id,
+      label: action.label,
+      icon: toContextIcon(action.icon),
+      onClick: action.onClick ?? (() => {}),
+      disabled: action.disabled,
+      destructive: action.destructive,
+    },
+  ]);
+}
+
+export function feedbackActionsToDropdownItems(
+  actions: readonly FeedbackActionDefinition[]
+): CommonDropdownItem[] {
+  return actions.flatMap((action, index): CommonDropdownItem[] => [
+    ...(index > 0
+      ? [
+          {
+            id: `feedback-action-separator-${index}`,
+            type: 'separator' as const,
+          },
+        ]
+      : []),
+    {
+      id: action.id,
+      type: 'action',
+      label: action.label,
+      icon: action.icon,
+      onClick: action.onClick ?? (() => {}),
+      disabled: action.disabled,
+      variant: action.destructive ? 'destructive' : 'default',
+    },
+  ]);
+}

--- a/apps/web/tests/unit/components/admin/feedback-actions.test.tsx
+++ b/apps/web/tests/unit/components/admin/feedback-actions.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildFeedbackActions,
+  feedbackActionsToContextMenuItems,
+  feedbackActionsToDropdownItems,
+} from '@/components/features/admin/feedback-table/feedback-actions';
+
+const feedback = {
+  id: 'feedback_1',
+  status: 'pending' as const,
+};
+
+function buildActions(
+  status: 'pending' | 'dismissed' = 'pending',
+  isDismissPending = false
+) {
+  const onCopyAsMarkdown = vi.fn();
+  const onDismiss = vi.fn();
+  const item = { ...feedback, status };
+  const actions = buildFeedbackActions(item, {
+    onCopyAsMarkdown,
+    onDismiss,
+    isDismissPending: () => isDismissPending,
+  });
+
+  return { actions, item, onCopyAsMarkdown, onDismiss };
+}
+
+describe('feedback action registry', () => {
+  it('keeps the table context menu, rail context menu, and header overflow in parity', () => {
+    const { actions } = buildActions();
+    const contextItems = feedbackActionsToContextMenuItems(actions);
+    const dropdownItems = feedbackActionsToDropdownItems(actions);
+
+    expect(actions.map(action => action.id)).toEqual([
+      'copy-feedback-markdown',
+      'dismiss-feedback',
+    ]);
+    expect(
+      contextItems
+        .flatMap(item => ('id' in item ? [item.id] : []))
+        .filter(id => !id.startsWith('feedback-action-separator'))
+    ).toEqual(actions.map(action => action.id));
+    expect(
+      dropdownItems.flatMap(item => (item.type === 'action' ? [item.id] : []))
+    ).toEqual(actions.map(action => action.id));
+  });
+
+  it('routes all action surfaces through the same callbacks', () => {
+    const { actions, item, onCopyAsMarkdown, onDismiss } = buildActions();
+
+    actions[0].onClick?.();
+    actions[1].onClick?.();
+
+    expect(onCopyAsMarkdown).toHaveBeenCalledWith(item);
+    expect(onDismiss).toHaveBeenCalledWith(item);
+  });
+
+  it('disables dismiss in every surface after dismissal or while pending', () => {
+    for (const { status, pending } of [
+      { status: 'dismissed' as const, pending: false },
+      { status: 'pending' as const, pending: true },
+    ]) {
+      const { actions } = buildActions(status, pending);
+      const contextDismiss = feedbackActionsToContextMenuItems(actions).find(
+        item => 'id' in item && item.id === 'dismiss-feedback'
+      );
+      const dropdownDismiss = feedbackActionsToDropdownItems(actions).find(
+        item => item.type === 'action' && item.id === 'dismiss-feedback'
+      );
+
+      expect(actions[1].disabled).toBe(true);
+      expect('disabled' in contextDismiss! && contextDismiss.disabled).toBe(
+        true
+      );
+      expect(dropdownDismiss?.disabled).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- define feedback entity actions once and adapt them for table, rail context, and compact header overflow
- preserve dismissal, clipboard, close controls, and admin authorization behavior
- add adapter parity coverage

## Verification
- `pnpm --filter web exec vitest run tests/unit/components/admin/feedback-actions.test.tsx --maxWorkers 1`
- `pnpm biome check apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx apps/web/components/features/admin/feedback-table/feedback-actions.tsx apps/web/tests/unit/components/admin/feedback-actions.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

Linear: JOV-4712