### PR TITLE
feat: add authenticated instant-merch MCP writes

### DIFF
--- a/apps/web/app/api/mcp/[username]/route.test.ts
+++ b/apps/web/app/api/mcp/[username]/route.test.ts
@@ -11,10 +11,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Hoist mocks
 // ---------------------------------------------------------------------------
 const hoisted = vi.hoisted(() => ({
+  getCachedAuth: vi.fn(),
   getProfileByUsername: vi.fn(),
   getReleasesForProfileLite: vi.fn(),
   getLiveMerchCardsForProfile: vi.fn(),
   getUpcomingTourDatesForProfile: vi.fn(),
+  createMerchGeneration: vi.fn(),
+  selectMerchDesign: vi.fn(),
+  publishMerchCard: vi.fn(),
+  proposeMerchAction: vi.fn(),
 }));
 
 vi.mock('server-only', () => ({}));
@@ -23,12 +28,23 @@ vi.mock('@/lib/services/profile', () => ({
   getProfileByUsername: hoisted.getProfileByUsername,
 }));
 
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: hoisted.getCachedAuth,
+}));
+
+vi.mock('@/lib/chat/tools/merch-propose', () => ({
+  proposeMerchAction: hoisted.proposeMerchAction,
+}));
+
 vi.mock('@/lib/discography/queries', () => ({
   getReleasesForProfileLite: hoisted.getReleasesForProfileLite,
 }));
 
 vi.mock('@/lib/merch/service', () => ({
+  createMerchGeneration: hoisted.createMerchGeneration,
   getLiveMerchCardsForProfile: hoisted.getLiveMerchCardsForProfile,
+  publishMerchCard: hoisted.publishMerchCard,
+  selectMerchDesign: hoisted.selectMerchDesign,
 }));
 
 vi.mock('@/lib/tour-dates/queries', () => ({
@@ -75,6 +91,31 @@ describe('POST /api/mcp/[username] — JSON-RPC id echo', () => {
     hoisted.getReleasesForProfileLite.mockResolvedValue([]);
     hoisted.getLiveMerchCardsForProfile.mockResolvedValue([]);
     hoisted.getUpcomingTourDatesForProfile.mockResolvedValue([]);
+    hoisted.getCachedAuth.mockResolvedValue({ userId: null });
+    hoisted.createMerchGeneration.mockResolvedValue({
+      success: true,
+      generationId: '00000000-0000-0000-0000-000000000001',
+      options: [],
+    });
+    hoisted.selectMerchDesign.mockResolvedValue({
+      success: true,
+      merchCardId: '00000000-0000-4000-8000-000000000002',
+      status: 'draft',
+    });
+    hoisted.proposeMerchAction.mockResolvedValue({
+      success: true,
+      action: 'publish_merch',
+      merchCardId: '00000000-0000-4000-8000-000000000002',
+      title: 'Tour Tee',
+      currentStatus: 'draft',
+      retailPrice: '$25.00',
+      primaryImageUrl: null,
+    });
+    hoisted.publishMerchCard.mockResolvedValue({
+      id: '00000000-0000-4000-8000-000000000002',
+      status: 'live',
+      title: 'Tour Tee',
+    });
   });
 
   it('echoes a numeric request id in the success response', async () => {
@@ -164,6 +205,134 @@ describe('POST /api/mcp/[username] — JSON-RPC id echo', () => {
     const body = await res.json();
     expect(body.id).toBeNull();
     expect(body.error).toBeDefined();
+  });
+
+  it('lists agent-native merch write tools without exposing them as public reads', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({ jsonrpc: '2.0', id: 8, method: 'tools/list' }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+    const body = await res.json();
+    const names = body.result.tools.map((tool: { name: string }) => tool.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'generate_merch',
+        'select_merch_design',
+        'publish_merch_card',
+      ])
+    );
+  });
+
+  it('rejects merch generation without an authenticated owner session', async () => {
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({
+        jsonrpc: '2.0',
+        id: 9,
+        method: 'tools/call',
+        params: { name: 'generate_merch', arguments: { prompt: 'tour tee' } },
+      }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+    const body = await res.json();
+    expect(body.error.message).toContain('Authentication required');
+    expect(hoisted.createMerchGeneration).not.toHaveBeenCalled();
+  });
+
+  it('routes generation through the canonical merch service with the session owner', async () => {
+    hoisted.getCachedAuth.mockResolvedValue({ userId: 'owner-1' });
+    const { POST } = await import('./route');
+    await POST(
+      makeRequest({
+        jsonrpc: '2.0',
+        id: 10,
+        method: 'tools/call',
+        params: {
+          name: 'generate_merch',
+          arguments: { prompt: 'tour tee', itemType: 'hoodie' },
+        },
+      }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+    expect(hoisted.createMerchGeneration).toHaveBeenCalledWith({
+      profileId: 'p1',
+      clerkUserId: 'owner-1',
+      prompt: 'tour tee\nItem type: hoodie',
+      command: 'create_merch',
+    });
+  });
+
+  it('returns a publish proposal after selecting a draft design', async () => {
+    hoisted.getCachedAuth.mockResolvedValue({ userId: 'owner-1' });
+    const { POST } = await import('./route');
+    const res = await POST(
+      makeRequest({
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/call',
+        params: {
+          name: 'select_merch_design',
+          arguments: {
+            generationId: '00000000-0000-4000-8000-000000000001',
+            optionNumber: 1,
+          },
+        },
+      }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+    const body = await res.json();
+    expect(body.result.content[0].text).toContain('publishProposal');
+    expect(hoisted.selectMerchDesign).toHaveBeenCalledWith({
+      generationId: '00000000-0000-4000-8000-000000000001',
+      clerkUserId: 'owner-1',
+      optionNumber: 1,
+      optionId: undefined,
+      publish: false,
+    });
+  });
+
+  it('requires explicit confirmation before publishing and then uses the canonical publisher', async () => {
+    hoisted.getCachedAuth.mockResolvedValue({ userId: 'owner-1' });
+    const { POST } = await import('./route');
+    const proposal = await POST(
+      makeRequest({
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/call',
+        params: {
+          name: 'publish_merch_card',
+          arguments: {
+            merchCardId: '00000000-0000-4000-8000-000000000002',
+          },
+        },
+      }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+    const proposalBody = await proposal.json();
+    expect(proposalBody.result.content[0].text).toContain('confirmed');
+    expect(hoisted.publishMerchCard).not.toHaveBeenCalled();
+
+    await POST(
+      makeRequest({
+        jsonrpc: '2.0',
+        id: 12,
+        method: 'tools/call',
+        params: {
+          name: 'publish_merch_card',
+          arguments: {
+            merchCardId: '00000000-0000-4000-8000-000000000002',
+            confirmed: true,
+          },
+        },
+      }),
+      { params: Promise.resolve({ username: 'artist1' }) }
+    );
+    expect(hoisted.publishMerchCard).toHaveBeenCalledWith({
+      cardId: '00000000-0000-4000-8000-000000000002',
+      profileId: 'p1',
+      clerkUserId: 'owner-1',
+    });
   });
 
   it('returns 404 with null id when artist is not found (pre-body-parse)', async () => {

--- a/apps/web/app/api/mcp/[username]/route.ts
+++ b/apps/web/app/api/mcp/[username]/route.ts
@@ -16,14 +16,24 @@
  *   - get_ticket_link           → resolve a ticket URL for an event
  *   - check_merch_availability  → confirm a merch item is purchasable
  *   - add_to_cart               → redirect to the merch purchase URL
+ *   - generate_merch             → generate three draft design options (auth)
+ *   - select_merch_design        → select an option and create a draft (auth)
+ *   - publish_merch_card         → propose or confirm publication (auth)
  */
 
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { BASE_URL } from '@/constants/app';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { proposeMerchAction } from '@/lib/chat/tools/merch-propose';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
-import { getLiveMerchCardsForProfile } from '@/lib/merch/service';
+import {
+  createMerchGeneration,
+  getLiveMerchCardsForProfile,
+  publishMerchCard,
+  selectMerchDesign,
+} from '@/lib/merch/service';
 import { getProfileByUsername } from '@/lib/services/profile';
 import { getUpcomingTourDatesForProfile } from '@/lib/tour-dates/queries';
 
@@ -291,6 +301,49 @@ function buildToolDescriptors() {
         required: ['itemId'],
       },
     },
+    {
+      name: 'generate_merch',
+      description:
+        'Generate exactly three merch design options for the authenticated owner of this artist profile. Creates drafts only; it never publishes.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          prompt: { type: 'string', maxLength: 500 },
+          itemType: { type: 'string', maxLength: 80 },
+        },
+      },
+    },
+    {
+      name: 'select_merch_design',
+      description:
+        'Select one generated merch option for the authenticated owner and create a draft merch card. Returns a publish confirmation proposal; it does not publish.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          generationId: { type: 'string', format: 'uuid' },
+          optionNumber: { type: 'integer', minimum: 1, maximum: 3 },
+          optionId: { type: 'string', format: 'uuid' },
+        },
+        required: ['generationId'],
+      },
+    },
+    {
+      name: 'publish_merch_card',
+      description:
+        'Propose publishing a merch card, or publish it only when confirmed is explicitly true. Requires authenticated ownership and the existing merch sellability checks.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          merchCardId: { type: 'string', format: 'uuid' },
+          confirmed: {
+            type: 'boolean',
+            description:
+              'Set true only after the artist explicitly confirms the publish proposal.',
+          },
+        },
+        required: ['merchCardId'],
+      },
+    },
   ];
 }
 
@@ -398,6 +451,122 @@ async function callTool(
     const item = merch.find(m => m.id === itemId);
     if (!item) return { error: `Merch item not found: ${itemId}` };
     return { data: { itemId, checkoutUrl: `${profileUrl}/merch` } };
+  }
+
+  if (
+    name === 'generate_merch' ||
+    name === 'select_merch_design' ||
+    name === 'publish_merch_card'
+  ) {
+    const { userId } = await getCachedAuth();
+    if (!userId) return { error: 'Authentication required for merch writes' };
+
+    if (name === 'generate_merch') {
+      const parsed = z
+        .object({
+          prompt: z.string().max(500).optional(),
+          itemType: z.string().max(80).optional(),
+        })
+        .safeParse(args);
+      if (!parsed.success) return { error: 'Invalid generate_merch arguments' };
+
+      const prompt = [
+        parsed.data.prompt,
+        parsed.data.itemType ? `Item type: ${parsed.data.itemType}` : undefined,
+      ]
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+      try {
+        const result = await createMerchGeneration({
+          profileId: profile.id,
+          clerkUserId: userId,
+          prompt: prompt || 'Make premium merch for this artist.',
+          command: 'create_merch',
+        });
+        return {
+          data: {
+            ...result,
+            nextStep:
+              'Pick an option number, then review the publish proposal.',
+          },
+        };
+      } catch {
+        return { error: 'Unable to generate merch options' };
+      }
+    }
+
+    if (name === 'select_merch_design') {
+      const parsed = z
+        .object({
+          generationId: z.string().uuid(),
+          optionNumber: z.number().int().min(1).max(3).optional(),
+          optionId: z.string().uuid().optional(),
+        })
+        .refine(
+          (value: { optionNumber?: number; optionId?: string }) =>
+            value.optionNumber !== undefined || value.optionId
+        )
+        .safeParse(args);
+      if (!parsed.success)
+        return { error: 'Invalid select_merch_design arguments' };
+
+      try {
+        const result = await selectMerchDesign({
+          generationId: parsed.data.generationId,
+          clerkUserId: userId,
+          optionNumber: parsed.data.optionNumber,
+          optionId: parsed.data.optionId,
+          publish: false,
+        });
+        if (!result.success) return { data: result };
+        const publishProposal = await proposeMerchAction({
+          action: 'publish',
+          merchCardId: result.merchCardId,
+          profileId: profile.id,
+        });
+        return { data: { ...result, publishProposal } };
+      } catch {
+        return { error: 'Unable to select merch design' };
+      }
+    }
+
+    const parsed = z
+      .object({
+        merchCardId: z.string().uuid(),
+        confirmed: z.boolean().optional().default(false),
+      })
+      .safeParse(args);
+    if (!parsed.success)
+      return { error: 'Invalid publish_merch_card arguments' };
+
+    if (!parsed.data.confirmed) {
+      const proposal = await proposeMerchAction({
+        action: 'publish',
+        merchCardId: parsed.data.merchCardId,
+        profileId: profile.id,
+      });
+      return { data: { confirmed: false, proposal } };
+    }
+
+    try {
+      const card = await publishMerchCard({
+        cardId: parsed.data.merchCardId,
+        profileId: profile.id,
+        clerkUserId: userId,
+      });
+      return {
+        data: {
+          confirmed: true,
+          success: true,
+          merchCardId: card.id,
+          status: card.status,
+          title: card.title,
+        },
+      };
+    } catch {
+      return { error: 'Unable to publish merch card' };
+    }
   }
 
   return { error: `Unknown tool: ${name}` };

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -118,7 +118,7 @@ async function getCreatorProfileForMerch(
   return profile;
 }
 
-async function assertCanManageMerchProfile(
+export async function assertCanManageMerchProfile(
   profileId: string,
   clerkUserId: string
 ): Promise<void> {
@@ -600,6 +600,7 @@ export async function createMerchGeneration(params: {
   readonly conversationId?: string | null;
   readonly turnId?: string | null;
 }): Promise<MerchGenerationResult> {
+  await assertCanManageMerchProfile(params.profileId, params.clerkUserId);
   const command = merchCommandSchema.parse(params.command);
   const profile = await getCreatorProfileForMerch(params.profileId);
   const releaseContext = await getReleaseContext(params.profileId);


### PR DESCRIPTION
## Summary
- Extend the existing per-artist MCP gateway with authenticated `generate_merch`, `select_merch_design`, and `publish_merch_card` tools.
- Route all writes through the canonical merch service and existing publish proposal helper; no direct DB access or private scripts in the gateway.
- Require an authenticated session and canonical profile ownership for generation/selection/publish; publication is proposal-first and only executes with `confirmed: true`.

## Duplicate / epic reconciliation
- Parent action-tools epic: #13479 (this PR is a bounded instant-merch child slice).
- Agent-native product epic: #13478.
- Same-contract REST/CLI follow-up: #13480 (not implemented here).
- Instant Merch demo epic: #15302 is closed; this PR does not reopen or duplicate it and only fills the MCP transport gap.

## Verification
- `pnpm --filter web exec vitest run 'app/api/mcp/[username]/route.test.ts'` — 13 passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check apps/web/app/api/mcp/[username]/route.ts apps/web/app/api/mcp/[username]/route.test.ts apps/web/lib/merch/service.ts` — passed.
- `git diff --check` — passed.

## Risk / rollout
- Draft only; do not merge or enable auto-merge from this task.
- Existing public MCP reads remain unchanged. Write tools require the current authenticated Clerk/app session, canonical ownership, and the existing merch sellability guard before publication.
- No public merch was generated or published.
