### PR TITLE
fix(library): align leading columns to workspace seam

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -97,6 +97,7 @@ import {
   convertToCommonDropdownItems,
   TableContextMenu,
 } from '@/components/organisms/table/molecules/TableContextMenu';
+import { alignment } from '@/components/organisms/table/table.styles';
 import {
   type DspAvatarItem,
   DspAvatarStack,
@@ -706,7 +707,7 @@ const LIBRARY_CATALOG_COLUMNS = [
     cell: ({ row }) => <StatusCell asset={row.original} />,
     size: 112,
     minSize: 96,
-    meta: { className: 'pl-2.5 pr-2' },
+    meta: { className: alignment.workspaceSeamX },
   }),
   libraryColumnHelper.display({
     id: 'artwork',
@@ -763,7 +764,7 @@ const LIBRARY_TABLE_COLUMNS = [
     minSize: 220,
     size: 9999,
     enableSorting: false,
-    meta: { className: 'pl-2.5 pr-2' },
+    meta: { className: alignment.workspaceSeamX },
   }),
   libraryColumnHelper.display({
     id: 'releaseDate',

--- a/apps/web/components/organisms/table/table.styles.ts
+++ b/apps/web/components/organisms/table/table.styles.ts
@@ -16,6 +16,7 @@ export const typography = {
 
 // Alignment & Spacing - Perfect Vertical Alignment
 export const alignment = {
+  workspaceSeamX: 'px-3',
   checkboxCell: 'flex items-center justify-center', // Center checkbox
   numberCell: 'flex items-center justify-end tabular-nums', // Right-align numbers
   rowHeight: 'system-b-table-row-height', // Comfortable density with room for two-line cells

--- a/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
+++ b/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
@@ -33,4 +33,14 @@ describe('workspace page optical seam contract', () => {
     expect(tableStyles).toContain("cellPadding: 'px-3 py-1'");
     expect(tableStyles).toContain("headerPadding: 'px-3 py-1.5'");
   });
+
+  it('keeps Library leading columns on the shared table seam', () => {
+    const librarySurface = read('app/app/(shell)/library/LibrarySurface.tsx');
+
+    expect(librarySurface).toContain(
+      "import { alignment } from '@/components/organisms/table/table.styles';"
+    );
+    expect(librarySurface.match(/alignment\.workspaceSeamX/g)).toHaveLength(2);
+    expect(librarySurface).not.toContain('pl-2.5');
+  });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4717 -->

## Summary
- Replace the two Library leading-column `pl-2.5 pr-2` overrides with the shared table workspace-seam token.
- Keep dense row geometry, row interaction states, and responsive overflow unchanged.
- Add a source regression preventing a Library-local leading seam override.

## Bug-to-Test
- Regression test added: `workspace-page-seam-contract.test.ts`.

## Verification Results
- `pnpm --filter web exec vitest run tests/unit/app/workspace-page-seam-contract.test.ts tests/unit/library/LibrarySurface.test.tsx` (50 passed; known non-failing jsdom media-pause diagnostics)
- `pnpm biome check --write apps/web/app/app/(shell)/library/LibrarySurface.tsx apps/web/components/organisms/table/table.styles.ts apps/web/tests/unit/app/workspace-page-seam-contract.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Normal pre-commit and pre-push hooks

## Test plan
- Source guard verifies both leading columns resolve through `alignment.workspaceSeamX` and rejects `pl-2.5`.
- Existing Library surface tests cover table/mobile interaction behavior.
