### PR TITLE
fix(contacts): remove redundant empty-state action [JOV-4723]

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -219,7 +219,6 @@ export const ContactsTable = memo(function ContactsTable({
     <div className='flex h-full min-h-0 flex-row' data-testid='contacts-table'>
       {/* Main content area */}
       <div className='flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden'>
-        <h1 className='sr-only'>Contacts</h1>
         <p className='sr-only'>
           Manage bookings, management, and press contacts for {artistName}
         </p>
@@ -240,12 +239,8 @@ export const ContactsTable = memo(function ContactsTable({
           {isEmpty ? (
             <EmptyState
               icon={<UserPlus className='h-6 w-6' aria-hidden='true' />}
-              heading='No Contacts'
-              description='Add a contact to manage bookings, management, and press.'
-              action={{
-                label: 'Add Contact',
-                onClick: () => onAddContact(),
-              }}
+              heading='No Contacts Yet'
+              description='Add bookings, management, and press contacts.'
             />
           ) : (
             <UnifiedTable

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -196,7 +196,7 @@ describe('ContactsTable', () => {
     expect(screen.queryByText('No Contacts Yet')).not.toBeInTheDocument();
   });
 
-  it('offers the canonical add contact action from the empty state', () => {
+  it('keeps the header action as the only add contact CTA for the empty state', () => {
     const onAddContact = vi.fn();
 
     renderContactsTable({
@@ -208,18 +208,17 @@ describe('ContactsTable', () => {
       onAddContact,
     });
 
-    expect(screen.getByRole('heading', { name: 'No Contacts' })).toBeVisible();
     expect(
-      screen.getByText(
-        'Add a contact to manage bookings, management, and press.'
-      )
+      screen.getByRole('heading', { name: 'No Contacts Yet' })
     ).toBeVisible();
-    const addContactButton = screen.getByRole('button', {
-      name: 'Add Contact',
-    });
-    expect(addContactButton).toHaveTextContent('Add Contact');
+    expect(
+      screen.getByText('Add bookings, management, and press contacts.')
+    ).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Add Contact' })
+    ).not.toBeInTheDocument();
 
-    fireEvent.click(addContactButton);
-    expect(onAddContact).toHaveBeenCalledTimes(1);
+    expect(setHeaderActions).toHaveBeenCalledWith(expect.anything());
+    expect(onAddContact).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4723 -->

## Summary
- remove the duplicate hidden Contacts page heading; the shell breadcrumb owns the page h1
- keep header Add Contact as the sole create CTA
- reduce the empty state to one heading and one supporting line

## Verification
- `pnpm exec biome check --write apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx apps/web/tests/unit/dashboard/ContactsTable.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/dashboard/ContactsTable.test.tsx --maxWorkers 1` (3/3)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable: non-bug classification)

Closes JOV-4723.