### PR TITLE
fix(marketing): use canonical download proof [JOV-4726]

### DIFF
--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -22,7 +22,7 @@ export const revalidate = false;
 
 const DOWNLOAD_URL = '/api/desktop/download';
 const DESKTOP_RELEASES_HTML_URL = 'https://github.com/JovieInc/Jovie/releases';
-const DESKTOP_IMAGE = getMarketingExportImage('shell-v1-releases-desktop');
+const DESKTOP_IMAGE = getMarketingExportImage('dashboard-releases-desktop');
 const PROFILE_IMAGE = getMarketingExportImage('tim-white-profile-live-mobile');
 
 const FAQ_ITEMS = [
@@ -215,7 +215,7 @@ export default function DownloadPage() {
                   <div className='absolute inset-x-0 top-8 bottom-0 overflow-hidden rounded-xl border border-subtle bg-surface-1/5 shadow-card'>
                     <Image
                       src={DESKTOP_IMAGE.publicUrl}
-                      alt='Jovie native desktop workspace showing releases and release planning'
+                      alt='Jovie desktop workspace showing the releases catalog and release details'
                       width={DESKTOP_IMAGE.width}
                       height={DESKTOP_IMAGE.height}
                       priority

--- a/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
@@ -30,6 +30,10 @@ const requiredSharedPrimitives = [
   'public-action-secondary',
   'FaqSection',
 ] as const;
+const currentProofScenario =
+  "getMarketingExportImage('dashboard-releases-desktop')";
+const retiredProofScenario =
+  "getMarketingExportImage('shell-v1-releases-desktop')";
 
 describe('download page System B source contract', () => {
   it('keeps download page visuals on named System B primitives', () => {
@@ -67,6 +71,16 @@ describe('download page System B source contract', () => {
         pattern
       );
     }
+  });
+
+  it('uses the current releases dashboard proof instead of the experimental shell', () => {
+    const source = readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8');
+
+    expect(source).toContain(currentProofScenario);
+    expect(source).not.toContain(retiredProofScenario);
+    expect(source).toContain(
+      'Jovie desktop workspace showing the releases catalog and release details'
+    );
   });
 
   it('removes the page-scoped system-b-download CSS block', () => {


### PR DESCRIPTION
## Summary
- bind `/download` to the canonical `dashboard-releases-desktop` marketing export
- replace the retired experimental-shell alt text with a factual releases-workspace description
- lock the binding with the direct download source contract

## Checks
- `pnpm exec biome check --write apps/web/app/(marketing)/download/page.tsx apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts`
- `pnpm --filter web exec vitest run tests/unit/marketing/download-system-b-style-guard.test.ts --maxWorkers 1` (6/6)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`

## Dependency / admission
JOV-4724 / #15360 owns the refreshed `dashboard-releases-desktop` asset and its truthful capture. This PR intentionally does not edit screenshot assets. It is ready for source CI but held from merge until #15360 lands; remove `hold` and native-queue it immediately afterward.