### PR TITLE
fix(shell): align dashboard header workspace seam

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -132,12 +132,6 @@ export function DashboardHeader({
           className='flex min-w-0 flex-1 items-center gap-2 tracking-[-0.012em]'
           data-search-active={isSearchActive ? 'true' : 'false'}
         >
-          <div
-            className='flex h-7 w-7 shrink-0 items-center justify-center'
-            data-testid='dashboard-header-rail-slot'
-          >
-            {railToggle}
-          </div>
           {commandPaletteHeader ? (
             <div
               className='flex h-full min-w-0 flex-1 items-center'
@@ -158,6 +152,15 @@ export function DashboardHeader({
               {searchSurface}
             </div>
           ) : null}
+          {/* Keep the workspace title on the canonical left seam. The shared
+              rail slot stays mounted at a fixed width, but follows title/search
+              content so opening search or a rail never shifts the title. */}
+          <div
+            className='flex h-7 w-7 shrink-0 items-center justify-center'
+            data-testid='dashboard-header-rail-slot'
+          >
+            {railToggle}
+          </div>
         </div>
         {action ? (
           <div

--- a/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
+++ b/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
@@ -43,4 +43,15 @@ describe('workspace page optical seam contract', () => {
     expect(librarySurface.match(/alignment\.workspaceSeamX/g)).toHaveLength(2);
     expect(librarySurface).not.toContain('pl-2.5');
   });
+
+  it('keeps the dashboard title before the reserved rail control so it starts on the workspace seam', () => {
+    const header = read(
+      'components/features/dashboard/organisms/DashboardHeader.tsx'
+    );
+    const titleOrCommand = header.indexOf('commandPaletteHeader ?');
+    const railSlot = header.indexOf("data-testid='dashboard-header-rail-slot'");
+
+    expect(titleOrCommand).toBeGreaterThan(-1);
+    expect(railSlot).toBeGreaterThan(titleOrCommand);
+  });
 });

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -182,7 +182,7 @@ describe('DashboardHeader', () => {
     ).toBeInTheDocument();
   });
 
-  it('reserves the mirrored rail-toggle slot beside the breadcrumb through search activation', () => {
+  it('keeps the breadcrumb on the workspace seam while reserving the mirrored rail-toggle slot through search activation', () => {
     const { container, rerender } = render(
       <DashboardHeader
         breadcrumbs={[{ label: 'Library', href: '/app/library' }]}
@@ -196,7 +196,7 @@ describe('DashboardHeader', () => {
     expect(slot).toContainElement(
       screen.getByRole('button', { name: 'Show artist profile' })
     );
-    expect(slot.compareDocumentPosition(screen.getByRole('heading'))).toBe(
+    expect(screen.getByRole('heading').compareDocumentPosition(slot)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
 


### PR DESCRIPTION
## Summary
- Keep DashboardHeader title and breadcrumb content on the canonical workspace left seam.
- Preserve the fixed accessible right-rail control slot after title/search so search and rail state do not shift header geometry.
- Lock the source and rendered header ordering with focused regression coverage.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/DashboardHeader.test.tsx tests/unit/app/workspace-page-seam-contract.test.ts --maxWorkers 1` (22/22)
- `pnpm component-ship-gate`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check ...`
- `git diff --check`

Linear: JOV-4759