### PR TITLE
feat(marketing): add instant merch landing page

### DIFF
--- a/apps/web/app/(marketing)/instant-merch/InstantMerchLanding.test.tsx
+++ b/apps/web/app/(marketing)/instant-merch/InstantMerchLanding.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '@/tests/utils/a11y';
+import { CREATE_MERCH_HREF, InstantMerchLanding } from './InstantMerchLanding';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('InstantMerchLanding', () => {
+  it('routes both CTAs into the authenticated merch conversation', () => {
+    render(<InstantMerchLanding />);
+
+    expect(screen.getByTestId('instant-merch-primary-cta')).toHaveAttribute(
+      'href',
+      CREATE_MERCH_HREF
+    );
+    expect(screen.getByTestId('instant-merch-final-cta')).toHaveAttribute(
+      'href',
+      CREATE_MERCH_HREF
+    );
+    expect(CREATE_MERCH_HREF).toBe('/app/chat?q=Make%20me%20merch');
+  });
+
+  it('keeps the landing composition responsive at the layout boundaries', () => {
+    render(<InstantMerchLanding />);
+
+    expect(screen.getByTestId('marketing-section-how-it-works')).toHaveClass(
+      'py-16',
+      'sm:py-20'
+    );
+    expect(screen.getByTestId('marketing-section-feature-grid')).toHaveClass(
+      'py-16',
+      'sm:py-20'
+    );
+    expect(screen.getByText('Describe the drop').closest('div')).toBeTruthy();
+    expect(screen.getByText('Choose a direction').closest('div')).toBeTruthy();
+    expect(
+      screen.getByText('Approve the next step').closest('div')
+    ).toBeTruthy();
+  });
+
+  it('has no axe violations in the rendered marketing surface', async () => {
+    const { container } = render(<InstantMerchLanding />);
+
+    await expectNoA11yViolations(container);
+  });
+});

--- a/apps/web/app/(marketing)/instant-merch/InstantMerchLanding.tsx
+++ b/apps/web/app/(marketing)/instant-merch/InstantMerchLanding.tsx
@@ -1,0 +1,155 @@
+import { Button } from '@jovie/ui';
+import Link from 'next/link';
+import { ChatGenerationArtifactSurface } from '@/components/jovie/components/ChatGenerationArtifactSurface';
+import {
+  MarketingContainer,
+  MarketingFeatureGrid,
+  MarketingHero,
+  MarketingPageShell,
+} from '@/components/marketing';
+import { APP_ROUTES } from '@/constants/routes';
+import { INSTANT_MERCH_COPY as copy } from '@/data/instantMerchCopy';
+
+const CREATE_MERCH_HREF = `${APP_ROUTES.CHAT}?q=${encodeURIComponent('Make me merch')}`;
+
+function MerchFlowPreview() {
+  return (
+    <ChatGenerationArtifactSurface
+      title='Merch Options'
+      subtitle='Review before you publish'
+      className='w-full'
+    >
+      <div className='grid gap-3 sm:grid-cols-3'>
+        {['Heavyweight tee', 'Tour hoodie', 'Limited cap'].map(
+          (product, index) => (
+            <div
+              key={product}
+              className='rounded-xl border border-subtle bg-surface-0 p-4'
+            >
+              <div
+                aria-hidden='true'
+                className='aspect-square rounded-lg bg-panel'
+              />
+              <p className='mt-3 text-sm font-medium text-primary-token'>
+                {product}
+              </p>
+              <p className='mt-1 text-xs text-tertiary-token'>
+                Concept {index + 1}
+              </p>
+            </div>
+          )
+        )}
+      </div>
+    </ChatGenerationArtifactSurface>
+  );
+}
+
+export function InstantMerchLanding() {
+  return (
+    <MarketingPageShell className='bg-base text-primary-token'>
+      <main>
+        <MarketingHero
+          eyebrow={copy.hero.eyebrow}
+          title={copy.hero.title}
+          body={copy.hero.body}
+          media={<MerchFlowPreview />}
+          headingId='instant-merch-hero-heading'
+          sectionTestId='marketing-section-hero'
+          primaryCtaLabel={copy.hero.primaryCta}
+          primaryCtaHref={CREATE_MERCH_HREF}
+          primaryCtaTestId='instant-merch-primary-cta'
+          secondaryCtaLabel={copy.hero.secondaryCta}
+          secondaryCtaHref='#instant-merch-flow'
+          subcopy={copy.hero.subcopy}
+        />
+
+        <section
+          id='instant-merch-flow'
+          aria-labelledby='instant-merch-flow-heading'
+          className='border-t border-subtle py-16 sm:py-20'
+          data-testid='marketing-section-how-it-works'
+        >
+          <MarketingContainer width='page'>
+            <div className='mx-auto max-w-3xl text-center'>
+              <p className='homepage-section-eyebrow'>{copy.flow.eyebrow}</p>
+              <h2
+                id='instant-merch-flow-heading'
+                className='mt-3 text-balance text-2xl font-semibold tracking-tight text-primary-token sm:text-3xl'
+              >
+                {copy.flow.title}
+              </h2>
+              <p className='mt-3 text-pretty leading-7 text-secondary-token'>
+                {copy.flow.body}
+              </p>
+            </div>
+            <div className='mx-auto mt-12 grid max-w-5xl gap-8 md:grid-cols-3'>
+              {copy.flow.steps.map((step, index) => (
+                <article
+                  key={step.title}
+                  className='border-t border-subtle pt-5'
+                >
+                  <p className='text-xs font-mono text-tertiary-token'>
+                    0{index + 1}
+                  </p>
+                  <h3 className='mt-3 text-lg font-medium text-primary-token'>
+                    {step.title}
+                  </h3>
+                  <p className='mt-2 text-sm leading-6 text-secondary-token'>
+                    {step.description}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </MarketingContainer>
+        </section>
+
+        <section
+          aria-labelledby='instant-merch-details-heading'
+          className='bg-panel py-16 sm:py-20'
+          data-testid='marketing-section-feature-grid'
+        >
+          <MarketingContainer width='page'>
+            <div className='mx-auto max-w-3xl'>
+              <p className='homepage-section-eyebrow'>{copy.details.eyebrow}</p>
+              <h2
+                id='instant-merch-details-heading'
+                className='mt-3 text-balance text-2xl font-semibold tracking-tight text-primary-token sm:text-3xl'
+              >
+                {copy.details.title}
+              </h2>
+              <MarketingFeatureGrid items={copy.details.items} />
+            </div>
+          </MarketingContainer>
+        </section>
+
+        <section
+          aria-labelledby='instant-merch-cta-heading'
+          className='py-16 sm:py-24'
+          data-testid='marketing-section-cta'
+        >
+          <MarketingContainer width='prose' className='text-center'>
+            <h2
+              id='instant-merch-cta-heading'
+              className='text-balance text-2xl font-semibold tracking-tight text-primary-token sm:text-3xl'
+            >
+              {copy.cta.title}
+            </h2>
+            <p className='mt-3 text-pretty leading-7 text-secondary-token'>
+              {copy.cta.body}
+            </p>
+            <Button asChild className='mt-8' data-primary-action='true'>
+              <Link
+                href={CREATE_MERCH_HREF}
+                data-testid='instant-merch-final-cta'
+              >
+                {copy.cta.primaryCta}
+              </Link>
+            </Button>
+          </MarketingContainer>
+        </section>
+      </main>
+    </MarketingPageShell>
+  );
+}
+
+export { CREATE_MERCH_HREF };

--- a/apps/web/app/(marketing)/instant-merch/page.tsx
+++ b/apps/web/app/(marketing)/instant-merch/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { APP_NAME, BASE_URL } from '@/constants/app';
+import { APP_ROUTES } from '@/constants/routes';
+import { INSTANT_MERCH_COPY } from '@/data/instantMerchCopy';
+import { InstantMerchLanding } from './InstantMerchLanding';
+
+export const revalidate = false;
+
+const INSTANT_MERCH_URL = `${BASE_URL}${APP_ROUTES.INSTANT_MERCH}`;
+
+export const metadata: Metadata = {
+  title: `${INSTANT_MERCH_COPY.seo.title} | ${APP_NAME}`,
+  description: INSTANT_MERCH_COPY.seo.description,
+  metadataBase: new URL(BASE_URL),
+  alternates: { canonical: INSTANT_MERCH_URL },
+  openGraph: {
+    type: 'website',
+    url: INSTANT_MERCH_URL,
+    title: `${INSTANT_MERCH_COPY.seo.title} | ${APP_NAME}`,
+    description: INSTANT_MERCH_COPY.seo.description,
+    siteName: APP_NAME,
+    images: [
+      {
+        url: `${BASE_URL}/og/default.png`,
+        width: 1200,
+        height: 630,
+        alt: INSTANT_MERCH_COPY.seo.title,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${INSTANT_MERCH_COPY.seo.title} | ${APP_NAME}`,
+    description: INSTANT_MERCH_COPY.seo.description,
+    images: [`${BASE_URL}/og/default.png`],
+  },
+};
+
+export default function InstantMerchPage() {
+  return <InstantMerchLanding />;
+}

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -162,6 +162,7 @@ export const APP_ROUTES = {
   DOWNLOAD: '/download',
   SUPPORT: '/support',
   PAY: '/pay',
+  INSTANT_MERCH: '/instant-merch',
 
   // Legal
   LEGAL_PRIVACY: '/legal/privacy',

--- a/apps/web/data/instantMerchCopy.ts
+++ b/apps/web/data/instantMerchCopy.ts
@@ -1,0 +1,69 @@
+export const INSTANT_MERCH_COPY = {
+  seo: {
+    title: 'Instant Merch for Artists',
+    description:
+      'Turn a merch idea into a considered product concept from your Jovie conversation, then review it before it reaches your profile.',
+  },
+  hero: {
+    eyebrow: 'Instant Merch',
+    title: 'Make the drop before the moment passes.',
+    body: 'Tell Jovie what you want to make. Review three product concepts, choose the one that feels right, and keep control before anything goes live.',
+    primaryCta: 'Create merch in Jovie',
+    secondaryCta: 'See how it works',
+    subcopy:
+      'Requires a Jovie account. Nothing publishes without your approval.',
+  },
+  flow: {
+    eyebrow: 'The creation flow',
+    title: 'From rough idea to ready-to-review.',
+    body: 'The same conversation-led merch flow already inside Jovie, introduced with a clearer starting point.',
+    steps: [
+      {
+        title: 'Describe the drop',
+        description:
+          'Start with a product, a release, a mood, or a deadline. Jovie turns the brief into options.',
+      },
+      {
+        title: 'Choose a direction',
+        description:
+          'Review the concepts, pricing context, and product details before selecting one.',
+      },
+      {
+        title: 'Approve the next step',
+        description:
+          'Your selection stays in your account until you decide whether to publish it to your profile.',
+      },
+    ],
+  },
+  details: {
+    eyebrow: 'Built for the release cycle',
+    title: 'Less coordination. More time making the thing.',
+    items: [
+      {
+        title: 'Start in plain language',
+        description:
+          'No merch brief template required. Begin with the idea as it exists in your head.',
+      },
+      {
+        title: 'Keep the decision yours',
+        description:
+          'Jovie proposes. You select, revise, or stop. The landing page does not promise an automatic launch.',
+      },
+      {
+        title: 'Use the profile you already have',
+        description:
+          'Approved merch can continue through Jovie’s existing profile and fulfillment surfaces.',
+      },
+      {
+        title: 'See the honest state',
+        description:
+          'Concepts and product mockups are distinct steps. The flow does not call an unfinished asset live.',
+      },
+    ],
+  },
+  cta: {
+    title: 'Have an idea for the next drop?',
+    body: 'Open the authenticated Jovie conversation and start with the words you already have.',
+    primaryCta: 'Start creating merch',
+  },
+} as const;

--- a/apps/web/data/marketing/routeManifest.ts
+++ b/apps/web/data/marketing/routeManifest.ts
@@ -295,6 +295,26 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     noindex: true,
   },
   {
+    glob: '(marketing)/instant-merch/page.tsx',
+    recipeId: 'feature',
+    renderedSections: approvedBindings(
+      'apps/web/app/(marketing)/instant-merch/InstantMerchLanding.tsx',
+      'hero',
+      'feature-grid',
+      'how-it-works',
+      'cta'
+    ),
+    bindingEvidence: {
+      status: 'verified',
+      source: 'route audit 2026-08-01',
+      notes:
+        'Uses the authenticated chat merch creation flow; product concepts are illustrative and not proof claims.',
+    },
+    status: 'active',
+    specVersion: '1.0.0',
+    url: '/instant-merch',
+  },
+  {
     glob: '(marketing)/launch/page.tsx',
     recipeId: 'launch',
     renderedSections: approvedBindings(


### PR DESCRIPTION
## Summary
- Add `/instant-merch`, a focused landing page for artists who want to turn a merch idea into a reviewable product concept.
- Reuse the existing `ChatGenerationArtifactSurface` merch surface and route the CTA into the authenticated chat flow with `q=Make%20me%20merch`.
- Register the route with the typed marketing registry and keep copy in a dedicated data module.
- Avoid unverifiable metrics, customer proof, raw personal data, and direct database writes. The preview is explicitly illustrative; nothing publishes without approval.

## Verification
- `pnpm --filter @jovie/web exec vitest run --config=vitest.config.mts 'app/(marketing)/instant-merch/InstantMerchLanding.test.tsx' tests/unit/marketing/recipe-manifest.test.ts` — 2 files, 43 tests passed.
- `pnpm biome check ...` on all 6 changed files — passed.
- `git diff --check` — passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — blocked by 11 pre-existing AI SDK v4/v2 type incompatibilities in unrelated files (`app/api/chat/conversations/[id]/messages/route.ts`, `lib/chat/run.ts`, `lib/connectors/gmail/extract-event-signal.ts`, `lib/hud/humanize-pr-title.ts`, `lib/inbox/classifier.ts`, `lib/merch/graphic-engine.ts`, and unrelated insight/pitch/retouching services).
- Design-system/component registry commands are not present in this checkout's package scripts; the documented script entrypoints are also absent on `origin/main`.

## Scope
- 6 files, 345 added lines; under the 800-line / 40-file PR limit.
- Draft only. Do not merge or publish merch from this PR.
