### PR TITLE
fix(connections): reveal selected platform brand colors

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -123,12 +123,17 @@ describe('ProfilesWorkspace', () => {
     expect(
       mark.querySelector('.group-focus-visible\\/connection-row\\:opacity-100')
     ).not.toBeNull();
+    expect(
+      mark.querySelector(
+        '.group-aria-\\[selected\\=true\\]\\/connection-row\\:opacity-100'
+      )
+    ).not.toBeNull();
     expect(mark.querySelector('.opacity-0')).not.toBeNull();
     const user = userEvent.setup();
-    await user.click(
-      screen.getByRole('button', { name: 'Actions for Spotify' })
-    );
-    await user.click(screen.getByRole('menuitem', { name: /View Details/i }));
+    await user.click(screen.getByText('Spotify'));
+
+    const selectedRow = screen.getByText('Spotify').closest('tr');
+    expect(selectedRow).toHaveAttribute('aria-selected', 'true');
 
     const selectedReveal = screen
       .getByRole('img', { name: 'Spotify' })

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -163,7 +163,7 @@ function ConnectionBrandIcon({
 
   const revealClassName = emphasized
     ? 'absolute inset-0 opacity-100'
-    : 'absolute inset-0 opacity-0 transition-opacity duration-fast motion-reduce:transition-none group-hover/connection-row:opacity-100 group-focus-visible/connection-row:opacity-100';
+    : 'absolute inset-0 opacity-0 transition-opacity duration-fast motion-reduce:transition-none group-hover/connection-row:opacity-100 group-focus-visible/connection-row:opacity-100 group-aria-[selected=true]/connection-row:opacity-100';
 
   return (
     <span


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4773 -->

## Summary
- repairs the selected Connections-row brand mark state missed by #15412’s merge race
- makes the official platform color reveal respond to the row’s aria-selected state as well as hover and focus
- preserves neutral fallback marks

## Verification
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm component-ship-gate`
- `biome check` and `git diff --check`