### PR TITLE
fix(connections): reveal platform colors on selection

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -93,7 +93,7 @@ describe('ProfilesWorkspace', () => {
     ).toHaveAttribute('href', '/app/settings/artist-profile');
   });
 
-  it('uses the canonical mark state contract and a compact URL display', () => {
+  it('uses the canonical mark state contract and a compact URL display', async () => {
     renderWorkspace(data);
 
     const url = screen.getByTitle('https://open.spotify.com/artist/tim');
@@ -107,6 +107,19 @@ describe('ProfilesWorkspace', () => {
     expect(
       mark.querySelector('.group-focus-visible\\/connection-row\\:opacity-100')
     ).not.toBeNull();
+    expect(mark.querySelector('.opacity-0')).not.toBeNull();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Spotify' })
+    );
+    await user.click(screen.getByRole('menuitem', { name: /View Details/i }));
+
+    const selectedReveal = screen
+      .getByRole('img', { name: 'Spotify' })
+      .querySelector('span[aria-hidden="true"]');
+    expect(selectedReveal).toHaveClass('opacity-100');
+    expect(selectedReveal).not.toHaveClass('opacity-0');
+    expect(selectedReveal).toHaveStyle({ color: '#1DB954' });
   });
 
   it('renders a connection summary and filters without exposing locked ranks', async () => {

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -151,22 +151,23 @@ function ConnectionBrandIcon({
   const metadata = getPlatformIconMetadata(row.platform);
   if (!metadata) {
     return (
-      <ConnectionTypeGlyph
-        row={row}
-        className={cn('text-tertiary-token', className)}
-      />
+      <span
+        className={cn('inline-flex shrink-0 text-tertiary-token', className)}
+        aria-label={row.label}
+        role='img'
+      >
+        <SocialIcon platform={row.platform} className='h-full w-full' />
+      </span>
     );
   }
 
-  const iconClassName = cn('h-4 w-4', className);
-  const revealClassName = cn(
-    'absolute inset-0 opacity-0 transition-opacity duration-fast motion-reduce:transition-none',
-    'group-hover/connection-row:opacity-100 group-focus-visible/connection-row:opacity-100',
-    emphasized && 'opacity-100'
-  );
+  const revealClassName = emphasized
+    ? 'absolute inset-0 opacity-100'
+    : 'absolute inset-0 opacity-0 transition-opacity duration-fast motion-reduce:transition-none group-hover/connection-row:opacity-100 group-focus-visible/connection-row:opacity-100';
+
   return (
     <span
-      className={cn('relative inline-flex shrink-0', iconClassName)}
+      className={cn('relative inline-flex h-4 w-4 shrink-0', className)}
       aria-label={row.label}
       role='img'
     >


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4761 -->

## Summary
- promote the Connections official-platform color state into shared `PlatformBrandMark`
- reveal canonical brand color on hover, keyboard focus, and selected rows without competing opacity utilities
- retain neutral fallback marks and compact host-plus-path URL display

## Verification
- `pnpm --filter web exec vitest run tests/unit/atoms/PlatformBrandMark.test.tsx app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1` (12/12)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `biome check --write` on changed files

Closes JOV-4761.