### PR TITLE
fix(auth): recover staging OAuth runtime proof (Closes #15371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Staging OAuth runtime proof no longer dead-clicks pre-hydration provider buttons (#15371):** AuthShell keeps Google/Apple buttons disabled until React hydrates, surfaces Better Auth soft-errors, and the production-smoke OAuth test waits on `data-auth-shell-hydrated` so provider navigation is actually emitted.
 - **Onboarding shows real presence-build tasks live after signup (JOV-3988):** new creators get four seeded workflow tasks (research artist, assemble profile, smart link, welcome draft) that only surface data already found, stream tool artifacts in the welcome chat, and fall back to the existing welcome path when the kill-switch is off or the queue fails.
 - [internal] **Typecheck singleflight no longer replaces live owners by age (JOV-4524):** locks are reclaimed only for dead owners, missing-pid age expiry, or bounded corrupt-lock recovery; live owners past the 30m window stay authoritative, with structured recovery logs and regression coverage.
 - [internal] **Machine-access revenue-share compliance package (JOV-3831):** draft decision set (70/30 artist-majority, opt-in default OFF, monthly $10 Connect fiat floor, platform stablecoin off-ramp), consent/ToS language, tax reporting path, and Pay Per Crawl public-docs verification — Tim sign-off still required before P1 build.

--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -156,7 +156,10 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
 
   const handleProviderSelect = useCallback(
     async (provider: PrimaryAuthOAuthProvider) => {
-      if (pendingProvider) return;
+      // SSR HTML paints enabled-looking buttons before React attaches listeners.
+      // Refuse pre-hydration starts so a fast click cannot become a silent no-op
+      // (staging OAuth runtime proof / real users on slow first paint).
+      if (!hasHydrated || pendingProvider) return;
 
       const callbackURL = getCallbackUrl(mode);
       const errorCallbackURL = getErrorCallbackUrl(mode);
@@ -173,12 +176,22 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
         // `callbackURL` (or `newUserCallbackURL` for new users). Plan
         // decision 8. Account linking is enabled for verified google↔apple
         // (server-side, in `socialProviders` config) — audit row 19.
-        await authClient.signIn.social({
+        const result = await authClient.signIn.social({
           provider,
           callbackURL,
           errorCallbackURL,
           newUserCallbackURL,
         });
+        // better-auth may resolve with `{ error }` instead of throwing. Surface
+        // that the same way as a thrown failure so pending state never sticks
+        // with no provider navigation (IdentityPageClient uses the same gate).
+        if (result?.error) {
+          throw new Error(
+            typeof result.error.message === 'string' && result.error.message
+              ? result.error.message
+              : 'OAuth start failed'
+          );
+        }
       } catch (error) {
         setOauthError(getAuthStartErrorMessage(mode));
         setPendingProvider(null);
@@ -193,7 +206,7 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
         );
       }
     },
-    [mode, pendingProvider]
+    [hasHydrated, mode, pendingProvider]
   );
 
   if (hasHydrated && isAuthLoaded && isSignedIn) {
@@ -215,6 +228,7 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
         data-auth-shell-mode={mode}
         data-auth-shell-compact={compact ? 'true' : undefined}
         data-auth-shell-ready='true'
+        data-auth-shell-hydrated={hasHydrated ? 'true' : 'false'}
         data-auth-shell-providers='0'
         className='relative min-h-72'
       >
@@ -224,6 +238,7 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
           forceHardNavigation={forceOppositeModeHardNavigation}
           providers={enabledOAuthProviders}
           pendingProvider={pendingProvider}
+          interactive={hasHydrated}
           errorMessage={oauthError}
           onProviderSelect={handleProviderSelect}
           redirectUrl={resolvedRedirect}
@@ -239,11 +254,12 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
       data-auth-shell-mode={mode}
       data-auth-shell-compact={compact ? 'true' : undefined}
       data-auth-shell-ready='true'
+      data-auth-shell-hydrated={hasHydrated ? 'true' : 'false'}
       className='relative min-h-96'
     >
       <GoogleOneTap
         mode={mode}
-        suppress={pendingProvider !== null || otpStepActive}
+        suppress={!hasHydrated || pendingProvider !== null || otpStepActive}
       />
       <AuthOAuthStartSurface
         mode={mode}
@@ -251,6 +267,7 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
         forceHardNavigation={forceOppositeModeHardNavigation}
         providers={enabledOAuthProviders}
         pendingProvider={pendingProvider}
+        interactive={hasHydrated}
         errorMessage={oauthError}
         onProviderSelect={handleProviderSelect}
         redirectUrl={resolvedRedirect}
@@ -285,6 +302,7 @@ function AuthOAuthStartSurface({
   forceHardNavigation,
   providers,
   pendingProvider,
+  interactive,
   errorMessage,
   onProviderSelect,
   redirectUrl,
@@ -296,6 +314,11 @@ function AuthOAuthStartSurface({
   forceHardNavigation: boolean;
   providers: readonly PrimaryAuthOAuthProvider[];
   pendingProvider: PrimaryAuthOAuthProvider | null;
+  /**
+   * False until the client hydrates React event handlers. Keeps OAuth buttons
+   * disabled on SSR/first paint so a click cannot be a silent no-op.
+   */
+  interactive: boolean;
   errorMessage: string | null;
   onProviderSelect: (provider: PrimaryAuthOAuthProvider) => void;
   redirectUrl: string;
@@ -303,6 +326,7 @@ function AuthOAuthStartSurface({
   onOtpStepChange?: (active: boolean) => void;
 }>) {
   const hasProviders = providers.length > 0;
+  const providersBusy = !interactive || Boolean(pendingProvider);
 
   return (
     <div data-auth-sso-surface>
@@ -312,15 +336,15 @@ function AuthOAuthStartSurface({
         <fieldset
           data-auth-provider-slots
           className='grid grid-cols-1 gap-1.5'
-          aria-busy={pendingProvider ? 'true' : undefined}
+          aria-busy={providersBusy ? 'true' : undefined}
         >
           <legend className='sr-only'>Social sign-in options</legend>
           {providers.map(provider => (
             <AuthProviderButtonSlot
               key={provider}
               provider={provider}
-              disabled={Boolean(pendingProvider)}
-              pending={pendingProvider === provider}
+              disabled={!interactive || Boolean(pendingProvider)}
+              pending={interactive && pendingProvider === provider}
               onClick={() => onProviderSelect(provider)}
             />
           ))}

--- a/apps/web/tests/e2e/oauth-providers.spec.ts
+++ b/apps/web/tests/e2e/oauth-providers.spec.ts
@@ -74,6 +74,14 @@ test.describe('candidate-bound Better Auth OAuth runtime @production-smoke', () 
         `${contract.provider} OAuth UI entry`
       );
 
+      // Provider buttons stay disabled until React hydrates event handlers.
+      // Waiting on enabled (not merely visible) is the contract that prevents a
+      // pre-hydration click from becoming a silent no-op with no social POST.
+      await expect(
+        page.locator('[data-auth-shell-hydrated="true"]'),
+        `${CONFIRMED_RUNTIME_CONTRACT}: auth shell never hydrated`
+      ).toBeVisible({ timeout: 20_000 });
+
       const button = page.locator(
         `button[data-auth-provider-slot="${contract.provider}"]`
       );
@@ -93,15 +101,6 @@ test.describe('candidate-bound Better Auth OAuth runtime @production-smoke', () 
       const providerNavigation = new Promise<URL>((resolve, reject) => {
         resolveProviderNavigation = resolve;
         rejectProviderNavigation = reject;
-        navigationTimer = setTimeout(
-          () =>
-            reject(
-              new Error(
-                `${CONFIRMED_RUNTIME_CONTRACT}: ${contract.provider} provider navigation was not emitted`
-              )
-            ),
-          20_000
-        );
       });
 
       await page.route(`https://${contract.host}/**`, async route => {
@@ -138,6 +137,17 @@ test.describe('candidate-bound Better Auth OAuth runtime @production-smoke', () 
       );
 
       try {
+        // Start the navigation budget at click time (not route-setup time) so
+        // hydration wait does not steal from the post-click OAuth budget.
+        navigationTimer = setTimeout(
+          () =>
+            rejectProviderNavigation(
+              new Error(
+                `${CONFIRMED_RUNTIME_CONTRACT}: ${contract.provider} provider navigation was not emitted`
+              )
+            ),
+          20_000
+        );
         await button.click({ noWaitAfter: true });
         const [request, providerUrl] = await Promise.all([
           socialPost,

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -98,6 +98,25 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
     ).not.toBeNull();
   });
 
+  it('keeps OAuth buttons disabled until client hydration attaches handlers', async () => {
+    const serverMarkup = renderToStaticMarkup(<AuthShell mode='sign-in' />);
+    expect(serverMarkup).toContain('data-auth-shell-hydrated="false"');
+    // SSR emits `disabled=""` before the provider slot attribute.
+    expect(serverMarkup).toMatch(
+      /disabled=""[^>]*data-auth-provider-slot="google"/
+    );
+
+    const { container } = render(<AuthShell mode='sign-in' />);
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-auth-shell-hydrated="true"]')
+      ).not.toBeNull();
+    });
+    expect(
+      await screen.findByRole('button', { name: /google/i })
+    ).toBeEnabled();
+  });
+
   it('does not call the proxy-backed One Tap route when the plugin is unconfigured', async () => {
     render(<AuthShell mode='sign-up' />);
 
@@ -131,9 +150,9 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
       });
     });
 
-    expect(
-      await screen.findByRole('button', { name: /google/i })
-    ).toBeVisible();
+    const google = await screen.findByRole('button', { name: /google/i });
+    await waitFor(() => expect(google).toBeEnabled());
+    expect(google).toBeVisible();
   });
 
   it('starts Google sign-in through Better Auth social with mode-aware callbacks', async () => {
@@ -141,6 +160,7 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
     render(<AuthShell mode='sign-in' />);
 
     const google = await screen.findByRole('button', { name: /google/i });
+    await waitFor(() => expect(google).toBeEnabled());
     await user.click(google);
 
     await waitFor(() => {
@@ -160,6 +180,7 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
     render(<AuthShell mode='sign-up' />);
 
     const apple = await screen.findByRole('button', { name: /apple/i });
+    await waitFor(() => expect(apple).toBeEnabled());
     await user.click(apple);
 
     await waitFor(() => {
@@ -171,6 +192,21 @@ describe('AuthShell — Better Auth SSO + email-code contract', () => {
         })
       );
     });
+  });
+
+  it('surfaces Better Auth social soft-errors instead of leaving the button pending', async () => {
+    const user = userEvent.setup();
+    signInSocialMock.mockResolvedValueOnce({
+      error: { message: 'provider unavailable' },
+    });
+    render(<AuthShell mode='sign-in' />);
+
+    const google = await screen.findByRole('button', { name: /google/i });
+    await waitFor(() => expect(google).toBeEnabled());
+    await user.click(google);
+
+    expect(await screen.findByText(/could not start sign-in/i)).toBeVisible();
+    await waitFor(() => expect(google).toBeEnabled());
   });
 
   it('keeps the signed-in first render deterministic, then hides after hydration', async () => {


### PR DESCRIPTION
## Summary
Production Controller is blocked on aliased staging Better Auth OAuth runtime proof (`CONFIRMED_OAUTH_RUNTIME_CONTRACT: google/apple provider navigation was not emitted`). Live staging already renders enabled-looking provider buttons and `POST /api/auth/sign-in/social` returns correct provider URLs server-side; the failure is a client-side dead click before React hydrates.

Root cause: AuthShell SSR HTML paints Google/Apple buttons as **enabled** before client event handlers attach. Playwright (and real users on slow first paint) can click a button that does nothing — no social POST, no provider navigation.

## Fix
- Keep OAuth provider buttons **disabled until hydration** (`data-auth-shell-hydrated`)
- Refuse pre-hydration `signIn.social` starts
- Surface Better Auth soft `{ error }` responses (match IdentityPageClient) so pending never sticks
- OAuth smoke test waits on `data-auth-shell-hydrated="true"` and starts the navigation budget at click time

## Files
- `apps/web/components/features/auth/AuthShell.tsx`
- `apps/web/tests/e2e/oauth-providers.spec.ts`
- `apps/web/tests/unit/auth/AuthShell.test.tsx`
- `CHANGELOG.md`

## Tests
- `pnpm --filter web exec vitest run tests/unit/auth/AuthShell.test.tsx tests/unit/auth/AuthProviderButtons.test.tsx tests/unit/components/organisms/AuthShell.flag.test.tsx tests/unit/components/organisms/AuthShellWrapper.test.tsx tests/unit/components/AuthShellWrapper.test.tsx` → 28 passed
- `pnpm biome check --write` on changed paths
- `pnpm --filter @jovie/web run typecheck` → green
- Live evidence: staging social POST returns Google/Apple authorize URLs; browser click after load emits navigation to accounts.google.com / appleid.apple.com

## Proof target (Summer)
Fresh Production Controller on tip main: Alias OAuth green → Promote → Production Verified; `jov.ie/api/version` matches main short SHA.

## Idempotency
`summer-pc-staging-oauth-5950e314-30720265496`

Closes #15371