### PR TITLE
fix(search): use dense table result rows

### DIFF
--- a/apps/web/components/jovie/components/picker-rows.tsx
+++ b/apps/web/components/jovie/components/picker-rows.tsx
@@ -198,9 +198,12 @@ export const PromptArt = memo(function PromptArt() {
 
 export const RowVisual = memo(function RowVisual({
   item,
+  variant = 'picker',
 }: {
   readonly item: PickerItem;
+  readonly variant?: 'picker' | 'dense';
 }) {
+  if (variant === 'dense') return <DenseRowVisual item={item} />;
   if (item.kind === 'skill') return <SkillArt skill={item.skill} />;
   if (item.kind === 'nav') return <NavArt nav={item.nav} />;
   if (item.kind === 'prompt') return <PromptArt />;
@@ -221,11 +224,66 @@ export const RowVisual = memo(function RowVisual({
   );
 });
 
-export const RowBody = memo(function RowBody({
+/** Compact, unboxed semantic column for dense entity-table rows. */
+const DenseRowVisual = memo(function DenseRowVisual({
   item,
 }: {
   readonly item: PickerItem;
 }) {
+  if (item.kind === 'entity' && item.entity.thumbnail) {
+    return (
+      <span
+        className={cn(
+          'relative size-7 shrink-0 overflow-hidden',
+          item.entity.kind === 'artist' ? 'rounded-full' : 'rounded-sm'
+        )}
+        aria-hidden='true'
+      >
+        <Image
+          src={item.entity.thumbnail}
+          alt=''
+          fill
+          sizes='28px'
+          className='object-cover'
+          unoptimized
+        />
+      </span>
+    );
+  }
+
+  const Icon =
+    item.kind === 'skill'
+      ? (ICON_MAP[item.skill.iconName] ?? Calendar)
+      : item.kind === 'nav'
+        ? (ICON_MAP[item.nav.iconName] ?? Calendar)
+        : item.kind === 'prompt'
+          ? Sparkles
+          : item.entity.kind === 'event'
+            ? Calendar
+            : item.entity.kind === 'track'
+              ? Music2
+              : item.entity.kind === 'artist'
+                ? UserCircle
+                : Music;
+
+  return (
+    <span
+      className='flex size-7 shrink-0 items-center justify-center text-tertiary-token'
+      aria-hidden='true'
+    >
+      <Icon className='size-4' strokeWidth={1.5} />
+    </span>
+  );
+});
+
+export const RowBody = memo(function RowBody({
+  item,
+  variant = 'picker',
+}: {
+  readonly item: PickerItem;
+  readonly variant?: 'picker' | 'dense';
+}) {
+  if (variant === 'dense') return <DenseRowBody item={item} />;
   if (item.kind === 'skill') {
     return (
       <div className='min-w-0 flex-1'>
@@ -255,6 +313,40 @@ export const RowBody = memo(function RowBody({
     <div className='min-w-0 flex-1'>
       <p className='system-b-picker-row-title'>{item.entity.label}</p>
       {meta ? <p className='system-b-picker-row-meta'>{meta}</p> : null}
+    </div>
+  );
+});
+
+function denseRowText(item: PickerItem): {
+  title: string;
+  meta: string | null;
+} {
+  if (item.kind === 'skill') {
+    return { title: item.skill.label, meta: item.skill.description };
+  }
+  if (item.kind === 'nav') {
+    return { title: item.nav.label, meta: item.nav.description };
+  }
+  if (item.kind === 'prompt') {
+    return { title: item.prompt.label, meta: item.prompt.description };
+  }
+  return { title: item.entity.label, meta: formatRowMeta(item.entity) };
+}
+
+const DenseRowBody = memo(function DenseRowBody({
+  item,
+}: {
+  readonly item: PickerItem;
+}) {
+  const { title, meta } = denseRowText(item);
+  return (
+    <div className='flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden'>
+      <span className='truncate text-app font-caption text-primary-token'>
+        {title}
+      </span>
+      {meta ? (
+        <span className='truncate text-2xs text-tertiary-token'>{meta}</span>
+      ) : null}
     </div>
   );
 });

--- a/apps/web/components/organisms/CmdKPalette.test.tsx
+++ b/apps/web/components/organisms/CmdKPalette.test.tsx
@@ -76,9 +76,36 @@ describe('CmdKPalette', () => {
         name: 'Calendar Plan release dates and campaign moments. ⌘1',
       })
     ).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.getByRole('option', {
+        name: 'Calendar Plan release dates and campaign moments. ⌘1',
+      })
+    ).toHaveClass('system-b-table-row-shell');
 
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(pushMock).toHaveBeenCalledWith('/app/calendar');
+  });
+
+  it('keeps dense table results keyboard-selectable before committing', () => {
+    render(<MainPlaneHarness />);
+
+    const input = screen.getByRole('combobox', {
+      name: 'Command Palette Search',
+    });
+    const profile = screen.getByRole('option', {
+      name: 'Profile Open your profile in the chat workspace. ⌘1',
+    });
+
+    expect(profile).toHaveAttribute('aria-selected', 'true');
+    expect(profile).toHaveClass('system-b-table-row-shell');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Connections Manage artist identities and connected services. ⌘2',
+      })
+    ).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -395,7 +395,7 @@ export function CmdKPalette({
 
   const results = (
     <div
-      className='min-h-0 flex-1 overflow-y-auto px-2 pb-2 pt-1.5'
+      className='min-h-0 flex-1 overflow-y-auto pb-2 pt-1.5'
       role='listbox'
       aria-label='Command Palette Results'
       id={generatedListId}

--- a/apps/web/components/organisms/SharedCommandPalette.stories.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { InlinePalette, type PaletteSection } from './SharedCommandPalette';
+
+const sections: readonly PaletteSection[] = [
+  {
+    id: 'go-to',
+    label: 'Go To',
+    items: [
+      {
+        kind: 'nav',
+        nav: {
+          kind: 'nav',
+          id: 'library',
+          label: 'Library',
+          description: 'Manage releases, images, and merch.',
+          iconName: 'Music',
+          surfaces: ['cmdk'],
+          href: '/app/library',
+        },
+      },
+    ],
+  },
+];
+
+const meta = {
+  title: 'Organisms/SharedCommandPalette',
+  component: InlinePalette,
+  parameters: {
+    layout: 'centered',
+    jovie: {
+      // CmdKPaletteRow is an internal render helper. Its props are covered by
+      // the Cmd+K interaction test rather than a public Storybook API.
+      uncoveredProps: [
+        'commitIndex',
+        'item',
+        'index',
+        'isActive',
+        'onMouseEnter',
+      ],
+    },
+  },
+  args: {
+    sections,
+    selectedIndex: 0,
+    setSelectedIndex: () => undefined,
+    onCommit: () => undefined,
+    variant: 'inline',
+  },
+} satisfies Meta<typeof InlinePalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SlashSuggestions: Story = {};
+
+export const Empty: Story = {
+  args: {
+    sections: [],
+    emptyHint: 'No matching commands',
+  },
+};

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -28,6 +28,7 @@ import {
   RowBody,
   RowVisual,
 } from '../jovie/components/picker-rows';
+import { ShellListRowFrame } from './table/atoms/ShellListRowFrame';
 
 export interface PaletteSection {
   readonly id: string;
@@ -163,7 +164,7 @@ function CmdKPaletteRow({
   shortcutLabel,
 }: CmdKPaletteRowProps) {
   return (
-    <div
+    <ShellListRowFrame
       role='option'
       id={rowId}
       tabIndex={-1}
@@ -176,21 +177,18 @@ function CmdKPaletteRow({
         e.preventDefault();
         onCommit(index);
       }}
-      className={cn(
-        'flex min-h-14 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left outline-none transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
-        isActive
-          ? 'bg-[color-mix(in_oklab,var(--app-shell-content-surface)_76%,white_14%)] text-primary-token shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_36%,transparent),0_10px_28px_-24px_rgba(0,0,0,0.9)]'
-          : 'hover:bg-white/[0.045]'
-      )}
+      isSelected={isActive}
+      interactive
+      className='system-b-table-row-shell flex min-h-11 w-full items-center gap-2 px-3 py-1.5 text-left'
     >
-      <RowVisual item={item} />
-      <RowBody item={item} />
+      <RowVisual item={item} variant='dense' />
+      <RowBody item={item} variant='dense' />
       {shortcutLabel ? (
         <span className='ml-auto flex min-w-9 shrink-0 justify-end tabular-nums text-2xs font-medium text-quaternary-token'>
           {shortcutLabel}
         </span>
       ) : null}
-    </div>
+    </ShellListRowFrame>
   );
 }
 
@@ -236,7 +234,7 @@ export function PaletteList({
             <div
               className={cn(
                 variant === 'cmdk'
-                  ? 'px-3 pb-1.5 pt-2 text-2xs font-semibold uppercase tracking-[0.08em] text-quaternary-token'
+                  ? 'px-3 pb-1 pt-2 text-2xs font-medium text-quaternary-token'
                   : 'px-3 pb-1 pt-3 text-3xs font-semibold uppercase tracking-[0.1em] text-tertiary-token'
               )}
             >

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -1,4 +1,5 @@
 'use client';
+// @coverage-via apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
 
 /**
  * SharedCommandPalette — primitives shared by the chat slash picker and the

--- a/apps/web/tests/unit/chat/picker-rows-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/picker-rows-style-guard.test.ts
@@ -3,10 +3,13 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const ROOT = join(__dirname, '../../..');
-const PICKER_ROWS = join(ROOT, 'components/jovie/components/picker-rows.tsx');
+const SHARED_COMMAND_PALETTE = join(
+  ROOT,
+  'components/organisms/SharedCommandPalette.tsx'
+);
 
-const RAW_VISUAL_CLASS_PATTERNS = [
-  /(?:^|[\s'"])(?:bg|text|border|accent|shadow|rounded|p|px|py|pt|pr|pb|pl|m|mx|my|mt|mr|mb|ml|h|w|size|top|left|right|bottom|inset|gap|tracking|leading|font|from|via|to)-(?:[^\s'"]+)/g,
+const RAW_ROW_SURFACE_PATTERNS = [
+  /(?:^|[\s'"])(?:bg|border|shadow|rounded|ring|outline)-(?:[^\s'"]+)/g,
   /['"][^'"]*#[0-9a-fA-F]{3,8}[^'"]*['"]/g,
   /['"][^'"]*rgba?\([^'"]*['"]/g,
   /['"][^'"]*bg-gradient-to-[^'"]*['"]/g,
@@ -17,28 +20,45 @@ function lineNumberFor(source: string, index: number): number {
   return source.slice(0, index).split('\n').length;
 }
 
-function rawVisualOffendersFor(source: string): string[] {
-  return RAW_VISUAL_CLASS_PATTERNS.flatMap(pattern =>
+function rawRowSurfaceOffendersFor(source: string): string[] {
+  return RAW_ROW_SURFACE_PATTERNS.flatMap(pattern =>
     [...source.matchAll(pattern)].map(
       match =>
-        `picker-rows.tsx:${lineNumberFor(source, match.index ?? 0)} ${match[0].replace(/\s+/g, ' ').trim()}`
+        `SharedCommandPalette.tsx:${lineNumberFor(source, match.index ?? 0)} ${match[0].replace(/\s+/g, ' ').trim()}`
     )
   );
 }
 
+function cmdKPaletteRowSource(source: string): string {
+  const start = source.indexOf('function CmdKPaletteRow');
+  const end = source.indexOf('\nexport function PaletteList', start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
 describe('picker row style guard', () => {
-  it('keeps picker artwork and row visuals behind System B primitives', () => {
-    const source = readFileSync(PICKER_ROWS, 'utf8');
-    const offenders = rawVisualOffendersFor(source);
+  it('keeps Cmd+K result rows on the shared dense table-row primitive', () => {
+    const source = readFileSync(SHARED_COMMAND_PALETTE, 'utf8');
+    const rowSource = cmdKPaletteRowSource(source);
+    const offenders = rawRowSurfaceOffendersFor(rowSource);
 
     expect(
       offenders,
-      `Picker row visuals should live in system-b-picker-* CSS primitives.\n${offenders.join('\n')}`
+      `Cmd+K result-row surfaces should live in the shared table-row primitive.\n${offenders.join('\n')}`
     ).toEqual([]);
+    expect(source).toContain(
+      "import { ShellListRowFrame } from './table/atoms/ShellListRowFrame';"
+    );
+    expect(rowSource).toContain("className='system-b-table-row-shell");
+    expect(rowSource).toContain("<RowVisual item={item} variant='dense' />");
+    expect(rowSource).toContain("<RowBody item={item} variant='dense' />");
+    expect(rowSource).not.toContain('system-b-picker-row');
   });
 
-  it('catches standard Tailwind visual utilities without rejecting allowed layout scaffolding', () => {
-    const offenders = rawVisualOffendersFor(
+  it('catches local row-surface treatment without rejecting structural table layout', () => {
+    const offenders = rawRowSurfaceOffendersFor(
       "<div className='bg-zinc-900 rounded-lg h-9 w-9 text-sm min-w-0 flex-1 object-cover' />"
     );
 
@@ -46,13 +66,13 @@ describe('picker row style guard', () => {
       expect.arrayContaining([
         expect.stringContaining('bg-zinc-900'),
         expect.stringContaining('rounded-lg'),
-        expect.stringContaining('h-9'),
-        expect.stringContaining('w-9'),
-        expect.stringContaining('text-sm'),
       ])
     );
     expect(offenders).not.toEqual(
       expect.arrayContaining([
+        expect.stringContaining('h-9'),
+        expect.stringContaining('w-9'),
+        expect.stringContaining('text-sm'),
         expect.stringContaining('min-w-0'),
         expect.stringContaining('flex-1'),
         expect.stringContaining('object-cover'),

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -67,7 +67,7 @@ vi.mock('@/lib/queries/useReleasesQuery', () => ({
       {
         id: 'rel-1',
         title: 'Midnight Run',
-        artworkUrl: null,
+        artworkUrl: 'https://cdn.example.com/midnight-run.jpg',
         artistNames: ['Test Artist'],
         releaseDate: '2024-01-01',
         releaseType: 'single',
@@ -193,6 +193,39 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
 
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(pushMock).toHaveBeenCalledWith(APP_ROUTES.PROFILES);
+  });
+
+  it('renders cmd+k results with the shared dense-table row contract', () => {
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'Command Palette Search' }),
+      { target: { value: 'Connections' } }
+    );
+
+    const selected = screen.getByRole('option', {
+      name: 'Connections Manage artist identities and connected services. ⌘1',
+    });
+    expect(selected).toHaveClass('system-b-table-row-shell');
+    expect(selected).toHaveClass('system-b-table-row-selected');
+    expect(selected).not.toHaveClass('system-b-picker-row');
+    expect(selected.querySelector('.system-b-picker-art')).toBeNull();
+  });
+
+  it('preserves real entity artwork without restoring boxed icon chrome', () => {
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'Command Palette Search' }),
+      { target: { value: 'Midnight Run' } }
+    );
+
+    const release = screen.getByRole('option', {
+      name: `Midnight Run Single · Jan 1 ${CMD_LABEL}1`,
+    });
+    expect(release.querySelector('[data-testid="img"]')).toHaveAttribute(
+      'data-src',
+      'https://cdn.example.com/midnight-run.jpg'
+    );
+    expect(release.querySelector('.system-b-picker-art')).toBeNull();
   });
 
   it('renders nav, skill, and release sections when open', () => {

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1701
+  "count": 1699
 }


### PR DESCRIPTION
## Summary
- restyle full-main-content unified search results with the canonical shared dense table row frame and state tokens
- preserve stable result selection, listbox/option and combobox active-descendant semantics, keyboard activation, and reserved shortcut geometry
- retain real release and artist artwork as an unboxed fixed media column with semantic icon fallbacks and one-line provider/entity metadata

## Verification
- pnpm biome check --write on all four changed files
- pnpm --filter web exec vitest run tests/unit/commands/SharedCommandPalette.test.tsx (21 passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web run test:bug-to-test
- git diff --check

## Risk
Low. Shared interaction state and result identity logic are unchanged; the change is scoped to Cmd-K row composition and dense-row rendering.

Linear: JOV-4755