### PR TITLE
fix(ci): budget product screenshot publication [JOV-2769]

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     # The catalog currently takes ~17 minutes and the generated branch must
     # still pass the repository's normal pre-push gate before publication.
-    timeout-minutes: 120
+    timeout-minutes: 150
     permissions:
       contents: read
     defaults:
@@ -146,7 +146,7 @@ jobs:
 
       - name: Create or update screenshot PR
         if: steps.diff.outputs.changed == 'true'
-        timeout-minutes: 75
+        timeout-minutes: 90
         working-directory: .
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -40,7 +40,9 @@ jobs:
   generate:
     name: Generate Screenshots
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # The catalog currently takes ~17 minutes and the generated branch must
+    # still pass the repository's normal pre-push gate before publication.
+    timeout-minutes: 120
     permissions:
       contents: read
     defaults:
@@ -144,6 +146,7 @@ jobs:
 
       - name: Create or update screenshot PR
         if: steps.diff.outputs.changed == 'true'
+        timeout-minutes: 75
         working-directory: .
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -656,6 +656,24 @@ def test_deep_lanes_are_staggered_and_bounded() -> None:
     assert "'0 9 * * 2'" in harness
 
 
+def test_product_screenshot_budget_covers_capture_and_publication() -> None:
+    """The screenshot publisher must outlive capture plus the normal push gate."""
+    job = _job_block("screenshots.yml", "generate")
+    capture = _step_block("screenshots.yml", "Capture screenshot catalog")
+    publication = _step_block("screenshots.yml", "Create or update screenshot PR")
+
+    job_timeout = int(re.search(r"timeout-minutes: (\d+)", job).group(1))
+    capture_timeout = int(
+        re.search(r"timeout-minutes: (\d+)", capture).group(1)
+    )
+    publication_timeout = int(
+        re.search(r"timeout-minutes: (\d+)", publication).group(1)
+    )
+
+    assert publication_timeout >= 60
+    assert job_timeout >= capture_timeout + publication_timeout + 10
+
+
 def test_cost_monitoring_docs_match_activation_gated_observer() -> None:
     """Declared scheduling must not be confused with activation or rollback."""
     workflow = (WORKFLOWS / "cost-anomaly-gate.yml").read_text(encoding="utf-8")

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -670,8 +670,8 @@ def test_product_screenshot_budget_covers_capture_and_publication() -> None:
         re.search(r"timeout-minutes: (\d+)", publication).group(1)
     )
 
-    assert publication_timeout >= 60
-    assert job_timeout >= capture_timeout + publication_timeout + 10
+    assert publication_timeout >= 75
+    assert job_timeout >= capture_timeout + publication_timeout + 20
 
 
 def test_cost_monitoring_docs_match_activation_gated_observer() -> None:


### PR DESCRIPTION
## Summary
- raise the Product Screenshots job budget from 35 minutes to 150 minutes
- give generated screenshot publication 90 minutes for the normal repository pre-push gate
- enforce the capture + publication + orchestration budget relationship in workflow hygiene tests

## Root cause
Exact-main run 30716856984 completed all 57 product screenshots in 17.3 minutes, then the job-level 35-minute timeout canceled the generated screenshot branch during its normal pre-push gate. The remote screenshots/auto-update ref was left untouched, so capture was green but publication was false-red.

## Verification
- python3 -m pytest scripts/tests/test_agent_workflow_hygiene.py -q (35 passed)
- git diff --check
- bug-to-test: satisfied
- Regression test: scripts/tests/test_agent_workflow_hygiene.py

## Risk
Workflow/test-only change. Freshness cancellation stays enabled; Git push remains atomic and no CI gate is bypassed.

No UI code changed, so visual taste review is not applicable.

<!-- linear-issue-id:JOV-2769 -->