### PR TITLE
perf(merch): shorten concept generation critical path

### DIFF
--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MerchDesignCarouselResult } from '@/lib/merch/types';
-import { ChatMerchDesignCarousel } from './ChatMerchDesignCarousel';
+import {
+  ChatMerchDesignCarousel,
+  ChatMerchDesignCarouselLoading,
+  prefetchMerchDesignPreviews,
+} from './ChatMerchDesignCarousel';
 
 const mutateMock = vi.hoisted(() => vi.fn());
 
@@ -207,5 +211,33 @@ describe('ChatMerchDesignCarousel', () => {
       result.generationId
     );
     dispatch.mockRestore();
+  });
+
+  it('preloads each ready preview once for instant concept navigation', () => {
+    const OriginalImage = globalThis.Image;
+    const image = vi.fn();
+    Object.defineProperty(globalThis, 'Image', {
+      configurable: true,
+      value: image,
+    });
+
+    prefetchMerchDesignPreviews([...result.designs, result.designs[0]]);
+
+    expect(image).toHaveBeenCalledTimes(2);
+    Object.defineProperty(globalThis, 'Image', {
+      configurable: true,
+      value: OriginalImage,
+    });
+  });
+
+  it('reserves a quiet three-concept area while image generation runs', () => {
+    const { container } = render(<ChatMerchDesignCarouselLoading />);
+
+    expect(screen.getByLabelText('Preparing merch concepts')).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+    expect(container.querySelectorAll('.aspect-square')).toHaveLength(3);
+    expect(screen.queryByText(/generating/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@jovie/ui';
 import { Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import Image from 'next/image';
-import { type KeyboardEvent, useCallback, useState } from 'react';
+import { type KeyboardEvent, useCallback, useEffect, useState } from 'react';
 import { ThreadImageCard } from '@/components/shell/ThreadImageCard';
 import type {
   MerchDesignCarouselResult,
@@ -75,6 +75,55 @@ function isProductsResponse(
   );
 }
 
+/**
+ * Start all concept previews together after the tool result arrives. The
+ * browser owns request deduplication; this prevents arrow navigation from
+ * becoming a second image-loading wait without changing the image provider's
+ * work or URL provenance.
+ */
+export function prefetchMerchDesignPreviews(
+  designs: readonly MerchDesignPreview[]
+): void {
+  if (typeof globalThis.Image === 'undefined') return;
+
+  const urls = new Set(
+    designs.flatMap(design =>
+      design.status === 'ready' && design.preview_url
+        ? [design.preview_url]
+        : []
+    )
+  );
+  for (const url of urls) {
+    const image = new globalThis.Image();
+    image.decoding = 'async';
+    image.src = url;
+  }
+}
+
+/**
+ * The running tool reserves the same three-up media area that the chooser
+ * needs. Its intentionally quiet placeholders communicate progress without
+ * making users read or react while external image generation is still pending.
+ */
+export function ChatMerchDesignCarouselLoading() {
+  return (
+    <section
+      aria-busy='true'
+      aria-label='Preparing merch concepts'
+      className='max-w-2xl'
+    >
+      <div className='grid grid-cols-3 gap-2.5' aria-hidden='true'>
+        {[0, 1, 2].map(index => (
+          <div
+            key={index}
+            className='aspect-square rounded-xl bg-surface-1 shadow-card'
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function ChatMerchDesignCarousel({
   result,
   profileId,
@@ -99,6 +148,10 @@ export function ChatMerchDesignCarousel({
   const confirmAction = useConfirmChatMerchActionMutation();
   const count = designs.length;
   const current = designs[Math.min(active, Math.max(0, count - 1))];
+
+  useEffect(() => {
+    prefetchMerchDesignPreviews(designs);
+  }, [designs]);
 
   const go = useCallback(
     (dir: -1 | 1) => {

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -35,6 +35,7 @@ import {
 } from './components/ChatMerchCard';
 import {
   ChatMerchDesignCarousel,
+  ChatMerchDesignCarouselLoading,
   isChatMerchDesignCarouselResult,
 } from './components/ChatMerchDesignCarousel';
 import { ChatPitchCard } from './components/ChatPitchCard';
@@ -551,6 +552,9 @@ function renderMerchGenerationArtifact(
   event: PersistedToolEvent,
   profileId?: string
 ): ReactNode {
+  if (event.state === 'running') {
+    return <ChatMerchDesignCarouselLoading />;
+  }
   if (isChatMerchDesignCarouselResult(event.output)) {
     return (
       <ChatMerchDesignCarousel result={event.output} profileId={profileId} />

--- a/apps/web/lib/merch/design-generation.test.ts
+++ b/apps/web/lib/merch/design-generation.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { selectionCountsToWeights } from './design-generation';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveMerchGenerationPrerequisites,
+  selectionCountsToWeights,
+} from './design-generation';
 
 describe('selectionCountsToWeights', () => {
   it('is empty (equal weighting) with no selection history', () => {
@@ -25,10 +28,49 @@ describe('selectionCountsToWeights', () => {
   });
 
   it('never produces a zero/negative weight that could lock a model out', () => {
-    const w = selectionCountsToWeights([
+    const weights = selectionCountsToWeights([
       { modelKey: 'gpt-image-1.5', count: 0 },
       { modelKey: 'recraft-v3', count: -3 },
     ]);
-    for (const v of Object.values(w)) expect(v).toBeGreaterThanOrEqual(1);
+    for (const weight of Object.values(weights)) {
+      expect(weight).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('resolveMerchGenerationPrerequisites', () => {
+  it('starts independent reads together before any one resolves', async () => {
+    let resolveArtist!: (value: string) => void;
+    let resolveCatalog!: (value: string) => void;
+    let resolveWeights!: (value: string) => void;
+    const artistName = vi.fn(
+      () => new Promise<string>(resolve => (resolveArtist = resolve))
+    );
+    const catalog = vi.fn(
+      () => new Promise<string>(resolve => (resolveCatalog = resolve))
+    );
+    const modelWeights = vi.fn(
+      () => new Promise<string>(resolve => (resolveWeights = resolve))
+    );
+
+    const result = resolveMerchGenerationPrerequisites({
+      artistName,
+      catalog,
+      modelWeights,
+    });
+
+    expect(artistName).toHaveBeenCalledOnce();
+    expect(catalog).toHaveBeenCalledOnce();
+    expect(modelWeights).toHaveBeenCalledOnce();
+
+    resolveCatalog('catalog');
+    resolveWeights('weights');
+    resolveArtist('artist');
+
+    await expect(result).resolves.toEqual({
+      artistName: 'artist',
+      catalog: 'catalog',
+      modelWeights: 'weights',
+    });
   });
 });

--- a/apps/web/lib/merch/design-generation.ts
+++ b/apps/web/lib/merch/design-generation.ts
@@ -43,6 +43,32 @@ import type { MerchDesignCarouselResult, MerchDesignPreview } from './types';
 
 const DEFAULT_DESIGN_COUNT = 3;
 
+/**
+ * Starts independent generation prerequisites together so image rendering is
+ * not delayed by unrelated profile, catalog, and preference reads. Keeping
+ * this small helper generic makes the concurrency contract directly testable.
+ */
+export async function resolveMerchGenerationPrerequisites<
+  TArtistName,
+  TCatalog,
+  TModelWeights,
+>(tasks: {
+  readonly artistName: () => Promise<TArtistName>;
+  readonly catalog: () => Promise<TCatalog>;
+  readonly modelWeights: () => Promise<TModelWeights>;
+}): Promise<{
+  readonly artistName: TArtistName;
+  readonly catalog: TCatalog;
+  readonly modelWeights: TModelWeights;
+}> {
+  const [artistName, catalog, modelWeights] = await Promise.all([
+    tasks.artistName(),
+    tasks.catalog(),
+    tasks.modelWeights(),
+  ]);
+  return { artistName, catalog, modelWeights };
+}
+
 /** Distinct art directions so the carousel reads as real variety, not 3 of the same. */
 const STYLE_DIRECTIONS: readonly { label: string; style: string }[] = [
   {
@@ -271,13 +297,26 @@ export async function generateMerchDesigns(params: {
   readonly conversationId?: string | null;
   readonly turnId?: string | null;
 }): Promise<MerchDesignCarouselResult> {
-  const name = await artistName(params.profileId);
+  const startedAt = Date.now();
   const generationId = randomUUID();
   const count = Math.min(Math.max(params.count ?? DEFAULT_DESIGN_COUNT, 1), 4);
-  // Resolve live Printful economics up front so selected designs can go live
-  // without a separate cost-hydration step (JOV-3393 demo path).
-  const catalog = await resolveGenerationPricing(params.prompt);
+  // These reads do not depend on one another. Starting them together removes
+  // avoidable time-to-first-image without relaxing the pricing or provenance
+  // contract used when an artist selects a design.
+  const prerequisites = await resolveMerchGenerationPrerequisites({
+    artistName: () => artistName(params.profileId),
+    catalog: () => resolveGenerationPricing(params.prompt),
+    modelWeights: () => getModelSelectionWeights(params.profileId),
+  });
+  const name = prerequisites.artistName;
+  const catalog = prerequisites.catalog;
+  const modelWeights = prerequisites.modelWeights;
   const pricing = catalog.pricing;
+
+  logger.info('[merch-designs] generation prerequisites ready', {
+    ms: Date.now() - startedAt,
+    generationId,
+  });
 
   await db.insert(merchGenerationBatches).values({
     id: generationId,
@@ -290,9 +329,6 @@ export async function generateMerchDesigns(params: {
     artistBrief: minimalBrief(name, params.prompt),
     status: 'generating',
   });
-
-  // Bias model selection toward the artist's previously-picked aesthetic.
-  const modelWeights = await getModelSelectionWeights(params.profileId);
 
   const directions = STYLE_DIRECTIONS.slice(0, count);
   const grossMargin =
@@ -392,6 +428,13 @@ export async function generateMerchDesigns(params: {
   );
 
   const ready = designs.filter((d): d is MerchDesignPreview => d !== null);
+
+  logger.info('[merch-designs] generation response ready', {
+    ms: Date.now() - startedAt,
+    generationId,
+    requestedDesignCount: count,
+    readyDesignCount: ready.length,
+  });
 
   // Non-blocking: attach the truthful Printful product mockup to each design.
   attachPrintfulMockupsAsync(


### PR DESCRIPTION
## Summary
- starts profile identity, catalog economics, and model-learning reads concurrently before image dispatch
- records preparation and response phase timings without claiming provider latency improvements
- reserves a quiet three-slot merch artifact while the tool runs and prefetches unique concept previews for instant switching

## Evidence
- `pnpm --filter web exec vitest run lib/merch/design-generation.test.ts components/jovie/components/ChatMerchDesignCarousel.test.tsx --maxWorkers 1` — 2 files, 10 tests passed
- `pnpm biome check --write` on all five changed files — passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed

External LLM/image generation time is not altered by this PR. The added timing logs separate our prerequisite latency from provider work.

Linear: JOV-4738
