### PR TITLE
test(screenshots): skip placeholder database integration [JOV-4733]

### DIFF
--- a/apps/web/tests/unit/lib/notifications/audience-upsert.integration.test.ts
+++ b/apps/web/tests/unit/lib/notifications/audience-upsert.integration.test.ts
@@ -7,9 +7,31 @@ import { audienceMembers } from '@/lib/db/schema/analytics';
 
 const CREATOR_PROFILE_ID = 'a96b46e1-1250-4e7c-98b2-9e271eb72c37';
 
-const hasRealDatabase =
-  Boolean(process.env.DATABASE_URL) &&
-  !process.env.DATABASE_URL?.includes('dummy');
+const SCREENSHOT_WORKFLOW_PLACEHOLDER_DATABASE_URLS = new Set([
+  'postgresql://localhost/noop',
+  'postgres://localhost/noop',
+]);
+
+function isRealDatabaseUrl(databaseUrl?: string): boolean {
+  return Boolean(
+    databaseUrl &&
+      !databaseUrl.includes('dummy') &&
+      !SCREENSHOT_WORKFLOW_PLACEHOLDER_DATABASE_URLS.has(databaseUrl)
+  );
+}
+
+const hasRealDatabase = isRealDatabaseUrl(process.env.DATABASE_URL);
+
+describe('audience upsert database environment', () => {
+  it('rejects screenshot workflow placeholder database URLs', () => {
+    expect(isRealDatabaseUrl('postgresql://localhost/noop')).toBe(false);
+    expect(isRealDatabaseUrl('postgres://localhost/noop')).toBe(false);
+  });
+
+  it('accepts configured database URLs', () => {
+    expect(isRealDatabaseUrl('postgresql://db.example.com/jovie')).toBe(true);
+  });
+});
 
 describe('audience upsert via db client', () => {
   it.skipIf(!hasRealDatabase)(


### PR DESCRIPTION
## Summary
- classify the Product Screenshots placeholder database URLs as non-real for the audience DB integration suite
- preserve execution for configured PostgreSQL databases
- add focused classification coverage for both placeholder URL schemes

## Evidence
- Exact Product Screenshots capture run: https://github.com/JovieInc/Jovie/actions/runs/30714505584
- Catalog capture itself: **57/57 passed in 17.3m**
- Publication failure: `audience-upsert.integration.test.ts` attempted cleanup against `postgresql://localhost/noop` during the generated-branch pre-push gate

## Verification
- `DATABASE_URL=postgresql://localhost/noop pnpm --filter web exec vitest run tests/unit/lib/notifications/audience-upsert.integration.test.ts --maxWorkers 1` — 2 passed, 1 skipped
- `pnpm biome check apps/web/tests/unit/lib/notifications/audience-upsert.integration.test.ts`
- `git diff --check`

No hook bypass or workflow gate weakening; this narrows only an impossible DB integration environment.