### PR TITLE
fix(ci): validate canonical legacy component evidence

### DIFF
--- a/docs/VISUAL_TESTING_POLICY.md
+++ b/docs/VISUAL_TESTING_POLICY.md
@@ -25,11 +25,20 @@ source lacks:
 
 1. **Test** — colocated `*.test.ts(x)` / `*.spec.ts(x)`, **touched in the same
    diff**, or a verified `// @coverage-via <path>` whose target imports the
-   component.
-2. **Story** — colocated `*.stories.ts(x)`.
+   component. Existing components may also use a changed central test that
+   imports and exercises the exact component module, or asserts against an
+   exact source-file read; name mentions, mocks, and unasserted reads do not
+   count. Newly added components may not use this exception.
+2. **Story** — colocated `*.stories.ts(x)`. Existing marketing/site components
+   may use a verified real-component story in the canonical
+   `MarketingRecipes`, `MarketingSections`, or `MarketingShells` catalog;
+   newly added components still require an adjacent story.
 3. **Match** — story imports the real component module; required public props
    appear in story args/JSX (or `parameters.jovie.uncoveredProps` allowlist);
    disabled/loading props are exercised when present on the component API.
+   Canonical catalog stories scope evidence to the component's own JSX and use
+   `parameters.jovie.uncoveredPropsByComponent` for any explicit exemption, so
+   unrelated stories and components cannot satisfy the match.
 4. **Hygiene** — `pnpm storybook:quality` (no pure-black voids, no fake CTAs).
 5. **Ratchet** — multi-root floors in `scripts/story-coverage-baseline.json`
    may only improve; new uncovered components fail even if percent holds.

--- a/scripts/component-ship-gate.mjs
+++ b/scripts/component-ship-gate.mjs
@@ -21,8 +21,10 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import {
   checkStoryMatchesComponent,
+  extractExportedComponentNames,
   isUnderShipScope,
   normalizeRepoPath,
   parseCoverageVia,
@@ -38,6 +40,13 @@ import {
 } from './story-coverage-ratchet.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const CANONICAL_MARKETING_STORIES = Object.freeze([
+  'apps/web/components/marketing/storybook/MarketingRecipes.stories.tsx',
+  'apps/web/components/marketing/storybook/MarketingSections.stories.tsx',
+  'apps/web/components/marketing/storybook/MarketingShells.stories.tsx',
+]);
+const TEST_FILE_RE = /\.(?:test|spec)\.[jt]sx?$/i;
 
 function parseArgs(argv) {
   const flags = {
@@ -96,7 +105,7 @@ function changedFiles(diffBase) {
     .filter(Boolean);
 }
 
-function findAdjacentArtifacts(sourceRel) {
+function findAdjacentArtifacts(sourceRel, repoRoot = REPO_ROOT) {
   const dir = dirname(sourceRel);
   const base = sourceRel
     .split('/')
@@ -114,21 +123,556 @@ function findAdjacentArtifacts(sourceRel) {
     `${dir}/${base}.spec.ts`,
   ];
   const storyRel =
-    storyCandidates.find(p => existsSync(join(REPO_ROOT, p))) ?? null;
+    storyCandidates.find(p => existsSync(join(repoRoot, p))) ?? null;
   const testRel =
-    testCandidates.find(p => existsSync(join(REPO_ROOT, p))) ?? null;
+    testCandidates.find(p => existsSync(join(repoRoot, p))) ?? null;
   return { storyRel, testRel, base };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function withoutTsxExtension(value) {
+  return normalizeRepoPath(value).replace(/\.(?:tsx?|jsx?)$/i, '');
+}
+
+function moduleResolvesToSource({ moduleSpecifier, importerRel, sourceRel }) {
+  const sourceWithoutExtension = withoutTsxExtension(sourceRel);
+  let candidate;
+
+  if (moduleSpecifier.startsWith('@/')) {
+    candidate = `apps/web/${moduleSpecifier.slice(2)}`;
+  } else if (moduleSpecifier.startsWith('.')) {
+    candidate = join(dirname(importerRel), moduleSpecifier);
+  } else {
+    return false;
+  }
+
+  return withoutTsxExtension(candidate) === sourceWithoutExtension;
+}
+
+function parseTypeScriptSource(source, path) {
+  return ts.createSourceFile(
+    path,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith('x') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+}
+
+function walkAst(node, visit) {
+  visit(node);
+  ts.forEachChild(node, child => walkAst(child, visit));
+}
+
+function collectBindingNames(name, names = new Set()) {
+  if (ts.isIdentifier(name)) {
+    names.add(name.text);
+    return names;
+  }
+  if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element))
+        collectBindingNames(element.name, names);
+    }
+  }
+  return names;
+}
+
+function shadowedBindingNames(sourceFile, importedNames) {
+  const candidates = new Set(importedNames);
+  const shadowed = new Set();
+  walkAst(sourceFile, node => {
+    let bindingName = null;
+    if (
+      ts.isVariableDeclaration(node) ||
+      ts.isParameter(node) ||
+      ts.isBindingElement(node)
+    ) {
+      bindingName = node.name;
+    } else if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isClassExpression(node)) &&
+      node.name
+    ) {
+      bindingName = node.name;
+    }
+    if (!bindingName) return;
+    for (const name of collectBindingNames(bindingName)) {
+      if (candidates.has(name)) shadowed.add(name);
+    }
+  });
+  return shadowed;
+}
+
+function exactRuntimeImports({
+  sourceFile,
+  importerRel,
+  sourceRel,
+  exportNames,
+}) {
+  const imports = [];
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !statement.importClause ||
+      statement.importClause.isTypeOnly ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !moduleResolvesToSource({
+        moduleSpecifier: statement.moduleSpecifier.text,
+        importerRel,
+        sourceRel,
+      })
+    ) {
+      continue;
+    }
+
+    const importedNames = [];
+    if (statement.importClause.name) {
+      importedNames.push({
+        exportName: exportNames[0] ?? statement.importClause.name.text,
+        localName: statement.importClause.name.text,
+      });
+    }
+
+    const bindings = statement.importClause.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        if (element.isTypeOnly) continue;
+        const exportName = (element.propertyName ?? element.name).text;
+        if (!exportNames.includes(exportName)) continue;
+        importedNames.push({
+          exportName,
+          localName: element.name.text,
+        });
+      }
+    }
+
+    if (importedNames.length > 0) {
+      imports.push({
+        statement: statement.getText(sourceFile),
+        importedNames,
+      });
+    }
+  }
+
+  return imports;
+}
+
+function staticStringValue(node, bindings = new Map(), seen = new Set()) {
+  const literal = unwrapStringLiteral(node);
+  if (literal !== null) return literal;
+  if (node && ts.isIdentifier(node) && bindings.has(node.text)) {
+    if (seen.has(node.text)) return null;
+    return staticStringValue(
+      bindings.get(node.text),
+      bindings,
+      new Set([...seen, node.text])
+    );
+  }
+  if (
+    node &&
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.PlusToken
+  ) {
+    const left = staticStringValue(node.left, bindings, seen);
+    const right = staticStringValue(node.right, bindings, seen);
+    return left === null || right === null ? null : left + right;
+  }
+  return null;
+}
+
+function isExactModuleMocked({ sourceFile, importerRel, sourceRel }) {
+  const moduleBindings = new Map();
+  walkAst(sourceFile, node => {
+    if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name)) return;
+    moduleBindings.set(node.name.text, node.initializer);
+  });
+
+  let mocked = false;
+  walkAst(sourceFile, node => {
+    if (mocked || !ts.isCallExpression(node)) return;
+    const callee = node.expression;
+    if (
+      !ts.isPropertyAccessExpression(callee) ||
+      !['vi', 'jest'].includes(callee.expression.getText(sourceFile)) ||
+      !['mock', 'doMock', 'unstable_mockModule'].includes(callee.name.text)
+    ) {
+      return;
+    }
+    const moduleArgument = node.arguments[0];
+    if (!moduleArgument) return;
+    const moduleSpecifier = staticStringValue(moduleArgument, moduleBindings);
+    if (
+      moduleSpecifier === null ||
+      moduleResolvesToSource({ moduleSpecifier, importerRel, sourceRel })
+    ) {
+      mocked = true;
+    }
+  });
+  return mocked;
+}
+
+function isTypeOrImportUse(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (ts.isImportDeclaration(current) || ts.isTypeNode(current)) return true;
+    if (ts.isStatement(current)) return false;
+  }
+  return false;
+}
+
+function hasRuntimeImportedUse(sourceFile, importedNames) {
+  const allNames = importedNames.map(item => item.localName);
+  const shadowedNames = shadowedBindingNames(sourceFile, allNames);
+  const names = new Set(allNames.filter(name => !shadowedNames.has(name)));
+  if (names.size === 0) return false;
+  let used = false;
+  walkAst(sourceFile, node => {
+    if (
+      !used &&
+      ts.isIdentifier(node) &&
+      names.has(node.text) &&
+      !isTypeOrImportUse(node)
+    ) {
+      used = true;
+    }
+  });
+  return used;
+}
+
+function unwrapStringLiteral(node) {
+  let current = node;
+  while (
+    current &&
+    (ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isParenthesizedExpression(current) ||
+      ts.isSatisfiesExpression(current))
+  ) {
+    current = current.expression;
+  }
+  return current &&
+    (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current))
+    ? current.text
+    : null;
+}
+
+function nodeFsReadBindings(sourceFile) {
+  const direct = new Set();
+  const namespace = new Set();
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !statement.importClause ||
+      statement.importClause.isTypeOnly ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !['node:fs', 'fs'].includes(statement.moduleSpecifier.text)
+    ) {
+      continue;
+    }
+    if (statement.importClause.name) {
+      namespace.add(statement.importClause.name.text);
+    }
+    const bindings = statement.importClause.namedBindings;
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      namespace.add(bindings.name.text);
+    } else if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        if (element.isTypeOnly) continue;
+        const importedName = (element.propertyName ?? element.name).text;
+        if (importedName === 'readFileSync') direct.add(element.name.text);
+      }
+    }
+  }
+
+  const shadowed = shadowedBindingNames(sourceFile, [...direct, ...namespace]);
+  return {
+    direct: new Set([...direct].filter(name => !shadowed.has(name))),
+    namespace: new Set([...namespace].filter(name => !shadowed.has(name))),
+  };
+}
+
+function isReadFileSyncCall(node, bindings) {
+  if (!ts.isCallExpression(node)) return false;
+  return (
+    (ts.isIdentifier(node.expression) &&
+      bindings.direct.has(node.expression.text)) ||
+    (ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'readFileSync' &&
+      ts.isIdentifier(node.expression.expression) &&
+      bindings.namespace.has(node.expression.expression.text))
+  );
+}
+
+function hasExplicitSourceRead(sourceFile, sourceRel) {
+  const readBindings = nodeFsReadBindings(sourceFile);
+  if (readBindings.direct.size === 0 && readBindings.namespace.size === 0) {
+    return false;
+  }
+  const exactPaths = new Set([
+    sourceRel,
+    sourceRel.replace(/^apps\/web\//, ''),
+  ]);
+  const pathBindings = new Set();
+  walkAst(sourceFile, node => {
+    if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name)) return;
+    const value = unwrapStringLiteral(node.initializer);
+    if (value && exactPaths.has(value)) pathBindings.add(node.name.text);
+  });
+
+  const callReadsExactPath = call => {
+    let matches = false;
+    for (const argument of call.arguments) {
+      walkAst(argument, node => {
+        if (matches) return;
+        const literal = unwrapStringLiteral(node);
+        if (literal && exactPaths.has(literal)) matches = true;
+        if (ts.isIdentifier(node) && pathBindings.has(node.text))
+          matches = true;
+      });
+    }
+    return matches;
+  };
+
+  const assertedNames = new Set();
+  let directReadAssertion = false;
+  walkAst(sourceFile, node => {
+    if (
+      !ts.isCallExpression(node) ||
+      !ts.isIdentifier(node.expression) ||
+      node.expression.text !== 'expect' ||
+      node.arguments.length === 0
+    ) {
+      return;
+    }
+    const subject = node.arguments[0];
+    if (ts.isIdentifier(subject)) assertedNames.add(subject.text);
+    walkAst(subject, child => {
+      if (
+        isReadFileSyncCall(child, readBindings) &&
+        callReadsExactPath(child)
+      ) {
+        directReadAssertion = true;
+      }
+    });
+  });
+
+  if (directReadAssertion) return true;
+
+  let assertedReadBinding = false;
+  walkAst(sourceFile, node => {
+    if (
+      assertedReadBinding ||
+      !ts.isVariableDeclaration(node) ||
+      !ts.isIdentifier(node.name) ||
+      !assertedNames.has(node.name.text) ||
+      !node.initializer
+    ) {
+      return;
+    }
+    walkAst(node.initializer, child => {
+      if (
+        isReadFileSyncCall(child, readBindings) &&
+        callReadsExactPath(child)
+      ) {
+        assertedReadBinding = true;
+      }
+    });
+  });
+  return assertedReadBinding;
+}
+
+function hasRealLegacyTestEvidence({
+  testSource,
+  testRel,
+  sourceRel,
+  componentSource,
+}) {
+  const sourceFile = parseTypeScriptSource(testSource, testRel);
+  const exportNames = extractExportedComponentNames(componentSource);
+  const imports = exactRuntimeImports({
+    sourceFile,
+    importerRel: testRel,
+    sourceRel,
+    exportNames,
+  });
+  const importedNames = imports.flatMap(entry => entry.importedNames);
+  const usesImportedComponent =
+    imports.length > 0 &&
+    !isExactModuleMocked({ sourceFile, importerRel: testRel, sourceRel }) &&
+    hasRuntimeImportedUse(sourceFile, importedNames);
+
+  return usesImportedComponent || hasExplicitSourceRead(sourceFile, sourceRel);
+}
+
+function findChangedLegacyTest({
+  changed,
+  sourceRel,
+  componentSource,
+  repoRoot,
+}) {
+  for (const testRel of changed) {
+    if (!TEST_FILE_RE.test(testRel)) continue;
+    if (!existsSync(join(repoRoot, testRel))) continue;
+    const testSource = readText(testRel, repoRoot);
+    if (
+      hasRealLegacyTestEvidence({
+        testSource,
+        testRel,
+        sourceRel,
+        componentSource,
+      })
+    ) {
+      return testRel;
+    }
+  }
+  return null;
+}
+
+function findCanonicalMarketingStory({ sourceRel, componentSource, repoRoot }) {
+  if (
+    !sourceRel.startsWith('apps/web/components/marketing/') &&
+    !sourceRel.startsWith('apps/web/components/site/')
+  ) {
+    return null;
+  }
+
+  for (const storyRel of CANONICAL_MARKETING_STORIES) {
+    if (!existsSync(join(repoRoot, storyRel))) continue;
+    const storySource = readText(storyRel, repoRoot);
+    const sourceFile = parseTypeScriptSource(storySource, storyRel);
+    const exportNames = extractExportedComponentNames(componentSource);
+    const imports = exactRuntimeImports({
+      sourceFile,
+      importerRel: storyRel,
+      sourceRel,
+      exportNames,
+    });
+    const importedNames = imports.flatMap(entry => entry.importedNames);
+    if (importedNames.length === 0) continue;
+    if (isExactModuleMocked({ sourceFile, importerRel: storyRel, sourceRel })) {
+      continue;
+    }
+
+    const importByLocalName = new Map(
+      importedNames.map(item => [item.localName, item.exportName])
+    );
+    const openingTags = [];
+    const componentAllowlist = new Set();
+
+    for (const statement of sourceFile.statements) {
+      if (
+        !ts.isVariableStatement(statement) ||
+        !statement.modifiers?.some(
+          modifier => modifier.kind === ts.SyntaxKind.ExportKeyword
+        )
+      ) {
+        continue;
+      }
+
+      const statementTags = [];
+      walkAst(statement, node => {
+        if (
+          !ts.isJsxOpeningElement(node) &&
+          !ts.isJsxSelfClosingElement(node)
+        ) {
+          return;
+        }
+        if (!ts.isIdentifier(node.tagName)) return;
+        const exportName = importByLocalName.get(node.tagName.text);
+        if (!exportName) return;
+        statementTags.push(
+          node
+            .getText(sourceFile)
+            .replace(
+              new RegExp(`^<${escapeRegExp(node.tagName.text)}\\b`),
+              `<${exportName}`
+            )
+        );
+      });
+      if (statementTags.length === 0) continue;
+      openingTags.push(...statementTags);
+
+      if (exportNames.length !== 1) continue;
+      walkAst(statement, node => {
+        if (
+          !ts.isPropertyAssignment(node) ||
+          node.name.getText(sourceFile).replace(/['"]/g, '') !==
+            'uncoveredPropsByComponent' ||
+          !ts.isObjectLiteralExpression(node.initializer)
+        ) {
+          return;
+        }
+        for (const property of node.initializer.properties) {
+          if (
+            !ts.isPropertyAssignment(property) ||
+            !ts.isArrayLiteralExpression(property.initializer)
+          ) {
+            continue;
+          }
+          const componentName = property.name
+            .getText(sourceFile)
+            .replace(/['"]/g, '');
+          if (!importByLocalName.has(componentName)) continue;
+          for (const element of property.initializer.elements) {
+            const value = unwrapStringLiteral(element);
+            if (value) componentAllowlist.add(value);
+          }
+        }
+      });
+    }
+    if (openingTags.length === 0) continue;
+
+    const scopedStorySource = [
+      ...imports.map(entry => entry.statement),
+      ...openingTags,
+      componentAllowlist.size > 0
+        ? `const componentCoverage = { uncoveredProps: ${JSON.stringify([...componentAllowlist])} };`
+        : '',
+    ].join('\n');
+    const match = checkStoryMatchesComponent({
+      componentSource,
+      storySource: scopedStorySource,
+      componentRel: sourceRel,
+      storyRel,
+    });
+    if (match.ok) return { storyRel, storySource: scopedStorySource };
+  }
+
+  return null;
+}
+
+function existedAtDiffBase(diffBase, sourceRel) {
+  const result = spawnSync(
+    'git',
+    ['cat-file', '-e', `${diffBase}:${sourceRel}`],
+    { cwd: REPO_ROOT, encoding: 'utf8' }
+  );
+  return result.status === 0;
 }
 
 /**
  * Diff gate for changed component sources.
  */
-export function checkChangedComponents(changed, { repoRoot = REPO_ROOT } = {}) {
+export function checkChangedComponents(
+  changed,
+  { repoRoot = REPO_ROOT, legacyComponents = new Set() } = {}
+) {
   const issues = [];
   const componentSources = changed.filter(isUnderShipScope);
 
   for (const sourceRel of componentSources) {
-    const { storyRel, testRel, base } = findAdjacentArtifacts(sourceRel);
+    const {
+      storyRel: adjacentStoryRel,
+      testRel,
+      base,
+    } = findAdjacentArtifacts(sourceRel, repoRoot);
+    const canUseCentralEvidence = legacyComponents.has(sourceRel);
     let componentSource;
     try {
       componentSource = readText(sourceRel, repoRoot);
@@ -166,6 +710,19 @@ export function checkChangedComponents(changed, { repoRoot = REPO_ROOT } = {}) {
       }
     }
 
+    if (!testOk && canUseCentralEvidence) {
+      const centralTest = findChangedLegacyTest({
+        changed,
+        sourceRel,
+        componentSource,
+        repoRoot,
+      });
+      if (centralTest) {
+        testOk = true;
+        resolvedTest = centralTest;
+      }
+    }
+
     if (!testOk) {
       issues.push({
         path: sourceRel,
@@ -182,19 +739,28 @@ export function checkChangedComponents(changed, { repoRoot = REPO_ROOT } = {}) {
     }
 
     // --- Story presence ---
+    const centralStory = canUseCentralEvidence
+      ? findCanonicalMarketingStory({
+          sourceRel,
+          componentSource,
+          repoRoot,
+        })
+      : null;
+    const storyRel = adjacentStoryRel ?? centralStory?.storyRel ?? null;
+
     if (!storyRel) {
       issues.push({
         path: sourceRel,
         rule: 'missing-story',
-        detail: `No adjacent ${base}.stories.tsx`,
+        detail: `No adjacent ${base}.stories.tsx or verified canonical marketing story`,
       });
       continue;
     }
 
     // --- Match checks ---
-    let storySource;
+    let storySource = adjacentStoryRel ? null : centralStory?.storySource;
     try {
-      storySource = readText(storyRel, repoRoot);
+      storySource ??= readText(storyRel, repoRoot);
     } catch {
       issues.push({
         path: storyRel,
@@ -265,7 +831,12 @@ export function runComponentShipGate(options = {}) {
   // 1) Diff gate (skip when no base — still run ratchet/quality)
   if (flags.diffBase) {
     const changed = changedFiles(flags.diffBase);
-    const diff = checkChangedComponents(changed);
+    const legacyComponents = new Set(
+      changed
+        .filter(isUnderShipScope)
+        .filter(sourceRel => existedAtDiffBase(flags.diffBase, sourceRel))
+    );
+    const diff = checkChangedComponents(changed, { legacyComponents });
     report.sections.diff = diff;
     if (!diff.ok) report.ok = false;
   } else {

--- a/scripts/lib/__tests__/component-ship-gate.test.mjs
+++ b/scripts/lib/__tests__/component-ship-gate.test.mjs
@@ -36,6 +36,42 @@ function fixtureRepo(tree) {
   return root;
 }
 
+const LEGACY_COMPONENT_REL =
+  'apps/web/components/marketing/legacy/LegacyPanel.tsx';
+const LEGACY_TEST_REL = 'apps/web/tests/unit/marketing/LegacyPanel.test.tsx';
+const LEGACY_STORY_REL =
+  'apps/web/components/marketing/storybook/MarketingSections.stories.tsx';
+const LEGACY_COMPONENT_SOURCE =
+  'export interface LegacyPanelProps { readonly title: string }\n' +
+  'export function LegacyPanel({ title }: LegacyPanelProps) { return <h2>{title}</h2> }';
+const LEGACY_TEST_SOURCE =
+  "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';\nvoid LegacyPanel;";
+const LEGACY_STORY_SOURCE =
+  "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';\n" +
+  "export const Legacy = { render: () => <LegacyPanel title='Legacy' /> };";
+
+function legacyEvidenceResult({
+  componentSource = LEGACY_COMPONENT_SOURCE,
+  testSource = LEGACY_TEST_SOURCE,
+  storySource = LEGACY_STORY_SOURCE,
+  testRel = LEGACY_TEST_REL,
+  changedTest = true,
+  legacy = true,
+} = {}) {
+  const root = fixtureRepo({
+    [LEGACY_COMPONENT_REL]: componentSource,
+    [testRel]: testSource,
+    [LEGACY_STORY_REL]: storySource,
+  });
+  return checkChangedComponents(
+    changedTest ? [LEGACY_COMPONENT_REL, testRel] : [LEGACY_COMPONENT_REL],
+    {
+      repoRoot: root,
+      legacyComponents: legacy ? new Set([LEGACY_COMPONENT_REL]) : new Set(),
+    }
+  );
+}
+
 describe('component-ship-policy scope', () => {
   it('includes shippable surfaces and excludes tests/stories/utils', () => {
     expect(isUnderShipScope('packages/ui/atoms/button.tsx')).toBe(true);
@@ -178,6 +214,167 @@ describe('diff gate', () => {
     expect(list.some(c => c.covered)).toBe(true);
     void bare;
     void checkChangedComponents;
+  });
+
+  it('accepts central evidence only for a changed legacy component', () => {
+    expect(legacyEvidenceResult().ok).toBe(true);
+
+    const unchangedTest = legacyEvidenceResult({ changedTest: false });
+    expect(unchangedTest.ok).toBe(false);
+    expect(
+      unchangedTest.issues.some(issue => issue.rule === 'missing-test')
+    ).toBe(true);
+
+    const newComponent = legacyEvidenceResult({ legacy: false });
+    expect(newComponent.ok).toBe(false);
+    expect(newComponent.issues.map(issue => issue.rule)).toEqual(
+      expect.arrayContaining(['missing-test', 'missing-story'])
+    );
+  });
+
+  it.each([
+    [
+      'an exact import replaced by a component mock',
+      [
+        "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        "const target = '@/components/marketing/legacy/LegacyPanel';",
+        'vi.mock(target, () => ({ LegacyPanel: () => null }));',
+        'void LegacyPanel;',
+      ].join('\n'),
+    ],
+    [
+      'a commented import',
+      [
+        "// import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        'void LegacyPanel;',
+      ].join('\n'),
+    ],
+    [
+      'runtime use of a local binding that shadows the import',
+      [
+        "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        'function exerciseShadow() {',
+        '  const LegacyPanel = () => null;',
+        '  return LegacyPanel();',
+        '}',
+        'exerciseShadow();',
+      ].join('\n'),
+    ],
+    [
+      'an asserted source read from a fake local reader',
+      [
+        "const readFileSync = () => 'fake source';",
+        "const source = readFileSync('components/marketing/legacy/LegacyPanel.tsx', 'utf8');",
+        "expect(source).toContain('LegacyPanel');",
+      ].join('\n'),
+    ],
+  ])('rejects %s as central test evidence', (_case, testSource) => {
+    const result = legacyEvidenceResult({ testSource });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some(issue => issue.rule === 'missing-test')).toBe(
+      true
+    );
+  });
+
+  it('accepts an asserted exact source read through node:fs', () => {
+    const result = legacyEvidenceResult({
+      testRel: LEGACY_TEST_REL.replace('.tsx', '.ts'),
+      testSource: [
+        "import { readFileSync } from 'node:fs';",
+        "import { resolve } from 'node:path';",
+        "const source = readFileSync(resolve(process.cwd(), 'components/marketing/legacy/LegacyPanel.tsx'), 'utf8');",
+        "expect(source).toContain('LegacyPanel');",
+      ].join('\n'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it.each([
+    [
+      'props and exemptions from unrelated story content',
+      [
+        "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        "import { OtherPanel } from '@/components/marketing/other/OtherPanel';",
+        "export const MissingTitle = { parameters: { jovie: { uncoveredProps: ['title'] } }, render: () => <LegacyPanel /> };",
+        "export const Unrelated = { render: () => <OtherPanel title='Not evidence' /> };",
+      ].join('\n'),
+    ],
+    [
+      'comment- and string-only JSX',
+      [
+        "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        'const fakeMarkup = "<LegacyPanel title=\'String only\' />";',
+        "/* <LegacyPanel title='Comment only' /> */",
+        'export const Empty = { render: () => null };',
+      ].join('\n'),
+    ],
+    [
+      'a rendered mock',
+      [
+        "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        "vi.mock('@/components/marketing/legacy/LegacyPanel' + '', () => ({ LegacyPanel: () => null }));",
+        "export const Mocked = { render: () => <LegacyPanel title='Mocked' /> };",
+      ].join('\n'),
+    ],
+    [
+      'a same-named import from the wrong module',
+      [
+        "import { LegacyPanel } from '@/components/marketing/other/LegacyPanel';",
+        "export const WrongModule = { render: () => <LegacyPanel title='Legacy' /> };",
+      ].join('\n'),
+    ],
+  ])('rejects %s as canonical story evidence', (_case, storySource) => {
+    const result = legacyEvidenceResult({ storySource });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some(issue => issue.rule === 'missing-story')).toBe(
+      true
+    );
+  });
+
+  it('honors only a component-scoped prop exemption', () => {
+    const result = legacyEvidenceResult({
+      componentSource: [
+        'export interface LegacyPanelProps {',
+        '  readonly title: string;',
+        '  readonly disabled: boolean;',
+        '}',
+        'export function LegacyPanel({ title }: LegacyPanelProps) { return <h2>{title}</h2> }',
+      ].join('\n'),
+      storySource: [
+        "import { LegacyPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        'export const Legacy = {',
+        "  parameters: { jovie: { uncoveredPropsByComponent: { LegacyPanel: ['disabled'] } } },",
+        "  render: () => <LegacyPanel title='Legacy' />,",
+        '};',
+      ].join('\n'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('does not let one export exempt another export', () => {
+    const result = legacyEvidenceResult({
+      componentSource: [
+        'export interface PrimaryPanelProps { readonly title: string }',
+        'export function PrimaryPanel({ title }: PrimaryPanelProps) { return <h2>{title}</h2> }',
+        'export interface SecondaryPanelProps { readonly disabled: boolean }',
+        'export function SecondaryPanel() { return null }',
+      ].join('\n'),
+      testSource: [
+        "import { PrimaryPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        'void PrimaryPanel;',
+      ].join('\n'),
+      storySource: [
+        "import { PrimaryPanel, SecondaryPanel } from '@/components/marketing/legacy/LegacyPanel';",
+        'export const Both = {',
+        "  parameters: { jovie: { uncoveredPropsByComponent: { PrimaryPanel: ['disabled'] } } },",
+        "  render: () => <><PrimaryPanel title='Primary' /><SecondaryPanel /></>,",
+        '};',
+      ].join('\n'),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some(issue => issue.rule === 'missing-story')).toBe(
+      true
+    );
   });
 });
 


### PR DESCRIPTION
## Description

Repairs the component ship gate so legacy marketing/site components may use the repository's canonical Storybook catalogs and changed central tests without inheriting unrelated adjacency debt.

The exception is fail-closed:
- new components still require adjacent tests and stories
- tests require an exact, unmocked runtime import/use or an asserted exact source read through `node:fs`
- canonical stories require the exact module and real JSX inside an exported story
- prop exemptions are component-scoped and cannot leak across multi-export modules

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- [x] Unit tests pass — `pnpm exec vitest run scripts/lib/__tests__/component-ship-gate.test.mjs` (21/21)
- [x] New tests added
- [x] Full gate passes — `pnpm component-ship-gate`

### Bug-to-Test Rule

- [x] Regression test added or updated
- [x] bug-to-test: satisfied

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Independent adversarial review passed twice

## Accessibility / Browser / Database / Deployment

Not applicable: CI policy and documentation only. No runtime UI, database, environment, external-data, or deployment configuration changes.

design-canonical: not applicable

## Checklist

- [x] PR title follows conventional commit format
- [x] Branch is up to date with target branch
- [x] Documentation updated
