### PR TITLE
fix(ios): recover native chat sessions and reduce stream jank

### DIFF
--- a/apps/ios/Jovie/Core/ChatRepository.swift
+++ b/apps/ios/Jovie/Core/ChatRepository.swift
@@ -181,6 +181,18 @@ final class ChatRepository {
   }
 
   private func apply(events: [MobileChatStreamEvent], clientTurnId: String) {
+    var pendingDeltas: [String: String] = [:]
+
+    func flushDelta(for turnID: String) {
+      guard let text = pendingDeltas.removeValue(forKey: turnID), !text.isEmpty else { return }
+      updateAssistant(clientTurnId: turnID) { item in
+        var updated = item
+        updated.status = .streaming
+        updated.content += text
+        return updated
+      }
+    }
+
     for event in events {
       switch event {
       case let .turnReserved(conversationId, _, _):
@@ -191,26 +203,23 @@ final class ChatRepository {
           return updated
         }
 
-      case let .assistantDelta(clientTurnId, text):
-        updateAssistant(clientTurnId: clientTurnId) { item in
-          var updated = item
-          updated.status = .streaming
-          updated.content += text
-          return updated
-        }
+      case let .assistantDelta(eventClientTurnId, text):
+        pendingDeltas[eventClientTurnId, default: ""] += text
 
-      case let .assistantCompleted(clientTurnId, conversationId, _, text):
+      case let .assistantCompleted(eventClientTurnId, conversationId, _, text):
+        flushDelta(for: eventClientTurnId)
         activeConversationID = conversationId
-        updateAssistant(clientTurnId: clientTurnId) { item in
+        updateAssistant(clientTurnId: eventClientTurnId) { item in
           var updated = item
           updated.status = .completed
           updated.content = text
           return updated
         }
 
-      case let .webHandoff(clientTurnId, conversationId, url, summary):
+      case let .webHandoff(eventClientTurnId, conversationId, url, summary):
+        flushDelta(for: eventClientTurnId)
         activeConversationID = conversationId
-        updateAssistant(clientTurnId: clientTurnId) { item in
+        updateAssistant(clientTurnId: eventClientTurnId) { item in
           var updated = item
           updated.status = .completed
           updated.content = summary
@@ -220,8 +229,13 @@ final class ChatRepository {
         }
 
       case let .error(_, message):
+        flushDelta(for: clientTurnId)
         markAssistantFailed(clientTurnId: clientTurnId, message: message)
       }
+    }
+
+    for eventClientTurnId in Array(pendingDeltas.keys) {
+      flushDelta(for: eventClientTurnId)
     }
   }
 

--- a/apps/ios/Jovie/Core/MobileChatClient.swift
+++ b/apps/ios/Jovie/Core/MobileChatClient.swift
@@ -62,9 +62,17 @@ struct MobileChatClient: MobileChatClientProtocol, Sendable {
   }
 
   func sendTurn(_ request: MobileChatTurnRequest) async throws -> [MobileChatStreamEvent] {
+    try await sendTurn(request, forceRefresh: false)
+  }
+
+  private func sendTurn(
+    _ request: MobileChatTurnRequest,
+    forceRefresh: Bool
+  ) async throws -> [MobileChatStreamEvent] {
     var urlRequest = try await authorizedRequest(
       url: baseURL.appending(path: "/api/mobile/v1/chat/turns"),
-      method: "POST"
+      method: "POST",
+      forceRefresh: forceRefresh
     )
     urlRequest.setValue("application/x-ndjson", forHTTPHeaderField: "Accept")
     urlRequest.httpBody = try encoder.encode(request)
@@ -75,15 +83,27 @@ struct MobileChatClient: MobileChatClientProtocol, Sendable {
       throw MobileChatClientError.invalidResponse
     }
 
+    if httpResponse.statusCode == 401, !forceRefresh {
+      return try await sendTurn(request, forceRefresh: true)
+    }
+    if httpResponse.statusCode == 401, forceRefresh {
+      NativeSessionTokenStore.clear()
+    }
+
     guard (200 ... 299).contains(httpResponse.statusCode) else {
       throw MobileChatClientError.requestFailed(statusCode: httpResponse.statusCode)
     }
 
+    NativeSessionTokenStore.refresh(from: response)
     return try parseStreamEvents(from: data)
   }
 
-  private func authorizedRequest(url: URL, method: String) async throws -> URLRequest {
-    let token = try await tokenProvider.bearerToken(forceRefresh: false)
+  private func authorizedRequest(
+    url: URL,
+    method: String,
+    forceRefresh: Bool = false
+  ) async throws -> URLRequest {
+    let token = try await tokenProvider.bearerToken(forceRefresh: forceRefresh)
     var request = URLRequest(url: url)
     request.httpMethod = method
     request.timeoutInterval = requestTimeout

--- a/apps/ios/Jovie/Core/NativeSessionTokenStore.swift
+++ b/apps/ios/Jovie/Core/NativeSessionTokenStore.swift
@@ -68,6 +68,24 @@ enum NativeSessionTokenStore {
     UserDefaults.standard.removeObject(forKey: expiresAtKey)
   }
 
+  /// Persists the Better Auth bearer-plugin roll emitted on successful API calls.
+  /// The response header contains only the token; keep the existing user identity
+  /// and extend the local lease to match the server's seven-day session lifetime.
+  static func refresh(from response: URLResponse) {
+    guard
+      let httpResponse = response as? HTTPURLResponse,
+      let token = httpResponse.value(forHTTPHeaderField: "set-auth-token"),
+      !token.isEmpty,
+      let stored = load()
+    else { return }
+
+    save(
+      token: token,
+      userID: stored.userID,
+      expiresAt: Date().addingTimeInterval(60 * 60 * 24 * 7)
+    )
+  }
+
   private static func loadToken() -> String? {
     var query = baseQuery()
     query[kSecReturnData as String] = true
@@ -108,8 +126,8 @@ enum NativeSessionTokenStore {
  * the bearer plugin authenticates API calls with it. No client refresh —
  * the server rolls `expiresAt` per `updateAge`, and the bearer plugin's
  * `set-auth-token` response header refreshes the stored token + expiry on
- * each API call (handled in `APIClient`). A terminal 401 from the server
- * clears the Keychain (handled in `APIClient`'s 401 path).
+ * successful API calls (handled by `APIClient` and `MobileChatClient`). A
+ * terminal 401 clears the Keychain in each client.
  */
 struct NativeSessionTokenProvider: TokenProviding {
   func bearerToken(forceRefresh: Bool) async throws -> String {

--- a/apps/ios/Jovie/Features/Chat/MobileChatView.swift
+++ b/apps/ios/Jovie/Features/Chat/MobileChatView.swift
@@ -104,9 +104,6 @@ struct MobileChatView: View {
       .onChange(of: repository.timeline.count) {
         scrollToBottomIfPinned(using: proxy, animated: true)
       }
-      .onChange(of: repository.timeline.last?.content) {
-        scrollToBottomIfPinned(using: proxy, animated: false)
-      }
       .onChange(of: repository.timeline.last?.status) {
         guard repository.timeline.last?.status == .streaming else { return }
         guard MobileChatKeyboardPolicy.shouldDismissOnStreamingStart(

--- a/apps/ios/JovieTests/ChatRepositoryTests.swift
+++ b/apps/ios/JovieTests/ChatRepositoryTests.swift
@@ -116,6 +116,32 @@ struct ChatRepositoryTests {
     #expect(repository.timeline.map(\.content) == ["Here is your plan"])
   }
 
+  @Test func sendCoalescesStreamDeltasIntoAssistantTimeline() async {
+    let client = ScriptedChatClient(
+      sendTurnResult: .success([
+        .turnReserved(conversationId: "conv_stream", turnId: "turn_1", clientTurnId: "PLACEHOLDER"),
+        .assistantDelta(clientTurnId: "PLACEHOLDER", text: "A"),
+        .assistantDelta(clientTurnId: "PLACEHOLDER", text: " streamed"),
+        .assistantDelta(clientTurnId: "PLACEHOLDER", text: " answer"),
+      ]),
+      listConversationsResult: .success([]),
+      fetchConversationResult: .failure(MobileChatClientError.requestFailed(statusCode: 404))
+    )
+
+    let repository = ChatRepository(
+      client: client,
+      cache: ChatCache(defaults: UserDefaults(suiteName: "ie.jov.Jovie.tests.chat-repo-stream")!),
+      clerkUserID: "user_repo_stream",
+      webBaseURL: URL(string: "https://preview.example")!
+    )
+
+    await repository.send(text: "Stream this")
+
+    let assistantItem = repository.timeline.first { $0.role == .assistant }
+    #expect(assistantItem?.status == .completed)
+    #expect(assistantItem?.content == "A streamed answer")
+  }
+
   @Test func sendAppliesWebHandoffEventAndFlagsRequiresWebHandoff() async {
     let handoffURL = URL(string: "https://jov.ie/app/chat/conv_handoff")!
     let client = ScriptedChatClient(

--- a/apps/ios/JovieTests/MobileChatClientTests.swift
+++ b/apps/ios/JovieTests/MobileChatClientTests.swift
@@ -250,12 +250,17 @@ struct MobileChatClientTests {
 
     let client = makeClient(tokenProvider: tokenProvider)
 
-    // sendTurn does not itself retry on 401 (only sendJSON-backed GET calls do);
-    // a non-2xx response from the POST turn endpoint must surface as requestFailed.
-    await #expect(throws: MobileChatClientError.requestFailed(statusCode: 401)) {
-      _ = try await client.sendTurn(makeTurnRequest())
-    }
-    #expect(await tokenProvider.recordedForceRefreshValues() == [false])
+    let events = try await client.sendTurn(makeTurnRequest())
+
+    #expect(events == [
+      .assistantCompleted(
+        clientTurnId: "client_turn_1",
+        conversationId: "conv_1",
+        turnId: "turn_1",
+        text: "Hello"
+      ),
+    ])
+    #expect(await tokenProvider.recordedForceRefreshValues() == [false, true])
   }
 
   @Test func listConversationsRetriesWithFreshTokenAfterUnauthorized() async throws {


### PR DESCRIPTION
## Summary
- Retry native chat `POST /api/mobile/v1/chat/turns` once with a forced token after `401`, clear terminally unauthorized native sessions, and persist Better Auth `set-auth-token` rolls.
- Coalesce buffered NDJSON assistant deltas into one repository timeline mutation and stop scrolling on every content mutation, avoiding repeated SwiftUI layout/parser work during a response.
- Add regression coverage for expired-token recovery and streamed-delta application.

## Root cause
The native POST turn path differed from the working JSON client: it used the stale bearer token once and ignored the server's rolling `set-auth-token` header, so an otherwise valid native session could fail chat with `401`. Separately, the client buffers the backend's NDJSON response; once delivered, `ChatRepository` applied every delta synchronously and `MobileChatView` scrolled on every content change. That multiplied timeline invalidations, parsing, and scroll work into the visible jank.

## Bounded gap
The backend currently emits an NDJSON response through a synchronous `ReadableStream`, while `MobileChatClient.sendTurn` still returns an array. This PR fixes reliable auth recovery and makes the buffered-delta burst cheap; true progressive UI delivery will require a larger async-stream protocol change and is intentionally not included here.

## Verification
- `JOVIE_IOS_RESET_SIMULATOR=0 bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieTests/MobileChatClientTests` — **10 tests passed**
- `JOVIE_IOS_RESET_SIMULATOR=0 bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieTests/ChatRepositoryTests` — **14 tests passed**
- `pnpm run ios:lint` — **clean**
- `git diff --check` — **clean**

The full `pnpm run ios:test` command is not claimed green: the pre-existing full run timed out during UI tests after about 600 seconds.

## Files
- `apps/ios/Jovie/Core/MobileChatClient.swift`
- `apps/ios/Jovie/Core/ChatRepository.swift`
- `apps/ios/Jovie/Core/NativeSessionTokenStore.swift`
- `apps/ios/Jovie/Features/Chat/MobileChatView.swift`
- `apps/ios/JovieTests/MobileChatClientTests.swift`
- `apps/ios/JovieTests/ChatRepositoryTests.swift`

No secrets, personal data, or health data included.
