### PR TITLE
fix(sidebar): quiet New Chat hierarchy

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -12,6 +12,7 @@ import {
   useSidebar,
 } from '@/components/organisms/Sidebar';
 import { SidebarCollapsibleGroup } from '@/components/organisms/SidebarCollapsibleGroup';
+import { SIDEBAR_SECTION_RHYTHM } from '@/components/shell/SidebarSection';
 import {
   readThreadReadState,
   type SidebarThread,
@@ -453,7 +454,7 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
           </>
         ) : (
           <SidebarGroup className='mb-0.5'>
-            <SidebarGroupContent className='space-y-0.5'>
+            <SidebarGroupContent className={SIDEBAR_SECTION_RHYTHM.navGroup}>
               {navSections.map((section, index) => (
                 <div key={section.key} data-nav-section>
                   {/* Section divider for visual separation (except for first section) */}
@@ -474,7 +475,7 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
                       {index === 0 && searchSurface ? (
                         <div
                           data-sidebar-search-slot='true'
-                          className='mb-4 mt-1.5 h-7 shrink-0 group-data-[collapsible=icon]:hidden'
+                          className={`${SIDEBAR_SECTION_RHYTHM.searchSlot} group-data-[collapsible=icon]:hidden`}
                         >
                           {searchSurface}
                         </div>
@@ -491,7 +492,7 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
         )}
 
         {threadsVisible ? (
-          <div className='mt-1.5'>
+          <div className={SIDEBAR_SECTION_RHYTHM.threads}>
             <SidebarThreadsSection
               threads={sidebarThreads}
               activeThreadId={activeThreadId}

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -24,9 +24,9 @@ function toContract(items: readonly (typeof primaryNavigation)[number][]) {
 }
 
 describe('canonical customer shell navigation', () => {
-  it('keeps New Chat as the elevated first action and Connections in the canonical order', () => {
+  it('keeps New Chat as the quiet secondary first action and Connections in the canonical order', () => {
     expect(toContract(primaryNavigation)).toEqual(CANONICAL_NAVIGATION);
-    expect(primaryNavigation[0].tone).toBe('primary');
+    expect(primaryNavigation[0].tone).toBe('secondary');
     expect(primaryNavigation.every(item => item.tier === 'core')).toBe(true);
   });
 

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -53,7 +53,7 @@ export const chatNavItem: NavItem = {
   id: 'chat',
   icon: SquarePen,
   iconName: 'SquarePen',
-  tone: 'primary',
+  tone: 'secondary',
   tier: 'core',
   description: 'Start a new conversation',
 };

--- a/apps/web/components/features/dashboard/dashboard-nav/types.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/types.ts
@@ -15,8 +15,8 @@ export interface NavItem {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   /** Shared Icon registry key for authenticated shell rendering. */
   iconName?: IconName;
-  /** Gives the one primary sidebar action the shared elevated row treatment. */
-  tone?: 'default' | 'primary';
+  /** Applies a shared sidebar hierarchy treatment without bespoke row chrome. */
+  tone?: 'default' | 'secondary' | 'primary';
   /**
    * Capacity tier. Defaults to `core` when omitted so existing entries stay
    * on the approved rail until explicitly marked experimental.
@@ -29,6 +29,6 @@ export interface NavItem {
 
 export interface DashboardNavProps {
   readonly collapsed?: boolean;
-  /** Shell-owned surface placed after the elevated New Chat action. */
+  /** Shell-owned surface placed after the secondary New Chat action. */
   readonly children?: ReactNode;
 }

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -32,13 +32,18 @@ interface SidebarNavChromeOptions {
   readonly tight?: boolean;
   /** An absolute trailing action layers over the label's faded edge. */
   readonly trailingOverlay?: boolean;
-  readonly tone?: 'default' | 'primary';
+  readonly tone?: 'default' | 'secondary' | 'primary';
   readonly className?: string;
 }
 
 // Create actions are deliberately not a second selected-nav treatment. Keep
 // them compact and secondary so the active destination remains the strongest
 // signal in the rail.
+const SIDEBAR_SECONDARY_CHROME =
+  'w-fit grid-cols-[18px_auto] gap-x-1.5 px-2.5 text-sidebar-item-foreground font-medium hover:bg-sidebar-accent';
+
+// Retained for callers that explicitly need the established elevated action
+// treatment. Customer navigation uses the quiet secondary tone instead.
 const SIDEBAR_PRIMARY_CHROME =
   'w-fit grid-cols-[18px_auto] gap-x-1.5 bg-sidebar-accent/40 px-2.5 text-sidebar-item-foreground font-medium shadow-none hover:bg-sidebar-accent/70';
 
@@ -57,6 +62,10 @@ function getToneClassName({
 }: Pick<SidebarNavChromeOptions, 'active' | 'nested' | 'tone'>): string {
   if (tone === 'primary') {
     return SIDEBAR_PRIMARY_CHROME;
+  }
+
+  if (tone === 'secondary') {
+    return SIDEBAR_SECONDARY_CHROME;
   }
 
   if (active) {
@@ -79,7 +88,7 @@ export function getSidebarNavRowClassName({
 
   return cn(
     'relative grid items-center rounded-full transition-[background-color,box-shadow,color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
-    tone === 'primary' ? undefined : 'w-full',
+    tone === 'primary' || tone === 'secondary' ? undefined : 'w-full',
     'font-normal',
     tight ? 'gap-x-2 text-xs' : 'gap-x-2.5 text-xs',
     collapsed
@@ -114,7 +123,7 @@ export function getSidebarNavIconClassName({
     // the canonical Jovie teal token so the active signal remains quiet.
     tone === 'primary'
       ? 'text-accent-teal!'
-      : active
+      : active && tone !== 'secondary'
         ? 'text-accent-teal!'
         : inactiveIconColor,
     className

--- a/apps/web/components/shell/SidebarSection.test.tsx
+++ b/apps/web/components/shell/SidebarSection.test.tsx
@@ -1,8 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { SidebarSection } from './SidebarSection';
+import { SIDEBAR_SECTION_RHYTHM, SidebarSection } from './SidebarSection';
 
 describe('SidebarSection', () => {
+  it('exports the separator-free section rhythm used by the shell', () => {
+    expect(SIDEBAR_SECTION_RHYTHM).toEqual({
+      navGroup: 'space-y-0.5',
+      searchSlot: 'mb-4 mt-1.5 h-7 shrink-0',
+      threads: 'mt-1.5',
+    });
+  });
+
   it('renders the chevron header with the section name', () => {
     render(
       <SidebarSection

--- a/apps/web/components/shell/SidebarSection.tsx
+++ b/apps/web/components/shell/SidebarSection.tsx
@@ -12,6 +12,16 @@ const DEFAULT_ITEM_HEIGHT = 30;
 const SECTION_PADDING = 12;
 
 /**
+ * Shared shell spacing contract for adjacent sidebar sections. Consumers keep
+ * their own content but use these tokens for stable, separator-free rhythm.
+ */
+export const SIDEBAR_SECTION_RHYTHM = {
+  navGroup: 'space-y-0.5',
+  searchSlot: 'mb-4 mt-1.5 h-7 shrink-0',
+  threads: 'mt-1.5',
+} as const;
+
+/**
  * SidebarSection — collapsible header + body for a sidebar group.
  *
  * Header is a single row: rotating chevron + section name. Click toggles

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -60,14 +60,11 @@ describe('DashboardNav interactions', () => {
     );
     const inbox = screen.getByRole('link', { name: 'Inbox' });
 
-    expect(newChat).toHaveClass(
-      'w-fit',
-      'rounded-full',
-      'bg-sidebar-accent/40'
-    );
+    expect(newChat).toHaveClass('w-fit', 'rounded-full');
+    expect(newChat).not.toHaveClass('bg-sidebar-accent/40');
     expect(newChat).not.toHaveClass('bg-sidebar-accent-active', 'w-full');
-    expect(newChat.querySelector('svg')).toHaveClass('text-accent-teal!');
-    expect(searchSlot).toHaveClass('mt-1.5', 'mb-4');
+    expect(newChat.querySelector('svg')).toHaveClass('text-sidebar-muted/70');
+    expect(searchSlot).toHaveClass('mt-1.5', 'mb-4', 'h-7', 'shrink-0');
     expect(screen.getAllByRole('button', { name: 'Search' })).toHaveLength(1);
     expect(
       newChat.compareDocumentPosition(searchSlot!) &

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -268,14 +268,14 @@ describe('DashboardNav', () => {
     const chatLink = getByRole('link', { name: 'New Chat' });
     expect(chatLink).toHaveClass('w-fit');
     expect(chatLink).toHaveClass('rounded-full');
-    expect(chatLink).toHaveClass('bg-sidebar-accent/40');
+    expect(chatLink).not.toHaveClass('bg-sidebar-accent/40');
     expect(chatLink).toHaveClass('text-sidebar-item-foreground');
     expect(chatLink).toHaveClass('font-medium');
     expect(chatLink).not.toHaveClass('bg-sidebar-accent-active');
     expect(chatLink).not.toHaveClass(
       'shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
     );
-    expect(chatLink.querySelector('svg')).toHaveClass('text-accent-teal!');
+    expect(chatLink.querySelector('svg')).toHaveClass('text-sidebar-muted/70');
     expect(chatLink).not.toHaveAttribute('aria-current');
   });
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4715 -->

## Summary
- make New Chat a compact quiet-secondary sidebar action without selected or accent-filled chrome
- centralize separator-free nav, fixed Search slot, and thread spacing in `SIDEBAR_SECTION_RHYTHM`
- preserve shared focus-visible and reduced-motion behavior, with source tests for hierarchy and geometry

## Verification
- `pnpm --filter web exec vitest run components/shell/SidebarSection.test.tsx components/features/dashboard/dashboard-nav/config.test.ts tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/dashboard/DashboardNav.test.tsx` (38 passed)
- `pnpm biome check --write` on changed files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter web run test:bug-to-test` (not applicable: not a bug fix)
- normal commit and push hooks passed

## Risk
Low, scoped sidebar presentation only. Search retains fixed `h-7 shrink-0` geometry.