### PR TITLE
fix(library): prevent preset filter wrapping

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -871,7 +871,7 @@ function LibraryViewFilterChips({
 }) {
   return (
     <div
-      className='flex min-w-0 flex-wrap items-center gap-1'
+      className='flex shrink-0 flex-nowrap items-center gap-1'
       data-testid='library-view-filter-chips'
     >
       {PRESETS.map(view => (

--- a/apps/web/tests/unit/library/library-toolbar-layout-contract.test.ts
+++ b/apps/web/tests/unit/library/library-toolbar-layout-contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd();
+
+function read(relativePath: string) {
+  return readFileSync(join(WEB_ROOT, relativePath), 'utf8');
+}
+
+describe('Library toolbar layout contract', () => {
+  it('keeps preset filters in the shared toolbar scroll rail instead of wrapping', () => {
+    const toolbar = read(
+      'components/organisms/table/molecules/PageToolbar.tsx'
+    );
+    const library = read('app/app/(shell)/library/LibrarySurface.tsx');
+    const filterChips = library.slice(
+      library.indexOf('function LibraryViewFilterChips'),
+      library.indexOf('function LibrarySavedViewRow')
+    );
+
+    expect(toolbar).toContain('overflow-x-auto overflow-y-hidden');
+    expect(filterChips).toContain(
+      "className='flex shrink-0 flex-nowrap items-center gap-1'"
+    );
+    expect(filterChips).not.toContain(
+      "className='flex min-w-0 flex-wrap items-center gap-1'"
+    );
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4719 -->

## Summary
- Keep Library preset filters on one non-wrapping rail inside the existing PageToolbar horizontal-containment contract.
- Preserve the in-flow Context Panel, toolbar/table seam, dense rows, actions, and keyboard-reachable overflow.

## Bug-to-Test
- Regression test added: `library-toolbar-layout-contract.test.ts`.

## Verification Results
- `pnpm --filter web exec vitest run tests/unit/library/library-toolbar-layout-contract.test.ts`
- `pnpm --filter web exec vitest run tests/unit/library/LibrarySurface.test.tsx` (40 passed; known non-failing jsdom media-pause diagnostics)
- `pnpm biome check --write apps/web/app/app/(shell)/library/LibrarySurface.tsx apps/web/tests/unit/library/library-toolbar-layout-contract.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Normal pre-commit and pre-push hooks
