### PR TITLE
fix(ci): fully isolate screenshot publish hooks [JOV-2769]

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -175,9 +175,16 @@ jobs:
           for ATTEMPT in 1 2 3; do
             set +e
             # Capture-only overrides must not leak into the repository's normal
-            # pre-push tests. They intentionally alter dev chrome and auth
-            # fallback behavior, so run the hook with those two values unset.
-            PUSH_OUTPUT=$(env -u NEXT_DISABLE_TOOLBAR -u E2E_CLERK_USER_ID \
+            # pre-push tests. They intentionally alter database, dev chrome, and
+            # auth behavior, so run the hook without the screenshot job env.
+            PUSH_OUTPUT=$(env \
+              -u DATABASE_URL \
+              -u NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY \
+              -u CLERK_SECRET_KEY \
+              -u NEXT_DISABLE_TOOLBAR \
+              -u NEXT_PUBLIC_CLERK_PROXY_DISABLED \
+              -u E2E_USE_TEST_AUTH_BYPASS \
+              -u E2E_CLERK_USER_ID \
               git -c "http.https://github.com/.extraheader=$AUTH_HEADER" push --force origin "$BRANCH" 2>&1)
             PUSH_EXIT=$?
             set -e

--- a/scripts/tests/test_agent_workflow_hygiene.py
+++ b/scripts/tests/test_agent_workflow_hygiene.py
@@ -672,7 +672,16 @@ def test_product_screenshot_budget_covers_capture_and_publication() -> None:
 
     assert publication_timeout >= 75
     assert job_timeout >= capture_timeout + publication_timeout + 20
-    assert "env -u NEXT_DISABLE_TOOLBAR -u E2E_CLERK_USER_ID" in publication
+    for capture_only_variable in (
+        "DATABASE_URL",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "CLERK_SECRET_KEY",
+        "NEXT_DISABLE_TOOLBAR",
+        "NEXT_PUBLIC_CLERK_PROXY_DISABLED",
+        "E2E_USE_TEST_AUTH_BYPASS",
+        "E2E_CLERK_USER_ID",
+    ):
+        assert f"-u {capture_only_variable}" in publication
 
 
 def test_cost_monitoring_docs_match_activation_gated_observer() -> None:


### PR DESCRIPTION
JOV-2769

## Summary
- strip every screenshot-job-only environment override from the generated branch push hook
- keep the GitHub bot token while restoring canonical test environment semantics
- guard the full isolation list in workflow hygiene tests

## Root cause
Exact-main Product Screenshots run 30723089337 captured 57/57 and cleared the prior shard-4 failures, then failed in pre-push shard 5 because `E2E_USE_TEST_AUTH_BYPASS=1` leaked from the capture job into `development-only.test.ts`. The earlier patch isolated only the two variables known from the first run; this patch isolates the complete capture-only job environment.

## Verification
- `python3 -m pytest scripts/tests/test_agent_workflow_hygiene.py -q` — 35 passed
- polluted-parent/sanitized-child Vitest reenactment — 3 files, 29 tests passed
- `git diff --check` — clean

bug-to-test: satisfied
Regression test: scripts/tests/test_agent_workflow_hygiene.py
