### PR TITLE
fix(ci): isolate screenshot publication hooks [JOV-2769]

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -174,7 +174,11 @@ jobs:
           PUSHED=false
           for ATTEMPT in 1 2 3; do
             set +e
-            PUSH_OUTPUT=$(git -c "http.https://github.com/.extraheader=$AUTH_HEADER" push --force origin "$BRANCH" 2>&1)
+            # Capture-only overrides must not leak into the repository's normal
+            # pre-push tests. They intentionally alter dev chrome and auth
+            # fallback behavior, so run the hook with those two values unset.
+            PUSH_OUTPUT=$(env -u NEXT_DISABLE_TOOLBAR -u E2E_CLERK_USER_ID \
+              git -c "http.https://github.com/.extraheader=$AUTH_HEADER" push --force origin "$BRANCH" 2>&1)
             PUSH_EXIT=$?
             set -e
 

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -672,6 +672,7 @@ def test_product_screenshot_budget_covers_capture_and_publication() -> None:
 
     assert publication_timeout >= 75
     assert job_timeout >= capture_timeout + publication_timeout + 20
+    assert "env -u NEXT_DISABLE_TOOLBAR -u E2E_CLERK_USER_ID" in publication
 
 
 def test_cost_monitoring_docs_match_activation_gated_observer() -> None:


### PR DESCRIPTION
## Summary
- keep screenshot capture overrides for build/capture
- unset NEXT_DISABLE_TOOLBAR and E2E_CLERK_USER_ID only for the generated-branch git push child
- add a workflow contract assertion so capture-only env cannot leak back into normal pre-push tests

## Root cause
Exact-main run 30720393808 captured 57/57 screenshots in 17.3 minutes and passed integrity/change detection. Publication then failed in the normal pre-push shard 4/8 because the job-level capture env altered unit-test behavior: four demo-recording cases inherited NEXT_DISABLE_TOOLBAR=1, and the auth fallback inherited E2E_CLERK_USER_ID=user_test. The atomic push left screenshots/auto-update unchanged and created no PR.

## Verification
- python3 -m pytest scripts/tests/test_agent_workflow_hygiene.py -q (35 passed)
- polluted parent env plus sanitized child: demo-recording + auth-helper 18/18 passed
- git diff --check
- bug-to-test: satisfied
- Regression test: scripts/tests/test_agent_workflow_hygiene.py

## Risk
Workflow/test-only. No gate is skipped: git push still runs the full normal hook, now without two values that exist solely to shape screenshot capture.

<!-- linear-issue-id:JOV-2769 -->