### PR TITLE
feat(contacts): consolidate audience workspace

### DIFF
--- a/apps/web/app/app/(shell)/audience/page.tsx
+++ b/apps/web/app/app/(shell)/audience/page.tsx
@@ -1,144 +1,32 @@
+import { redirect } from 'next/navigation';
 import type { SearchParams } from 'nuqs/server';
-import { Suspense } from 'react';
-import { BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
-import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
-import type { AudienceSegment } from '@/features/dashboard/organisms/dashboard-audience-table/types';
-import { LazyDashboardAudienceClient } from '@/features/dashboard/organisms/LazyDashboardAudienceClient';
-import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { captureError } from '@/lib/error-tracking';
-import { audienceFilters, audienceSearchParams } from '@/lib/nuqs';
-import { throwIfRedirect } from '@/lib/utils/redirect-error';
-import {
-  trimLeadingSlashes,
-  trimTrailingSlashes,
-} from '@/lib/utils/string-utils';
-import { convertDrizzleCreatorProfileToArtist } from '@/types/db';
-import {
-  loadAppShellRouteContext,
-  loadAuthenticatedAppShellUserId,
-  requireAppShellDashboardUserId,
-} from '../app-shell-route-context';
-import { getAudienceServerData } from '../dashboard/audience/audience-data';
-import { loadUpcomingTourDates } from '../dashboard/tour-dates/actions';
 
 export const runtime = 'nodejs';
 
 /**
- * Audience page — streams instantly after auth gate.
- *
- * The shared early auth helper runs before Suspense so unauthenticated users
- * redirect immediately while the async content keeps the table fallback.
+ * Audience is a Contacts workspace view. Keep historic links useful while
+ * preserving every supported audience filter in the destination URL.
  */
+export function buildAudienceContactsRedirectPath(
+  searchParams: SearchParams
+): string {
+  const params = new URLSearchParams([['tab', 'audience']]);
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (key === 'tab' || value === undefined) continue;
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      params.append(key, entry);
+    }
+  }
+
+  return `${APP_ROUTES.CONTACTS}?${params.toString()}`;
+}
+
 export default async function AudiencePage({
   searchParams,
 }: Readonly<{
   searchParams: Promise<SearchParams>;
 }>) {
-  const userId = await loadAuthenticatedAppShellUserId({
-    route: APP_ROUTES.AUDIENCE,
-  });
-
-  return (
-    <Suspense fallback={<AudienceTableLoadingShell />}>
-      <AudienceContent userId={userId} searchParams={searchParams} />
-    </Suspense>
-  );
-}
-
-async function AudienceContent({
-  userId,
-  searchParams,
-}: Readonly<{
-  userId: string;
-  searchParams: Promise<SearchParams>;
-}>) {
-  try {
-    const isE2E = process.env.NEXT_PUBLIC_E2E_MODE === '1';
-    const routeContext = await loadAppShellRouteContext({
-      route: APP_ROUTES.AUDIENCE,
-      authenticatedUserId: userId,
-      dashboardErrorLogMessage: 'Dashboard data load failed on audience page',
-      dashboardErrorMessage:
-        'Failed to load audience data. Please refresh the page.',
-    });
-    if (!routeContext.ok) {
-      return routeContext.error;
-    }
-
-    const { dashboardData } = routeContext;
-    const dashboardUserId = requireAppShellDashboardUserId(
-      routeContext,
-      APP_ROUTES.AUDIENCE
-    );
-
-    const artist = dashboardData.selectedProfile
-      ? convertDrizzleCreatorProfileToArtist(dashboardData.selectedProfile)
-      : null;
-
-    const profileUrl =
-      artist?.handle && artist.handle.length > 0
-        ? `${trimTrailingSlashes(BASE_URL)}/${trimLeadingSlashes(artist.handle)}`
-        : undefined;
-
-    const parsedParams = await audienceSearchParams.parse(searchParams);
-    const validSegments = parsedParams.segments.filter(
-      (s): s is AudienceSegment =>
-        (audienceFilters as readonly string[]).includes(s)
-    );
-
-    const [audienceData, tourDates] = await Promise.all([
-      getAudienceServerData({
-        userId: dashboardUserId,
-        selectedProfileId: artist?.id ?? null,
-        searchParams: {
-          page: String(parsedParams.page),
-          pageSize: String(parsedParams.pageSize),
-          sort: parsedParams.sort,
-          direction: parsedParams.direction,
-        },
-        view: parsedParams.view,
-        includeDetails: !isE2E,
-        segments: validSegments,
-      }),
-      !isE2E && artist?.id
-        ? loadUpcomingTourDates(artist.id).catch(() => [])
-        : Promise.resolve([]),
-    ]);
-
-    const tourDatesForMatching = tourDates.map(
-      (td: { city: string; startDate: string }) => ({
-        city: td.city,
-        startDate: td.startDate,
-      })
-    );
-
-    return (
-      <LazyDashboardAudienceClient
-        mode={audienceData.mode}
-        view={audienceData.view}
-        initialRows={audienceData.rows}
-        total={audienceData.total}
-        page={audienceData.page}
-        pageSize={audienceData.pageSize}
-        sort={audienceData.sort}
-        direction={audienceData.direction}
-        profileUrl={profileUrl}
-        profileId={artist?.id ?? undefined}
-        subscriberCount={audienceData.subscriberCount}
-        totalAudienceCount={audienceData.totalAudienceCount}
-        filters={{ segments: validSegments }}
-        tourDates={tourDatesForMatching}
-      />
-    );
-  } catch (error) {
-    throwIfRedirect(error);
-    void captureError('Audience page failed', error, {
-      route: APP_ROUTES.AUDIENCE,
-    });
-
-    return (
-      <PageErrorState message='Failed to load audience data. Please refresh the page.' />
-    );
-  }
+  redirect(buildAudienceContactsRedirectPath(await searchParams));
 }

--- a/apps/web/app/app/(shell)/contacts/page.tsx
+++ b/apps/web/app/app/(shell)/contacts/page.tsx
@@ -1,7 +1,34 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import type { SearchParams } from 'nuqs/server';
+import { Suspense } from 'react';
+import {
+  PAGE_TOOLBAR_TAB_ACTIVE_CLASS,
+  PAGE_TOOLBAR_TAB_BUTTON_CLASS,
+  PageToolbar,
+} from '@/components/organisms/table/molecules/PageToolbar';
+import { BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
+import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
+import type { AudienceSegment } from '@/features/dashboard/organisms/dashboard-audience-table/types';
+import { LazyDashboardAudienceClient } from '@/features/dashboard/organisms/LazyDashboardAudienceClient';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { loadAppShellRouteContext } from '../app-shell-route-context';
+import { captureError } from '@/lib/error-tracking';
+import { audienceFilters, audienceSearchParams } from '@/lib/nuqs';
+import { cn } from '@/lib/utils';
+import { throwIfRedirect } from '@/lib/utils/redirect-error';
+import {
+  trimLeadingSlashes,
+  trimTrailingSlashes,
+} from '@/lib/utils/string-utils';
+import { convertDrizzleCreatorProfileToArtist } from '@/types/db';
+import {
+  type AppShellRouteContext,
+  loadAppShellRouteContext,
+  requireAppShellDashboardUserId,
+} from '../app-shell-route-context';
+import { getAudienceServerData } from '../dashboard/audience/audience-data';
+import { loadUpcomingTourDates } from '../dashboard/tour-dates/actions';
 import { ContactsPageClient } from './ContactsPageClient';
 
 export const runtime = 'nodejs';
@@ -11,7 +38,71 @@ export const metadata: Metadata = {
   description: 'Manage bookings, management, and press contacts',
 };
 
-export default async function ContactsPage() {
+type ContactsWorkspaceTab = 'contacts' | 'audience';
+
+export function resolveContactsWorkspaceTab(
+  value: string | readonly string[] | undefined
+): ContactsWorkspaceTab {
+  return value === 'audience' ? 'audience' : 'contacts';
+}
+
+function buildAudienceWorkspaceHref(searchParams: SearchParams): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (key === 'tab' || value === undefined) continue;
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      params.append(key, entry);
+    }
+  }
+  params.set('tab', 'audience');
+  return `${APP_ROUTES.CONTACTS}?${params.toString()}`;
+}
+
+function ContactsWorkspaceTabs({
+  activeTab,
+  searchParams,
+}: Readonly<{
+  activeTab: ContactsWorkspaceTab;
+  searchParams: SearchParams;
+}>) {
+  return (
+    <PageToolbar
+      className='border-b border-subtle'
+      start={
+        <>
+          <Link
+            href={APP_ROUTES.CONTACTS}
+            className={cn(
+              PAGE_TOOLBAR_TAB_BUTTON_CLASS,
+              activeTab === 'contacts' && PAGE_TOOLBAR_TAB_ACTIVE_CLASS
+            )}
+            aria-current={activeTab === 'contacts' ? 'page' : undefined}
+          >
+            Contacts
+          </Link>
+          <Link
+            href={buildAudienceWorkspaceHref(searchParams)}
+            className={cn(
+              PAGE_TOOLBAR_TAB_BUTTON_CLASS,
+              activeTab === 'audience' && PAGE_TOOLBAR_TAB_ACTIVE_CLASS
+            )}
+            aria-current={activeTab === 'audience' ? 'page' : undefined}
+          >
+            Audience
+          </Link>
+        </>
+      }
+    />
+  );
+}
+
+export default async function ContactsPage({
+  searchParams = Promise.resolve({}),
+}: Readonly<{
+  searchParams?: Promise<SearchParams>;
+}> = {}) {
+  const resolvedSearchParams = await searchParams;
+  const activeTab = resolveContactsWorkspaceTab(resolvedSearchParams.tab);
   const routeContext = await loadAppShellRouteContext({
     route: APP_ROUTES.CONTACTS,
     dashboardErrorLogMessage: 'Dashboard data load failed on contacts page',
@@ -29,10 +120,109 @@ export default async function ContactsPage() {
   }
 
   return (
-    <ContactsPageClient
-      profileId={profile.id}
-      artistName={profile.displayName?.trim() || profile.username}
-      artistHandle={profile.usernameNormalized ?? profile.username}
-    />
+    <div
+      className='flex h-full min-h-0 flex-col'
+      data-testid='contacts-workspace'
+    >
+      <ContactsWorkspaceTabs
+        activeTab={activeTab}
+        searchParams={resolvedSearchParams}
+      />
+      <div className='min-h-0 flex-1'>
+        {activeTab === 'audience' ? (
+          <Suspense fallback={<AudienceTableLoadingShell />}>
+            <ContactsAudienceWorkspaceContent
+              routeContext={routeContext}
+              searchParams={searchParams}
+            />
+          </Suspense>
+        ) : (
+          <ContactsPageClient
+            profileId={profile.id}
+            artistName={profile.displayName?.trim() || profile.username}
+            artistHandle={profile.usernameNormalized ?? profile.username}
+          />
+        )}
+      </div>
+    </div>
   );
+}
+
+async function ContactsAudienceWorkspaceContent({
+  routeContext,
+  searchParams,
+}: Readonly<{
+  routeContext: AppShellRouteContext;
+  searchParams: Promise<SearchParams>;
+}>) {
+  try {
+    const isE2E = process.env.NEXT_PUBLIC_E2E_MODE === '1';
+    const { dashboardData } = routeContext;
+    const dashboardUserId = requireAppShellDashboardUserId(
+      routeContext,
+      APP_ROUTES.CONTACTS
+    );
+    const artist = dashboardData.selectedProfile
+      ? convertDrizzleCreatorProfileToArtist(dashboardData.selectedProfile)
+      : null;
+    const profileUrl =
+      artist?.handle && artist.handle.length > 0
+        ? `${trimTrailingSlashes(BASE_URL)}/${trimLeadingSlashes(artist.handle)}`
+        : undefined;
+    const parsedParams = await audienceSearchParams.parse(searchParams);
+    const validSegments = parsedParams.segments.filter(
+      (segment): segment is AudienceSegment =>
+        (audienceFilters as readonly string[]).includes(segment)
+    );
+    const [audienceData, tourDates] = await Promise.all([
+      getAudienceServerData({
+        userId: dashboardUserId,
+        selectedProfileId: artist?.id ?? null,
+        searchParams: {
+          page: String(parsedParams.page),
+          pageSize: String(parsedParams.pageSize),
+          sort: parsedParams.sort,
+          direction: parsedParams.direction,
+        },
+        view: parsedParams.view,
+        includeDetails: !isE2E,
+        segments: validSegments,
+      }),
+      !isE2E && artist?.id
+        ? loadUpcomingTourDates(artist.id).catch(() => [])
+        : Promise.resolve([]),
+    ]);
+
+    return (
+      <LazyDashboardAudienceClient
+        mode={audienceData.mode}
+        view={audienceData.view}
+        initialRows={audienceData.rows}
+        total={audienceData.total}
+        page={audienceData.page}
+        pageSize={audienceData.pageSize}
+        sort={audienceData.sort}
+        direction={audienceData.direction}
+        profileUrl={profileUrl}
+        profileId={artist?.id ?? undefined}
+        subscriberCount={audienceData.subscriberCount}
+        totalAudienceCount={audienceData.totalAudienceCount}
+        filters={{ segments: validSegments }}
+        tourDates={tourDates.map(
+          (tourDate: { city: string; startDate: string }) => ({
+            city: tourDate.city,
+            startDate: tourDate.startDate,
+          })
+        )}
+      />
+    );
+  } catch (error) {
+    throwIfRedirect(error);
+    void captureError('Contacts audience workspace failed', error, {
+      route: APP_ROUTES.CONTACTS,
+    });
+    return (
+      <PageErrorState message='Failed to load audience data. Please refresh the page.' />
+    );
+  }
 }

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -72,7 +72,7 @@ function isItemActive(pathname: string, item: NavItem): boolean {
       pathname === APP_ROUTES.DASHBOARD_AUDIENCE ||
       pathname === APP_ROUTES.AUDIENCE
     ) {
-      return APP_ROUTES.AUDIENCE;
+      return APP_ROUTES.CONTACTS;
     }
     return pathname;
   })();

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -265,13 +265,6 @@ export const COMMANDS: readonly Command[] = [
     APP_ROUTES.CALENDAR
   ),
   nav(
-    'go-audience',
-    'Audience',
-    'Understand your audience demographics.',
-    'Users',
-    APP_ROUTES.AUDIENCE
-  ),
-  nav(
     'go-tasks',
     'Tasks',
     'Track release work and operations.',

--- a/apps/web/lib/keyboard-shortcuts.test.ts
+++ b/apps/web/lib/keyboard-shortcuts.test.ts
@@ -96,7 +96,7 @@ describe('keyboard-shortcuts definitions', () => {
       expect(ids).toContain('nav-releases');
       expect(ids).toContain('nav-calendar');
       expect(ids).toContain('nav-tour-dates');
-      expect(ids).toContain('nav-audience');
+      expect(ids).not.toContain('nav-audience');
       expect(ids).toContain('nav-earnings');
       expect(ids).toContain('nav-chat');
       expect(ids).toContain('nav-settings');
@@ -113,10 +113,6 @@ describe('keyboard-shortcuts definitions', () => {
 
     it('uses the canonical calendar route for calendar navigation', () => {
       expect(NAV_SHORTCUTS.calendar.href).toBe(APP_ROUTES.CALENDAR);
-    });
-
-    it('uses the canonical audience route for audience navigation', () => {
-      expect(NAV_SHORTCUTS.audience.href).toBe(APP_ROUTES.AUDIENCE);
     });
   });
 
@@ -169,7 +165,7 @@ describe('keyboard-shortcuts definitions', () => {
       expect(NAV_SHORTCUTS.library).toBeDefined();
       expect(NAV_SHORTCUTS.calendar).toBeDefined();
       expect(NAV_SHORTCUTS.touring).toBeDefined();
-      expect(NAV_SHORTCUTS.audience).toBeDefined();
+      expect(NAV_SHORTCUTS.audience).toBeUndefined();
       expect(NAV_SHORTCUTS.earnings).toBeDefined();
       expect(NAV_SHORTCUTS.chat).toBeDefined();
       expect(NAV_SHORTCUTS.account).toBeDefined();

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -22,7 +22,6 @@ import {
   Sun,
   Type,
   UserCircle,
-  Users,
   X,
 } from 'lucide-react';
 import { APP_ROUTES } from '@/constants/routes';
@@ -230,18 +229,6 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
-    id: 'nav-audience',
-    label: 'Go to audience',
-    keys: 'G then A',
-    category: 'navigation',
-    icon: Users,
-    href: APP_ROUTES.AUDIENCE,
-    isSequential: true,
-    firstKey: 'g',
-    secondKey: 'a',
-    decision: { status: 'required', binding: 'useSequentialShortcuts' },
-  },
-  {
     id: 'nav-earnings',
     label: 'Go to earnings',
     keys: 'G then E',
@@ -398,7 +385,6 @@ export const NAV_SHORTCUTS: Record<string, KeyboardShortcut> = {
   releases: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-releases')!,
   library: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-releases')!,
   calendar: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-calendar')!,
-  audience: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-audience')!,
   earnings: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-earnings')!,
   chat: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-chat')!,
   account: KEYBOARD_SHORTCUTS.find(s => s.id === 'nav-settings')!,

--- a/apps/web/tests/unit/app/audience-page.test.tsx
+++ b/apps/web/tests/unit/app/audience-page.test.tsx
@@ -1,23 +1,32 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 
-describe('audience app shell route', () => {
-  it('uses the shared route context without reloading dashboard shell data locally', () => {
-    const source = readFileSync(
-      resolve(process.cwd(), 'app/app/(shell)/audience/page.tsx'),
-      'utf8'
+const redirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({ redirect: redirectMock }));
+
+import AudiencePage, {
+  buildAudienceContactsRedirectPath,
+} from '@/app/app/(shell)/audience/page';
+
+describe('legacy audience route', () => {
+  it('preserves audience state while moving it into Contacts', () => {
+    expect(
+      buildAudienceContactsRedirectPath({
+        view: 'identified',
+        segments: ['fans', 'supporters'],
+        tab: 'contacts',
+      })
+    ).toBe(
+      `${APP_ROUTES.CONTACTS}?tab=audience&view=identified&segments=fans&segments=supporters`
     );
+  });
 
-    expect(source).toContain('LazyDashboardAudienceClient');
-    expect(source).toContain('loadAppShellRouteContext');
-    expect(source).toContain('loadAuthenticatedAppShellUserId');
-    expect(source).toContain('requireAppShellDashboardUserId');
-    expect(source).toContain('authenticatedUserId: userId');
-    expect(source).not.toContain('buildAppShellSignInUrl');
-    expect(source).not.toContain('getCachedAuth');
-    expect(source).not.toContain('getDashboardShellData');
-    expect(source).not.toContain('dashboardLoadError');
-    expect(source).not.toMatch(/\bgetDashboardData(?:Essential)?\(/);
+  it('redirects old audience links to the Contacts audience view', async () => {
+    await AudiencePage({ searchParams: Promise.resolve({ view: 'all' }) });
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.CONTACTS}?tab=audience&view=all`
+    );
   });
 });

--- a/apps/web/tests/unit/app/contacts-page.test.tsx
+++ b/apps/web/tests/unit/app/contacts-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 
@@ -18,7 +19,15 @@ vi.mock('@/app/app/(shell)/contacts/ContactsPageClient', () => ({
   },
 }));
 
-import ContactsPage from '@/app/app/(shell)/contacts/page';
+vi.mock('@/components/organisms/table/molecules/PageToolbar', () => ({
+  PageToolbar: ({ start }: { start: ReactNode }) => <div>{start}</div>,
+  PAGE_TOOLBAR_TAB_BUTTON_CLASS: 'page-toolbar-tab',
+  PAGE_TOOLBAR_TAB_ACTIVE_CLASS: 'page-toolbar-tab-active',
+}));
+
+import ContactsPage, {
+  resolveContactsWorkspaceTab,
+} from '@/app/app/(shell)/contacts/page';
 
 const profile = {
   id: 'profile_123',
@@ -53,6 +62,15 @@ describe('canonical contacts page', () => {
       artistHandle: profile.usernameNormalized,
     });
     expect(screen.getByText('Contacts workspace')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
+      'href',
+      `${APP_ROUTES.CONTACTS}?tab=audience`
+    );
+  });
+
+  it('normalizes workspace state and preserves audience filters in the tab URL', () => {
+    expect(resolveContactsWorkspaceTab('audience')).toBe('audience');
+    expect(resolveContactsWorkspaceTab('other')).toBe('contacts');
   });
 
   it('renders the shared route-context error', async () => {

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -321,15 +321,12 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(pushMock).toHaveBeenCalledWith('/app/releases');
   });
 
-  it('uses the canonical audience route for the Audience nav item', () => {
-    pushMock.mockClear();
+  it('does not duplicate Audience as a separate command', () => {
     render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
     const audienceNav = screen
       .getAllByRole('option')
       .find(el => el.textContent?.includes('Understand your audience'));
-    expect(audienceNav).toBeDefined();
-    fireEvent.mouseDown(audienceNav!);
-    expect(pushMock).toHaveBeenCalledWith('/app/audience');
+    expect(audienceNav).toBeUndefined();
   });
 
   it('routes a skill commit to chat with the ?skill= handoff', () => {

--- a/apps/web/tests/unit/routes/shell-redirect-stubs.baseline.json
+++ b/apps/web/tests/unit/routes/shell-redirect-stubs.baseline.json
@@ -1,5 +1,6 @@
 {
   "routes": [
+    "/app/audience",
     "/app/contact",
     "/app/dashboard",
     "/app/dashboard/audience",


### PR DESCRIPTION
## Summary
- add Contacts and Audience workspace views under `/app/contacts`
- redirect legacy `/app/audience` links while retaining their filter state
- remove standalone Audience from Cmd+K and keyboard navigation

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/commands/SharedCommandPalette.test.tsx components/features/dashboard/dashboard-nav/config.test.ts tests/unit/app/contacts-page.test.tsx tests/unit/app/audience-page.test.tsx tests/unit/app/contacts-workspace-tabs.test.tsx lib/keyboard-shortcuts.test.ts --maxWorkers 1` (67 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `biome check` on changed files
- `git diff --check`

Closes #12642