### PR TITLE
fix(chat): place model switch notice in thread [JOV-4758]

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -106,7 +106,6 @@ export function JovieChat({
     hasMessages,
     isLoadingConversation,
     conversationTitle,
-    modelRotationNotice,
     status,
     activeConversationId,
     inputRef,
@@ -633,35 +632,21 @@ export function JovieChat({
   } as const;
 
   const composerSurface = (
-    <>
-      {/* 👎 recovery loop (JOV-3362 / #11461): quiet status line while the
-          conversation is rotated onto a fallback model. aria-live so screen
-          readers hear the switch; auto-clears after 3 clean turns. */}
-      {modelRotationNotice ? (
-        <p
-          aria-live='polite'
-          data-testid='chat-model-rotation-notice'
-          className='mb-1.5 px-1 text-xs text-secondary-token'
-        >
-          {modelRotationNotice}
-        </p>
-      ) : null}
-      <ChatComposerSurface
-        chatInputProps={chatInputProps}
-        showThreadView={showThreadView}
-        isRateLimited={isRateLimited}
-        showManifest={showManifest}
-        manifestCollapsed={manifestCollapsed}
-        showChips={showChips}
-        pendingFiles={pendingFiles}
-        aggregate={aggregate}
-        isUploading={isUploading}
-        isPro={isProUser}
-        onRemoveFile={removeFile}
-        onCollapseManifest={() => setManifestCollapsed(true)}
-        onExpandManifest={() => setManifestCollapsed(false)}
-      />
-    </>
+    <ChatComposerSurface
+      chatInputProps={chatInputProps}
+      showThreadView={showThreadView}
+      isRateLimited={isRateLimited}
+      showManifest={showManifest}
+      manifestCollapsed={manifestCollapsed}
+      showChips={showChips}
+      pendingFiles={pendingFiles}
+      aggregate={aggregate}
+      isUploading={isUploading}
+      isPro={isProUser}
+      onRemoveFile={removeFile}
+      onCollapseManifest={() => setManifestCollapsed(true)}
+      onExpandManifest={() => setManifestCollapsed(false)}
+    />
   );
 
   const inlineChatError =

--- a/apps/web/components/jovie/JovieChatSections.tsx
+++ b/apps/web/components/jovie/JovieChatSections.tsx
@@ -152,6 +152,7 @@ interface ChatThreadMessage {
   readonly status?: string;
   readonly parts: MessagePart[];
   readonly toolStepCapExhausted?: boolean;
+  readonly modelRotationNotice?: string;
   /** Persisted chat turn id — enables 👍/👎 model attribution (JOV #11460). */
   readonly turnId?: string;
 }
@@ -196,6 +197,33 @@ export function ChatThreadMessages({
   onScrollToBottom,
   conversationId,
 }: ChatThreadMessagesProps) {
+  const renderMessage = (message: ChatThreadMessage, index: number) => {
+    const isThinking =
+      message.role === 'assistant' && message.status === 'pending';
+
+    return (
+      <div key={message.id} className='pb-4'>
+        {message.modelRotationNotice ? (
+          <ChatModelRotationMetadata notice={message.modelRotationNotice} />
+        ) : null}
+        <ChatMessage
+          id={message.id}
+          role={message.role}
+          parts={message.parts}
+          isStreaming={isStreaming && index === lastAssistantIndex}
+          isThinking={isThinking}
+          avatarUrl={message.role === 'user' ? avatarUrl : undefined}
+          profileId={profileId}
+          skipEntrance={knownMessageIds.has(message.id)}
+          toolStepCapExhausted={message.toolStepCapExhausted}
+          turnId={message.turnId}
+          conversationId={conversationId ?? undefined}
+          enableFeedback
+        />
+      </div>
+    );
+  };
+
   return (
     <div>
       {shouldVirtualizeMessages ? (
@@ -211,8 +239,6 @@ export function ChatThreadMessages({
           {virtualizer.getVirtualItems().map(virtualItem => {
             const message = messages[virtualItem.index];
             const index = virtualItem.index;
-            const isThinking =
-              message.role === 'assistant' && message.status === 'pending';
             return (
               <div
                 key={message.id}
@@ -226,22 +252,7 @@ export function ChatThreadMessages({
                   transform: `translateY(${virtualItem.start}px)`,
                 }}
               >
-                <div className='pb-4'>
-                  <ChatMessage
-                    id={message.id}
-                    role={message.role}
-                    parts={message.parts}
-                    isStreaming={isStreaming && index === lastAssistantIndex}
-                    isThinking={isThinking}
-                    avatarUrl={message.role === 'user' ? avatarUrl : undefined}
-                    profileId={profileId}
-                    skipEntrance={knownMessageIds.has(message.id)}
-                    toolStepCapExhausted={message.toolStepCapExhausted}
-                    turnId={message.turnId}
-                    conversationId={conversationId ?? undefined}
-                    enableFeedback
-                  />
-                </div>
+                {renderMessage(message, index)}
               </div>
             );
           })}
@@ -254,28 +265,7 @@ export function ChatThreadMessages({
             paddingBottom: messageViewportPaddingBottom,
           }}
         >
-          {messages.map((message, index) => {
-            const isThinking =
-              message.role === 'assistant' && message.status === 'pending';
-            return (
-              <div key={message.id} className='pb-4'>
-                <ChatMessage
-                  id={message.id}
-                  role={message.role}
-                  parts={message.parts}
-                  isStreaming={isStreaming && index === lastAssistantIndex}
-                  isThinking={isThinking}
-                  avatarUrl={message.role === 'user' ? avatarUrl : undefined}
-                  profileId={profileId}
-                  skipEntrance={knownMessageIds.has(message.id)}
-                  toolStepCapExhausted={message.toolStepCapExhausted}
-                  turnId={message.turnId}
-                  conversationId={conversationId ?? undefined}
-                  enableFeedback
-                />
-              </div>
-            );
-          })}
+          {messages.map((message, index) => renderMessage(message, index))}
         </div>
       )}
 
@@ -290,6 +280,20 @@ export function ChatThreadMessages({
 
       <ScrollToBottom visible={!isStuckToBottom} onClick={onScrollToBottom} />
     </div>
+  );
+}
+
+function ChatModelRotationMetadata({ notice }: { readonly notice: string }) {
+  return (
+    <p
+      role='status'
+      aria-live='polite'
+      aria-atomic='true'
+      data-testid='chat-model-rotation-notice'
+      className='pb-2 text-center text-xs text-tertiary-token'
+    >
+      {notice}
+    </p>
   );
 }
 

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -5,14 +5,7 @@ import { useAsyncRateLimiter } from '@tanstack/react-pacer';
 import { useQueryClient } from '@tanstack/react-query';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import { useRouter } from 'next/navigation';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { track } from '@/lib/analytics';
 import { matchCommand } from '@/lib/chat/command-registry';
 import {
@@ -21,10 +14,9 @@ import {
   saveComposerDraft,
 } from '@/lib/chat/composer-draft-store';
 import {
-  modelRotationNoticeForStep,
+  consumeModelRotationNotice,
   readModelRotationStep,
   recordAssistantTurnClean,
-  subscribeModelRotation,
 } from '@/lib/chat/model-rotation-store';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';
 import { trimMessagesForChatRequest } from '@/lib/chat/request-validation';
@@ -836,20 +828,6 @@ export function useJovieChat({
   const isLoading = status === 'streaming' || status === 'submitted';
   const hasMessages = messages.length > 0;
 
-  // Reactive view of the 👎 model-rotation state (JOV-3362 / #11461). The
-  // store mutates from ChatFeedbackControl (a different component), so the
-  // hook subscribes rather than reading module state during render only.
-  const rotationSnapshot = useCallback(
-    () => readModelRotationStep(activeConversationId),
-    [activeConversationId]
-  );
-  const modelRotationStep = useSyncExternalStore(
-    subscribeModelRotation,
-    rotationSnapshot,
-    () => 0
-  );
-  const modelRotationNotice = modelRotationNoticeForStep(modelRotationStep);
-
   useEffect(() => {
     if (status !== 'ready') return;
     queryClient.invalidateQueries({
@@ -1023,6 +1001,10 @@ export function useJovieChat({
       // client only transmits an integer step; the server resolves + clamps
       // the actual model from its own vetted chain.
       const modelRotationStep = readModelRotationStep(activeConversationId);
+      const modelRotationNotice = consumeModelRotationNotice(
+        activeConversationId,
+        modelRotationStep
+      );
 
       const sendOptions = {
         body: {
@@ -1039,6 +1021,7 @@ export function useJovieChat({
         clientTurnId,
         clientMessageId: `${clientTurnId}:user`,
         requestId: clientTurnId,
+        ...(modelRotationNotice ? { modelRotationNotice } : {}),
         parts: [
           { type: 'text' as const, text: trimmedText },
           ...(files ?? []),
@@ -1234,8 +1217,6 @@ export function useJovieChat({
     activeConversationId,
     /** Auto-generated or user-set conversation title (null if not yet generated) */
     conversationTitle,
-    /** Quiet status line while the conversation is rotated off the default model (👎 recovery). */
-    modelRotationNotice,
     // Refs
     inputRef,
     // Handlers

--- a/apps/web/components/jovie/timeline/chat-timeline.ts
+++ b/apps/web/components/jovie/timeline/chat-timeline.ts
@@ -23,6 +23,8 @@ export interface ChatTimelineMessage {
   readonly serverMessageId?: string;
   readonly failedReason?: string;
   readonly toolStepCapExhausted?: boolean;
+  /** Quiet system metadata shown immediately before a rotated user turn. */
+  readonly modelRotationNotice?: string;
   readonly updatedAt: number;
   readonly completedAt?: number;
   readonly streamRevision: number;
@@ -100,6 +102,7 @@ export type ChatTimelineEvent =
       readonly type: 'message.send.started';
       readonly clientTurnId: string;
       readonly clientMessageId: string;
+      readonly modelRotationNotice?: string;
       readonly parts: MessagePart[];
     })
   | (BaseEvent & {
@@ -269,6 +272,7 @@ function appendSendStarted(
         clientTurnId: event.clientTurnId,
         clientMessageId: event.clientMessageId,
         requestId: event.requestId ?? undefined,
+        modelRotationNotice: event.modelRotationNotice,
         updatedAt: now,
         streamRevision: 0,
         source: 'local',

--- a/apps/web/lib/chat/model-rotation-store.test.ts
+++ b/apps/web/lib/chat/model-rotation-store.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/constants/ai-models';
 import {
   AUTO_REVERT_CLEAN_STREAK,
+  consumeModelRotationNotice,
   friendlyModelLabel,
   modelRotationNoticeForStep,
   readModelRotationStep,
@@ -100,8 +101,24 @@ describe('model-rotation-store', () => {
   it('modelRotationNoticeForStep is null at step 0 and names the rotated model above it', () => {
     expect(modelRotationNoticeForStep(0)).toBeNull();
     const notice = modelRotationNoticeForStep(1);
-    expect(notice).toContain('Switched to');
+    expect(notice).toContain('Now using');
     expect(notice).toContain(friendlyModelLabel(resolveRotatedChatModel(1)));
+  });
+
+  it('announces a rotated model once, including when the request is retried', () => {
+    recordThumbsDownRotation(CONVO);
+    const step = readModelRotationStep(CONVO);
+    expect(consumeModelRotationNotice(CONVO, step)).toContain('Now using');
+    expect(consumeModelRotationNotice(CONVO, step)).toBeNull();
+  });
+
+  it('does not re-announce when another thumbs-down is clamped to the same model', () => {
+    recordThumbsDownRotation(CONVO);
+    const step = readModelRotationStep(CONVO);
+    expect(consumeModelRotationNotice(CONVO, step)).not.toBeNull();
+    recordThumbsDownRotation(CONVO);
+    expect(readModelRotationStep(CONVO)).toBe(step);
+    expect(consumeModelRotationNotice(CONVO, step)).toBeNull();
   });
 
   it('friendlyModelLabel produces a human-readable name', () => {

--- a/apps/web/lib/chat/model-rotation-store.ts
+++ b/apps/web/lib/chat/model-rotation-store.ts
@@ -36,6 +36,8 @@ interface RotationState {
 }
 
 const rotationByConversationId = new Map<string, RotationState>();
+/** Rotation steps already surfaced in the transcript for this session. */
+const announcedRotationStepByConversationId = new Map<string, number>();
 const listeners = new Set<() => void>();
 
 function rotationKey(conversationId: string | null | undefined): string {
@@ -57,12 +59,14 @@ function pruneRotationCache(): void {
     const oldestKey = rotationByConversationId.keys().next().value;
     if (!oldestKey) break;
     rotationByConversationId.delete(oldestKey);
+    announcedRotationStepByConversationId.delete(oldestKey);
   }
 }
 
 function writeState(key: string, state: RotationState): void {
   if (state.step <= 0) {
     rotationByConversationId.delete(key);
+    announcedRotationStepByConversationId.delete(key);
   } else {
     rotationByConversationId.set(key, state);
     pruneRotationCache();
@@ -86,8 +90,12 @@ export function recordThumbsDownRotation(
 ): void {
   const key = rotationKey(conversationId);
   const current = rotationByConversationId.get(key);
+  const nextStep = Math.min((current?.step ?? 0) + 1, MAX_ROTATION_STEP);
+  if (nextStep !== current?.step) {
+    announcedRotationStepByConversationId.delete(key);
+  }
   writeState(key, {
-    step: Math.min((current?.step ?? 0) + 1, MAX_ROTATION_STEP),
+    step: nextStep,
     cleanStreak: 0,
   });
 }
@@ -103,6 +111,7 @@ export function undoThumbsDownRotation(
   const key = rotationKey(conversationId);
   const current = rotationByConversationId.get(key);
   if (!current) return;
+  announcedRotationStepByConversationId.delete(key);
   writeState(key, {
     step: Math.max(current.step - 1, 0),
     cleanStreak: current.cleanStreak,
@@ -156,11 +165,30 @@ export function friendlyModelLabel(modelId: string): string {
 export function modelRotationNoticeForStep(step: number): string | null {
   if (step <= 0) return null;
   const model = resolveRotatedChatModel(step);
-  return `Switched to ${friendlyModelLabel(model)} for better quality`;
+  return `Now using ${friendlyModelLabel(model)}`;
+}
+
+/**
+ * Return the transcript metadata for a rotated send once per active rotation.
+ * A failed request can be retried, but the transcript should not repeat the
+ * same switch notice on every attempt.
+ */
+export function consumeModelRotationNotice(
+  conversationId: string | null | undefined,
+  step: number
+): string | null {
+  if (step <= 0) return null;
+  const key = rotationKey(conversationId);
+  if (announcedRotationStepByConversationId.get(key) === step) return null;
+  const notice = modelRotationNoticeForStep(step);
+  if (!notice) return null;
+  announcedRotationStepByConversationId.set(key, step);
+  return notice;
 }
 
 /** Test helper — reset module state between unit tests. */
 export function resetModelRotationStoreForTests(): void {
   rotationByConversationId.clear();
+  announcedRotationStepByConversationId.clear();
   listeners.clear();
 }

--- a/apps/web/tests/unit/chat/chat-timeline-reducer.test.ts
+++ b/apps/web/tests/unit/chat/chat-timeline-reducer.test.ts
@@ -36,6 +36,23 @@ describe('chat timeline reducer', () => {
     ]);
   });
 
+  it('anchors model rotation metadata to the rotated user turn', () => {
+    const state = reduceChatTimeline(createInitialChatTimelineState(), {
+      type: 'message.send.started',
+      conversationId: 'conv_1',
+      clientTurnId: 'turn_client_1',
+      clientMessageId: 'turn_client_1:user',
+      modelRotationNotice: 'Now using Gemini 2.5 Pro',
+      parts: [textPart('Try again')],
+      now: 100,
+    });
+
+    expect(selectRenderableMessages(state)[0]).toMatchObject({
+      role: 'user',
+      modelRotationNotice: 'Now using Gemini 2.5 Pro',
+    });
+  });
+
   it('reconciles server acknowledgement without changing render keys', () => {
     const sending = reduceChatTimeline(createInitialChatTimelineState(), {
       type: 'message.send.started',


### PR DESCRIPTION
## Summary
- replace the persistent composer-adjacent model rotation notice with neutral in-thread metadata at the rotated send boundary
- show only the friendly model label and keep the composer geometry unchanged
- deduplicate retries and clamped rotations while preserving the existing routing mechanics
- announce the metadata politely to assistive technology

## Bug-to-Test
bug-to-test: not applicable

## Test Coverage
- 28 focused model-rotation and timeline reducer tests passed
- normal hooked gate passed all eight Vitest shards
- full web typecheck passed
- Biome checked 7,477 web files with no fixes required

## Pre-Landing Review
No issues found after fixing the clamped-chain duplicate edge case before commit.

## Design Review
Lite review clean: quiet borderless metadata, semantic tokens, no focus steal or composer layout shift.

## Linear follow-ups
None.

## Test plan
- [x] Rotation notice copy is neutral and uses a friendly model label
- [x] Notice is anchored to the rotated transcript turn
- [x] Retry and clamped-step duplicates are suppressed
- [x] Full web typecheck and Biome pass