### PR TITLE
fix(connections): adopt canonical contextual row actions [JOV-4727]

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { TooltipProvider } from '@jovie/ui';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -157,6 +157,24 @@ describe('ProfilesWorkspace', () => {
     expect(screen.getByRole('link', { name: 'Upgrade' })).toHaveAttribute(
       'href',
       '/app/settings/billing'
+    );
+  });
+
+  it('uses the shared semantic, contextual action slot without shifting rows', () => {
+    renderWorkspace(data);
+
+    expect(
+      within(screen.getByRole('columnheader', { name: 'Actions' })).getByText(
+        'Actions'
+      )
+    ).toHaveClass('sr-only');
+
+    const action = screen.getByRole('button', {
+      name: 'Actions for Spotify',
+    });
+    expect(action.parentElement).not.toHaveClass('sm:opacity-0');
+    expect(action.closest('td')).toHaveClass(
+      'system-b-table-contextual-action-cell'
     );
   });
 

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -551,14 +551,18 @@ export function ProfilesWorkspace({
       }),
       columnHelper.display({
         id: 'actions',
-        header: () => <span className='sr-only'>Actions</span>,
+        header: 'Actions',
         size: 44,
-        meta: { className: 'px-3' },
+        meta: {
+          className: 'px-3',
+          headerVisibility: 'sr-only',
+          actionVisibility: 'contextual',
+        },
         cell: context => {
           const row = context.row.original;
           const actionItems = convertContextMenuItems(getContextMenuItems(row));
           return (
-            <div className='flex justify-end opacity-100 transition-opacity duration-subtle sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:focus-within:pointer-events-auto sm:focus-within:opacity-100'>
+            <div className='flex justify-end'>
               <TableActionMenu items={actionItems} align='end' trigger='custom'>
                 <button
                   type='button'

--- a/apps/web/tests/unit/organisms/table/table-action-contract.test.ts
+++ b/apps/web/tests/unit/organisms/table/table-action-contract.test.ts
@@ -14,6 +14,7 @@ const contextualActionColumns = [
   'components/features/admin/admin-users-table/AdminUsersTableUnified.tsx',
   'components/features/admin/admin-creator-profiles/utils/column-definitions.tsx',
   'components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx',
+  'app/app/(shell)/profiles/ProfilesWorkspace.tsx',
 ];
 
 describe('table action contract', () => {


### PR DESCRIPTION
## Summary
- routes the Connections action column through the existing UnifiedTable semantic header and contextual visibility contract
- preserves the existing connection action registry and right-rail action source
- adds regression coverage for the semantic header and reserved contextual action slot

## Verification
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx tests/unit/organisms/table/table-action-contract.test.ts --maxWorkers 1` (10/10)
- `pnpm biome check --write apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx apps/web/tests/unit/organisms/table/table-action-contract.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- normal pre-push: component ship gate + affected verification (12/12)

## Risk
Low, presentation/metadata-only. The shared table CSS keeps the action column width reserved and handles hover, focus, selection, menu-open, and reduced-motion states.