### PR TITLE
fix(chat): simplify profile preview rail

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -257,9 +257,9 @@ export function ProfileContactSidebar() {
   const { previewData, setPreviewData } = usePreviewPanelData();
   const { selectedProfile } = useDashboardData();
 
-  // Rail mode: 'view' shows the phone-preview bento (default — "show off" /
-  // "give me my link"); 'edit' shows the link-editing tabs. The Edit profile
-  // button flips to edit; Done flips back.
+  // Rail mode: 'view' is the deliberately compact, read-only chat summary;
+  // 'edit' remains available for legacy deep links while Connections is the
+  // canonical management workspace.
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const router = useRouter();
   const pathname = usePathname();
@@ -850,6 +850,11 @@ export function ProfileContactSidebar() {
     router.push(APP_ROUTES.AUDIENCE);
   }, [router]);
 
+  const handleManageConnections = useCallback(() => {
+    close();
+    router.push(APP_ROUTES.PROFILES);
+  }, [close, router]);
+
   // Handle smart add — receives a detected link from SidebarLinkInput
   const handleSmartAddLink = useCallback(
     async (link: DetectedLink) => {
@@ -1208,7 +1213,7 @@ export function ProfileContactSidebar() {
         <ProfileBentoView
           previewData={previewData}
           profileUrl={profileUrl}
-          onClose={close}
+          onManageConnections={handleManageConnections}
           onEditProfile={() => setMode('edit')}
         />
       </EntitySidebarShell>

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebarSections.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebarSections.tsx
@@ -1,175 +1,86 @@
 'use client';
 
-import { Button, CommonDropdown, type CommonDropdownItem } from '@jovie/ui';
-import {
-  Check,
-  Copy,
-  ExternalLink,
-  MoreVertical,
-  Pencil,
-  SlidersHorizontal,
-  X,
-} from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { Button } from '@jovie/ui';
+import { Check, UserRound } from 'lucide-react';
+import Link from 'next/link';
 import { type PreviewPanelData } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
-import { toast } from '@/components/feedback';
 import {
   DrawerMediaThumb,
   DrawerSurfaceCard,
+  EntityHeaderCard,
 } from '@/components/molecules/drawer';
 import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { useProfileHeaderParts } from '@/components/organisms/profile-sidebar/ProfileSidebarHeader';
 import { DrawerHero } from '@/components/shell/DrawerHero';
-import { ProfilePreviewBento } from '@/features/profile/ProfilePreviewBento';
-import { UtmBuilderDialog } from '@/features/profile/UtmBuilderDialog';
-import {
-  buildPreviewArtistFromProfile,
-  buildProfilePreviewLinks,
-} from '@/features/profile/view-models';
-import { copyToClipboard } from '@/hooks/useClipboard';
-import type { LegacySocialLink } from '@/types/db';
+import { APP_ROUTES } from '@/constants/routes';
 import { ProfileSmartLinkAnalytics } from './ProfileSmartLinkAnalytics';
 
-function toPreviewSocialLinks(
-  links: PreviewPanelData['links']
-): LegacySocialLink[] {
-  const now = new Date().toISOString();
-  return buildProfilePreviewLinks(links).map(link => ({
-    id: link.id,
-    platform: link.platform,
-    url: link.url,
-    title: link.title,
-    order: 0,
-    is_visible: link.isVisible,
-    created_at: now,
-    updated_at: now,
-    artist_id: 'preview',
-    clicks: 0,
-  }));
-}
-
+/**
+ * Read-only profile summary for the explicitly opened chat rail. Profile
+ * editing and connection management live in the Connections workspace; chat
+ * only needs a compact identity, share link, and a single clear hand-off.
+ */
 export function ProfileBentoView({
   previewData,
   profileUrl,
-  onClose,
-  onEditProfile,
+  onManageConnections,
+  onEditProfile: _onEditProfile,
 }: Readonly<{
   previewData: PreviewPanelData;
   profileUrl: string;
-  onClose: () => void;
-  onEditProfile: () => void;
+  onManageConnections?: () => void;
+  /** Legacy callback retained while the editing rail is retired from chat. */
+  onEditProfile?: () => void;
 }>) {
-  const [utmOpen, setUtmOpen] = useState(false);
-
-  const artist = buildPreviewArtistFromProfile({
-    username: previewData.username,
-    displayName: previewData.displayName,
-    avatarUrl: previewData.avatarUrl,
-    bio: previewData.bio,
-  });
-  const socialLinks = toPreviewSocialLinks(previewData.links);
-
-  const handleCopyLink = useCallback(async () => {
-    const copied = await copyToClipboard(profileUrl);
-    if (copied) {
-      toast.success('Profile link copied');
-      return;
-    }
-    toast.error('Failed to copy link');
-  }, [profileUrl]);
-
-  const menuItems: CommonDropdownItem[] = [
-    {
-      type: 'action',
-      id: 'open-link',
-      label: 'Open Link',
-      icon: <ExternalLink className='h-3.5 w-3.5' />,
-      onClick: () =>
-        globalThis.open(profileUrl, '_blank', 'noopener,noreferrer'),
-    },
-    {
-      type: 'action',
-      id: 'copy-link',
-      label: 'Copy Link',
-      icon: <Copy className='h-3.5 w-3.5' />,
-      onClick: handleCopyLink,
-    },
-    {
-      type: 'action',
-      id: 'utm-builder',
-      label: 'UTM Builder',
-      icon: <SlidersHorizontal className='h-3.5 w-3.5' />,
-      onClick: () => setUtmOpen(true),
-    },
-  ];
+  const title = previewData.displayName || `@${previewData.username}`;
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto'>
-      <ProfilePreviewBento
-        artist={artist}
-        socialLinks={socialLinks}
-        genres={previewData.genres}
-        profileHref={previewData.profilePath}
-        showLiveBadge
-        caption='Your Live Profile'
-        phoneAlign='top'
-        showBottomFade
-        className='shrink-0'
-        heroClassName='aspect-4/5 max-h-110 w-full pt-2'
-        phoneFrameClassName='h-110 w-57'
-        topRight={
-          <div className='flex items-center gap-1.5'>
-            <Button
-              type='button'
-              variant='ghost'
-              size='icon'
-              aria-label='Close'
-              onClick={onClose}
-              className='h-6 w-6 rounded-full border border-white/12 bg-black/50 text-white backdrop-blur-md hover:bg-black/65 dark:text-white'
-            >
-              <X className='h-3.5 w-3.5' />
-            </Button>
-            <CommonDropdown
-              items={menuItems}
-              align='end'
-              // The UTM action opens a Dialog. Keeping this transient menu
-              // non-modal avoids competing Radix body pointer-event layers.
-              modal={false}
-              aria-label='Profile Actions'
-              trigger={
-                <Button
-                  type='button'
-                  variant='ghost'
-                  size='icon'
-                  aria-label='Profile Actions'
-                  className='h-6 w-6 rounded-full border border-white/12 bg-black/50 text-white backdrop-blur-md hover:bg-black/65 dark:text-white'
-                >
-                  <MoreVertical className='h-3.5 w-3.5' />
-                </Button>
-              }
-            />
-          </div>
+    <div
+      className='flex min-h-0 flex-1 flex-col gap-3 overflow-x-hidden overflow-y-auto px-3 pb-3 pt-2 lg:px-0 lg:pb-0'
+      data-testid='profile-preview-summary'
+    >
+      <EntityHeaderCard
+        image={
+          <DrawerMediaThumb
+            src={previewData.avatarUrl}
+            alt={title}
+            fallback={<UserRound className='h-5 w-5 text-tertiary-token' />}
+            dimension={40}
+            sizes='40px'
+            sizeClassName='h-10 w-10 rounded-full'
+          />
         }
-        footer={
-          <div className='space-y-2 px-1.5 pb-1.5 pt-1.5 lg:px-0 lg:pb-0'>
-            <ProfileSmartLinkAnalytics profileUrl={profileUrl} variant='flat' />
-            <Button
-              type='button'
-              variant='primary'
-              onClick={onEditProfile}
-              className='h-10 w-full rounded-xl text-xs font-caption tracking-tight'
-            >
-              <Pencil className='mr-2 h-3.5 w-3.5' aria-hidden='true' />
-              Edit Profile
-            </Button>
-          </div>
+        title={title}
+        subtitle={`@${previewData.username}`}
+        meta={
+          previewData.bio ? (
+            <span className='line-clamp-2 text-2xs leading-4 text-secondary-token'>
+              {previewData.bio}
+            </span>
+          ) : undefined
         }
+        stableLayout
+        titleLineClamp={1}
+        subtitleLineClamp={1}
+        metaOverflow='wrap'
+        data-testid='profile-preview-entity-header'
       />
-      <UtmBuilderDialog
-        open={utmOpen}
-        onClose={() => setUtmOpen(false)}
-        baseUrl={profileUrl}
-      />
+      <ProfileSmartLinkAnalytics profileUrl={profileUrl} variant='flat' />
+      {onManageConnections ? (
+        <Button
+          type='button'
+          variant='secondary'
+          size='sm'
+          className='w-full'
+          onClick={onManageConnections}
+        >
+          Manage in Connections
+        </Button>
+      ) : (
+        <Button asChild variant='secondary' size='sm' className='w-full'>
+          <Link href={APP_ROUTES.PROFILES}>Manage in Connections</Link>
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx
+++ b/apps/web/tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx
@@ -7,10 +7,6 @@ const mockState = vi.hoisted(() => ({
   push: vi.fn(),
   replace: vi.fn(),
   setPreviewData: vi.fn(),
-  refetchDspMatches: vi.fn(),
-  dspMatches: [] as Record<string, unknown>[],
-  dspMatchesLoading: false,
-  dspMatchesError: null as Error | null,
   previewData: {
     username: 'tim',
     displayName: 'Tim White',
@@ -99,10 +95,10 @@ vi.mock('@/lib/queries', () => ({
     isError: false,
   }),
   useDspMatchesQuery: () => ({
-    data: mockState.dspMatches,
-    isLoading: mockState.dspMatchesLoading,
-    error: mockState.dspMatchesError,
-    refetch: mockState.refetchDspMatches,
+    data: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   }),
   usePressPhotosQuery: () => ({
     data: [],
@@ -130,90 +126,41 @@ vi.mock('@/features/dashboard/organisms/dsp-matches/hooks', () => ({
   }),
 }));
 
-const suggestedMatch = {
-  id: 'match-1',
-  providerId: 'deezer',
-  externalArtistName: 'Tim White',
-  externalArtistUrl: null,
-  externalArtistImageUrl: null,
-  confidenceScore: 0.92,
-  matchingIsrcCount: 12,
-};
-
 describe('ProfileContactSidebar scroll contract', () => {
   beforeEach(() => {
-    mockState.dspMatches = [];
-    mockState.dspMatchesLoading = false;
-    mockState.dspMatchesError = null;
-    mockState.refetchDspMatches.mockReset();
+    mockState.close.mockReset();
+    mockState.push.mockReset();
   });
 
-  it('uses child-owned scrolling without the legacy full-height wrapper', () => {
-    const { container } = render(<ProfileContactSidebar />);
+  it('uses a compact read-only summary instead of mounting the phone preview', () => {
+    render(<ProfileContactSidebar />);
 
-    // The rail opens in the preview (bento) mode; the editing tabs live behind
-    // the "Edit profile" button.
-    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
-
-    const shellBody = container.querySelector('[data-scroll-strategy="child"]');
-    const tabbedCard = screen.getByTestId('profile-contact-tabbed-card');
-    const scrollRegion = screen.getByTestId(
-      'profile-contact-tabbed-card-scroll-region'
+    expect(screen.getByTestId('profile-preview-summary')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-preview-entity-header')
+    ).toHaveTextContent('Tim White');
+    expect(screen.getByTestId('profile-preview-summary')).toHaveClass(
+      'min-h-0',
+      'overflow-x-hidden',
+      'overflow-y-auto'
     );
-
-    expect(shellBody).toBeInTheDocument();
-    expect(shellBody).not.toHaveClass('overflow-y-auto');
-    expect(tabbedCard.closest('.min-h-full')).toBeNull();
-    expect(scrollRegion).toHaveAttribute('data-scroll-mode', 'internal');
-    expect(scrollRegion).toHaveClass('overflow-y-auto');
+    expect(
+      screen.getByTestId('profile-smart-link-control')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Manage in Connections' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Your Live Profile')).toBeNull();
   });
 
-  it('keeps loading, empty, populated, and error suggestion transitions at the fixed scroll tail', () => {
-    mockState.dspMatchesLoading = true;
+  it('hands profile management back to Connections and closes the chat rail', () => {
+    render(<ProfileContactSidebar />);
 
-    const view = render(<ProfileContactSidebar />);
-    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
-    fireEvent.click(screen.getByTestId('drawer-tab-dsp'));
-    fireEvent.click(screen.getByRole('button', { name: 'Add Music link' }));
-
-    const tabbedCard = screen.getByTestId('profile-contact-tabbed-card');
-    const scrollRegion = screen.getByTestId(
-      'profile-contact-tabbed-card-scroll-region'
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Manage in Connections' })
     );
-    const linkInput = screen.getByRole('textbox', { name: 'Add Link' });
-    expect(tabbedCard).toHaveClass('min-h-0', 'flex-1', 'overflow-hidden');
-    const rerenderState = () => {
-      view.rerender(<ProfileContactSidebar />);
-      expect(
-        screen.getByTestId('profile-contact-tabbed-card-scroll-region')
-      ).toBe(scrollRegion);
-      expect(scrollRegion).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
-      expect(scrollRegion).toContainElement(linkInput);
-    };
 
-    rerenderState();
-    expect(screen.queryByTestId('suggested-dsp-matches')).toBeNull();
-
-    mockState.dspMatchesLoading = false;
-    rerenderState();
-    expect(screen.queryByTestId('suggested-dsp-matches')).toBeNull();
-
-    mockState.dspMatches = [suggestedMatch];
-    rerenderState();
-    const populatedSuggestions = screen.getByTestId('suggested-dsp-matches');
-    expect(populatedSuggestions).toHaveAttribute('data-state', 'ready');
-    expect(scrollRegion.lastElementChild).toBe(populatedSuggestions);
-
-    mockState.dspMatches = [];
-    mockState.dspMatchesLoading = true;
-    rerenderState();
-    expect(screen.queryByTestId('suggested-dsp-matches')).toBeNull();
-
-    mockState.dspMatchesLoading = false;
-    mockState.dspMatchesError = new Error('Network error');
-    rerenderState();
-    const errorSuggestions = screen.getByTestId('suggested-dsp-matches');
-    expect(errorSuggestions).toHaveAttribute('data-state', 'error');
-    expect(scrollRegion.lastElementChild).toBe(errorSuggestions);
+    expect(mockState.close).toHaveBeenCalledTimes(1);
+    expect(mockState.push).toHaveBeenCalledWith('/app/profiles');
   });
 });


### PR DESCRIPTION
## Summary
- replace the nested phone/mock preview with a compact, read-only entity summary in the explicitly opened Chat rail
- retain the shareable profile link and analytics while making Connections the single management hand-off
- protect default-closed, explicit-open, and no-overflow behavior with focused rail tests

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx tests/unit/chat/ChatEntityRightPanelHost.test.tsx components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.test.tsx --maxWorkers 1` (41/41)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write ...`
- `pnpm component-ship-gate`

Closes JOV-4769.