### PR TITLE
fix(nav): hide empty Inbox at active route

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -125,13 +125,9 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
     () =>
       primaryNavigation.filter(
         item =>
-          item.id !== 'inbox' ||
-          shouldShowInboxNavigation(
-            inboxNavigation,
-            isItemActive(pathname, item)
-          )
+          item.id !== 'inbox' || shouldShowInboxNavigation(inboxNavigation)
       ),
-    [inboxNavigation, pathname]
+    [inboxNavigation]
   );
   const activePrimaryItemId = useMemo(() => {
     const active = eligiblePrimaryNavigation.find(item => {

--- a/apps/web/lib/inbox/navigation-availability.test.ts
+++ b/apps/web/lib/inbox/navigation-availability.test.ts
@@ -24,16 +24,13 @@ describe('Inbox navigation availability', () => {
     });
   });
 
-  it('fails open for unknown availability and preserves an active empty Inbox', () => {
+  it('fails open for unknown availability and hides a conclusively empty Inbox', () => {
     expect(
-      shouldShowInboxNavigation(UNKNOWN_INBOX_NAVIGATION_AVAILABILITY, false)
+      shouldShowInboxNavigation(UNKNOWN_INBOX_NAVIGATION_AVAILABILITY)
     ).toBe(true);
-    expect(shouldShowInboxNavigation(undefined, false)).toBe(true);
-    expect(
-      shouldShowInboxNavigation({ state: 'empty', pendingCount: 0 }, true)
-    ).toBe(true);
-    expect(
-      shouldShowInboxNavigation({ state: 'empty', pendingCount: 0 }, false)
-    ).toBe(false);
+    expect(shouldShowInboxNavigation(undefined)).toBe(true);
+    expect(shouldShowInboxNavigation({ state: 'empty', pendingCount: 0 })).toBe(
+      false
+    );
   });
 });

--- a/apps/web/lib/inbox/navigation-availability.ts
+++ b/apps/web/lib/inbox/navigation-availability.ts
@@ -26,8 +26,7 @@ export function resolveInboxNavigationAvailability(
 }
 
 export function shouldShowInboxNavigation(
-  availability: InboxNavigationAvailability | undefined,
-  isActive: boolean
+  availability: InboxNavigationAvailability | undefined
 ): boolean {
-  return isActive || availability?.state !== 'empty';
+  return availability?.state !== 'empty';
 }

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -133,19 +133,16 @@ describe('DashboardNav', () => {
     expect(getByRole('link', { name: 'New Chat' })).toBeInTheDocument();
   });
 
-  it('keeps a settled-empty Inbox visible while its root destination is active', () => {
+  it('hides a settled-empty Inbox while its root destination is active', () => {
     mockUsePathname.mockReturnValue(APP_ROUTES.DASHBOARD);
-    const { getByRole } = renderDashboardNav({
+    const { queryByRole } = renderDashboardNav({
       renderFn: fastRender,
       overrides: {
         inboxNavigation: { state: 'empty', pendingCount: 0 },
       },
     });
 
-    expect(getByRole('link', { name: 'Inbox' })).toHaveAttribute(
-      'aria-current',
-      'page'
-    );
+    expect(queryByRole('link', { name: 'Inbox' })).toBeNull();
   });
 
   it('keeps Inbox visible when availability is unknown', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4718 -->

## Summary
- hide Inbox whenever existing server-derived availability is conclusively empty, including `/app`
- retain fail-open behavior for unknown/error availability
- cover the active-route empty Inbox regression with shared navigation tests

## Verification
- `pnpm --filter web exec vitest run lib/inbox/navigation-availability.test.ts tests/unit/dashboard/DashboardNav.test.tsx` (19 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write` on changed files
- normal pre-commit and pre-push hooks passed, including affected-test shards

## Risk
Low. This changes only the existing shell visibility predicate; availability remains server-rendered and no route redirect is introduced.