### PR TITLE
fix(shell): unify workspace elevation tiers

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -99,7 +99,9 @@ export function DashboardHeader({
       data-testid='dashboard-header'
       className={cn(
         'z-20',
-        transparent ? 'bg-transparent' : 'bg-(--linear-app-content-surface)',
+        // Keep ordinary headers on the AppShellFrame plane. Chat explicitly
+        // opts into transparent so its owned ambient wash remains full bleed.
+        transparent ? 'bg-transparent' : 'bg-(--app-shell-content-surface)',
         className
       )}
     >

--- a/apps/web/components/molecules/drawer/EntitySidebarShell.stories.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { EntitySidebarShell } from './EntitySidebarShell';
+
+const meta: Meta<typeof EntitySidebarShell> = {
+  title: 'Molecules/Drawer/EntitySidebarShell',
+  component: EntitySidebarShell,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    isOpen: true,
+    ariaLabel: 'Release details',
+    title: 'Release details',
+    entityHeader: <div className='px-3 py-2'>Afterglow</div>,
+    children: <div className='px-3 py-2'>Inspector content</div>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Minimal: Story = {
+  args: {
+    headerMode: 'minimal',
+    entityHeaderSurface: 'flat',
+  },
+};

--- a/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+// @coverage-via apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
+
 import type { CommonDropdownItem } from '@jovie/ui';
 import type { ReactNode } from 'react';
 import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';

--- a/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
@@ -214,7 +214,10 @@ export function EntitySidebarShell({
         className={cn(
           'flex h-full min-h-0 flex-col gap-1.5',
           workspaceSurface === 'raised' &&
-            'overflow-hidden rounded-(--linear-app-shell-radius) bg-surface-1 shadow-card',
+            // RightDrawer owns the inspector elevation. Keep the workspace
+            // transparent so every entity rail shares one uninterrupted plane
+            // instead of nesting a same-level card inside it.
+            'overflow-hidden bg-transparent shadow-none',
           !contentBleed && 'px-1.5 py-1.5 lg:px-0 lg:py-0'
         )}
       >

--- a/apps/web/components/molecules/drawer/RightDrawer.stories.tsx
+++ b/apps/web/components/molecules/drawer/RightDrawer.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { RightDrawer } from './RightDrawer';
+
+const meta: Meta<typeof RightDrawer> = {
+  title: 'Molecules/Drawer/RightDrawer',
+  component: RightDrawer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    isOpen: true,
+    width: 360,
+    ariaLabel: 'Entity details',
+    children: <div className='p-4'>Inspector content</div>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {};
+
+export const Closed: Story = {
+  args: {
+    isOpen: false,
+  },
+};

--- a/apps/web/components/molecules/drawer/RightDrawer.tsx
+++ b/apps/web/components/molecules/drawer/RightDrawer.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+// @coverage-via apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
+
 import type { CommonDropdownItem } from '@jovie/ui';
 import { CommonDropdown } from '@jovie/ui';
 import React, { useEffect, useId, useRef, useState } from 'react';

--- a/apps/web/components/molecules/drawer/RightDrawer.tsx
+++ b/apps/web/components/molecules/drawer/RightDrawer.tsx
@@ -343,7 +343,10 @@ export function RightDrawer({
       tabIndex={isOpen ? -1 : undefined}
       inert={isOpen ? undefined : true}
       className={cn(
-        'z-10 shrink-0 h-full min-h-0 flex flex-col',
+        // Desktop inspector is an in-flow sibling of route content, but it
+        // remains its own raised surface. This gives the shell one stable
+        // elevation ladder: base/sidebar → main plane → inspector → overlays.
+        'z-10 shrink-0 h-full min-h-0 flex flex-col rounded-(--app-shell-radius) border border-(--app-shell-frame-seam) bg-surface-1 shadow-(--linear-app-drawer-shadow)',
         'outline-none focus:outline-none focus-visible:ring-0',
         'overflow-hidden',
         'transition-[width,opacity] duration-cinematic ease-cinematic motion-reduce:transition-none',

--- a/apps/web/components/organisms/AppShellFrame.stories.tsx
+++ b/apps/web/components/organisms/AppShellFrame.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { AppShellFrame } from './AppShellFrame';
+
+const meta: Meta<typeof AppShellFrame> = {
+  title: 'Organisms/AppShellFrame',
+  component: AppShellFrame,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    sidebar: <aside className='h-full w-56 p-4'>Navigation</aside>,
+    header: <header className='px-3 py-2'>Library</header>,
+    main: <div className='p-3'>Main content</div>,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithInspector: Story = {
+  args: {
+    rightPanel: <aside className='h-full w-80 p-3'>Entity details</aside>,
+  },
+};

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -1,3 +1,5 @@
+// @coverage-via apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { CanvasGrain } from '@/components/atoms/CanvasGrain';

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -95,7 +95,10 @@ export const AppShellFrame = memo(function AppShellFrame({
             <main
               id='main-content'
               className={cn(
-                'relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-(--color-bg-surface-0)/90',
+                // The header and route column live on this one raised plane.
+                // Do not use a translucent recessed well here: it makes the
+                // frame, header, and content read as unrelated backgrounds.
+                'relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-(--app-shell-content-surface)',
                 'lg:rounded-(--app-shell-radius) lg:border lg:border-(--app-shell-border) lg:bg-(--app-shell-content-surface) lg:shadow-(--linear-app-shell-shadow)'
               )}
             >

--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -390,8 +390,8 @@
   --linear-text-quaternary: #7d879d;
   --linear-text-inverse: #020307;
   /* Backgrounds — Noir Ion stepped surfaces */
-  --linear-bg-page: #030407;
-  /* app canvas */
+  --linear-bg-page: #06080d;
+  /* app canvas / sidebar base — the shell's recess is one continuous plane */
   --linear-bg-header: transparent;
   --linear-bg-surface-0: #06080d;
   /* shell / recessed wells */

--- a/apps/web/tests/components/molecules/drawer/EntitySidebarShell.test.tsx
+++ b/apps/web/tests/components/molecules/drawer/EntitySidebarShell.test.tsx
@@ -9,6 +9,21 @@ vi.mock('@/components/organisms/RightDrawer', () => ({
 }));
 
 describe('EntitySidebarShell', () => {
+  it('keeps the raised workspace flat so RightDrawer owns inspector elevation', () => {
+    render(
+      <EntitySidebarShell isOpen ariaLabel='Details drawer' title='Details'>
+        <p>Body content</p>
+      </EntitySidebarShell>
+    );
+
+    const workspace = screen
+      .getByTestId('right-drawer')
+      .querySelector('[data-right-rail-workspace]');
+    expect(workspace).toHaveAttribute('data-surface-variant', 'raised');
+    expect(workspace).toHaveClass('bg-transparent', 'shadow-none');
+    expect(workspace).not.toHaveClass('rounded-(--linear-app-shell-radius)');
+  });
+
   it('keeps header, identity area, and tabs together in a sticky top rail', () => {
     render(
       <EntitySidebarShell

--- a/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
@@ -49,8 +49,12 @@ describe('RightDrawer', () => {
     expect(aside).toHaveStyle({ width: '360px' });
     expect(aside).not.toHaveClass('border-l');
     expect(aside).not.toHaveClass('bg-surface-0');
-    expect(aside).not.toHaveClass('lg:border');
-    expect(aside).not.toHaveClass('shadow-(--linear-app-drawer-shadow)');
+    expect(aside).toHaveClass(
+      'rounded-(--app-shell-radius)',
+      'border-(--app-shell-frame-seam)',
+      'bg-surface-1',
+      'shadow-(--linear-app-drawer-shadow)'
+    );
     expect(aside).toHaveClass('outline-none', 'focus:outline-none');
   });
 

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -63,7 +63,7 @@ describe('surface elevation guardrails', () => {
       /:root\.dark[\s\S]*--sidebar-background:\s*var\(--linear-app-sidebar-background-rgb\);/
     );
     expect(linearTokens).toMatch(
-      /:root\.dark[\s\S]*--linear-app-content-surface:\s*#0a0d16;/
+      /:root\.dark[\s\S]*--linear-bg-page:\s*#06080d;/
     );
     expect(linearTokens).toMatch(
       /:root\.dark[\s\S]*--linear-app-sidebar-background-rgb:\s*6 8 13;/
@@ -430,17 +430,12 @@ describe('surface elevation guardrails', () => {
       'group-data-[variant=sidebar]:lg:shadow-[var(--linear-app-sidebar-shadow)]'
     );
     expect(rightDrawer).toContain('border-l border-(--app-shell-frame-seam)');
-    // Mobile overlay retains shadow; desktop drawer is flat so elevation
-    // comes from DrawerSurfaceCard cards inside the shell, not the outer aside.
+    // The in-flow desktop drawer owns the raised inspector tier. Its children
+    // must stay flat so entity surfaces do not reintroduce same-level nesting.
     expect(rightDrawer).toContain('shadow-(--linear-app-drawer-shadow)');
-    // Desktop-only classes: no border, no radius — flat inline sidebar.
-    // Assert the production Tailwind v4 token form so this negative check
-    // tracks the class AppShellFrame / RightRail actually emit.
-    expect(rightDrawer).not.toContain('lg:rounded-(--linear-app-shell-radius)');
-    expect(rightDrawer).not.toContain(
-      'lg:rounded-[var(--linear-app-shell-radius)]'
-    );
-    expect(rightDrawer).not.toContain('lg:border');
+    expect(rightDrawer).toContain('rounded-(--app-shell-radius)');
+    expect(rightDrawer).toContain('border-(--app-shell-frame-seam)');
+    expect(rightDrawer).toContain('bg-surface-1');
     expect(adminTableShell).toContain('bg-(--app-shell-content-surface)/96');
   });
 

--- a/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
+++ b/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
@@ -34,10 +34,10 @@ describe('EntitySidebarShell', () => {
     expect(workspace).toHaveAttribute('data-surface-variant', 'raised');
     expect(workspace).toHaveClass(
       'overflow-hidden',
-      'rounded-(--linear-app-shell-radius)',
-      'bg-surface-1',
-      'shadow-card'
+      'bg-transparent',
+      'shadow-none'
     );
+    expect(workspace).not.toHaveClass('rounded-(--linear-app-shell-radius)');
   });
 
   it('keeps the entity header pinned and leaves minimal-mode tab composition to the body', () => {
@@ -261,7 +261,7 @@ describe('EntitySidebarShell', () => {
     );
 
     expect(workspace).toHaveAttribute('data-surface-variant', 'raised');
-    expect(workspace).toHaveClass('bg-surface-1', 'shadow-card');
+    expect(workspace).toHaveClass('bg-transparent', 'shadow-none');
     expect(identity).toHaveTextContent('Compact entity identity');
     expect(sectionStack).toHaveTextContent('Tabbed details');
     expect(

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -26,6 +26,8 @@ describe('AppShellFrame', () => {
       'motion-reduce:transition-none'
     );
     expect(mainContent).toHaveClass('lg:shadow-(--linear-app-shell-shadow)');
+    expect(mainContent).toHaveClass('bg-(--app-shell-content-surface)');
+    expect(mainContent).not.toHaveClass('bg-(--color-bg-surface-0)/90');
     // #main-content keeps its full rounded shell radius — no Electron override
     // strips the top corners now that the header lives inside the card.
     expect(mainContent).toHaveClass('lg:rounded-(--app-shell-radius)');

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -70,7 +70,7 @@ describe('DashboardHeader', () => {
     expect(actionWrapper).not.toHaveClass(
       'rounded-full',
       'border',
-      'bg-(--linear-app-content-surface)',
+      'bg-(--app-shell-content-surface)',
       'p-1'
     );
     expect(actionWrapper).toHaveClass('flex', 'items-center', 'gap-1');
@@ -223,7 +223,7 @@ describe('DashboardHeader', () => {
     );
 
     const header = getByTestId('dashboard-header');
-    expect(header).toHaveClass('bg-(--linear-app-content-surface)');
+    expect(header).toHaveClass('bg-(--app-shell-content-surface)');
     expect(header).not.toHaveClass('bg-transparent');
   });
 
@@ -234,7 +234,7 @@ describe('DashboardHeader', () => {
 
     const header = getByTestId('dashboard-header');
     expect(header).toHaveClass('bg-transparent');
-    expect(header).not.toHaveClass('bg-(--linear-app-content-surface)');
+    expect(header).not.toHaveClass('bg-(--app-shell-content-surface)');
     // Layout is unchanged — the desktop row keeps the compact header height.
     expect(
       container.querySelector(

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1699
+  "count": 1698
 }

--- a/apps/web/tests/unit/design-system/noir-ion-tokens.test.ts
+++ b/apps/web/tests/unit/design-system/noir-ion-tokens.test.ts
@@ -54,7 +54,7 @@ describe('Noir Ion — approved dark anchors', () => {
   });
 
   it('maps shell canvas + sidebar to Noir Ion shell ladder', () => {
-    expect(linearDark).toContain('--linear-bg-page: #030407;');
+    expect(linearDark).toContain('--linear-bg-page: #06080d;');
     expect(linearDark).toContain('--linear-app-content-surface: #0a0d16;');
     expect(linearDark).toContain('--linear-bg-surface-1: #0f1420;');
     expect(linearDark).toContain(


### PR DESCRIPTION
## Summary
- align the app canvas with the sidebar base surface
- keep main header and route content on one continuous raised plane
- move desktop inspector elevation to the shared `RightDrawer`, keeping entity workspaces flat inside it

## Verification
- `pnpm exec biome check` on 9 changed files
- focused shell/drawer/elevation tests (62 total)

Linear: JOV-4744