### PR TITLE
docs(marketing): ban artifact-selling copy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -189,6 +189,7 @@ The example above says one thing three times. Jovie should say it once.
 - Multiple nested surfaces whose only job is to create the feeling of "designed"
 - Treating borders as the primary way to separate content instead of using spacing, alignment, contrast, and typography
 - Hover motion that makes panels, buttons, screenshots, or cards jump, lift, or slide for no functional reason
+- **Selling the artifact instead of the product** — customer-facing copy must never describe how the page was designed, produced, captured, annotated, or verified. Ban phrases such as "no mockups," "not a concept render," "real screenshot," "captured from the registry," and similar provenance commentary. Replace them with the customer outcome or product capability the visual proves.
 - **Emoji/symbol on colored background square** — explicitly banned. This pattern cheapens the brand and reads as consumer-grade AI slop. Use accent color on title text only.
 - **Gold colors in brand/CTA expression** — banned. Avoid prestige-signaling metallic tones for identity or primary actions. (Feature accent orange/amber for Pro tier is a distinct, permitted use.)
 - **Saturated brand colors** for CTAs — CTAs are white-on-black (Apple approach). Accent colors are for feature differentiation only.

--- a/canon/VOICE.md
+++ b/canon/VOICE.md
@@ -26,6 +26,7 @@ Primary voice question:
 - Confidence must match evidence.
 - Do not overpromise what the product cannot reliably deliver.
 - Do not expose internal machinery unless the customer benefits from knowing it.
+- Do not sell the artifact instead of the product. Customer-facing copy must not discuss mockups, screenshots, concept renders, annotations, registries, design decisions, or production provenance. State the customer outcome or capability that the evidence demonstrates.
 
 ---
 

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -90,6 +90,7 @@ modes, neverUse rules.
 - `revalidate = false` (fully static — hard invariant).
 - Dark-only theme (System A — DESIGN.md).
 - Copy-in-data: copy lives in `apps/web/data/*Copy.ts`, not inline in the page.
+- Customer-facing copy sells the product outcome, never the artifact. Do not mention mockups, concept renders, screenshots, registries, annotations, design decisions, or how proof media was produced. Asset provenance belongs in code, alt text, review notes, or manifests—not the rendered marketing story.
 - One body face, one container width (`page` | `prose`), spacing-only transitions.
 - `data-testid="marketing-section-{sectionId}"` on each section wrapper.
 - Proof sections render only if `proofVerified: true` (the resolver already


### PR DESCRIPTION
## Description

- Ban copy that sells the landing-page construction instead of the product.
- Add the rule to design, voice, and marketing-agent canon so future pages stay product-truthful.
- Stack 1 of 9.

## Type of Change

- [x] Documentation update

## Testing

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added or updated where applicable

Integrated stack evidence:

- Full normal pre-push gate passed: Biome, Tailwind guard, typecheck, component-ship gate, and all 8 unit-test shards.
- Component evidence: 21 changed components; 127 stories scanned; ratchet clean.
- Design and marketing guard sweep: 64 files / 238 tests passed.
- Artist Profiles Playwright contract: 10/10 passed.
- Production build: 469/469 static pages; /artist-profiles and /artist-profile generated.
- Screenshot-catalog integrity passed.
- Independent design reviews: clarity/conversion, reduction/craft, and product-callout system all PASS.

bug-to-test: not applicable — feature, documentation, or test-contract work.

## Design Skill Evidence

- [x] Design-read: public product landing page for independent artists, dark high-contrast Jovie System B language, product-first and editorial.
- [x] Dials: DESIGN_VARIANCE 4/10; MOTION_INTENSITY 2/10; VISUAL_DENSITY 5/10.
- [x] Before/after evidence: browser-verified at 1440px and 390px; canonical product captures included in the stack.
- [x] Narrow lint and typecheck output included in local verification.
- [x] design-canonical: PASS — contrast, states, layout, reduced motion, icons, anti-slop, and evidence.
- [x] No state transition introduces layout shift.
- [x] No external-data embedding or vectorization pipeline is created, populated, or deployed.

## Deployment Notes

- No migrations, environment variables, feature flags, billing, auth, or external-data embedding changes.
- Standard production controller may deploy after the exact final main SHA clears the native merge queue.

