### PR TITLE
fix(connections): use share URLs only for social profiles

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -51,6 +51,22 @@ const data: ProfilesWorkspaceData = {
       lastObservedAt: '2026-07-16T00:00:00.000Z',
     },
     {
+      id: 'instagram',
+      rowType: 'surface',
+      kind: 'social',
+      platform: 'instagram',
+      label: 'Instagram',
+      handle: '@tim',
+      url: 'https://instagram.com/tim',
+      trackedUrl: 'https://jov.ie/tim/s/instagram',
+      qualificationStatus: 'qualified',
+      isOfficial: true,
+      monitoringState: 'active',
+      rank: 4,
+      previousRank: 5,
+      lastObservedAt: '2026-07-16T00:00:00.000Z',
+    },
+    {
       id: 'gmail',
       rowType: 'connector',
       kind: 'connector',
@@ -129,7 +145,7 @@ describe('ProfilesWorkspace', () => {
     expect(screen.getByText('Jovie Profile')).toBeInTheDocument();
     expect(screen.getByText('Spotify')).toBeInTheDocument();
     expect(screen.queryByText('7')).not.toBeInTheDocument();
-    expect(screen.getByText('3 Connections')).toBeInTheDocument();
+    expect(screen.getByText('4 Connections')).toBeInTheDocument();
     expect(screen.getByText('Monitored 1/5')).toBeInTheDocument();
     expect(screen.getByText('Needs Attention 1')).toBeInTheDocument();
     expect(screen.getByText('Monitoring Active')).toBeInTheDocument();
@@ -178,7 +194,11 @@ describe('ProfilesWorkspace', () => {
     expect(screen.getByTestId('profiles-rail-summary')).toBeInTheDocument();
     expect(
       screen.getByTestId('profiles-rail-shareable-link')
-    ).toHaveTextContent('jov.ie/tim/s/spotify');
+    ).toHaveTextContent('open.spotify.com/artist/tim');
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/artist/tim'
+    );
     expect(screen.getByText('Next Best Action')).toBeInTheDocument();
     expect(
       screen.getByText('Upgrade the monitoring limit to track this connection.')
@@ -186,6 +206,27 @@ describe('ProfilesWorkspace', () => {
     expect(screen.getByRole('link', { name: 'Upgrade' })).toHaveAttribute(
       'href',
       '/app/settings/billing'
+    );
+  });
+
+  it('uses the canonical Jovie URL only for supported social connections', async () => {
+    const user = userEvent.setup();
+    renderWorkspace(data);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Instagram' })
+    );
+    await user.click(screen.getByRole('menuitem', { name: /View Details/i }));
+    const panel = vi.mocked(useRegisterRightPanel).mock.calls.at(-1)?.[0];
+    expect(panel).not.toBeNull();
+
+    render(<TooltipProvider>{panel as ReactElement}</TooltipProvider>);
+    expect(
+      screen.getByTestId('profiles-rail-shareable-link')
+    ).toHaveTextContent('jov.ie/tim/s/instagram');
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'href',
+      'https://instagram.com/tim'
     );
   });
 

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -393,7 +393,7 @@ function ConnectionRail({
             footer={
               <ShareableLinkRow
                 url={
-                  row.rowType === 'surface'
+                  row.rowType === 'surface' && row.kind === 'social'
                     ? (row.trackedUrl ?? row.url)
                     : row.url
                 }

--- a/apps/web/app/app/(shell)/profiles/data.ts
+++ b/apps/web/app/app/(shell)/profiles/data.ts
@@ -349,6 +349,7 @@ export async function loadProfilesWorkspaceData(input: {
     const qualificationStatus =
       surface.qualificationStatus as ProfileQualificationStatus;
     const trackedUrl =
+      surface.kind === 'social' &&
       socialSourceIds.has(surface.id) &&
       resolveSocialShortcutPlatforms(surface.platform) &&
       profileRows[0]?.username


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4770 -->

## Summary
- exposes the canonical `jov.ie/{username}/s/{platform}` share URL only for supported social profile rows
- keeps DSP rows on their destination URL in the right rail
- keeps destination links as the Open action for both social and DSP rows

## Verification
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm component-ship-gate`
- `biome check` and `git diff --check`