### PR TITLE
fix(calendar): unify event actions

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -25,20 +25,23 @@ import {
   rejectEvents,
   undoRejectEvent,
 } from '@/app/app/(shell)/dashboard/tour-dates/events-actions';
+import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
 import { NavigationDestinationReady } from '@/components/features/dashboard/NavigationDestinationReady';
 import { PageContent, PageShell } from '@/components/organisms/PageShell';
 import {
   PageToolbar,
   PageToolbarTabButton,
+  TableContextMenu,
 } from '@/components/organisms/table';
+import { convertContextMenuItems } from '@/components/organisms/table/molecules/TableContextMenu';
 import { buildReleaseTasksRoute } from '@/constants/routes';
 import { getEventLocalDateKey } from '@/lib/events/date';
-import { normalizeTicketUrl } from '@/lib/events/ticket-url';
 import { queryKeys } from '@/lib/queries';
 import { type EventRecord, useEventsQuery } from '@/lib/queries/useEventsQuery';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import { cn } from '@/lib/utils';
 import { useDashboardData } from '../dashboard/DashboardDataContext';
+import { buildCalendarEventActions } from './calendar-event-actions';
 
 type FilterChip = 'all' | 'releases' | 'events' | 'needs_review';
 
@@ -891,109 +894,65 @@ interface EventRowProps {
 function EventRow(props: EventRowProps) {
   const { event } = props;
   const reviewedLabel = formatReviewedAt(event.reviewedAt);
-  const safeTicketUrl = normalizeTicketUrl(event.ticketUrl);
+  const actionItems = buildCalendarEventActions(event, {
+    variant: props.variant,
+    onConfirm: props.onConfirm,
+    onReject: props.onReject,
+    onUndoReject: props.onUndoReject,
+    disabled: props.disabled,
+  });
+  const menuItems = convertContextMenuItems(actionItems);
+
   return (
-    <li className='system-b-calendar-event-row flex items-start gap-3 rounded-lg border p-3'>
-      {props.variant === 'pending' && props.onToggleSelect && (
-        <input
-          type='checkbox'
-          checked={!!props.selected}
-          onChange={props.onToggleSelect}
-          disabled={props.disabled}
-          aria-label={`Select ${event.title}`}
-          className='system-b-calendar-pending-checkbox mt-1 h-3.5 w-3.5 cursor-pointer'
-        />
-      )}
-      <div className='min-w-0 flex-1'>
-        <div className='flex items-center gap-2 flex-wrap'>
-          <span className='system-b-calendar-row-title truncate font-caption'>
-            {event.title}
-          </span>
-          <ProviderChip provider={event.provider ?? 'Manual'} />
-          <TypeChip type={event.eventType} />
-          {event.status && (
-            <span className='system-b-calendar-status-text'>
-              {event.status}
+    <TableContextMenu items={actionItems}>
+      <li className='system-b-calendar-event-row group flex items-start gap-3 rounded-lg border p-3'>
+        {props.variant === 'pending' && props.onToggleSelect && (
+          <input
+            type='checkbox'
+            checked={!!props.selected}
+            onChange={props.onToggleSelect}
+            disabled={props.disabled}
+            aria-label={`Select ${event.title}`}
+            className='system-b-calendar-pending-checkbox mt-1 h-3.5 w-3.5 cursor-pointer'
+          />
+        )}
+        <div className='min-w-0 flex-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <span className='system-b-calendar-row-title truncate font-caption'>
+              {event.title}
             </span>
+            <ProviderChip provider={event.provider ?? 'Manual'} />
+            <TypeChip type={event.eventType} />
+            {event.status && (
+              <span className='system-b-calendar-status-text'>
+                {event.status}
+              </span>
+            )}
+          </div>
+          <div className='system-b-calendar-row-description mt-1'>
+            {event.subtitle}
+          </div>
+          {props.variant === 'pending' && event.lastSyncedAt && (
+            <div className='system-b-calendar-row-secondary mt-1'>
+              Last synced {formatReviewedAt(event.lastSyncedAt)}
+            </div>
+          )}
+          {props.variant === 'confirmed' && reviewedLabel && (
+            <div className='system-b-calendar-row-secondary mt-1'>
+              Reviewed {reviewedLabel}
+            </div>
           )}
         </div>
-        <div className='system-b-calendar-row-description mt-1'>
-          {event.subtitle}
+        <div className='flex h-7 w-7 shrink-0 items-center justify-center'>
+          <div
+            data-selected={props.selected || undefined}
+            className='opacity-0 transition-opacity duration-subtle ease-subtle group-hover:opacity-100 group-focus-within:opacity-100 data-[selected=true]:opacity-100'
+          >
+            <TableActionMenu items={menuItems} align='end' />
+          </div>
         </div>
-        {props.variant === 'pending' && event.lastSyncedAt && (
-          <div className='system-b-calendar-row-secondary mt-1'>
-            Last synced {formatReviewedAt(event.lastSyncedAt)}
-          </div>
-        )}
-        {props.variant === 'confirmed' && reviewedLabel && (
-          <div className='system-b-calendar-row-secondary mt-1'>
-            Reviewed {reviewedLabel}
-          </div>
-        )}
-      </div>
-      <div className='flex shrink-0 items-center gap-1'>
-        {safeTicketUrl && props.variant !== 'rejected' && (
-          <a
-            href={safeTicketUrl}
-            target='_blank'
-            rel='noreferrer'
-            className='system-b-calendar-action-ghost grid h-7 place-items-center rounded-md px-2 transition-colors duration-subtle ease-subtle'
-          >
-            Tickets
-          </a>
-        )}
-        {props.variant === 'pending' && (
-          <>
-            <Button
-              type='button'
-              variant='secondary'
-              size='sm'
-              onClick={props.onConfirm}
-              disabled={props.disabled}
-              className='system-b-calendar-action-confirm h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
-            >
-              Confirm
-            </Button>
-            <Button
-              type='button'
-              variant='tertiary'
-              size='sm'
-              destructive
-              onClick={props.onReject}
-              disabled={props.disabled}
-              className='system-b-calendar-action-reject h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
-            >
-              Reject
-            </Button>
-          </>
-        )}
-        {props.variant === 'confirmed' && props.onReject && (
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            destructive
-            onClick={props.onReject}
-            disabled={props.disabled}
-            className='system-b-calendar-action-danger-ghost h-7 rounded-md px-2 transition-colors duration-subtle ease-subtle'
-          >
-            Reject
-          </Button>
-        )}
-        {props.variant === 'rejected' && props.onUndoReject && (
-          <Button
-            type='button'
-            variant='secondary'
-            size='sm'
-            onClick={props.onUndoReject}
-            disabled={props.disabled}
-            className='system-b-calendar-action-secondary h-7 rounded-md px-3 font-caption transition-colors duration-subtle ease-subtle'
-          >
-            Undo Reject
-          </Button>
-        )}
-      </div>
-    </li>
+      </li>
+    </TableContextMenu>
   );
 }
 

--- a/apps/web/app/app/(shell)/calendar/calendar-event-actions.tsx
+++ b/apps/web/app/app/(shell)/calendar/calendar-event-actions.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Icon } from '@/components/atoms/Icon';
+import type { ContextMenuItemType } from '@/components/organisms/table';
+import { normalizeTicketUrl } from '@/lib/events/ticket-url';
+import type { EventRecord } from '@/lib/queries/useEventsQuery';
+
+export type CalendarEventActionVariant = 'confirmed' | 'pending' | 'rejected';
+
+export interface BuildCalendarEventActionsOptions {
+  readonly variant: CalendarEventActionVariant;
+  readonly onConfirm?: () => void;
+  readonly onReject?: () => void;
+  readonly onUndoReject?: () => void;
+  readonly disabled?: boolean;
+}
+
+/**
+ * The single Calendar event action source for row overflow and right-click
+ * context menus. It deliberately exposes only already-supported actions.
+ */
+export function buildCalendarEventActions(
+  event: EventRecord,
+  options: BuildCalendarEventActionsOptions
+): ContextMenuItemType[] {
+  const items: ContextMenuItemType[] = [];
+  const ticketUrl = normalizeTicketUrl(event.ticketUrl);
+
+  if (ticketUrl) {
+    items.push({
+      id: 'open-tickets',
+      label: 'Open Tickets',
+      icon: <Icon name='Ticket' className='h-4 w-4' />,
+      onClick: () => {
+        globalThis.open(ticketUrl, '_blank', 'noopener,noreferrer');
+      },
+    });
+  }
+
+  if (options.variant === 'pending' && options.onConfirm) {
+    items.push({
+      id: 'confirm',
+      label: 'Confirm',
+      icon: <Icon name='Check' className='h-4 w-4' />,
+      onClick: options.onConfirm,
+      disabled: options.disabled,
+    });
+  }
+
+  if (
+    (options.variant === 'pending' || options.variant === 'confirmed') &&
+    options.onReject
+  ) {
+    items.push({
+      id: 'reject',
+      label: 'Reject',
+      icon: <Icon name='X' className='h-4 w-4' />,
+      onClick: options.onReject,
+      disabled: options.disabled,
+      destructive: true,
+    });
+  }
+
+  if (options.variant === 'rejected' && options.onUndoReject) {
+    items.push({
+      id: 'undo-reject',
+      label: 'Undo Reject',
+      icon: <Icon name='Undo2' className='h-4 w-4' />,
+      onClick: options.onUndoReject,
+      disabled: options.disabled,
+    });
+  }
+
+  return items;
+}

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CalendarPageClient } from '@/app/app/(shell)/calendar/CalendarPageClient';
 import { CalendarRouteSkeleton } from '@/app/app/(shell)/calendar/CalendarRouteSkeleton';
@@ -195,7 +195,7 @@ describe('CalendarPageClient', () => {
     expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
   });
 
-  it('uses canonical Button variants for filters and event-review actions', () => {
+  it('uses the shared event action source for overflow and context actions', () => {
     mocks.useEventsQuery.mockReturnValue({
       data: [pendingEvent, confirmedEvent, rejectedEvent],
       isLoading: false,
@@ -213,18 +213,58 @@ describe('CalendarPageClient', () => {
       })
     );
 
-    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute(
-      'data-variant',
-      'secondary'
+    const pendingRow = screen
+      .getAllByText('Movement Festival')
+      .at(-1)
+      ?.closest('li');
+    expect(pendingRow).toHaveClass('group');
+    expect(
+      within(pendingRow!).getByRole('button', { name: 'More actions' })
+    ).toBeInTheDocument();
+
+    fireEvent.contextMenu(pendingRow!);
+    const contextMenu = screen.getByRole('menu');
+    expect(
+      within(contextMenu).getByRole('menuitem', { name: 'Confirm' })
+    ).toBeInTheDocument();
+    expect(
+      within(contextMenu).getByRole('menuitem', { name: 'Reject' })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(contextMenu).getByRole('menuitem', { name: 'Confirm' })
     );
+    expect(mocks.confirmEvent).toHaveBeenCalledWith(pendingEvent.id);
+  });
+
+  it('keeps the event overflow keyboard-accessible without changing its reserved slot', () => {
+    renderCalendar();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /18 Movement Festival/ })
+    );
+
+    const eventRow = screen
+      .getAllByText('Movement Festival')
+      .at(-1)
+      ?.closest('li');
+    const overflow = within(eventRow!).getByRole('button', {
+      name: 'More actions',
+    });
+
+    expect(eventRow).toHaveClass('group');
+    expect(overflow.parentElement?.parentElement).toHaveClass('h-7', 'w-7');
+
+    overflow.focus();
+    fireEvent.keyDown(overflow, { key: 'Enter', code: 'Enter' });
+
+    const menu = screen.getByRole('menu');
     expect(
-      screen
-        .getAllByRole('button', { name: 'Reject' })
-        .some(button => button.getAttribute('data-variant') === 'tertiary')
-    ).toBe(true);
+      within(menu).getByRole('menuitem', { name: 'Confirm' })
+    ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Show rejected · 1' })
-    ).toHaveAttribute('data-variant', 'ghost');
+      within(menu).getByRole('menuitem', { name: 'Reject' })
+    ).toBeInTheDocument();
   });
 
   it('does not fetch scoped release or event data without a selected profile', () => {
@@ -296,9 +336,15 @@ describe('CalendarPageClient', () => {
     fireEvent.click(rejectedToggle);
 
     expect(screen.getAllByText('Old Listing')).toHaveLength(2);
-    expect(screen.getByRole('button', { name: 'Undo Reject' })).toHaveClass(
-      'system-b-calendar-action-secondary'
-    );
+    expect(
+      screen.getAllByRole('button', { name: 'More actions' })
+    ).toHaveLength(3);
+    expect(
+      screen
+        .getByRole('checkbox', { name: /Movement Festival/ })
+        .closest('li')
+        ?.querySelector('[data-selected="true"]')
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- Use one typed Calendar event-action source for the existing ticket, confirm, reject, and undo-reject behaviors.
- Feed the same actions to the event-row overflow menu and right-click context menu.
- Reserve the action slot so hover, focus, and selected states do not shift row layout.

## Scope
Calendar only. This does not add an event right rail, alter authentication or transitions, or change the legacy TourDateSidebar.

## Verification
- pnpm --filter web exec vitest run tests/unit/calendar/CalendarPageClient.test.tsx tests/unit/calendar/calendar-inner-system-b-style-guard.test.ts --maxWorkers 1
- pnpm biome check --write apps/web/app/app/(shell)/calendar/calendar-event-actions.tsx apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check

JOV-4714