### PR TITLE
fix(search): activate current Cmd-K result on Enter [JOV-4725]

### DIFF
--- a/apps/web/components/organisms/CmdKPalette.stories.tsx
+++ b/apps/web/components/organisms/CmdKPalette.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { CmdKPalette } from './CmdKPalette';
+
+const meta = {
+  title: 'Organisms/CmdKPalette',
+  component: CmdKPalette,
+  parameters: {
+    layout: 'fullscreen',
+    jovie: {
+      uncoveredProps: [
+        'additionalSectionsAfter',
+        'onAdditionalSelect',
+        'onHeaderChange',
+      ],
+    },
+  },
+  args: {
+    profileId: 'storybook-profile',
+    open: true,
+    onOpenChange: () => undefined,
+    presentation: 'dialog',
+  },
+} satisfies Meta<typeof CmdKPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullPageSearch: Story = {};

--- a/apps/web/components/organisms/CmdKPalette.test.tsx
+++ b/apps/web/components/organisms/CmdKPalette.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type ReactNode, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { CmdKPalette } from './CmdKPalette';
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <span data-testid='img' data-src={src} data-alt={alt} />
+  ),
+}));
+
+vi.mock('@/lib/queries/useReleasesQuery', () => ({
+  useReleasesQuery: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/lib/queries/useArtistSearchQuery', () => ({
+  useArtistSearchQuery: () => ({
+    results: [],
+    state: 'idle',
+    search: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/queries/useChatCapabilitiesQuery', () => ({
+  useChatCapabilitiesQuery: () => ({
+    data: {
+      tools: {
+        albumArt: {
+          availability: 'available',
+          reason: null,
+          reasonCode: null,
+        },
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+function MainPlaneHarness() {
+  const [header, setHeader] = useState<ReactNode>(null);
+
+  return (
+    <>
+      <header>{header}</header>
+      <CmdKPalette
+        profileId='profile-1'
+        open
+        onOpenChange={vi.fn()}
+        presentation='main'
+        onHeaderChange={setHeader}
+      />
+    </>
+  );
+}
+
+describe('CmdKPalette', () => {
+  it('commits the currently filtered main-plane result with Enter', () => {
+    pushMock.mockClear();
+    render(<MainPlaneHarness />);
+
+    const input = screen.getByRole('searchbox', {
+      name: 'Command Palette Search',
+    });
+    fireEvent.change(input, { target: { value: 'Calendar' } });
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Calendar Plan release dates and campaign moments. ⌘1',
+      })
+    ).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(pushMock).toHaveBeenCalledWith('/app/calendar');
+  });
+});

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -18,6 +18,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -75,8 +76,10 @@ interface CmdKPaletteProps {
 
 function MainPlaneSearchInput({
   onQueryChange,
+  onKeyDown,
 }: {
   readonly onQueryChange: (query: string) => void;
+  readonly onKeyDown: (event: KeyboardEvent) => void;
 }) {
   const [query, setQuery] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -99,6 +102,13 @@ function MainPlaneSearchInput({
           const nextQuery = event.target.value;
           setQuery(nextQuery);
           onQueryChange(nextQuery);
+        }}
+        onKeyDown={(event: ReactKeyboardEvent<HTMLInputElement>) => {
+          // The shell header lives outside the command plane's DOM subtree.
+          // Commit here so Enter always reaches the selected result even when
+          // the header seam changes during a route transition.
+          event.stopPropagation();
+          onKeyDown(event.nativeEvent);
         }}
         placeholder='Search Jovie or run a command…'
         className='min-w-0 flex-1 appearance-none bg-transparent text-sm text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus-visible:outline-none'
@@ -269,10 +279,8 @@ export function CmdKPalette({
     [flatItems, additionalIds, onAdditionalSelect, handleClose, router]
   );
 
-  // Keyboard nav: arrow up/down/enter/escape with IME guard.
-  useEffect(() => {
-    if (!open) return;
-    function onKey(e: KeyboardEvent) {
+  const handleKeyboardCommand = useCallback(
+    (e: KeyboardEvent) => {
       if (e.isComposing) return;
       if (
         (e.metaKey || e.ctrlKey) &&
@@ -302,10 +310,19 @@ export function CmdKPalette({
         e.preventDefault();
         handleClose();
       }
-    }
-    globalThis.addEventListener('keydown', onKey, true);
-    return () => globalThis.removeEventListener('keydown', onKey, true);
-  }, [open, flatItems.length, commitIndex, selectedIndex, handleClose]);
+    },
+    [commitIndex, flatItems.length, handleClose, selectedIndex]
+  );
+  const handleKeyboardCommandRef = useRef(handleKeyboardCommand);
+  handleKeyboardCommandRef.current = handleKeyboardCommand;
+
+  // Keyboard nav: arrow up/down/enter/escape with IME guard.
+  useEffect(() => {
+    if (!open) return;
+    globalThis.addEventListener('keydown', handleKeyboardCommand);
+    return () =>
+      globalThis.removeEventListener('keydown', handleKeyboardCommand);
+  }, [handleKeyboardCommand, open]);
 
   const dialogInput = (
     <div className='flex h-full min-w-0 flex-1 items-center gap-2'>
@@ -340,6 +357,10 @@ export function CmdKPalette({
           setQuery(nextQuery);
           setSelectedIndex(0);
         }}
+        // This header element is mounted through context and otherwise keeps
+        // the callback from its first render. Resolve through a ref so Enter
+        // commits against the current filtered result list.
+        onKeyDown={event => handleKeyboardCommandRef.current(event)}
       />
     );
     return () => onHeaderChange?.(null);

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -175,6 +175,31 @@ describe('CommandPalette', () => {
     expect(screen.getByLabelText('Command Palette Search')).toHaveFocus();
   });
 
+  it('commits the selected sidebar-triggered main-plane result with Enter', () => {
+    pushMock.mockClear();
+    render(
+      withDashboard(
+        <>
+          <CommandPalette />
+          <HeaderSearchSurfaceFromContext />
+        </>
+      )
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search Jovie' }));
+    const input = screen.getByLabelText('Command Palette Search');
+    fireEvent.change(input, { target: { value: 'Calendar' } });
+    expect(input).toHaveValue('Calendar');
+    expect(
+      screen.getByRole('option', {
+        name: 'Calendar Plan release dates and campaign moments. ⌘1',
+      })
+    ).toHaveAttribute('aria-selected', 'true');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(pushMock).toHaveBeenCalledWith('/app/calendar');
+  });
+
   it('lists recent chats with safe fallback titles', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });


### PR DESCRIPTION
## Summary
- Resolve the sidebar-triggered Cmd-K header callback through the current palette state.
- Enter now commits the currently visible selected result instead of a stale first result.
- Add regression coverage for Search → Calendar → Enter.

## Verification
- `pnpm biome check --write apps/web/components/organisms/CmdKPalette.tsx apps/web/tests/unit/organisms/CommandPalette.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/organisms/CommandPalette.test.tsx tests/unit/commands/SharedCommandPalette.test.tsx --maxWorkers 1` (31 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`

## Tracking
Linear API was unreachable from this worktree (`fetch failed` through Doppler); a durable creation attempt was queued locally. This is the bounded ad-hoc source repair for the exact main runtime failure reported during the UI audit.