### PR TITLE
fix(connections): display canonical social links

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -218,6 +218,10 @@ describe('ProfilesWorkspace', () => {
     const user = userEvent.setup();
     renderWorkspace(data);
 
+    expect(
+      screen.getByTitle('https://jov.ie/tim/s/instagram')
+    ).toHaveTextContent('jov.ie · tim/s/instagram');
+
     await user.click(
       screen.getByRole('button', { name: 'Actions for Instagram' })
     );

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -186,10 +186,17 @@ function ConnectionBrandIcon({
   );
 }
 
+function connectionDisplayUrl(row: ProfileWorkspaceRow): string {
+  return row.rowType === 'surface' && row.kind === 'social'
+    ? (row.trackedUrl ?? row.url)
+    : row.url;
+}
+
 function connectionUrlDisplay(row: ProfileWorkspaceRow): string {
-  if (row.handle) return row.handle;
+  const displayUrl = connectionDisplayUrl(row);
+  if (row.handle && displayUrl === row.url) return row.handle;
   try {
-    const url = new URL(row.url);
+    const url = new URL(displayUrl);
     const host = url.hostname.replace(/^www\./, '');
     const path = url.pathname.replace(/^\/+|\/+$/g, '');
     if (!path) return host;
@@ -199,7 +206,7 @@ function connectionUrlDisplay(row: ProfileWorkspaceRow): string {
       return `${host} · ${path}`;
     }
   } catch {
-    return row.url;
+    return displayUrl;
   }
 }
 
@@ -207,8 +214,9 @@ function ConnectionUrlDisplay({
   row,
   className,
 }: Readonly<{ row: ProfileWorkspaceRow; className?: string }>) {
+  const displayUrl = connectionDisplayUrl(row);
   return (
-    <span className={cn('truncate', className)} title={row.url}>
+    <span className={cn('truncate', className)} title={displayUrl}>
       {connectionUrlDisplay(row)}
     </span>
   );


### PR DESCRIPTION
## Summary
- show an existing canonical Jovie social link in the Connections row subtitle when `trackedUrl` is available
- retain the underlying destination for the Open action
- do not touch public redirect routing; that work remains paused because JOV-4763 owns the public-profile surface

## Verification
- `pnpm --filter web exec vitest run app/app/(shell)/profiles/ProfilesWorkspace.test.tsx --maxWorkers 1`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `biome check --write apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx`
- `node scripts/repo-hygiene-guard.mjs --diff-base origin/main` (10,000 tracked files)

Follow-up from JOV-4771. The canonical DSP redirect route is deliberately not included: JOV-4763 owns the public-profile code.