### PR TITLE
fix(tasks): quiet unselected detail state

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -51,6 +51,7 @@ import {
 } from '@/components/jovie/hooks/useTextareaAutosize';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
 import { EntitySidebarShell } from '@/components/molecules/drawer';
+import { EmptyState } from '@/components/molecules/EmptyState';
 import {
   TOOLBAR_MENU_CONTENT_CLASS,
   TOOLBAR_MENU_SEPARATOR_CLASS,
@@ -658,18 +659,13 @@ function TaskDocumentPanel({
             data-testid='task-document-scroll-region'
           >
             <div className='flex min-h-full items-center justify-center px-6 py-6'>
-              <div className='max-w-[34rem] px-6 py-10 text-center'>
-                <div className='mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-surface-1 text-secondary-token'>
-                  <FileText className='h-5 w-5' />
-                </div>
-                <h2 className='mt-5 text-xl font-semibold tracking-[-0.03em] text-primary-token'>
-                  Pick A Task From The List To See What It Needs.
-                </h2>
-                <p className='mt-2 text-app leading-relaxed text-tertiary-token'>
-                  Open a task to review its status, metadata, due state, and
-                  body in the detail pane.
-                </p>
-              </div>
+              <EmptyState
+                icon={<FileText className='h-4 w-4' strokeWidth={2} />}
+                heading='Select a task'
+                description='Choose a task from the list to view its details.'
+                className='max-w-sm py-8'
+                testId='task-document-empty-state'
+              />
             </div>
           </div>
         </div>

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -769,9 +769,13 @@ describe('TasksPageClient', () => {
     renderPage();
 
     expect(screen.getByTestId('task-document-pane')).toBeVisible();
+    expect(screen.getByText('Select a task')).toBeInTheDocument();
+    expect(screen.getByTestId('task-document-empty-state')).toHaveTextContent(
+      'Choose a task from the list to view its details.'
+    );
     expect(
-      screen.getByText('Pick A Task From The List To See What It Needs.')
-    ).toBeInTheDocument();
+      screen.queryByText('Pick A Task From The List To See What It Needs.')
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Task Title')).not.toBeInTheDocument();
   });
 
@@ -819,9 +823,7 @@ describe('TasksPageClient', () => {
     renderPage();
 
     expect(screen.getByTestId('task-document-pane')).toBeInTheDocument();
-    expect(
-      screen.getByText('Pick A Task From The List To See What It Needs.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Select a task')).toBeInTheDocument();
     expect(screen.queryByLabelText('Task Title')).not.toBeInTheDocument();
 
     act(() => {
@@ -866,9 +868,7 @@ describe('TasksPageClient', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Assigned To Jovie 1' }));
 
     expect(screen.queryByLabelText('Task Title')).not.toBeInTheDocument();
-    expect(
-      screen.getByText('Pick A Task From The List To See What It Needs.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Select a task')).toBeInTheDocument();
     expect(getLatestTableProps()?.data?.map(task => task.id)).toEqual([
       'task-jovie',
     ]);
@@ -1025,7 +1025,9 @@ describe('TasksPageClient', () => {
 
     renderPage();
 
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('task-workspace-loading-rows')
+    ).toBeInTheDocument();
     expect(screen.getByText('Loading tasks')).toBeInTheDocument();
     expect(
       screen.queryByText('Your Task List Is Empty')
@@ -1548,9 +1550,7 @@ describe('TasksPageClient', () => {
   it('supports j and k keyboard navigation across visible tasks', () => {
     renderPage();
 
-    expect(
-      screen.getByText('Pick A Task From The List To See What It Needs.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Select a task')).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: 'j' });
     expect(screen.getByLabelText('Task Title')).toHaveValue(mockTaskTwo.title);
@@ -1583,9 +1583,7 @@ describe('TasksPageClient', () => {
     fireEvent.keyDown(window, { key: 'Escape' });
 
     expect(screen.queryByLabelText('Task Title')).not.toBeInTheDocument();
-    expect(
-      screen.getByText('Pick A Task From The List To See What It Needs.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Select a task')).toBeInTheDocument();
   });
 
   it('keeps task keyboard navigation out of text editors', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4720 -->

## Summary
- Replace the oversized task-detail placeholder with the shared `EmptyState` primitive.
- Use sentence-case `Select a task` plus one short supporting line and the existing FileText affordance.
- Keep JOV-4514 entity migration out of scope.

## Design evidence
Design-read: authenticated task-detail placeholder, quiet operational language, Jovie Linear-like product system.
Dials: DESIGN_VARIANCE=low, MOTION_INTENSITY=none, VISUAL_DENSITY=high.
Before/after evidence: focused task-detail render coverage; browser evidence intentionally excluded by task constraint.
Checklist: contrast pass, states pass, layout pass, motion pass, icons pass, anti-slop pass, evidence pass.

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/TasksPageClient.test.tsx` (58 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx`
- normal pre-push/component ship gate (pass)