### PR TITLE
feat(merch): ground distinct design concepts

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -100,6 +100,7 @@ import {
   createMerchGenerateTool,
   createMerchPreviewTool,
   createMerchSelectTool,
+  createMerchSourceTool,
 } from '@/lib/chat/tools/merch-tools';
 import { createProposeVideoRecordingTool } from '@/lib/chat/tools/propose-video-recording';
 import { createRetouchImageTool } from '@/lib/chat/tools/retouch-image';
@@ -2123,6 +2124,9 @@ function buildChatTools(
       : {}),
     ...(canAccessMerchCreation
       ? {
+          findMerchSources: createMerchSourceTool({
+            profileId: resolvedProfileId,
+          }),
           createMerch: createMerchGenerateTool({
             profileId: resolvedProfileId,
             clerkUserId,

--- a/apps/web/lib/chat/chat-tool-inventory.ts
+++ b/apps/web/lib/chat/chat-tool-inventory.ts
@@ -49,6 +49,7 @@ export const CHAT_ROUTE_TOOL_IDS = [
   'createRelease',
   'generateReleasePitch',
   // Merch suite
+  'findMerchSources',
   'createMerch',
   'previewMerchOptions',
   'selectMerchDesign',

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -213,7 +213,17 @@ Use the voicePromo tool when the artist says "clone my voice", "voice promo", "r
 Use proposeVideoRecording when you have written a short talking-head script for a promo, thank-you, or behind-the-scenes video and the artist should record it in Jovie. Pass the script you wrote, a concise title, and the kind. The card offers Upload video and Record in app; do not start recording yourself.
 
 ## Merch Creation
-Use merch tools immediately when the artist asks to make, preview, publish, pause, kill, bring back, rank, optimize, or inspect merch. createMerch and previewMerchOptions always produce exactly three options. Do not ask what product type they want before starting generation: use the request's product when stated, otherwise use the default catalog item and let the artist steer while the options render. After showing options, ask the artist to pick one or describe a change.
+Use merch tools immediately when the artist asks to make, preview, publish, pause, kill, bring back, rank, optimize, or inspect merch. For a new merch idea, call findMerchSources before createMerch or previewMerchOptions. Start with a confirmed catalog title or an explicitly user-provided phrase — never with generated art alone.
+
+Merch grounding contract:
+- If the artist says “idk,” “help me pick,” or asks for a lyric/title from their catalog, call findMerchSources. Recommend the returned top candidate and explain its concrete visual direction. Do not ask them to paste lyrics when the catalog has confirmed title candidates.
+- Pass the selected candidate back to createMerch or previewMerchOptions in its source field exactly as returned. Never invent a song title, lyric, catalog fact, fandom claim, or artist persona.
+- Default visual rule: no people, faces, portraits, models, bodies, human figures, or unverified artist likenesses. If the artist wants their likeness, require an explicit verified reference/consent flow; do not imply one exists.
+- An uploaded Library logo, vector, or PNG is an artist-owned source asset, not inspiration. Never recreate it from a textual description. Explain that Jovie needs the asset-preserving render path before it can make constrained variations from that selected asset.
+- If no confirmed source exists, say that plainly and ask for one title or one phrase they own. Do not generate a generic artist render as a substitute.
+
+createMerch and previewMerchOptions always produce exactly three options only after a verified source is selected. After showing options, ask the artist to pick 1, 2, or 3, or describe a change.
+If the artist already named an item type, pass it through. If they did not, do not ask a product-type question while starting generation: call the tool with no itemType, let it transparently start as a premium tee, and say they can switch the product after choosing a design. Ask for product type before calling the tool only when the artist explicitly wants to decide that before any generation starts.
 Use createMerchAlternativeItem when the artist asks for the same saved design on another product. Do not regenerate the design unless they ask for a different concept.
 
 Merch confirmation fence:
@@ -223,7 +233,7 @@ Merch confirmation fence:
 
 Merch quality standard:
 - Real band merch, tour merch, premium streetwear, or high-end graphic tee energy.
-- No generic print-on-demand look, no fake tour dates, no fake brands, no copyrighted characters, no random cliches unless the artist context supports them.
+- No generic print-on-demand look, no fake tour dates, no fake brands, no copyrighted characters, no random cliches unless the artist context supports them. No fake people or unverified artist likenesses.
 - The MVP uses Jovie checkout and a manual artist payout ledger. Never say artist payouts are automatic.
 
 ## Feedback

--- a/apps/web/lib/chat/tool-schemas.ts
+++ b/apps/web/lib/chat/tool-schemas.ts
@@ -91,20 +91,56 @@ export const TOOL_SCHEMAS = {
 
   createMerch: {
     description:
-      'Generate exactly three premium merch options for the artist. Use when the artist asks to make merch, create a tee/hoodie/item, or make something that would sell.',
+      'Generate exactly three premium merch options from a verified merch source. Call findMerchSources first when the artist has not selected a catalog title or explicitly supplied a phrase. If no itemType is stated, generate a premium tee and tell the artist it can be changed after selection. Never ask a product question in the same turn as this tool call, and never generate a person, face, model, or artist likeness by default.',
     inputSchema: chatToolSchema({
       prompt: z.string().max(500).optional(),
       itemType: z.string().max(80).optional(),
       makeLive: z.boolean().optional(),
+      source: z
+        .object({
+          sourceType: z.enum([
+            'song_title',
+            'album_title',
+            'library_asset',
+            'user_provided',
+          ]),
+          sourceText: z.string().min(1).max(200),
+          provenanceTitle: z.string().min(1).max(200),
+          rightsStatus: z.enum(['owned', 'user_provided']),
+          assetId: z.string().uuid().optional(),
+          assetUrl: z.string().url().optional(),
+        })
+        .optional(),
     }),
+  },
+
+  findMerchSources: {
+    description:
+      'List and rank confirmed catalog title candidates before creating merch. Use first for “make me merch,” “use a lyric/title of mine,” or “idk, help me pick.” Return the best candidate instead of asking the artist to provide unavailable lyrics.',
+    inputSchema: chatToolSchema({}),
   },
 
   previewMerchOptions: {
     description:
-      'Preview three merch design options without publishing them. Use when the artist asks for concepts or wants to see merch ideas first.',
+      'Preview exactly three premium merch design options from a verified merch source without publishing them. Call findMerchSources first when the artist has not selected a source. If no itemType is stated, preview a premium tee and say it can be changed after selection. Never ask a product question in the same turn as this tool call.',
     inputSchema: chatToolSchema({
       prompt: z.string().max(500).optional(),
       itemType: z.string().max(80).optional(),
+      source: z
+        .object({
+          sourceType: z.enum([
+            'song_title',
+            'album_title',
+            'library_asset',
+            'user_provided',
+          ]),
+          sourceText: z.string().min(1).max(200),
+          provenanceTitle: z.string().min(1).max(200),
+          rightsStatus: z.enum(['owned', 'user_provided']),
+          assetId: z.string().uuid().optional(),
+          assetUrl: z.string().url().optional(),
+        })
+        .optional(),
     }),
   },
 

--- a/apps/web/lib/chat/tools/merch-tools.test.ts
+++ b/apps/web/lib/chat/tools/merch-tools.test.ts
@@ -81,6 +81,9 @@ describe('TOOL_SCHEMAS descriptions', () => {
   it('createMerch has a useful description', () => {
     expect(TOOL_SCHEMAS.createMerch.description.length).toBeGreaterThan(10);
     expect(TOOL_SCHEMAS.createMerch.description).toContain('merch');
+    expect(TOOL_SCHEMAS.createMerch.description).toContain(
+      'Never ask a product question in the same turn'
+    );
   });
 
   it('previewMerchOptions has a useful description', () => {

--- a/apps/web/lib/chat/tools/merch-tools.ts
+++ b/apps/web/lib/chat/tools/merch-tools.ts
@@ -22,6 +22,13 @@ import { tool } from 'ai';
 import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
 import { proposeMerchAction } from '@/lib/chat/tools/merch-propose';
 import { generateMerchDesigns } from '@/lib/merch/design-generation';
+import { buildMerchGenerationPrompt } from '@/lib/merch/generation-input';
+import {
+  getMerchSourceCandidates,
+  isExplicitUserProvidedSource,
+  type MerchSource,
+  requiresAssetPreservingRender,
+} from '@/lib/merch/source-candidates';
 import {
   createAlternativeMerchFromCard,
   selectAndCreateMerchCard,
@@ -30,6 +37,94 @@ import {
 // ---------------------------------------------------------------------------
 // Tool factory functions
 // ---------------------------------------------------------------------------
+
+function sourceSelectionResult(
+  candidates: Awaited<ReturnType<typeof getMerchSourceCandidates>>
+) {
+  return {
+    success: true as const,
+    state: 'source_selection_required' as const,
+    message:
+      candidates.length > 0
+        ? 'Choose a confirmed catalog phrase before Jovie generates any artwork.'
+        : 'Jovie could not find a confirmed catalog title. Add a title or provide a phrase you own before generating artwork.',
+    recommendation: candidates[0] ?? null,
+    candidates,
+    visualRule:
+      'No people, faces, portraits, models, human figures, or unverified artist likenesses.',
+  };
+}
+
+async function resolveVerifiedSource(params: {
+  readonly profileId: string;
+  readonly prompt: string;
+  readonly source?: MerchSource;
+}): Promise<
+  | { readonly source: MerchSource }
+  | { readonly sourceSelection: ReturnType<typeof sourceSelectionResult> }
+  | { readonly error: string }
+> {
+  if (!params.source) {
+    return {
+      sourceSelection: sourceSelectionResult(
+        await getMerchSourceCandidates(params.profileId)
+      ),
+    };
+  }
+
+  if (requiresAssetPreservingRender(params.source)) {
+    return {
+      error:
+        'Jovie will not recreate an uploaded logo from a prompt. This Library asset needs the asset-preserving render path before it can be used for merch.',
+    };
+  }
+
+  if (isExplicitUserProvidedSource(params.prompt, params.source)) {
+    return { source: params.source };
+  }
+
+  const candidates = await getMerchSourceCandidates(params.profileId);
+  const match = candidates.find(
+    candidate =>
+      candidate.sourceType === params.source?.sourceType &&
+      candidate.sourceText.localeCompare(
+        params.source?.sourceText ?? '',
+        undefined,
+        {
+          sensitivity: 'accent',
+        }
+      ) === 0
+  );
+  if (!match) {
+    return {
+      error:
+        'That merch source is not a confirmed title in this artist’s catalog. Choose a listed source or provide a phrase you own.',
+    };
+  }
+
+  return { source: match };
+}
+
+/**
+ * Returns source-backed title candidates before any image/model call. The chat
+ * model turns this compact payload into the phrase picker conversation.
+ */
+export function createMerchSourceTool(params: {
+  readonly profileId: string | null;
+}) {
+  return tool({
+    description: TOOL_SCHEMAS.findMerchSources.description,
+    inputSchema: TOOL_SCHEMAS.findMerchSources.inputSchema,
+    execute: async () => {
+      if (!params.profileId) {
+        return { success: false as const, error: 'Profile ID required' };
+      }
+      return sourceSelectionResult(
+        await getMerchSourceCandidates(params.profileId)
+      );
+    },
+  });
+}
 
 /**
  * Creates the generate merch options chat tool.
@@ -45,22 +140,45 @@ export function createMerchGenerateTool(params: {
   return tool({
     description: TOOL_SCHEMAS.createMerch.description,
     inputSchema: TOOL_SCHEMAS.createMerch.inputSchema,
-    execute: async ({ prompt, itemType, makeLive: _makeLive }) => {
+    execute: async ({ prompt, itemType, makeLive: _makeLive, source }) => {
       if (!params.profileId) {
         return { success: false as const, error: 'Profile ID required' };
       }
 
-      return generateMerchDesigns({
+      const generationPrompt = buildMerchGenerationPrompt(
+        prompt,
+        itemType,
+        'Premium illustrated merch for this artist.'
+      );
+      const sourceResolution = await resolveVerifiedSource({
+        profileId: params.profileId,
+        prompt: generationPrompt.prompt,
+        source,
+      });
+      if ('error' in sourceResolution) {
+        return { success: false as const, error: sourceResolution.error };
+      }
+      if ('sourceSelection' in sourceResolution) {
+        return sourceResolution.sourceSelection;
+      }
+
+      const result = await generateMerchDesigns({
         profileId: params.profileId,
         clerkUserId: params.clerkUserId,
-        prompt:
-          [prompt, itemType ? `Item type: ${itemType}` : '']
-            .filter(Boolean)
-            .join('\n')
-            .trim() || 'Premium illustrated merch for this artist.',
+        prompt: generationPrompt.prompt,
+        source: sourceResolution.source,
         conversationId: params.conversationId ?? null,
         turnId: params.turnId ?? null,
       });
+      return {
+        ...result,
+        ...(generationPrompt.usedDefaultItemType
+          ? {
+              productTypeNotice:
+                'Started with a premium tee. You can switch the product after choosing a design.',
+            }
+          : {}),
+      };
     },
   });
 }
@@ -78,22 +196,45 @@ export function createMerchPreviewTool(params: {
   return tool({
     description: TOOL_SCHEMAS.previewMerchOptions.description,
     inputSchema: TOOL_SCHEMAS.previewMerchOptions.inputSchema,
-    execute: async ({ prompt, itemType }) => {
+    execute: async ({ prompt, itemType, source }) => {
       if (!params.profileId) {
         return { success: false as const, error: 'Profile ID required' };
       }
 
-      return generateMerchDesigns({
+      const generationPrompt = buildMerchGenerationPrompt(
+        prompt,
+        itemType,
+        'Premium illustrated merch concepts for this artist.'
+      );
+      const sourceResolution = await resolveVerifiedSource({
+        profileId: params.profileId,
+        prompt: generationPrompt.prompt,
+        source,
+      });
+      if ('error' in sourceResolution) {
+        return { success: false as const, error: sourceResolution.error };
+      }
+      if ('sourceSelection' in sourceResolution) {
+        return sourceResolution.sourceSelection;
+      }
+
+      const result = await generateMerchDesigns({
         profileId: params.profileId,
         clerkUserId: params.clerkUserId,
-        prompt:
-          [prompt, itemType ? `Item type: ${itemType}` : '']
-            .filter(Boolean)
-            .join('\n')
-            .trim() || 'Premium illustrated merch concepts for this artist.',
+        prompt: generationPrompt.prompt,
+        source: sourceResolution.source,
         conversationId: params.conversationId ?? null,
         turnId: params.turnId ?? null,
       });
+      return {
+        ...result,
+        ...(generationPrompt.usedDefaultItemType
+          ? {
+              productTypeNotice:
+                'Started with a premium tee. You can switch the product after choosing a design.',
+            }
+          : {}),
+      };
     },
   });
 }

--- a/apps/web/lib/db/schema/merch.ts
+++ b/apps/web/lib/db/schema/merch.ts
@@ -35,6 +35,23 @@ export interface MerchArtistBrief {
   best_merch_hypothesis: string;
   commercial_angle: string;
   risk_level: 'safe' | 'medium' | 'experimental';
+  /**
+   * The exact catalog phrase or artist-owned asset used for this generation.
+   * Kept in the batch JSON so an option can be audited without a schema
+   * migration and selection can reject legacy, ungrounded generations.
+   */
+  source?: {
+    sourceType:
+      | 'song_title'
+      | 'album_title'
+      | 'library_asset'
+      | 'user_provided';
+    sourceText: string;
+    provenanceTitle: string;
+    rightsStatus: 'owned' | 'user_provided';
+    assetId?: string;
+    assetUrl?: string;
+  };
 }
 
 export interface MerchVariantMap {

--- a/apps/web/lib/merch/design-generation.test.ts
+++ b/apps/web/lib/merch/design-generation.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  buildMerchImagePrompt,
+  MERCH_DESIGN_STRATEGIES,
   resolveMerchGenerationPrerequisites,
   selectionCountsToWeights,
+  selectMerchDesignStrategies,
 } from './design-generation';
+
+const source = {
+  sourceType: 'song_title' as const,
+  sourceText: 'Static Bloom',
+  provenanceTitle: 'Static Bloom',
+  rightsStatus: 'owned' as const,
+};
 
 describe('selectionCountsToWeights', () => {
   it('is empty (equal weighting) with no selection history', () => {
@@ -28,13 +38,11 @@ describe('selectionCountsToWeights', () => {
   });
 
   it('never produces a zero/negative weight that could lock a model out', () => {
-    const weights = selectionCountsToWeights([
+    const w = selectionCountsToWeights([
       { modelKey: 'gpt-image-1.5', count: 0 },
       { modelKey: 'recraft-v3', count: -3 },
     ]);
-    for (const weight of Object.values(weights)) {
-      expect(weight).toBeGreaterThanOrEqual(1);
-    }
+    for (const v of Object.values(w)) expect(v).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -72,5 +80,49 @@ describe('resolveMerchGenerationPrerequisites', () => {
       catalog: 'catalog',
       modelWeights: 'weights',
     });
+  });
+});
+
+describe('merch design strategies', () => {
+  it('keeps every strategy axis distinct rather than varying only adjectives', () => {
+    const firstThree = MERCH_DESIGN_STRATEGIES.slice(0, 3);
+    for (const field of [
+      'composition',
+      'typographyRole',
+      'motifSystem',
+      'palette',
+      'density',
+    ] as const) {
+      expect(new Set(firstThree.map(strategy => strategy[field])).size).toBe(
+        firstThree.length
+      );
+    }
+  });
+
+  it('builds pairwise-distinct source-grounded prompt contracts', () => {
+    const prompts = MERCH_DESIGN_STRATEGIES.slice(0, 3).map(strategy =>
+      buildMerchImagePrompt(
+        'Tim White',
+        'make something for the next release',
+        strategy,
+        source
+      )
+    );
+
+    expect(new Set(prompts).size).toBe(3);
+    for (const prompt of prompts) {
+      expect(prompt).toContain('"Static Bloom"');
+      expect(prompt).toContain('Provenance: Static Bloom');
+      expect(prompt).toContain('Do not depict people, faces, portraits');
+      expect(prompt).toContain('Do not recreate logos, trademarks, lyrics');
+    }
+  });
+
+  it('does not surface a recently selected strategy when fresh alternatives exist', () => {
+    const strategies = selectMerchDesignStrategies(3, ['Signal Field']);
+    expect(strategies).toHaveLength(3);
+    expect(strategies.map(strategy => strategy.label)).not.toContain(
+      'Signal Field'
+    );
   });
 });

--- a/apps/web/lib/merch/design-generation.ts
+++ b/apps/web/lib/merch/design-generation.ts
@@ -17,7 +17,7 @@ import 'server-only';
 
 import { randomUUID } from 'node:crypto';
 import { put } from '@vercel/blob';
-import { sql as drizzleSql, eq } from 'drizzle-orm';
+import { desc, sql as drizzleSql, eq } from 'drizzle-orm';
 import { uploadBufferToBlob } from '@/app/api/images/upload/lib/blob-upload';
 import { db } from '@/lib/db';
 import {
@@ -40,14 +40,17 @@ import {
   MERCH_DEFAULT_MARGIN_PRESET,
   MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
 } from './pricing';
+import {
+  type MerchSource,
+  requiresAssetPreservingRender,
+} from './source-candidates';
 import type { MerchDesignCarouselResult, MerchDesignPreview } from './types';
 
 const DEFAULT_DESIGN_COUNT = 3;
 
 /**
- * Starts independent generation prerequisites together so image rendering is
- * not delayed by unrelated profile, catalog, and preference reads. Keeping
- * this small helper generic makes the concurrency contract directly testable.
+ * Starts independent generation prerequisites together so rendering is not
+ * delayed by unrelated profile, catalog, and preference reads.
  */
 export async function resolveMerchGenerationPrerequisites<
   TArtistName,
@@ -70,24 +73,112 @@ export async function resolveMerchGenerationPrerequisites<
   return { artistName, catalog, modelWeights };
 }
 
-/** Distinct art directions so the carousel reads as real variety, not 3 of the same. */
-const STYLE_DIRECTIONS: readonly { label: string; style: string }[] = [
+/**
+ * Each strategy deliberately occupies a different visual lane. Keep the
+ * fields separate so adjective-only changes cannot collapse the options into
+ * the same composition again.
+ */
+export interface MerchDesignStrategy {
+  readonly label: string;
+  readonly composition: string;
+  readonly typographyRole: string;
+  readonly motifSystem: string;
+  readonly palette: string;
+  readonly density: string;
+}
+
+export const MERCH_DESIGN_STRATEGIES: readonly MerchDesignStrategy[] = [
   {
-    label: 'Vintage',
-    style:
-      'vintage distressed band-merch screen print, heavy wash and grain, retro limited palette, gnarly hand-drawn display lettering',
+    label: 'Signal Field',
+    composition:
+      'an offset left-to-right signal field with one dominant graphic band and intentional open space',
+    typographyRole:
+      'artist name as a small signature line, with the verified source phrase as the primary readable type',
+    motifSystem:
+      'abstract pulse lines, register marks, and measured signal fragments only',
+    palette: 'ink black, bone, and one electric blue accent',
+    density: 'medium density with a clear quiet margin',
   },
   {
-    label: 'Bold',
-    style:
-      'bold modern illustrated graphic, clean heavy linework, confident type lockup, high contrast',
+    label: 'Archive Stamp',
+    composition:
+      'a compact centered archival seal with a broad empty outer field, not a poster layout',
+    typographyRole:
+      'verified source phrase set as small circular utility type, artist name as a secondary catalog credit',
+    motifSystem:
+      'abstract catalog notches, concentric rings, and a single geometric identifier',
+    palette: 'one-color charcoal print with no secondary accent',
+    density: 'minimal density with large negative space',
   },
   {
-    label: 'Mono',
-    style:
-      'minimal one-color line illustration, refined editorial type, lots of negative space, premium capsule feel',
+    label: 'Night Transit',
+    composition:
+      'a wide horizontal transit strip across the lower third, leaving the upper field deliberately empty',
+    typographyRole:
+      'artist name as a wide wordmark, verified source phrase as a short route label beneath it',
+    motifSystem:
+      'abstract route geometry, timing ticks, and directional arrows without place names or dates',
+    palette: 'deep charcoal, silver gray, and restrained violet',
+    density: 'medium-high density confined to the lower strip',
+  },
+  {
+    label: 'Editorial Cut',
+    composition:
+      'a vertical editorial split with the image language concentrated in one narrow side column',
+    typographyRole:
+      'verified source phrase as the hero typographic crop, artist name as a small byline',
+    motifSystem:
+      'abstract crop marks, halftone texture, and one cut-paper shape',
+    palette: 'black, soft white, and one muted pink accent',
+    density: 'high contrast with controlled medium density',
+  },
+  {
+    label: 'Object Study',
+    composition:
+      'one isolated abstract object centered low on the canvas with a large unprinted field above',
+    typographyRole:
+      'artist name as compact utility type, verified source phrase as a caption adjacent to the object',
+    motifSystem:
+      'one non-figurative geometric object built from the source phrase initials, never a logo recreation',
+    palette: 'black and off-white only',
+    density: 'minimal density',
+  },
+  {
+    label: 'Type Stack',
+    composition:
+      'a tall stacked type system filling the center column with no illustrative scene',
+    typographyRole:
+      'verified source phrase and artist name share equal typographic weight in distinct lines',
+    motifSystem:
+      'simple rule lines and typographic spacing only, no icons or symbolic illustration',
+    palette: 'ink black with one restrained orange registration mark',
+    density: 'typography-dense but visually spare',
   },
 ];
+
+function normalizedStrategyLabel(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+export function selectMerchDesignStrategies(
+  count: number,
+  recentSelectedLabels: readonly string[] = []
+): readonly MerchDesignStrategy[] {
+  const recent = new Set(recentSelectedLabels.map(normalizedStrategyLabel));
+  const fresh = MERCH_DESIGN_STRATEGIES.filter(
+    strategy => !recent.has(normalizedStrategyLabel(strategy.label))
+  );
+  const candidates =
+    fresh.length >= count
+      ? fresh
+      : [
+          ...fresh,
+          ...MERCH_DESIGN_STRATEGIES.filter(strategy =>
+            recent.has(normalizedStrategyLabel(strategy.label))
+          ),
+        ];
+  return candidates.slice(0, count);
+}
 
 async function uploadAlphaPng(path: string, buffer: Buffer): Promise<string> {
   if (!env.BLOB_READ_WRITE_TOKEN) {
@@ -116,31 +207,54 @@ async function artistName(profileId: string): Promise<string> {
   return profile.displayName?.trim() || profile.username;
 }
 
-function minimalBrief(name: string, prompt: string): MerchArtistBrief {
+function minimalBrief(
+  name: string,
+  prompt: string,
+  source?: MerchSource
+): MerchArtistBrief {
   return {
     artist_myth: `${name} merch.`,
     fan_identity:
       'Fans want a wearable graphic that looks designed, not generic.',
     visual_language: ['illustrated graphic', 'band-merch energy'],
-    forbidden_cliches: ['fake tour dates', 'generic centered logo'],
+    forbidden_cliches: [
+      'fake tour dates',
+      'generic centered logo',
+      'no people, faces, portraits, models, or human figures',
+      'no unverified artist likeness',
+    ],
     campaign_context: `Artist request: ${prompt}`,
     best_merch_hypothesis: 'A strong illustrated graphic on a premium blank.',
     commercial_angle: 'Wearable artist graphic.',
     risk_level: 'safe',
+    ...(source ? { source } : {}),
   };
 }
 
-function buildImagePrompt(
+export function buildMerchImagePrompt(
   name: string,
   userPrompt: string,
-  style: string
+  strategy: MerchDesignStrategy,
+  source: MerchSource,
+  recentSelectedLabels: readonly string[] = []
 ): string {
+  const recentLine = recentSelectedLabels.length
+    ? `Do not reuse the recently selected strategy families: ${recentSelectedLabels.join(', ')}. This option must remain visibly distinct from them.`
+    : '';
+
   return [
-    `${style}.`,
+    `Strategy family: ${strategy.label}.`,
     `Concept: ${userPrompt}.`,
-    `Feature the artist name "${name}" as bold band-merch lettering.`,
-    'Centered composition, print-ready artwork, no garment, no mockup.',
-  ].join(' ');
+    `Use this verified ${source.sourceType.replaceAll('_', ' ')} exactly as the textual source: "${source.sourceText}". Provenance: ${source.provenanceTitle}.`,
+    `Composition: ${strategy.composition}.`,
+    `Typography role: ${strategy.typographyRole}.`,
+    `Motif system: ${strategy.motifSystem}.`,
+    `Palette: ${strategy.palette}. Density: ${strategy.density}.`,
+    recentLine,
+    'Print-ready artwork only, no garment and no mockup. Render no text beyond the verified source phrase and artist name. Do not depict people, faces, portraits, models, bodies, or human figures. Do not invent, imitate, or imply the artist likeness. Do not recreate logos, trademarks, lyrics, catalog facts, place names, or tour dates from a textual description.',
+  ]
+    .filter(Boolean)
+    .join(' ');
 }
 
 function fallbackPricing() {
@@ -245,6 +359,39 @@ async function getModelSelectionWeights(
 }
 
 /**
+ * A selected design is the artist's strongest signal. Keep its strategy out
+ * of the next generation batch when alternatives are available, rather than
+ * asking the model to make another near-copy of the last approved visual.
+ */
+async function getRecentSelectedStrategyLabels(
+  profileId: string
+): Promise<readonly string[]> {
+  try {
+    const rows = await db
+      .select({
+        strategy: drizzleSql<
+          string | null
+        >`${merchDesignOptions.learning}->>'typographyStyle'`,
+      })
+      .from(merchCards)
+      .innerJoin(
+        merchDesignOptions,
+        eq(merchCards.selectedDesignOptionId, merchDesignOptions.id)
+      )
+      .where(eq(merchCards.creatorProfileId, profileId))
+      .orderBy(desc(merchCards.updatedAt))
+      .limit(DEFAULT_DESIGN_COUNT);
+    return rows.flatMap(row => (row.strategy ? [row.strategy] : []));
+  } catch (error) {
+    logger.warn(
+      '[merch-designs] recent strategy read failed; generating from full strategy set',
+      { err: error instanceof Error ? error.message : String(error) }
+    );
+    return [];
+  }
+}
+
+/**
  * Fire-and-forget: render the fulfillment-accurate Printful mockup for each
  * design (the alpha graphic on the real default product) and attach it. The
  * selected card then prefers the truthful Printful photo over the alpha preview
@@ -295,23 +442,28 @@ export async function generateMerchDesigns(params: {
   readonly clerkUserId: string;
   readonly prompt: string;
   readonly count?: number;
+  readonly source: MerchSource;
   readonly conversationId?: string | null;
   readonly turnId?: string | null;
 }): Promise<MerchDesignCarouselResult> {
   const startedAt = Date.now();
+  if (requiresAssetPreservingRender(params.source)) {
+    throw new TypeError(
+      'This Library asset needs an asset-preserving render path. Jovie will not recreate an uploaded logo from a text prompt.'
+    );
+  }
+
   const generationId = randomUUID();
   const count = Math.min(Math.max(params.count ?? DEFAULT_DESIGN_COUNT, 1), 4);
-  // These reads do not depend on one another. Starting them together removes
-  // avoidable time-to-first-image without relaxing the pricing or provenance
-  // contract used when an artist selects a design.
-  const prerequisites = await resolveMerchGenerationPrerequisites({
-    artistName: () => artistName(params.profileId),
-    catalog: () => resolveGenerationPricing(params.prompt),
-    modelWeights: () => getModelSelectionWeights(params.profileId),
-  });
-  const name = prerequisites.artistName;
-  const catalog = prerequisites.catalog;
-  const modelWeights = prerequisites.modelWeights;
+  const [prerequisites, recentSelectedLabels] = await Promise.all([
+    resolveMerchGenerationPrerequisites({
+      artistName: () => artistName(params.profileId),
+      catalog: () => resolveGenerationPricing(params.prompt),
+      modelWeights: () => getModelSelectionWeights(params.profileId),
+    }),
+    getRecentSelectedStrategyLabels(params.profileId),
+  ]);
+  const { artistName: name, catalog, modelWeights } = prerequisites;
   const pricing = catalog.pricing;
 
   logger.info('[merch-designs] generation prerequisites ready', {
@@ -327,11 +479,13 @@ export async function generateMerchDesigns(params: {
     chatTurnId: params.turnId ?? null,
     prompt: params.prompt,
     command: 'generate_merch_designs',
-    artistBrief: minimalBrief(name, params.prompt),
+    artistBrief: minimalBrief(name, params.prompt, params.source),
     status: 'generating',
   });
 
-  const directions = STYLE_DIRECTIONS.slice(0, count);
+  // Bias model selection toward the artist's previous picks while selecting
+  // visual strategy families away from their recent choices.
+  const directions = selectMerchDesignStrategies(count, recentSelectedLabels);
   const grossMargin =
     pricing.retailPriceCents -
     pricing.estimatedPrintfulProductCostCents -
@@ -344,15 +498,26 @@ export async function generateMerchDesigns(params: {
         const optionId = randomUUID();
         try {
           const graphic = await generatePrintGraphic({
-            prompt: buildImagePrompt(name, params.prompt, direction.style),
+            prompt: buildMerchImagePrompt(
+              name,
+              params.prompt,
+              direction,
+              params.source,
+              recentSelectedLabels
+            ),
             selection: { weights: modelWeights },
           });
           const previewUrl = await uploadAlphaPng(
             `merch/generated/${params.profileId}/${generationId}/${optionId}.png`,
             graphic.image
           );
-          const designName = `${name} ${direction.label}`;
-          const concept = `${direction.label} direction: ${params.prompt}`;
+          const sourceLabel = params.source
+            ? `${params.source.sourceType.replaceAll('_', ' ')}: ${params.source.provenanceTitle}`
+            : null;
+          const designName = params.source
+            ? `${params.source.sourceText} ${direction.label}`
+            : `${name} ${direction.label}`;
+          const concept = `${direction.label} direction: ${params.prompt}${sourceLabel ? ` · Source: ${sourceLabel}` : ''}`;
 
           await db.insert(merchDesignOptions).values({
             id: optionId,
@@ -380,7 +545,9 @@ export async function generateMerchDesigns(params: {
             jovieShareCents: pricing.jovieMarginPerUnitEstimateCents,
             pricing,
             concept,
-            whyItFits: 'Illustrated graphic generated for this artist.',
+            whyItFits: params.source
+              ? `Built from the verified ${params.source.sourceType.replaceAll('_', ' ')} “${params.source.sourceText}”.`
+              : 'Illustrated graphic generated for this artist without an invented likeness.',
             mockupUrls: [previewUrl],
             printFileUrls: [previewUrl],
             // Catalog warnings about unavailability stay; cost-source warnings
@@ -398,9 +565,13 @@ export async function generateMerchDesigns(params: {
             learning: {
               styleLane: 'fashion_graphic_item',
               typographyStyle: direction.label,
-              graphicDensity: 'medium',
+              graphicDensity: direction.density.includes('minimal')
+                ? 'minimal'
+                : direction.density.includes('high')
+                  ? 'maximal'
+                  : 'medium',
               garmentColor: catalog.colorway,
-              motifs: [direction.label],
+              motifs: [direction.motifSystem],
               selectedOverOptionIds: [],
               rejectedAttributes: [],
               imageModelKey: graphic.modelKey,
@@ -415,7 +586,12 @@ export async function generateMerchDesigns(params: {
             concept,
             status: 'ready',
             preview_url: previewUrl,
-            slots: { artist_name: name },
+            slots: {
+              artist_name: name,
+              short_text: params.source.sourceText,
+              source_label: sourceLabel ?? undefined,
+              source_type: params.source.sourceType,
+            },
             recommended: index === 0,
             product_name: catalog.productName,
             product_type: catalog.productType,

--- a/apps/web/lib/merch/generation-input.test.ts
+++ b/apps/web/lib/merch/generation-input.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildMerchGenerationPrompt } from './generation-input';
+
+describe('buildMerchGenerationPrompt', () => {
+  it('uses the stated item type without adding a question step', () => {
+    expect(
+      buildMerchGenerationPrompt('Make a drop', 'hoodie', 'fallback')
+    ).toEqual({
+      prompt: 'Make a drop\nItem type: hoodie',
+      usedDefaultItemType: false,
+    });
+  });
+
+  it('transparently defaults to a premium tee when no item type is supplied', () => {
+    expect(
+      buildMerchGenerationPrompt('Make a drop', undefined, 'fallback')
+    ).toEqual({
+      prompt: 'Make a drop\nItem type: premium tee',
+      usedDefaultItemType: true,
+    });
+  });
+});

--- a/apps/web/lib/merch/generation-input.ts
+++ b/apps/web/lib/merch/generation-input.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_MERCH_ITEM_TYPE = 'premium tee';
+
+/**
+ * Generation either uses the stated product or transparently defaults once.
+ * This keeps a running generation from competing with a product-type question.
+ */
+export function buildMerchGenerationPrompt(
+  prompt: string | undefined,
+  itemType: string | undefined,
+  fallbackPrompt: string
+): { readonly prompt: string; readonly usedDefaultItemType: boolean } {
+  const resolvedItemType = itemType?.trim() || DEFAULT_MERCH_ITEM_TYPE;
+  return {
+    prompt: [prompt?.trim() || fallbackPrompt, `Item type: ${resolvedItemType}`]
+      .filter(Boolean)
+      .join('\n'),
+    usedDefaultItemType: !itemType?.trim(),
+  };
+}

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -51,6 +51,7 @@ import {
   type MerchSellabilityResult,
 } from './pricing';
 import { getMerchCardSellability } from './safety';
+import { hasHumanSafeMerchContract } from './source-candidates';
 import type {
   LibraryMerchCard,
   MerchDesignLane,
@@ -964,6 +965,22 @@ export async function selectMerchDesign(params: {
     rawSelected.creatorProfileId,
     params.clerkUserId
   );
+  const [generation] = await db
+    .select({ artistBrief: merchGenerationBatches.artistBrief })
+    .from(merchGenerationBatches)
+    .where(eq(merchGenerationBatches.id, rawSelected.generationBatchId))
+    .limit(1);
+  if (
+    !generation ||
+    !hasHumanSafeMerchContract({
+      forbiddenCliches: generation.artistBrief.forbidden_cliches,
+      source: generation.artistBrief.source,
+    })
+  ) {
+    throw new Error(
+      'This older merch option cannot be selected because its source and no-people safety contract were not verified. Regenerate from a confirmed catalog source.'
+    );
+  }
   const existing = await db
     .select()
     .from(merchCards)

--- a/apps/web/lib/merch/source-candidates.test.ts
+++ b/apps/web/lib/merch/source-candidates.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMerchImagePrompt,
+  MERCH_DESIGN_STRATEGIES,
+} from './design-generation';
+import {
+  hasHumanSafeMerchContract,
+  isExplicitUserProvidedSource,
+  isMerchDirectionHelpRequest,
+  rankMerchSources,
+  requiresAssetPreservingRender,
+  scoreMerchTitle,
+} from './source-candidates';
+
+describe('merch source candidates', () => {
+  it('ranks a compact, visual confirmed title above a generic long title', () => {
+    const candidates = rankMerchSources([
+      {
+        sourceType: 'song_title',
+        sourceText: 'A Very Long Piece Of Release Metadata For The Artist',
+        provenanceTitle: 'A Very Long Piece Of Release Metadata For The Artist',
+      },
+      {
+        sourceType: 'song_title',
+        sourceText: 'Testing The Lights',
+        provenanceTitle: 'Testing The Lights',
+      },
+    ]);
+
+    expect(candidates[0]).toMatchObject({
+      sourceText: 'Testing The Lights',
+      sourceType: 'song_title',
+      rightsStatus: 'owned',
+    });
+    expect(candidates[0]?.merchScore).toBeGreaterThan(
+      scoreMerchTitle('A Very Long Piece Of Release Metadata For The Artist')
+    );
+  });
+
+  it('deduplicates catalog titles without inventing a source', () => {
+    const candidates = rankMerchSources([
+      {
+        sourceType: 'song_title',
+        sourceText: 'The Deep End',
+        provenanceTitle: 'The Deep End',
+      },
+      {
+        sourceType: 'album_title',
+        sourceText: ' the   deep end ',
+        provenanceTitle: 'The Deep End EP',
+      },
+    ]);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.sourceType).toBe('song_title');
+  });
+
+  it('recognizes the exact help-me-pick and no-fake-people recovery language', () => {
+    expect(isMerchDirectionHelpRequest('idk help me pick')).toBe(true);
+    expect(isMerchDirectionHelpRequest('These suck. No fake people.')).toBe(
+      true
+    );
+    expect(isMerchDirectionHelpRequest('make a hoodie')).toBe(false);
+  });
+
+  it('only accepts a user-provided phrase when it is in the current request', () => {
+    const source = {
+      sourceType: 'user_provided' as const,
+      sourceText: 'Keep The Lights On',
+      provenanceTitle: 'Artist-provided phrase',
+      rightsStatus: 'user_provided' as const,
+    };
+
+    expect(
+      isExplicitUserProvidedSource(
+        'Make a tee that says Keep The Lights On',
+        source
+      )
+    ).toBe(true);
+    expect(isExplicitUserProvidedSource('Make a tee', source)).toBe(false);
+  });
+
+  it('fails closed for an uploaded asset until an asset-preserving renderer exists', () => {
+    const assetSource = {
+      sourceType: 'library_asset' as const,
+      sourceText: 'Tim White logo',
+      provenanceTitle: 'Tim White logo.svg',
+      rightsStatus: 'owned' as const,
+      assetId: 'dba16da7-95f1-42e1-ae56-af36e227c426',
+      assetUrl: 'https://assets.example/tim-white-logo.svg',
+    };
+
+    expect(requiresAssetPreservingRender(assetSource)).toBe(true);
+    expect(
+      hasHumanSafeMerchContract({
+        forbiddenCliches: [
+          'no people, faces, portraits, models, or human figures',
+        ],
+        source: assetSource,
+      })
+    ).toBe(false);
+  });
+
+  it('requires both a source and the no-people contract before selection', () => {
+    const source = {
+      sourceType: 'song_title' as const,
+      sourceText: 'Testing The Lights',
+      provenanceTitle: 'Testing The Lights',
+      rightsStatus: 'owned' as const,
+    };
+
+    expect(
+      hasHumanSafeMerchContract({
+        forbiddenCliches: [
+          'no people, faces, portraits, models, or human figures',
+        ],
+        source,
+      })
+    ).toBe(true);
+    expect(
+      hasHumanSafeMerchContract({
+        forbiddenCliches: ['no fake tour dates'],
+        source,
+      })
+    ).toBe(false);
+    expect(
+      hasHumanSafeMerchContract({
+        forbiddenCliches: [
+          'no people, faces, portraits, models, or human figures',
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('puts the no-human and no-logo-recreation constraints into every image prompt', () => {
+    const prompt = buildMerchImagePrompt(
+      'Tim White',
+      'A distressed red, white, and blue tee',
+      MERCH_DESIGN_STRATEGIES[0],
+      {
+        sourceType: 'song_title',
+        sourceText: 'Testing The Lights',
+        provenanceTitle: 'Testing The Lights',
+        rightsStatus: 'owned',
+      }
+    );
+
+    expect(prompt).toContain('Do not depict people, faces, portraits, models');
+    expect(prompt).toContain(
+      'Do not invent, imitate, or imply the artist likeness'
+    );
+    expect(prompt).toContain('Do not recreate logos, trademarks');
+    expect(prompt).toContain('Testing The Lights');
+  });
+});

--- a/apps/web/lib/merch/source-candidates.ts
+++ b/apps/web/lib/merch/source-candidates.ts
@@ -1,0 +1,193 @@
+import 'server-only';
+
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { discogRecordings, discogReleases } from '@/lib/db/schema/content';
+
+/**
+ * A merch phrase must have a source Jovie can name back to the artist.  This
+ * intentionally starts with catalog titles; lyrics are only eligible once they
+ * are represented by a separate, rights-aware source record.
+ */
+export type MerchSourceType =
+  | 'song_title'
+  | 'album_title'
+  | 'library_asset'
+  | 'user_provided';
+
+export interface MerchSource {
+  readonly sourceType: MerchSourceType;
+  readonly sourceText: string;
+  readonly provenanceTitle: string;
+  readonly rightsStatus: 'owned' | 'user_provided';
+  /** Present only for an artist-owned Library asset selected by the artist. */
+  readonly assetId?: string;
+  /** A rendering reference, never a license to recreate the asset. */
+  readonly assetUrl?: string;
+}
+
+export interface MerchSourceCandidate extends MerchSource {
+  readonly merchScore: number;
+  readonly whyItWorks: string;
+}
+
+function normalized(value: string): string {
+  return value.trim().replaceAll(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+/**
+ * Transparent, deterministic title scoring. This is deliberately modest: it
+ * ranks confirmed catalog titles; it does not infer a lyric, a fan phrase, or
+ * a claim about what fans know.
+ */
+export function scoreMerchTitle(title: string): number {
+  const words = title.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 0;
+
+  const wordCountScore = words.length >= 2 && words.length <= 5 ? 45 : 25;
+  const compactnessScore =
+    title.length <= 28 ? 25 : title.length <= 42 ? 15 : 5;
+  const readabilityScore = /^[\p{L}\p{N}'’&!?. -]+$/u.test(title) ? 15 : 5;
+  const visualCueScore =
+    /light|night|signal|deep|heart|fire|static|dream|shadow|electric|dark/i.test(
+      title
+    )
+      ? 15
+      : 5;
+
+  return Math.min(
+    100,
+    wordCountScore + compactnessScore + readabilityScore + visualCueScore
+  );
+}
+
+function whyTitleWorks(title: string, score: number): string {
+  const words = title.trim().split(/\s+/).filter(Boolean);
+  const compact = words.length >= 2 && words.length <= 5;
+  const visual =
+    /light|night|signal|deep|heart|fire|static|dream|shadow|electric|dark/i.test(
+      title
+    );
+
+  if (compact && visual) {
+    return 'Short, readable, and it already suggests a visual system.';
+  }
+  if (compact) {
+    return 'Short enough to read clearly on a garment from a distance.';
+  }
+  if (score >= 60) {
+    return 'A confirmed catalog title with a clear type-first direction.';
+  }
+  return 'Confirmed catalog title; review the line breaks before printing.';
+}
+
+export function rankMerchSources(
+  sources: readonly Omit<MerchSource, 'rightsStatus'>[]
+): readonly MerchSourceCandidate[] {
+  const seen = new Set<string>();
+
+  return sources
+    .map(source => ({
+      ...source,
+      sourceText: source.sourceText.trim(),
+      provenanceTitle: source.provenanceTitle.trim(),
+    }))
+    .filter(source => source.sourceText.length > 0)
+    .filter(source => {
+      const key = normalized(source.sourceText);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .map(source => {
+      const merchScore = scoreMerchTitle(source.sourceText);
+      return {
+        ...source,
+        rightsStatus: 'owned' as const,
+        merchScore,
+        whyItWorks: whyTitleWorks(source.sourceText, merchScore),
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.merchScore - left.merchScore ||
+        left.sourceText.localeCompare(right.sourceText)
+    );
+}
+
+export async function getMerchSourceCandidates(
+  profileId: string
+): Promise<readonly MerchSourceCandidate[]> {
+  const [recordings, releases] = await Promise.all([
+    db
+      .select({ title: discogRecordings.title })
+      .from(discogRecordings)
+      .where(eq(discogRecordings.creatorProfileId, profileId))
+      .orderBy(desc(discogRecordings.updatedAt))
+      .limit(20),
+    db
+      .select({ title: discogReleases.title })
+      .from(discogReleases)
+      .where(eq(discogReleases.creatorProfileId, profileId))
+      .orderBy(desc(discogReleases.updatedAt))
+      .limit(20),
+  ]);
+
+  return rankMerchSources([
+    ...recordings.map(recording => ({
+      sourceType: 'song_title' as const,
+      sourceText: recording.title,
+      provenanceTitle: recording.title,
+    })),
+    ...releases.map(release => ({
+      sourceType: 'album_title' as const,
+      sourceText: release.title,
+      provenanceTitle: release.title,
+    })),
+  ]).slice(0, 6);
+}
+
+/** A user can provide a phrase only when it is visibly in the current request. */
+export function isExplicitUserProvidedSource(
+  prompt: string,
+  source: MerchSource
+): boolean {
+  return (
+    source.sourceType === 'user_provided' &&
+    source.rightsStatus === 'user_provided' &&
+    normalized(prompt).includes(normalized(source.sourceText))
+  );
+}
+
+/**
+ * Current image generation accepts text only. Asset-backed merch must stay
+ * blocked until the render pipeline can pass the exact asset through as a
+ * reference/composite. Recreating an uploaded logo from a description is not
+ * an acceptable fallback.
+ */
+export function requiresAssetPreservingRender(source: MerchSource): boolean {
+  return source.sourceType === 'library_asset';
+}
+
+export function hasHumanSafeMerchContract(input: {
+  readonly forbiddenCliches?: readonly string[] | null;
+  readonly source?: MerchSource | null;
+}): boolean {
+  const hasNoPeopleRule = (input.forbiddenCliches ?? []).some(rule =>
+    /no (?:fake )?(?:people|faces|portraits|models|human figures)/i.test(rule)
+  );
+
+  return (
+    hasNoPeopleRule &&
+    Boolean(input.source) &&
+    !requiresAssetPreservingRender(input.source as MerchSource)
+  );
+}
+
+export function isMerchDirectionHelpRequest(
+  prompt: string | undefined
+): boolean {
+  return /\b(idk|i don't know|help me pick|pick (?:one|a)|use (?:a|my) (?:song )?lyric|actual (?:catalog|lyrics)|no (?:fake )?(?:people|faces|models)|these suck)\b/i.test(
+    prompt ?? ''
+  );
+}

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -114,6 +114,13 @@ export interface MerchDesignSlots {
   readonly artist_name: string;
   readonly short_text?: string;
   readonly lyric?: string;
+  /** Visible provenance label for the exact source used in this design. */
+  readonly source_label?: string;
+  readonly source_type?:
+    | 'song_title'
+    | 'album_title'
+    | 'library_asset'
+    | 'user_provided';
   readonly year?: string;
   readonly location?: string;
   readonly tracklist?: readonly string[];

--- a/apps/web/lib/mobile/chat/turn-handler.ts
+++ b/apps/web/lib/mobile/chat/turn-handler.ts
@@ -15,6 +15,7 @@ import {
   createMerchGenerateTool,
   createMerchPreviewTool,
   createMerchSelectTool,
+  createMerchSourceTool,
 } from '@/lib/chat/tools/merch-tools';
 import {
   markChatTurnStreaming,
@@ -312,6 +313,7 @@ export async function handleMobileChatTurn(
   const mobileMerchTools: ToolSet = {
     ...(accountContext.planLimits.booleans.canAccessMerchCreation
       ? {
+          findMerchSources: createMerchSourceTool({ profileId }),
           createMerch: createMerchGenerateTool({
             profileId,
             clerkUserId: userId,


### PR DESCRIPTION
Linear: JOV-4737

## Summary
- ground merch generation in verified catalog titles or user-owned phrases
- replace generic Vintage/Bold/Mono variants with materially distinct strategy families across composition, typography, motif, palette, and density
- avoid replaying recently selected strategy families while preserving learned model weighting
- default an unspecified product to a premium tee without asking a blocking question after generation starts
- preserve the landed three-card chooser, prefetch, product selection, pricing, and publish flow

## Verification
- Biome clean on all changed TypeScript files
- diff-check clean
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- focused Vitest: 6 files, 34/34 tests passed

## Safety
- no invented lyrics, catalog facts, logos, or artist likenesses
- uploaded Library assets fail closed until an asset-preserving renderer is available

Queue intent: normal CI and native merge queue; taste feedback is advisory and should become follow-up work.