### PR TITLE
fix(connections): isolate row action menu clicks [JOV-4729]

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -160,6 +160,33 @@ describe('ProfilesWorkspace', () => {
     );
   });
 
+  it('opens a row action menu without selecting the row via pointer or keyboard', async () => {
+    const user = userEvent.setup();
+    renderWorkspace(data);
+
+    const action = screen.getByRole('button', {
+      name: 'Actions for Spotify',
+    });
+
+    vi.mocked(useRegisterRightPanel).mockClear();
+    await user.click(action);
+
+    expect(
+      screen.getByRole('menuitem', { name: /View Details/i })
+    ).toBeInTheDocument();
+    expect(useRegisterRightPanel).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    vi.mocked(useRegisterRightPanel).mockClear();
+    action.focus();
+    await user.keyboard('{Enter}');
+
+    expect(
+      screen.getByRole('menuitem', { name: /View Details/i })
+    ).toBeInTheDocument();
+    expect(useRegisterRightPanel).not.toHaveBeenCalled();
+  });
+
   it('uses the shared semantic, contextual action slot without shifting rows', () => {
     renderWorkspace(data);
 

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -567,6 +567,8 @@ export function ProfilesWorkspace({
                 <button
                   type='button'
                   aria-label={`Actions for ${row.label}`}
+                  onClick={event => event.stopPropagation()}
+                  onKeyDown={event => event.stopPropagation()}
                   className='inline-flex h-11 w-11 items-center justify-center rounded-full border border-transparent bg-transparent text-tertiary-token transition-colors duration-fast hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus/50 sm:h-7 sm:w-7'
                 >
                   <MoreHorizontal className='h-4 w-4' aria-hidden />


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4729 -->

## Description

Stops the Connections overflow trigger from bubbling into `UnifiedTable` row selection. Pointer and Enter activation now open the canonical action menu without opening the detail rail.

## Testing

- `pnpm exec biome check --write apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx`
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1` — 8/8
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

### Bug-to-Test Rule

- [x] Regression test added
- [x] bug-to-test: satisfied

## Design

Uses the existing table-cell interaction boundary; no new visual primitive or motion. `design-canonical`: contrast, states, layout, motion, icons, anti-slop, and evidence — pass.

Closes JOV-4729