### PR TITLE
feat(merch): one-step approved default tee to profile (JOV-4736)

### DIFF
--- a/apps/web/app/api/chat/confirm-merch-action/route.ts
+++ b/apps/web/app/api/chat/confirm-merch-action/route.ts
@@ -40,9 +40,18 @@ const confirmMerchProductsSchema = chatToolSchema({
   action: z.literal('products'),
 });
 
+const confirmMerchCreateSchema = chatToolSchema({
+  profileId: z.string().uuid(),
+  generationId: z.string().uuid(),
+  optionId: z.string().uuid(),
+  optionNumber: z.number().int().min(1).max(4),
+  action: z.literal('create'),
+});
+
 const confirmMerchActionSchema = z.union([
   confirmMerchSelectSchema,
   confirmMerchProductsSchema,
+  confirmMerchCreateSchema,
   confirmMerchStatusActionSchema,
 ]);
 
@@ -117,15 +126,16 @@ export async function POST(req: Request) {
       );
     }
 
-    if (action === 'select') {
+    if (action === 'select' || action === 'create') {
       const result = await selectMerchDesign({
         generationId: parseResult.data.generationId,
         clerkUserId: userId,
         profileId,
         optionId: parseResult.data.optionId,
         optionNumber: parseResult.data.optionNumber,
-        catalogProductId: parseResult.data.catalogProductId,
-        publish: false,
+        catalogProductId:
+          action === 'select' ? parseResult.data.catalogProductId : undefined,
+        publish: action === 'create',
       });
 
       if (!result.product) {
@@ -138,13 +148,16 @@ export async function POST(req: Request) {
       await db.insert(chatAuditLog).values({
         userId,
         creatorProfileId: profileId,
-        action: AUDIT_ACTION_BY_CONFIRM[action],
+        action: AUDIT_ACTION_BY_CONFIRM.select,
         field: 'merch_selection',
         previousValue: null,
         newValue: JSON.stringify({
           merchCardId: result.merchCardId,
           selectedOptionId: result.selectedOptionId,
-          catalogProductId: parseResult.data.catalogProductId,
+          catalogProductId:
+            'catalogProductId' in parseResult.data
+              ? parseResult.data.catalogProductId
+              : undefined,
           status: result.status,
         }),
         ipAddress: ipAddress ?? null,

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx
@@ -80,6 +80,28 @@ describe('ChatMerchDesignCarousel', () => {
           onSuccess: (response: Record<string, unknown>) => void;
         }
       ) => {
+        if (input.action === 'create') {
+          callbacks.onSuccess({
+            success: true,
+            merchCardId: '00000000-0000-4000-8000-000000000020',
+            status: 'live',
+            selectedOptionId: '00000000-0000-4000-8000-000000000011',
+            title: 'Signal Vintage',
+            publicUrl:
+              'https://jovie.test/signal/merch/00000000-0000-4000-8000-000000000020',
+            product: {
+              productType: 'premium tee',
+              productName: 'Unisex Premium T-Shirt',
+              colorway: 'black',
+              artworkUrl: 'https://blob.example.com/one.png',
+              mockupUrl: 'https://printful.example.com/mockup.png',
+              mockupStatus: 'ready',
+              retailPrice: '$30.00',
+              artistProfit: '$10.00',
+              publishEligible: true,
+            },
+          });
+        }
         if (input.action === 'products') {
           callbacks.onSuccess({
             success: true,
@@ -138,57 +160,26 @@ describe('ChatMerchDesignCarousel', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'Use this design' }));
-
-    expect(mutateMock).toHaveBeenNthCalledWith(
-      1,
-      {
-        profileId: '00000000-0000-4000-8000-000000000001',
-        generationId: '00000000-0000-4000-8000-000000000010',
-        optionId: '00000000-0000-4000-8000-000000000011',
-        optionNumber: 1,
-        action: 'products',
-      },
-      expect.any(Object)
-    );
-    expect(screen.getByText('Choose a product')).toBeInTheDocument();
-    expect(screen.queryByText(/artist profit/)).not.toBeInTheDocument();
-
     await user.click(
-      screen.getByRole('button', { name: /Unisex Staple T-Shirt/ })
+      screen.getByRole('button', { name: 'Approve & publish tee' })
     );
-    expect(mutateMock).toHaveBeenNthCalledWith(
-      2,
+
+    expect(mutateMock).toHaveBeenCalledWith(
       {
         profileId: '00000000-0000-4000-8000-000000000001',
         generationId: '00000000-0000-4000-8000-000000000010',
         optionId: '00000000-0000-4000-8000-000000000011',
         optionNumber: 1,
-        catalogProductId: 71,
-        action: 'select',
+        action: 'create',
       },
       expect.any(Object)
     );
     expect(
-      screen.getByText('Product mockup is still rendering. Artwork shown.')
+      screen.getByText('Unisex Premium T-Shirt · black')
     ).toBeInTheDocument();
     expect(
       screen.getByText('$30.00 · $10.00 artist profit')
     ).toBeInTheDocument();
-    expect(screen.queryByAltText(/product mockup/i)).not.toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole('button', { name: 'Publish to profile' })
-    );
-    expect(mutateMock).toHaveBeenNthCalledWith(
-      3,
-      {
-        profileId: '00000000-0000-4000-8000-000000000001',
-        merchCardId: '00000000-0000-4000-8000-000000000020',
-        action: 'publish',
-      },
-      expect.any(Object)
-    );
     expect(
       screen.getByRole('button', { name: 'Live on profile' })
     ).toBeDisabled();
@@ -199,7 +190,9 @@ describe('ChatMerchDesignCarousel', () => {
     const user = userEvent.setup();
     render(<ChatMerchDesignCarousel result={result} />);
 
-    await user.click(screen.getByRole('button', { name: 'Use this design' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Approve & publish tee' })
+    );
 
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
+++ b/apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx
@@ -50,31 +50,6 @@ function isSelectionResponse(
   );
 }
 
-function isProductsResponse(
-  value: unknown
-): value is ConfirmChatMerchProductsResponse {
-  const products =
-    typeof value === 'object' && value !== null
-      ? (value as { products?: unknown }).products
-      : null;
-  return (
-    Array.isArray(products) &&
-    products.every(
-      product =>
-        typeof product === 'object' &&
-        product !== null &&
-        typeof (product as { catalogProductId?: unknown }).catalogProductId ===
-          'number' &&
-        (product as { catalogProductId: number }).catalogProductId > 0 &&
-        typeof (product as { productName?: unknown }).productName ===
-          'string' &&
-        typeof (product as { productType?: unknown }).productType ===
-          'string' &&
-        typeof (product as { colorway?: unknown }).colorway === 'string'
-    )
-  );
-}
-
 /**
  * Start all concept previews together after the tool result arrives. The
  * browser owns request deduplication; this prevents arrow navigation from
@@ -169,23 +144,23 @@ export function ChatMerchDesignCarousel({
       return;
     }
 
-    setPendingAction('products');
+    setPendingAction('select');
     confirmAction.mutate(
       {
         profileId,
         generationId: result.generationId,
         optionId: current.id,
         optionNumber: current.option_number,
-        action: 'products',
+        action: 'create',
       },
       {
         onSuccess: response => {
           setPendingAction(null);
-          if (isProductsResponse(response) && response.products.length > 0) {
-            setProductOptions(response.products);
+          if (isSelectionResponse(response)) {
+            setSelected(response);
             return;
           }
-          setErrorMessage('No products are available right now.');
+          setErrorMessage('Product creation did not return a verified card.');
         },
         onError: () => {
           setPendingAction(null);
@@ -340,6 +315,14 @@ export function ChatMerchDesignCarousel({
                   Product mockup is still rendering. Artwork shown.
                 </p>
               ) : null}
+              {selected.publicUrl ? (
+                <a
+                  className='mt-1 block text-2xs font-medium text-primary-token underline'
+                  href={selected.publicUrl}
+                >
+                  Verified product URL
+                </a>
+              ) : null}
               {selected.publishBlockedReasons?.length ? (
                 <p className='mt-1 line-clamp-2 text-2xs text-tertiary-token'>
                   {selected.publishBlockedReasons.join(' ')}
@@ -349,6 +332,18 @@ export function ChatMerchDesignCarousel({
           ) : current.concept ? (
             <p className='mt-0.5 line-clamp-2 text-xs text-secondary-token'>
               {current.concept}
+            </p>
+          ) : null}
+          {!selected && current.product_name ? (
+            <p className='mt-1 text-2xs text-tertiary-token'>
+              {current.recommended ? 'Best recommendation · ' : ''}
+              {current.product_name} · {current.colorway} · {current.sale_price}{' '}
+              · {current.artist_profit} creator profit
+            </p>
+          ) : null}
+          {!selected && current.fulfillment ? (
+            <p className='mt-1 text-2xs text-tertiary-token'>
+              {current.fulfillment} · {current.profile_destination}
             </p>
           ) : null}
           {errorMessage ? (
@@ -387,12 +382,12 @@ export function ChatMerchDesignCarousel({
             onClick={handleLoadProducts}
             disabled={current.status !== 'ready' || pendingAction !== null}
           >
-            {pendingAction === 'products' ? (
+            {pendingAction === 'select' ? (
               <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden />
             ) : null}
-            {pendingAction === 'products'
-              ? 'Loading products'
-              : 'Use this design'}
+            {pendingAction === 'select'
+              ? 'Creating and publishing tee'
+              : 'Approve & publish tee'}
           </Button>
         ) : null}
       </div>

--- a/apps/web/lib/merch/design-generation.ts
+++ b/apps/web/lib/merch/design-generation.ts
@@ -36,6 +36,7 @@ import { attachMockupsToDesignOption, generateProductMockups } from './mockups';
 import {
   buildMerchPricingSnapshot,
   calculateRecommendedSalePriceCents,
+  formatMerchMoney,
   MERCH_DEFAULT_MARGIN_PRESET,
   MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
 } from './pricing';
@@ -415,6 +416,25 @@ export async function generateMerchDesigns(params: {
             status: 'ready',
             preview_url: previewUrl,
             slots: { artist_name: name },
+            recommended: index === 0,
+            product_name: catalog.productName,
+            product_type: catalog.productType,
+            colorway: catalog.colorway,
+            sale_price: formatMerchMoney(pricing.retailPriceCents),
+            artist_profit: formatMerchMoney(
+              pricing.artistPayoutPerUnitEstimateCents
+            ),
+            fulfillment: 'Printful standard US',
+            profile_destination: 'Artist profile merch section',
+            sellability: {
+              sellable: pricing.printfulCostSource === 'printful',
+              reasons:
+                pricing.printfulCostSource === 'printful'
+                  ? []
+                  : [
+                      'Catalog/fulfillment unavailable; approval will quarantine this item as a private draft.',
+                    ],
+            },
           };
         } catch (error) {
           logger.warn('[merch-designs] generation failed for one design', {

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -756,9 +756,20 @@ async function hydrateOptionPrintfulEconomics(
     return option;
   }
 
-  const catalog = await resolveMerchCatalogSelection(
-    option.productType || option.printfulProductName || option.designName
-  );
+  let catalog;
+  try {
+    catalog = await resolveMerchCatalogSelection(
+      option.productType || option.printfulProductName || option.designName
+    );
+  } catch {
+    return {
+      ...option,
+      productionWarnings: [
+        ...option.productionWarnings,
+        'Catalog/fulfillment unavailable; product quarantined as a private draft.',
+      ],
+    };
+  }
   if (catalog.pricing.printfulCostSource !== 'printful') {
     return option;
   }

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -133,6 +133,19 @@ export interface MerchDesignPreview {
   /** Transparent (alpha) print-art preview. Present only when status is `ready`. */
   readonly preview_url?: string;
   readonly slots: MerchDesignSlots;
+  /** Product economics shown before the single approval action. */
+  readonly recommended?: boolean;
+  readonly product_name?: string;
+  readonly product_type?: string;
+  readonly colorway?: string;
+  readonly sale_price?: string;
+  readonly artist_profit?: string;
+  readonly fulfillment?: string;
+  readonly profile_destination?: string;
+  readonly sellability?: {
+    readonly sellable: boolean;
+    readonly reasons: readonly string[];
+  };
 }
 
 export interface MerchDesignCarouselResult {

--- a/apps/web/lib/queries/useConfirmChatMerchActionMutation.ts
+++ b/apps/web/lib/queries/useConfirmChatMerchActionMutation.ts
@@ -26,6 +26,14 @@ export interface ConfirmChatMerchSelectInput {
   readonly action: 'select';
 }
 
+export interface ConfirmChatMerchCreateInput {
+  readonly profileId: string;
+  readonly generationId: string;
+  readonly optionId: string;
+  readonly optionNumber: number;
+  readonly action: 'create';
+}
+
 export interface ConfirmChatMerchProductsInput {
   readonly profileId: string;
   readonly generationId: string;
@@ -37,7 +45,8 @@ export interface ConfirmChatMerchProductsInput {
 export type ConfirmChatMerchActionInput =
   | ConfirmChatMerchStatusActionInput
   | ConfirmChatMerchProductsInput
-  | ConfirmChatMerchSelectInput;
+  | ConfirmChatMerchSelectInput
+  | ConfirmChatMerchCreateInput;
 
 export interface ConfirmChatMerchStatusActionResponse {
   readonly success: true;

--- a/apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts
+++ b/apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts
@@ -165,6 +165,32 @@ describe('POST /api/chat/confirm-merch-action', () => {
     });
   });
 
+  it('creates and publishes the approved default tee in one action', async () => {
+    const { POST } = await import('@/app/api/chat/confirm-merch-action/route');
+    const response = await POST(
+      new Request('http://localhost/api/chat/confirm-merch-action', {
+        method: 'POST',
+        body: JSON.stringify({
+          profileId: '00000000-0000-4000-8000-000000000001',
+          generationId: '00000000-0000-4000-8000-000000000002',
+          optionId: '00000000-0000-4000-8000-000000000003',
+          optionNumber: 1,
+          action: 'create',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.selectMerchDesignMock).toHaveBeenCalledWith({
+      generationId: '00000000-0000-4000-8000-000000000002',
+      clerkUserId: 'user-1',
+      profileId: '00000000-0000-4000-8000-000000000001',
+      optionId: '00000000-0000-4000-8000-000000000003',
+      optionNumber: 1,
+      catalogProductId: undefined,
+      publish: true,
+    });
+  });
   it('returns live product choices before creating the merch card', async () => {
     const { POST } = await import('@/app/api/chat/confirm-merch-action/route');
     const response = await POST(


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4736 -->
## Summary
- Collapse the normal merch path into one explicit `Approve & publish tee` action.
- Use the canonical default premium t-shirt/catalog resolution without manual product selection.
- Return persisted product economics, fulfillment, profile destination, and a verified public product URL when live.
- Preserve existing design/person-artifact and sellability gates; catalog/fulfillment failures stay quarantined as private drafts with precise blockers.
- Keep the existing product-selection contract available for optional alternatives.

## Verification
- `pnpm biome check --write apps/web/app/api/chat/confirm-merch-action/route.ts apps/web/lib/queries/useConfirmChatMerchActionMutation.ts apps/web/lib/merch/types.ts apps/web/lib/merch/design-generation.ts apps/web/lib/merch/service.ts apps/web/components/jovie/components/ChatMerchDesignCarousel.tsx apps/web/components/jovie/components/ChatMerchDesignCarousel.test.tsx apps/web/tests/unit/api/chat/confirm-merch-action-route.test.ts`
- `pnpm --filter web exec vitest run lib/merch/*.test.ts lib/services/merch/*.test.ts lib/chat/tools/merch-propose.test.ts lib/chat/tools/merch-tools.test.ts tests/unit/api/chat/confirm-merch-action-route.test.ts components/jovie/components/ChatMerchDesignCarousel.test.tsx --reporter=dot`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

## Safety / rollout
- No production merch was created or published.
- No auth, payment, security, merge-queue, or CI bypasses.
- The existing explicit publish gate remains authoritative; unavailable catalog/fulfillment cannot become public.

## Cost Impact
- No new recurring external API calls or cron jobs.
