### PR TITLE
fix(backlog): harden Linear transport and admission idempotency

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -12,6 +12,7 @@ const execFileAsync = promisify(execFile);
 
 const classifier = await import('../classifier.mjs');
 const { reconcileIssues } = await import('../reconcile.mjs');
+const linear = await import('../linear-client.mjs');
 const scorer = await import('../scorer.mjs');
 const workstreamer = await import('../workstreamer.mjs');
 const reporter = await import('../reporter.mjs');
@@ -134,6 +135,90 @@ describe('reconciliation idempotency', () => {
     await reconcileIssues({ issues: [reread()], client });
 
     assert.equal(calls.comments.length, 1);
+  });
+
+  it('returns a deterministic dry-run receipt with no mutations', async () => {
+    const issue = makeIssue({ identifier: 'JOV-4604' });
+    const receipt = await reconcileIssues({
+      issues: [issue],
+      client: {
+        async addComment() {
+          throw new Error('must not mutate');
+        },
+      },
+      isDryRun: true,
+      backlogStateId: 'backlog-id',
+    });
+    assert.equal(receipt.schema, 'backlog-orchestrator/reconcile/v1');
+    assert.equal(receipt.mode, 'dry-run');
+    assert.equal(receipt.mutations, 0);
+    assert.equal(receipt.classified, 1);
+    assert.equal(receipt.results[0].identifier, 'JOV-4604');
+  });
+});
+
+describe('Linear transport', () => {
+  it('retries transient fetch failures and preserves the raw Linear auth format', async () => {
+    const previous = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = 'test-secret-that-must-not-leak';
+    let attempts = 0;
+    const sleeps = [];
+    /** @type {any} */
+    const fetchImpl = async (_url, options) => {
+      attempts += 1;
+      const headers = /** @type {Record<string, string>} */ (options.headers);
+      assert.equal(headers.Authorization, process.env.LINEAR_API_KEY);
+      if (attempts < 3) {
+        throw Object.assign(new Error('fetch failed'), { code: 'ETIMEDOUT' });
+      }
+      return { json: async () => ({ data: { viewer: { id: 'viewer' } } }) };
+    };
+    const data = await linear.graphql(
+      'query Test { viewer { id } }',
+      {},
+      {
+        fetchImpl,
+        sleepImpl: async ms => {
+          sleeps.push(ms);
+        },
+        retryBaseMs: 7,
+      }
+    );
+    assert.deepEqual(data, { viewer: { id: 'viewer' } });
+    assert.equal(attempts, 3);
+    assert.deepEqual(sleeps, [7, 14]);
+    if (previous === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = previous;
+  });
+
+  it('classifies an exhausted abort as a timeout without logging the secret', async () => {
+    const previous = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = 'timeout-secret';
+    await assert.rejects(
+      linear.graphql(
+        'query Timeout { viewer { id } }',
+        {},
+        {
+          timeoutMs: 1,
+          maxAttempts: 1,
+          fetchImpl: (_url, options) =>
+            new Promise((_resolve, reject) => {
+              options.signal.addEventListener('abort', () =>
+                reject(new DOMException('aborted', 'AbortError'))
+              );
+            }),
+        }
+      ),
+      error => {
+        const err = /** @type {{ code?: unknown; message?: string }} */ (error);
+        return (
+          err.code === 'TIMEOUT' &&
+          !String(err.message ?? '').includes('timeout-secret')
+        );
+      }
+    );
+    if (previous === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = previous;
   });
 });
 

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -126,6 +126,27 @@ async function runAudit(cache, isDryRun) {
   });
 
   console.log(report);
+  console.log('Audit receipt:');
+  console.log(
+    JSON.stringify(
+      {
+        schema: 'backlog-orchestrator/audit/v1',
+        mode: isDryRun ? 'dry-run' : 'shadow',
+        issueCount: allIssues.length,
+        triageCount: allIssues.filter(issue => issue.state?.name === 'Triage')
+          .length,
+        classified: classifications.length,
+        skipped,
+        wouldMove: classifications.filter(
+          c => c.category === 'duplicate' || c.category === 'obsolete'
+        ).length,
+        mutations: 0,
+        note: 'Triageable issues intentionally remain in Triage; only duplicate/obsolete classifications are move candidates.',
+      },
+      null,
+      2
+    )
+  );
 
   // Persist report
   const reportPath = resolve(__dirname, 'shadow-report-latest.txt');
@@ -149,13 +170,15 @@ async function runReconcile(cache, isDryRun, issueArg) {
 
   console.log(`Processing ${issues.length} issues`);
 
-  await reconciler.reconcileIssues({
+  const receipt = await reconciler.reconcileIssues({
     issues,
     client: linear,
     isDryRun,
     backlogStateId: BACKLOG_STATE_ID,
   });
 
+  console.log('Reconciliation receipt:');
+  console.log(JSON.stringify(receipt, null, 2));
   console.log('Reconciliation complete.');
 }
 
@@ -243,6 +266,16 @@ async function runAdmitNext(cache, isDryRun) {
 }
 
 main().catch(err => {
+  console.error(
+    'Failure receipt:',
+    JSON.stringify({
+      schema: 'backlog-orchestrator/failure/v1',
+      status: 'blocked',
+      code: err.code || 'UNKNOWN',
+      attempts: err.attempts,
+      message: err.message,
+    })
+  );
   console.error('Fatal error:', err);
   process.exit(1);
 });

--- a/scripts/backlog-orchestrator/classifier.mjs
+++ b/scripts/backlog-orchestrator/classifier.mjs
@@ -39,7 +39,6 @@ export class IssueClassification {
       issue.identifier,
       issue.title?.trim() || '',
       (issue.description || '').trim().slice(0, 200),
-      issue.state?.name || '',
       issue.labels?.nodes
         ?.map(l => l.name)
         .sort()
@@ -357,22 +356,30 @@ function computeRisk(c) {
  * Read/replay previously stored classification from a machine-owned comment.
  */
 export function parseStoredClassification(issue) {
-  const machineComments = (issue.comments?.nodes || []).filter(c =>
-    c.body.startsWith('<!-- backlog-orchestrator:v1 -->')
-  );
-  if (machineComments.length === 0) return null;
-  const latest = machineComments.sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  )[0];
-  try {
-    const jsonPart = latest.body
-      .split('<!--/backlog-orchestrator-->')[0]
-      ?.split('-->')[1]
-      ?.trim();
-    return jsonPart ? JSON.parse(jsonPart) : null;
-  } catch {
-    return null;
-  }
+  const entries = parseStoredClassifications(issue);
+  return entries[0] || null;
+}
+
+/** Return all parseable machine classifications, newest first. */
+export function parseStoredClassifications(issue) {
+  return (issue.comments?.nodes || [])
+    .filter(c => c.body?.startsWith('<!-- backlog-orchestrator:v1 -->'))
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+    .map(comment => {
+      try {
+        const jsonPart = comment.body
+          .split('<!--/backlog-orchestrator-->')[0]
+          ?.split('-->')[1]
+          ?.trim();
+        return jsonPart ? JSON.parse(jsonPart) : null;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
 }
 
 /**

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -5,9 +5,29 @@
  * No SDK — bare fetch with the team's API key env var.
  */
 
+import { setDefaultResultOrder } from 'node:dns';
+
+// Gem hosts may have an unreachable IPv6 route while IPv4 reaches Linear.
+// Prefer IPv4 so the bounded fetch/retry policy handles application failures,
+// not avoidable dual-stack connection stalls.
+setDefaultResultOrder('ipv4first');
+
 export const LINEAR_API_KEY_ENV = 'LINEAR_API_KEY';
 
 const API_URL = 'https://api.linear.app/graphql';
+export const LINEAR_REQUEST_TIMEOUT_MS = 10_000;
+export const LINEAR_MAX_ATTEMPTS = 3;
+export const LINEAR_RETRY_BASE_MS = 100;
+
+export class LinearTransportError extends Error {
+  /** @param {string} message @param {any} [options] */
+  constructor(message, { code, cause, attempts } = {}) {
+    super(message, { cause });
+    this.name = 'LinearTransportError';
+    this.code = code;
+    this.attempts = attempts;
+  }
+}
 
 function requireKey() {
   const key = process.env[LINEAR_API_KEY_ENV];
@@ -15,23 +35,84 @@ function requireKey() {
   return key;
 }
 
-export async function graphql(query, variables = {}) {
+/** @param {any} error */
+function isTransientNetworkError(error) {
+  return (
+    error?.name === 'AbortError' ||
+    error?.name === 'TimeoutError' ||
+    error?.code === 'ETIMEDOUT' ||
+    error?.code === 'ECONNRESET' ||
+    error?.code === 'ECONNREFUSED' ||
+    error?.code === 'ENETUNREACH' ||
+    error?.code === 'EAI_AGAIN' ||
+    error?.message === 'fetch failed'
+  );
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Bounded, retrying GraphQL transport. Only the API key is sent as the
+ * normal Linear `Authorization: <key>` header; it is never logged or exposed
+ * in an error. Retry is limited to transient network/timeout failures.
+ */
+export async function graphql(
+  query,
+  variables = {},
+  {
+    fetchImpl = globalThis.fetch,
+    timeoutMs = LINEAR_REQUEST_TIMEOUT_MS,
+    maxAttempts = LINEAR_MAX_ATTEMPTS,
+    retryBaseMs = LINEAR_RETRY_BASE_MS,
+    sleepImpl = sleep,
+  } = {}
+) {
   const key = requireKey();
-  const resp = await fetch(API_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: key,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-  const data = /** @type {any} */ (await resp.json());
-  if (data.errors) {
-    throw new Error(
-      `Linear API error: ${data.errors.map(e => e.message).join('; ')}`
-    );
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const resp = await fetchImpl(API_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: key,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+      const data = /** @type {any} */ (await resp.json());
+      if (data.errors) {
+        throw new Error(
+          `Linear API error: ${data.errors.map(e => e.message).join('; ')}`
+        );
+      }
+      return data.data;
+    } catch (error) {
+      lastError = error;
+      if (!isTransientNetworkError(error) || attempt === maxAttempts) {
+        const code =
+          error?.name === 'AbortError' || error?.name === 'TimeoutError'
+            ? 'TIMEOUT'
+            : isTransientNetworkError(error)
+              ? 'NETWORK'
+              : 'API';
+        throw new LinearTransportError(
+          `Linear GraphQL request failed (${code.toLowerCase()}, attempts=${attempt})`,
+          { code, cause: error, attempts: attempt }
+        );
+      }
+      await sleepImpl(retryBaseMs * 2 ** (attempt - 1));
+    } finally {
+      clearTimeout(timer);
+    }
   }
-  return data.data;
+  throw new LinearTransportError('Linear GraphQL request failed', {
+    code: 'NETWORK',
+    cause: lastError,
+    attempts: maxAttempts,
+  });
 }
 
 /**

--- a/scripts/backlog-orchestrator/reconcile.mjs
+++ b/scripts/backlog-orchestrator/reconcile.mjs
@@ -4,49 +4,103 @@
 
 import * as classifier from './classifier.mjs';
 
+export function buildReconcileReceipt({ issues, isDryRun, results }) {
+  return {
+    schema: 'backlog-orchestrator/reconcile/v1',
+    mode: isDryRun ? 'dry-run' : 'mutating',
+    issueCount: issues.length,
+    classified: results.filter(r => r.action === 'classify').length,
+    skipped: results.filter(r => r.action === 'skip').length,
+    wouldMove: results.filter(r => r.wouldMove).length,
+    mutations: isDryRun ? 0 : results.filter(r => r.mutated).length,
+    results,
+  };
+}
+
 export async function reconcileIssues({
   issues,
   client,
   isDryRun = false,
   backlogStateId = null,
 }) {
+  const results = [];
   for (const issue of issues) {
-    const stored = classifier.parseStoredClassification(issue);
     const c = classifier.classifyDeterministic(issue, issues);
+    const alreadyStored = classifier
+      .parseStoredClassifications(issue)
+      .some(entry => entry.fp === c.fingerprint);
 
-    if (stored && stored.fp === c.fingerprint) {
+    if (alreadyStored) {
       console.log(`  SKIP ${issue.identifier} — unchanged`);
+      results.push({
+        identifier: issue.identifier,
+        fingerprint: c.fingerprint,
+        action: 'skip',
+        reason: 'fingerprint-unchanged',
+      });
       continue;
     }
 
     console.log(
       `  ${c.category}: ${issue.identifier} — ${(issue.title || '').slice(0, 50)}`
     );
+    const wouldMove = Boolean(
+      backlogStateId &&
+        (c.category === 'duplicate' || c.category === 'obsolete')
+    );
 
     if (isDryRun) {
       console.log(
         `    (dry-run) would classify as ${c.category}, score ${c.valueScore}`
       );
+      results.push({
+        identifier: issue.identifier,
+        fingerprint: c.fingerprint,
+        action: 'classify',
+        category: c.category,
+        wouldMove,
+        mutated: false,
+      });
       continue;
     }
 
     const commentBody = classifier.buildStoredClassification(c);
+    let mutated = false;
     try {
-      await client.addComment(issue.id, commentBody);
+      const result = await client.addComment(issue.id, commentBody);
+      if (
+        result?.success === false ||
+        result?.commentCreate?.success === false
+      ) {
+        throw new Error('classification-comment-mutation-failed');
+      }
+      mutated = true;
     } catch (err) {
       console.error(`    Failed to add comment: ${err.message}`);
     }
 
-    if (
-      backlogStateId &&
-      (c.category === 'duplicate' || c.category === 'obsolete')
-    ) {
+    if (mutated && wouldMove) {
       try {
-        await client.transitionIssue(issue.id, backlogStateId);
+        const result = await client.transitionIssue(issue.id, backlogStateId);
+        if (
+          result?.success === false ||
+          result?.issueUpdate?.success === false
+        ) {
+          throw new Error('classification-transition-mutation-failed');
+        }
         console.log('    Moved to Backlog');
       } catch (err) {
         console.error(`    Failed to transition: ${err.message}`);
       }
     }
+    results.push({
+      identifier: issue.identifier,
+      fingerprint: c.fingerprint,
+      action: 'classify',
+      category: c.category,
+      wouldMove,
+      mutated,
+    });
   }
+  return buildReconcileReceipt({ issues, isDryRun, results });
 }


### PR DESCRIPTION
## Summary
- Add bounded Linear GraphQL fetches with transient network/timeout retry and IPv4 preference for the Gem runtime.
- Keep Linear's raw `Authorization: <key>` format and never include credentials in errors or receipts.
- Make classification fingerprints stable across state changes and treat any matching machine fingerprint as a reconcile no-op.
- Emit deterministic audit/reconcile/failure receipts and document why triageable issues remain in Triage.

## Evidence
- `pnpm backlog:test` — 28 passing tests.
- `git diff --check` — clean.
- Pre-commit secret scans (gitleaks + trufflehog) — no findings.
- Read-only Linear audit: 36 current JOV Triage issues; no mutations.

Fixes JOV-4604.

## Safety
- No non-dry-run Linear mutations, transitions, merges, or deploys performed.
- Gem/native MQ owns admission and landing.
