### PR TITLE
fix(shell): preserve mobile profile rail sheet

### DIFF
--- a/apps/web/components/shell/AppShellRightRail.tsx
+++ b/apps/web/components/shell/AppShellRightRail.tsx
@@ -31,12 +31,10 @@ export function AppShellRightRail({
       data-shell-rail-motion='right'
       aria-label='Context Panel'
       className={cn(
-        // Mobile drawers are fixed descendants of this stacking context, so the
-        // rail must sit above the z-20 shell header. Desktop returns to z-10.
-        // self-stretch (not self-start): the rail sits beside the non-scrolling
-        // shell clip and must fill the content-row height so open drawers clip
-        // inside the rail instead of floating over the transcript (JOV-3958).
-        'sticky top-0 z-30 flex h-full min-h-0 w-0 shrink-0 flex-col self-stretch overflow-hidden lg:z-10 lg:w-fit lg:p-1.5',
+        // The mobile RightDrawer is viewport-fixed. Keep this mount neutral
+        // below lg so it cannot clip the sheet; desktop alone owns the
+        // self-stretch in-flow slot and clipping beside route content.
+        'relative z-30 h-0 w-0 shrink-0 overflow-visible lg:sticky lg:top-0 lg:z-10 lg:flex lg:h-full lg:min-h-0 lg:w-fit lg:flex-col lg:self-stretch lg:overflow-hidden lg:p-1.5',
         // Mirror the left sidebar mount language so inner drawer width changes
         // reclaim canvas space with the same cinematic timing.
         'transition-[flex-basis,width,opacity,transform] duration-cinematic ease-cinematic motion-reduce:transition-none',

--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -15,22 +15,25 @@ describe('AppShellRightRail', () => {
     expect(rail).toHaveAttribute('aria-label', 'Context Panel');
     expect(rail).toHaveAttribute('data-shell-rail-motion', 'right');
     expect(rail).toHaveClass(
-      'sticky',
-      'top-0',
+      'relative',
       'z-30',
-      'lg:z-10',
       'w-0',
+      'h-0',
+      'overflow-visible',
+      'lg:sticky',
+      'lg:top-0',
+      'lg:z-10',
       'lg:w-fit',
-      'h-full',
-      'min-h-0',
-      'self-stretch',
-      'overflow-hidden',
+      'lg:h-full',
+      'lg:min-h-0',
+      'lg:self-stretch',
+      'lg:overflow-hidden',
       'lg:p-1.5',
       'duration-cinematic',
       'ease-cinematic'
     );
     expect(rail).toHaveClass('transition-[flex-basis,width,opacity,transform]');
-    expect(rail).not.toHaveClass('self-start');
+    expect(rail).not.toHaveClass('lg:self-start');
     expect(rail).not.toHaveClass('z-10');
     expect(rail).toContainElement(screen.getByTestId('fixture-panel'));
   });
@@ -77,6 +80,6 @@ describe('AppShellRightRail', () => {
 
     const rail = screen.getByTestId('app-shell-right-rail');
 
-    expect(rail).toHaveClass('fixture-rail', 'sticky', 'top-0');
+    expect(rail).toHaveClass('fixture-rail', 'relative', 'lg:sticky');
   });
 });

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -73,7 +73,7 @@ describe('AppShellFrame', () => {
     expect(rightRail).toContainElement(
       screen.getByTestId('fixture-right-rail')
     );
-    expect(rightRail).toHaveClass('sticky', 'top-0');
+    expect(rightRail).toHaveClass('lg:sticky', 'lg:top-0');
     expect(mainPlane).toHaveClass(
       'transition-[flex-basis,width]',
       'duration-cinematic',

--- a/apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts
+++ b/apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts
@@ -49,8 +49,9 @@ describe('shell UX regressions source contracts (JOV-3958/3959/3960)', () => {
     expect(previewHost).toContain('height: 100%');
     expect(previewHost).not.toContain('box-shadow');
     expect(previewHost).not.toContain('border:');
-    expect(rail).toMatch(/flex-col self-stretch overflow-hidden/);
-    expect(rail).not.toMatch(/flex-col self-start overflow-hidden/);
+    expect(rail).toMatch(/lg:flex-col lg:self-stretch lg:overflow-hidden/);
+    expect(rail).toMatch(/h-0 w-0[\s\S]*overflow-visible/);
+    expect(rail).not.toMatch(/lg:flex-col lg:self-start lg:overflow-hidden/);
   });
 
   it('keeps the sidebar collapse toggle borderless (JOV-3959)', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4774 -->

## Summary
- Make the shared right-rail mount neutral below `lg` so the viewport-fixed mobile drawer is not clipped by a zero-width, overflow-hidden ancestor.
- Preserve the existing desktop in-flow rail allocation, sticky frame, and clipping contract behind `lg:` modifiers.
- Extend the existing rail and shell regression tests with the responsive ownership split.

## Verification
- `pnpm --filter web exec vitest run components/shell/__tests__/AppShellRightRail.test.tsx tests/unit/shell/shell-ux-regressions-source.test.ts --maxWorkers 1` (11/11)
- `pnpm biome check apps/web/components/shell/AppShellRightRail.tsx apps/web/components/shell/__tests__/AppShellRightRail.test.tsx apps/web/tests/unit/shell/shell-ux-regressions-source.test.ts`

## Risk
- Shared AppShell geometry only. Desktop is explicitly preserved by responsive modifiers; mobile RightDrawer remains the existing fixed sheet adapter.