### PR TITLE
fix(shell): quiet healthy usage in header [JOV-4772]

### DIFF
--- a/apps/web/components/features/dashboard/atoms/HeaderChatUsageIndicator.tsx
+++ b/apps/web/components/features/dashboard/atoms/HeaderChatUsageIndicator.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { SimpleTooltip } from '@jovie/ui';
 import { AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { memo } from 'react';
 import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
-import { getChatUsageCopy } from '@/lib/chat-usage/copy';
+import {
+  getOverallRemainingPercent,
+  isChatUsageBelowWarningThreshold,
+} from '@/lib/chat-usage/metrics';
 import { env } from '@/lib/env-client';
 import { useChatUsageQuery } from '@/lib/queries';
 
@@ -22,43 +26,26 @@ export const HeaderChatUsageIndicator = memo(
       return null;
     }
 
-    const copy = getChatUsageCopy(data);
-    const isPaidPlan = data.plan === 'pro' || data.plan === 'max';
-    const showHealthyPaidUsage =
-      isPaidPlan && !data.isNearLimit && !data.isExhausted;
-
-    if (!isPaidPlan && !data.isNearLimit && !data.isExhausted) {
+    if (!isChatUsageBelowWarningThreshold(data)) {
       return null;
     }
 
-    if (showHealthyPaidUsage) {
-      return (
-        <Link
-          href={APP_ROUTES.PRICING}
-          className='group inline-flex items-center gap-1.5 rounded-lg border border-subtle bg-surface-1 px-2.5 py-1.5 text-app font-caption text-secondary-token transition-colors hover:bg-surface-2 hover:text-primary-token'
-          aria-label={copy.headerAriaLabel}
-        >
-          <span className='font-medium text-primary-token'>
-            {copy.planLabel}
-          </span>
-          <span className='text-tertiary-token' aria-hidden>
-            ·
-          </span>
-          <span className='tabular-nums'>{copy.headerLabel}</span>
-        </Link>
-      );
-    }
+    const remainingPercent = getOverallRemainingPercent(data);
+    const label = `${remainingPercent}% remaining`;
+    const detail = `${label}. Open the user menu for daily and monthly usage details.`;
 
     return (
-      <Link
-        href={APP_ROUTES.PRICING}
-        className='group inline-flex items-center gap-1.5 rounded-lg border border-amber-400/35 bg-amber-500/10 px-2.5 py-1.5 text-app font-caption text-amber-800 transition-colors hover:bg-amber-500/20 dark:text-amber-200'
-        aria-label={copy.headerAriaLabel}
-      >
-        <AlertTriangle className='h-3.5 w-3.5 shrink-0' />
-        <span className='max-sm:hidden sm:inline'>Chat</span>
-        <span className='tabular-nums'>{copy.headerLabel}</span>
-      </Link>
+      <SimpleTooltip content={detail} side='bottom'>
+        <Link
+          href={APP_ROUTES.PRICING}
+          className='group inline-flex items-center gap-1.5 rounded-lg border border-amber-400/35 bg-amber-500/10 px-2.5 py-1.5 text-app font-caption text-amber-800 transition-colors hover:bg-amber-500/20 dark:text-amber-200'
+          aria-label={detail}
+        >
+          <AlertTriangle className='h-3.5 w-3.5 shrink-0' />
+          <span className='max-sm:hidden sm:inline'>Usage</span>
+          <span className='tabular-nums'>{label}</span>
+        </Link>
+      </SimpleTooltip>
     );
   }
 );

--- a/apps/web/lib/chat-usage/metrics.ts
+++ b/apps/web/lib/chat-usage/metrics.ts
@@ -1,5 +1,7 @@
 import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
 
+export const CHAT_USAGE_WARNING_PERCENT = 10;
+
 export interface MonthlyUsageSnapshot {
   readonly limit: number;
   readonly used: number;
@@ -29,6 +31,14 @@ export function getOverallRemainingPercent(data: ChatUsageData): number {
   const dailyPercent = getRemainingPercent(data.remaining, data.dailyLimit);
   const monthlyPercent = getRemainingPercent(monthly.remaining, monthly.limit);
   return Math.min(dailyPercent, monthlyPercent);
+}
+
+/**
+ * Keeps the app-shell warning policy in one place while the user menu retains
+ * the detailed daily and monthly breakdown.
+ */
+export function isChatUsageBelowWarningThreshold(data: ChatUsageData): boolean {
+  return getOverallRemainingPercent(data) < CHAT_USAGE_WARNING_PERCENT;
 }
 
 export function formatResetAt(value: string | null | undefined): string {

--- a/apps/web/tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx
+++ b/apps/web/tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx
@@ -1,9 +1,23 @@
+import { TooltipProvider } from '@jovie/ui';
 import { describe, expect, it, vi } from 'vitest';
 import { HeaderChatUsageIndicator } from '@/features/dashboard/atoms/HeaderChatUsageIndicator';
 import { fastRender } from '@/tests/utils/fast-render';
 
 const mockUseChatUsageQuery = vi.fn();
 const mockUsePathname = vi.fn(() => '/app/chat');
+
+const usage = {
+  plan: 'pro' as const,
+  dailyLimit: 100,
+  used: 0,
+  remaining: 100,
+  monthlyLimit: 3000,
+  monthlyUsed: 0,
+  monthlyRemaining: 3000,
+  isNearLimit: false,
+  isExhausted: false,
+  warningThreshold: 5,
+};
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
@@ -13,65 +27,88 @@ vi.mock('@/lib/queries/useChatUsageQuery', () => ({
   useChatUsageQuery: () => mockUseChatUsageQuery(),
 }));
 
+function renderIndicator() {
+  return fastRender(
+    <TooltipProvider>
+      <HeaderChatUsageIndicator />
+    </TooltipProvider>
+  );
+}
+
 describe('HeaderChatUsageIndicator', () => {
   it('renders nothing when usage is healthy', () => {
     mockUseChatUsageQuery.mockReturnValue({
       data: {
+        ...usage,
         remaining: 12,
-        isNearLimit: false,
-        isExhausted: false,
+        used: 88,
+        monthlyRemaining: 360,
+        monthlyUsed: 2640,
       },
     });
 
-    const { queryByRole } = fastRender(<HeaderChatUsageIndicator />);
+    const { queryByRole } = renderIndicator();
 
     expect(queryByRole('link')).toBeNull();
   });
 
-  it('renders near-limit copy in header', () => {
+  it('renders a quiet warning when overall usage is below ten percent', () => {
     mockUseChatUsageQuery.mockReturnValue({
       data: {
-        plan: 'free',
-        remaining: 2,
-        isNearLimit: true,
-        isExhausted: false,
+        ...usage,
+        remaining: 9,
+        used: 91,
       },
     });
 
-    const { getByRole, getByText } = fastRender(<HeaderChatUsageIndicator />);
+    const { getByRole, getByText } = renderIndicator();
 
     expect(getByRole('link')).toBeDefined();
-    expect(getByText('2 messages left')).toBeDefined();
+    expect(getByText('9% remaining')).toBeDefined();
+    expect(getByRole('link')).toHaveAccessibleName(
+      '9% remaining. Open the user menu for daily and monthly usage details.'
+    );
   });
 
-  it('renders healthy paid plan usage in header', () => {
+  it('hides healthy paid plan usage in the header', () => {
     mockUseChatUsageQuery.mockReturnValue({
       data: {
-        plan: 'pro',
+        ...usage,
         remaining: 42,
-        isNearLimit: false,
-        isExhausted: false,
+        used: 58,
       },
     });
 
-    const { getByRole, getByText } = fastRender(<HeaderChatUsageIndicator />);
+    const { queryByRole } = renderIndicator();
 
-    expect(getByRole('link')).toBeDefined();
-    expect(getByText('Pro')).toBeDefined();
-    expect(getByText('42 messages left')).toBeDefined();
+    expect(queryByRole('link')).toBeNull();
+  });
+
+  it('does not warn at exactly ten percent remaining', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: {
+        ...usage,
+        remaining: 10,
+        used: 90,
+      },
+    });
+
+    const { queryByRole } = renderIndicator();
+
+    expect(queryByRole('link')).toBeNull();
   });
 
   it('suppresses the banner on nested demo routes', () => {
     mockUsePathname.mockReturnValueOnce('/demo/showcase/settings');
     mockUseChatUsageQuery.mockReturnValue({
       data: {
+        ...usage,
         remaining: 1,
-        isNearLimit: true,
-        isExhausted: false,
+        used: 99,
       },
     });
 
-    const { queryByRole } = fastRender(<HeaderChatUsageIndicator />);
+    const { queryByRole } = renderIndicator();
 
     expect(queryByRole('link')).toBeNull();
   });

--- a/apps/web/tests/unit/lib/chat-usage-metrics.test.ts
+++ b/apps/web/tests/unit/lib/chat-usage-metrics.test.ts
@@ -5,6 +5,7 @@ import {
   getMonthlyUsage,
   getOverallRemainingPercent,
   getRemainingPercent,
+  isChatUsageBelowWarningThreshold,
 } from '@/lib/chat-usage/metrics';
 import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
 
@@ -48,6 +49,32 @@ describe('chat usage metrics', () => {
         monthlyRemaining: 50,
       })
     ).toBe(16);
+  });
+
+  it('only warns when the tighter usage window is below ten percent', () => {
+    expect(
+      isChatUsageBelowWarningThreshold({
+        ...baseUsage,
+        dailyLimit: 100,
+        used: 91,
+        remaining: 9,
+        monthlyLimit: 3100,
+        monthlyUsed: 2790,
+        monthlyRemaining: 310,
+      })
+    ).toBe(true);
+
+    expect(
+      isChatUsageBelowWarningThreshold({
+        ...baseUsage,
+        dailyLimit: 100,
+        used: 90,
+        remaining: 10,
+        monthlyLimit: 3100,
+        monthlyUsed: 2790,
+        monthlyRemaining: 310,
+      })
+    ).toBe(false);
   });
 
   it('formats compact reset labels for the inline menu', () => {


### PR DESCRIPTION
## Summary
- hide routine healthy usage from the authenticated header
- show a compact accessible usage warning only below 10% across daily/monthly windows
- retain detailed usage in the user menu

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/HeaderChatUsageIndicator.test.tsx tests/unit/lib/chat-usage-metrics.test.ts --maxWorkers 1` (10/10)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write ...`
- `pnpm component-ship-gate`
- normal pre-push gate passed

Closes JOV-4772.