### PR TITLE
fix(ui): unify table action visibility

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -684,12 +684,16 @@ const LibraryEntityActionCell = memo(function LibraryEntityActionCell({
 function createLibraryActionColumn(metaClassName: string) {
   return libraryColumnHelper.display({
     id: 'actions',
-    header: () => <span className='sr-only'>Actions</span>,
+    header: 'Actions',
     cell: ({ row }) => <LibraryEntityActionCell asset={row.original} />,
     size: 40,
     minSize: 40,
     enableSorting: false,
-    meta: { className: metaClassName },
+    meta: {
+      className: metaClassName,
+      headerVisibility: 'sr-only',
+      actionVisibility: 'contextual',
+    },
   });
 }
 

--- a/apps/web/components/features/admin/admin-creator-profiles/utils/column-definitions.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/utils/column-definitions.tsx
@@ -106,7 +106,7 @@ export function createCreatorProfileColumns({
     // Actions column - shows ellipsis menu with SAME items as right-click context menu
     columnHelper.display({
       id: 'actions',
-      header: '',
+      header: 'Actions',
       cell: ({ row }: { row: Row<AdminCreatorProfileRow> }) => {
         const profile = row.original;
         const contextMenuItems = getContextMenuItems(profile);
@@ -119,6 +119,10 @@ export function createCreatorProfileColumns({
         );
       },
       size: 64,
+      meta: {
+        headerVisibility: 'sr-only',
+        actionVisibility: 'contextual',
+      },
     }),
   ] as ColumnDef<AdminCreatorProfileRow, unknown>[];
 }

--- a/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
+++ b/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
@@ -531,9 +531,13 @@ export function AdminUsersTableUnified(props: Readonly<AdminUsersTableProps>) {
       // Actions column - shows ellipsis menu with SAME items as right-click context menu
       columnHelper.display({
         id: 'actions',
-        header: '',
+        header: 'Actions',
         cell: ActionsCell,
         size: 48,
+        meta: {
+          headerVisibility: 'sr-only',
+          actionVisibility: 'contextual',
+        },
       }),
     ],
     [SelectHeader, SelectCell, ActionsCell]

--- a/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx
+++ b/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx
@@ -150,7 +150,7 @@ export function AdminWaitlistTableUnified({
       // Primary Goal column
       columnHelper.accessor('primaryGoal', {
         id: 'primaryGoal',
-        header: 'Primary goal',
+        header: 'Primary Goal',
         cell: ({ getValue }) => renderPrimaryGoalCell(getValue()),
         size: 140,
       }),
@@ -198,9 +198,13 @@ export function AdminWaitlistTableUnified({
       // Actions column - shows ellipsis menu with SAME items as right-click context menu
       columnHelper.display({
         id: 'actions',
-        header: '',
+        header: 'Actions',
         cell: createActionsCellRenderer(createContextMenuItems),
         size: 48,
+        meta: {
+          headerVisibility: 'sr-only',
+          actionVisibility: 'contextual',
+        },
       }),
     ],
     [

--- a/apps/web/components/features/dashboard/organisms/contacts-table/columns.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/columns.tsx
@@ -138,7 +138,7 @@ export function createContactColumns(
     // Actions column with dropdown menu
     contactColumnHelper.display({
       id: 'actions',
-      header: '',
+      header: 'Actions',
       cell: ({ row }) => {
         const contact = row.original;
         const items: TableActionMenuItem[] = convertContextMenuItems(
@@ -154,6 +154,10 @@ export function createContactColumns(
         );
       },
       size: 48,
+      meta: {
+        headerVisibility: 'sr-only',
+        actionVisibility: 'contextual',
+      },
     }),
   ];
 }

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx
@@ -243,7 +243,7 @@ export function MenuCell({ row }: CellContext<AudienceMember, unknown>) {
   const actionMenuItems = convertContextMenuItems(contextMenuItems);
 
   return (
-    <div className='flex items-center justify-end'>
+    <div className='system-b-table-contextual-action flex items-center justify-end'>
       <TableActionMenu items={actionMenuItems} align='end' />
     </div>
   );
@@ -491,7 +491,7 @@ export function QuickActionsCell({
         type='button'
         onClick={() => onViewProfile(member)}
         className='inline-flex h-7 w-7 items-center justify-center rounded-md text-tertiary-token transition-colors hover:bg-interactive-hover hover:text-secondary-token focus-visible:outline-none focus-visible:bg-interactive-hover'
-        aria-label='View profile'
+        aria-label='View Profile'
         title='View profile'
       >
         <Eye className='h-4 w-4' />
@@ -501,7 +501,7 @@ export function QuickActionsCell({
           type='button'
           onClick={() => onSendNotification(member)}
           className='inline-flex h-7 w-7 items-center justify-center rounded-md text-tertiary-token transition-colors hover:bg-interactive-hover hover:text-secondary-token focus-visible:outline-none focus-visible:bg-interactive-hover'
-          aria-label='Send notification'
+          aria-label='Send Notification'
           title='Send notification'
         >
           <Bell className='h-4 w-4' />

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/column-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/column-renderers.tsx
@@ -148,6 +148,7 @@ export function createActionsHeaderRenderer(
     if (selectedCount > 0 && onClearSelection) {
       return (
         <div className='flex items-center justify-end'>
+          <span className='sr-only'>Actions</span>
           <Button
             variant='ghost'
             size='sm'
@@ -161,8 +162,8 @@ export function createActionsHeaderRenderer(
       );
     }
 
-    // Empty header when no selection
-    return null;
+    // Keep a semantic action header even when no bulk action is present.
+    return <span className='sr-only'>Actions</span>;
   };
 }
 
@@ -318,7 +319,7 @@ export function createActionsCellRenderer(
     const actionMenuItems = convertContextMenuItems(contextMenuItems);
 
     return (
-      <div className='flex items-center justify-end'>
+      <div className='system-b-table-contextual-action flex items-center justify-end'>
         <TableActionMenu items={actionMenuItems} align='end' />
       </div>
     );

--- a/apps/web/tests/unit/organisms/table/table-action-contract.test.ts
+++ b/apps/web/tests/unit/organisms/table/table-action-contract.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../../..');
+
+function readWebFile(relativePath: string) {
+  return readFileSync(path.join(webRoot, relativePath), 'utf8');
+}
+
+const contextualActionColumns = [
+  'app/app/(shell)/library/LibrarySurface.tsx',
+  'components/features/dashboard/organisms/contacts-table/columns.tsx',
+  'components/features/admin/admin-users-table/AdminUsersTableUnified.tsx',
+  'components/features/admin/admin-creator-profiles/utils/column-definitions.tsx',
+  'components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx',
+];
+
+describe('table action contract', () => {
+  it('keeps residual entity-table overflow slots contextual and semantically named', () => {
+    for (const relativePath of contextualActionColumns) {
+      const source = readWebFile(relativePath);
+
+      expect(source, relativePath).toContain("header: 'Actions'");
+      expect(source, relativePath).toContain("headerVisibility: 'sr-only'");
+      expect(source, relativePath).toContain("actionVisibility: 'contextual'");
+    }
+  });
+
+  it('routes legacy action renderers through the shared contextual slot', () => {
+    for (const relativePath of [
+      'components/features/dashboard/organisms/release-provider-matrix/utils/column-renderers.tsx',
+      'components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx',
+    ]) {
+      expect(readWebFile(relativePath), relativePath).toContain(
+        'system-b-table-contextual-action'
+      );
+    }
+  });
+
+  it('keeps the legacy release header named when bulk selection is inactive', () => {
+    const source = readWebFile(
+      'components/features/dashboard/organisms/release-provider-matrix/utils/column-renderers.tsx'
+    );
+
+    expect(source).toContain(
+      "return <span className='sr-only'>Actions</span>;"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- move residual entity table overflow menus onto the shared contextual action contract
- preserve semantic-only Actions headers while reserving stable action-cell geometry
- cover legacy release and audience menu renderers with the same primitive

## Verification
- `pnpm biome check` (8 changed files)
- `pnpm --filter web exec vitest run tests/unit/organisms/table/table-action-contract.test.ts components/organisms/table/atoms/ActionsCell.test.tsx components/organisms/table/organisms/UnifiedTableHeader.test.tsx --maxWorkers 1` (17 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- normal pre-push gate (Biome, proxy, Tailwind, typecheck)

JOV-4713