### PR TITLE
feat(marketing): replace profile cards with outcome ledger

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.css
@@ -1,15 +1,3 @@
-/*
- * ArtistProfileOutcomesCarousel — System B colocated styles (JOV-4355).
- *
- * Effects utilities cannot express (exact rem radii, ch-max-widths, letter/
- * line spacing, alpha shadows, backdrop tints) live here, scoped to the
- * ap-outcomes tree. Tokens preferred over literals; color-mix(in oklab,
- * <token> N%, transparent) replaces hard-coded rgba under the forced-dark
- * marketing theme.
- */
-
-/* ---------- Section surface ---------- */
-
 .ap-outcomes {
   background: color-mix(
     in oklab,
@@ -18,161 +6,39 @@
   );
 }
 
-/* ---------- Rail controls ---------- */
-
-.ap-outcomes__nav-btn {
-  border: 1px solid
-    color-mix(in oklab, var(--color-text-primary-token) 10%, transparent);
-  background: color-mix(
-    in oklab,
-    var(--system-b-cinematic-black) 62%,
-    transparent
-  );
-  color: var(--color-text-primary-token);
-  box-shadow: 0 18px 44px
-    color-mix(in oklab, var(--system-b-cinematic-black) 28%, transparent);
+.ap-outcomes__row {
+  grid-template-columns: 2.5rem minmax(0, 0.55fr) minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: clamp(1rem, 3vw, 3rem);
 }
 
-.ap-outcomes__nav-btn:hover {
-  background: var(--color-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
-
-.ap-outcomes__nav-btn:focus-visible {
-  outline: none;
-  box-shadow:
-    0 0 0 2px var(--system-b-cinematic-black),
-    0 0 0 4px
-    color-mix(in oklab, var(--color-text-primary-token) 30%, transparent);
-}
-
-.ap-outcomes__rail-btn {
-  border: 1px solid
-    color-mix(in oklab, var(--system-b-cinematic-black) 12%, transparent);
-  color: var(--color-text-primary-token);
-  box-shadow: 0 18px 42px
-    color-mix(in oklab, var(--system-b-cinematic-black) 16%, transparent);
-}
-
-.ap-outcomes__rail-btn:focus-visible {
-  outline: none;
-  box-shadow:
-    0 18px 42px
-    color-mix(in oklab, var(--system-b-cinematic-black) 16%, transparent),
-    0 0 0 2px
-    color-mix(in oklab, var(--system-b-cinematic-black) 15%, transparent);
-}
-
-/* ---------- Outcome card ---------- */
-
-.ap-outcomes__card {
-  box-shadow: var(--shadow-lg);
-}
-
-.ap-outcomes__card-title {
-  max-width: 12ch;
-}
-
-.ap-outcomes__card-body {
-  max-width: 38ch;
-}
-
-/* ---------- Proof drawers ---------- */
-
-.ap-outcomes__drawer {
-  border-radius: 1.08rem;
-  background: color-mix(
-    in oklab,
-    var(--color-text-primary-token) 2%,
-    transparent
-  );
-  box-shadow: inset 0 1px 0
-    color-mix(in oklab, var(--color-text-primary-token) 4%, transparent);
-}
-
-.ap-outcomes__drawer-title {
-  letter-spacing: -0.02em;
-}
-
-.ap-outcomes__drawer-label {
-  letter-spacing: -0.01em;
-}
-
-.ap-outcomes__drawer-subtitle {
+.ap-outcomes__title {
   letter-spacing: -0.03em;
 }
 
-.ap-outcomes__tour-month {
-  line-height: 1.15;
-  letter-spacing: -0.01em;
+.ap-outcomes__description {
+  max-width: 42rem;
 }
 
-.ap-outcomes__tour-day {
-  letter-spacing: -0.04em;
+.ap-outcomes__result {
+  text-align: right;
+  white-space: nowrap;
 }
 
-.ap-outcomes__amount {
-  border-radius: 0.82rem;
-  border: 1px solid
-    color-mix(in oklab, var(--color-text-primary-token) 8%, transparent);
-  background: color-mix(
-    in oklab,
-    var(--color-text-primary-token) 3%,
-    transparent
-  );
-  color: var(--color-text-primary-token);
-}
+@media (max-width: 47.99rem) {
+  .ap-outcomes__row {
+    grid-template-columns: 2rem minmax(0, 1fr);
+    align-items: start;
+    row-gap: var(--space-3);
+  }
 
-.ap-outcomes__amount--featured {
-  border-color: color-mix(
-    in oklab,
-    var(--color-text-primary-token) 18%,
-    transparent
-  );
-  background: var(--color-bg-surface-1);
-  color: var(--color-text-primary-token);
-}
+  .ap-outcomes__description,
+  .ap-outcomes__result {
+    grid-column: 2;
+  }
 
-.ap-outcomes__amount-value {
-  letter-spacing: -0.02em;
-}
-
-.ap-outcomes__shot {
-  border-radius: 1.08rem;
-  box-shadow: 0 14px 32px
-    color-mix(in oklab, var(--system-b-cinematic-black) 22%, transparent);
-}
-
-/* ---------- Share-anywhere QR card ---------- */
-
-.ap-outcomes__qr-card {
-  border-radius: 1.2rem;
-  box-shadow: 0 16px 32px
-    color-mix(in oklab, var(--system-b-cinematic-black) 14%, transparent);
-}
-
-.ap-outcomes__qr-title {
-  letter-spacing: 0.02em;
-}
-
-.ap-outcomes__qr-frame {
-  /* QR ink and paper are protocol colors, not theme colors. Keeping them
-     local prevents dark mode from reducing the code's contrast or changing
-     its meaning. */
-  --qr-preview-ink: #000;
-  --qr-preview-paper: #fff;
-  background: var(--qr-preview-paper);
-  box-shadow: inset 0 0 0 1px rgba(17, 17, 17, 0.06);
-}
-
-.ap-outcomes__qr-cell--filled {
-  background: var(--qr-preview-ink);
-}
-
-.ap-outcomes__qr-cell--empty {
-  background: var(--qr-preview-paper);
-}
-
-.ap-outcomes__qr-url {
-  letter-spacing: -0.02em;
+  .ap-outcomes__result {
+    color: var(--color-text-tertiary-token);
+    text-align: left;
+  }
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
@@ -1,16 +1,4 @@
-'use client';
-
-import { Check, Mail } from 'lucide-react';
-import Image from 'next/image';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
-import {
-  HOMEPAGE_PROFILE_PREVIEW_ARTIST,
-  HOMEPAGE_PROFILE_PREVIEW_RELEASES,
-  HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES,
-} from '@/features/home/homepage-profile-preview-fixture';
-import { ProfilePrimaryActionCard } from '@/features/profile/ProfilePrimaryActionCard';
-import { cn } from '@/lib/utils';
-import { MarketingSnapRail } from '../MarketingSnapRail';
 import './ArtistProfileOutcomesCarousel.css';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
@@ -19,380 +7,62 @@ interface ArtistProfileOutcomesCarouselProps {
   readonly outcomes: ArtistProfileLandingCopy['outcomes'];
 }
 
-type OutcomeId =
-  ArtistProfileLandingCopy['outcomes']['landingCards'][number]['id'];
-
-// Per-card widths. Horizontal rail lets each outcome take the room its
-// mockup actually needs. Drive streams and Sell out need side-by-side
-// proofs, so they get wider slots; Share anywhere is a single QR card
-// and can stay narrow.
-const OUTCOME_CARD_WIDTHS: Record<OutcomeId, string> = {
-  'straight-to-listen': 'w-full sm:w-136 lg:w-152',
-  'local-dates-first': 'w-full sm:w-144 lg:w-160',
-  'support-without-friction': 'w-full sm:w-120 lg:w-128',
-  'capture-the-fan': 'w-full sm:w-108 lg:w-116',
-  'one-link-everywhere': 'w-full sm:w-96 lg:w-104',
-};
-
-const SHOWCASE_VIEWER_LOCATION = {
-  latitude: 34.0522,
-  longitude: -118.2437,
+const OUTCOME_RESULTS = {
+  'straight-to-listen': 'Listen Comes First',
+  'local-dates-first': 'Nearby Show Leads',
+  'support-without-friction': 'Support Stays Simple',
+  'capture-the-fan': 'Fan Opts In',
+  'one-link-everywhere': 'One Link Stays',
 } as const;
 
 export function ArtistProfileOutcomesCarousel({
   outcomes,
 }: Readonly<ArtistProfileOutcomesCarouselProps>) {
-  return (
-    <ArtistProfileSectionShell
-      className='ap-outcomes'
-      containerClassName='!max-w-none !px-0'
-      width='page'
-    >
-      <div>
-        <div className='mx-auto max-w-public-content px-5 sm:px-6 lg:px-0'>
-          <ArtistProfileSectionHeader
-            align='left'
-            headline={outcomes.headline}
-            body={outcomes.body}
-            className='max-w-152'
-            bodyClassName='max-w-120'
-          />
-        </div>
+  const ledgerRows = outcomes.landingCards.slice(0, 4);
 
-        {/* Compatibility stub: historical e2e asserts the legacy scroller node stays hidden. */}
+  return (
+    <ArtistProfileSectionShell className='ap-outcomes'>
+      <div className='mx-auto max-w-public-content'>
+        <ArtistProfileSectionHeader
+          align='left'
+          headline={outcomes.headline}
+          body={outcomes.body}
+          className='max-w-3xl'
+          bodyClassName='max-w-xl'
+        />
+
         <div
           data-testid='artist-profile-outcomes-scroller'
           className='hidden'
           aria-hidden='true'
         />
-
-        <div className='mt-10'>
-          <MarketingSnapRail
-            ariaLabel='Outcome Showcase'
-            instructionsId='artist-profile-outcomes-instructions'
-            instructions='Browse the five outcome cards. Previous and next controls are available when the cards form a horizontal rail.'
-            scrollerTestId='artist-profile-outcomes-grid'
-            previousLabel='Scroll Outcomes Left'
-            nextLabel='Scroll Outcomes Right'
-            testId='artist-profile-outcomes-rail'
-          >
-            {outcomes.landingCards.map(card => (
-              <OutcomeCard key={card.id} card={card} outcomes={outcomes} />
-            ))}
-          </MarketingSnapRail>
-        </div>
+        <ol
+          data-testid='artist-profile-outcomes-grid'
+          className='ap-outcomes__ledger mt-10 border-t border-subtle'
+          aria-label='Fan Outcomes'
+        >
+          {ledgerRows.map((outcome, index) => (
+            <li
+              key={outcome.id}
+              data-testid='artist-profile-outcome-card'
+              className='ap-outcomes__row grid border-b border-subtle py-5 sm:py-6'
+            >
+              <span className='ap-outcomes__index font-mono text-3xs text-tertiary-token'>
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <h3 className='ap-outcomes__title text-xl font-semibold text-primary-token sm:text-2xl'>
+                {outcome.title}
+              </h3>
+              <p className='ap-outcomes__description text-app leading-relaxed text-secondary-token'>
+                {outcome.description}
+              </p>
+              <p className='ap-outcomes__result font-mono text-xs font-semibold text-primary-token'>
+                {OUTCOME_RESULTS[outcome.id]}
+              </p>
+            </li>
+          ))}
+        </ol>
       </div>
     </ArtistProfileSectionShell>
   );
 }
-
-function OutcomeCard({
-  card,
-  outcomes,
-}: Readonly<{
-  card: ArtistProfileLandingCopy['outcomes']['landingCards'][number];
-  outcomes: ArtistProfileLandingCopy['outcomes'];
-}>) {
-  const proof = outcomes.syntheticProofs;
-
-  return (
-    <article
-      data-testid='artist-profile-outcome-card'
-      className={cn(
-        'ap-outcomes__card group relative flex shrink-0 snap-start flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0',
-        OUTCOME_CARD_WIDTHS[card.id]
-      )}
-    >
-      <div className='relative flex h-full flex-col p-4 sm:p-5'>
-        <div className='max-w-72'>
-          <h3 className='ap-outcomes__card-title text-2xl font-semibold leading-tight tracking-tight text-primary-token sm:text-3xl'>
-            {card.title}
-          </h3>
-          <p className='ap-outcomes__card-body mt-3 text-app leading-relaxed text-secondary-token'>
-            {card.description}
-          </p>
-        </div>
-
-        <div className='mt-6'>
-          {card.id === 'straight-to-listen' ? <DriveStreamsProof /> : null}
-          {card.id === 'local-dates-first' ? (
-            <SellOutProof proof={proof.visualProofs.sellOut} />
-          ) : null}
-          {card.id === 'support-without-friction' ? (
-            <GetPaidProof proof={proof.visualProofs.getPaid} />
-          ) : null}
-          {card.id === 'capture-the-fan' ? (
-            <CaptureFanProof proof={proof.captureFan} />
-          ) : null}
-          {card.id === 'one-link-everywhere' ? (
-            <ShareProof proof={proof.shareAnywhere} />
-          ) : null}
-        </div>
-      </div>
-    </article>
-  );
-}
-
-const SHOWCASE_NOW = new Date('2026-04-20T12:00:00.000Z');
-
-function DriveStreamsProof() {
-  return (
-    <div className='grid gap-2 sm:grid-cols-[1.02fr_0.98fr]'>
-      <div className='sm:pt-4'>
-        <ProfilePrimaryActionCard
-          artist={HOMEPAGE_PROFILE_PREVIEW_ARTIST}
-          latestRelease={HOMEPAGE_PROFILE_PREVIEW_RELEASES.live}
-          profileSettings={{ showOldReleases: true }}
-          tourDates={[]}
-          hasPlayableDestinations={true}
-          renderMode='preview'
-          previewActionLabel='Listen'
-          size='showcase'
-          now={SHOWCASE_NOW}
-          className='w-full'
-          dataTestId='artist-profile-drive-streams-live-card'
-        />
-      </div>
-      <div className='sm:-mb-2'>
-        <ProfilePrimaryActionCard
-          artist={HOMEPAGE_PROFILE_PREVIEW_ARTIST}
-          latestRelease={HOMEPAGE_PROFILE_PREVIEW_RELEASES.presave}
-          profileSettings={{ showOldReleases: true }}
-          tourDates={[]}
-          hasPlayableDestinations={true}
-          renderMode='preview'
-          previewActionLabel='Listen'
-          size='showcase'
-          now={SHOWCASE_NOW}
-          className='w-full'
-          dataTestId='artist-profile-drive-streams-presave-card'
-        />
-      </div>
-    </div>
-  );
-}
-
-function SellOutProof({
-  proof,
-}: Readonly<{
-  proof: ArtistProfileLandingCopy['outcomes']['syntheticProofs']['visualProofs']['sellOut'];
-}>) {
-  return (
-    <div className='grid gap-2 sm:grid-cols-[0.9fr_1.1fr]'>
-      <div className='sm:pt-4'>
-        <ProfilePrimaryActionCard
-          artist={HOMEPAGE_PROFILE_PREVIEW_ARTIST}
-          latestRelease={null}
-          profileSettings={{ showOldReleases: true }}
-          tourDates={HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES}
-          hasPlayableDestinations={false}
-          renderMode='preview'
-          size='showcase'
-          viewerLocation={SHOWCASE_VIEWER_LOCATION}
-          now={SHOWCASE_NOW}
-          className='w-full'
-          dataTestId='artist-profile-sell-out-tour-card'
-        />
-      </div>
-
-      <div className='ap-outcomes__drawer flex h-full flex-col border border-subtle px-3.5 py-3'>
-        <p className='ap-outcomes__drawer-title text-xs font-semibold text-primary-token'>
-          {proof.drawerTitle}
-        </p>
-        <p className='mt-1 text-2xs text-tertiary-token'>
-          {proof.drawerSubtitle}
-        </p>
-        <div className='mt-2.5 divide-y divide-white/6'>
-          {proof.drawerRows.map(row => (
-            <div
-              key={row.id}
-              className='grid grid-cols-[2.45rem_minmax(0,1fr)_auto] items-center gap-2 py-2.25'
-            >
-              <span className='ap-outcomes__tour-month text-2xs font-medium text-secondary-token'>
-                {row.month}
-                <span className='ap-outcomes__tour-day block text-sm font-semibold text-primary-token'>
-                  {row.day}
-                </span>
-              </span>
-              <span className='min-w-0'>
-                <span className='block truncate text-xs font-semibold text-primary-token'>
-                  {row.venue}
-                </span>
-                <span className='block truncate text-2xs text-tertiary-token'>
-                  {row.location}
-                </span>
-              </span>
-              <span className='text-2xs font-medium text-secondary-token'>
-                {row.ctaLabel}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function GetPaidProof({
-  proof,
-}: Readonly<{
-  proof: ArtistProfileLandingCopy['outcomes']['syntheticProofs']['visualProofs']['getPaid'];
-}>) {
-  return (
-    <div className='grid gap-2 sm:grid-cols-[0.9fr_1.1fr]'>
-      <div className='ap-outcomes__drawer flex flex-col justify-between border border-subtle px-3 py-3 sm:pt-3.5'>
-        <div>
-          <p className='ap-outcomes__drawer-label text-2xs font-medium text-tertiary-token'>
-            {proof.drawerTitle}
-          </p>
-          <p className='ap-outcomes__drawer-subtitle mt-1 text-app font-semibold text-primary-token'>
-            {proof.drawerSubtitle}
-          </p>
-        </div>
-
-        <div className='mt-3 space-y-1.5'>
-          <p className='ap-outcomes__drawer-label text-2xs font-medium text-tertiary-token'>
-            {proof.chooseAmountLabel}
-          </p>
-          <div className='grid gap-1.5'>
-            {proof.amountRows.map(row => (
-              <div
-                key={row.id}
-                className={cn(
-                  'ap-outcomes__amount flex items-center justify-between px-3 py-1.75 text-xs',
-                  row.featured && 'ap-outcomes__amount--featured'
-                )}
-              >
-                <span className='ap-outcomes__amount-value font-semibold'>
-                  {row.amount}
-                </span>
-                <span
-                  className={cn(
-                    'text-3xs font-medium',
-                    row.featured
-                      ? 'text-secondary-token'
-                      : 'text-tertiary-token'
-                  )}
-                >
-                  {row.currency}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <span className='mt-3 inline-flex w-fit rounded-full bg-surface-1 px-3.5 py-2 text-2xs font-semibold text-primary-token'>
-          {proof.ctaLabel}
-        </span>
-      </div>
-
-      <article className='ap-outcomes__shot relative min-h-53 overflow-hidden border border-subtle bg-surface-input sm:-translate-y-2'>
-        <Image
-          alt={proof.screenshotAlt}
-          fill
-          sizes='(max-width: 768px) 100vw, 320px'
-          src={proof.screenshotSrc}
-          className='object-cover object-bottom'
-        />
-      </article>
-    </div>
-  );
-}
-
-function CaptureFanProof({
-  proof,
-}: Readonly<{
-  proof: ArtistProfileLandingCopy['outcomes']['syntheticProofs']['captureFan'];
-}>) {
-  return (
-    <div className='rounded-xl border border-subtle bg-surface-1 p-4 sm:p-5'>
-      <div className='flex items-center gap-3'>
-        <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-2 text-primary-token'>
-          <Mail className='h-4 w-4' aria-hidden='true' />
-        </span>
-        <div>
-          <p className='text-xs font-semibold text-primary-token'>
-            {proof.inputLabel}
-          </p>
-          <p className='mt-1 font-mono text-xs text-tertiary-token'>
-            {proof.inputValue}
-          </p>
-        </div>
-      </div>
-
-      <div className='mt-4 flex items-center justify-between gap-3 rounded-lg border border-subtle bg-surface-0 px-3 py-2.5'>
-        <span className='text-xs font-medium text-secondary-token'>
-          {proof.ctaLabel}
-        </span>
-        <span className='inline-flex items-center gap-1.5 rounded-full bg-primary-token px-3 py-1.5 text-3xs font-semibold text-surface-1'>
-          <Check className='h-3 w-3' aria-hidden='true' />
-          {proof.confirmedLabel}
-        </span>
-      </div>
-
-      <p className='mt-4 flex items-center gap-2 text-xs font-medium text-secondary-token'>
-        <span
-          aria-hidden='true'
-          className='h-1.5 w-1.5 rounded-full bg-success'
-        />
-        {proof.followUpLabel}
-      </p>
-    </div>
-  );
-}
-
-function ShareProof({
-  proof,
-}: Readonly<{
-  proof: ArtistProfileLandingCopy['outcomes']['syntheticProofs']['shareAnywhere'];
-}>) {
-  return (
-    <div className='flex justify-center sm:pt-2'>
-      <div className='ap-outcomes__qr-card relative ml-auto flex w-full max-w-62 flex-col items-center bg-badge-text px-4 py-4.5 text-center text-primary-token'>
-        <p className='ap-outcomes__qr-title text-2xs font-semibold text-secondary-token'>
-          {proof.title}
-        </p>
-
-        <div className='ap-outcomes__qr-frame mt-3.5 flex h-39 w-39 items-center justify-center rounded-xl'>
-          <div className='grid grid-cols-7 gap-2'>
-            {QR_CELLS.map(cell => (
-              <span
-                key={cell.id}
-                className={cn(
-                  'h-2.5 w-2.5 rounded-xs',
-                  cell.filled
-                    ? 'ap-outcomes__qr-cell--filled'
-                    : 'ap-outcomes__qr-cell--empty'
-                )}
-              />
-            ))}
-          </div>
-        </div>
-
-        <p className='ap-outcomes__qr-url mt-3.5 font-mono text-2xs font-semibold text-primary-token'>
-          {proof.url}
-        </p>
-        <p className='mt-2 text-2xs font-medium text-tertiary-token'>
-          {proof.subtitle}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-const QR_PATTERN = [
-  '1110111',
-  '1010101',
-  '1110111',
-  '0001000',
-  '1111101',
-  '1010001',
-  '1110111',
-] as const;
-
-const QR_CELLS = QR_PATTERN.flatMap((row, rowIndex) =>
-  row.split('').map((cell, cellIndex) => ({
-    id: `r${rowIndex}c${cellIndex}`,
-    filled: cell === '1',
-  }))
-);

--- a/apps/web/data/artistProfileCopy.ts
+++ b/apps/web/data/artistProfileCopy.ts
@@ -345,6 +345,11 @@ export interface ArtistProfileLandingCopy {
   readonly specWall: {
     readonly headline: string;
     readonly subhead: string;
+    readonly callouts?: readonly {
+      readonly id: 'identity' | 'release' | 'action' | 'navigation';
+      readonly title: string;
+      readonly body: string;
+    }[];
   };
   readonly howItWorks: {
     readonly headline: string;
@@ -427,7 +432,7 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     eyebrow: '',
     headline: 'The link your music deserves.',
     subhead:
-      'One adaptive home for music, merch, social links, and fan capture — free to start.',
+      'One profile that puts the right action first—from pre-save and release day to nearby shows, support, and fan follow-up.',
     ctaLabel: 'Claim your profile',
     signature: 'jov.ie/you',
     proofWhisper: 'Used by artists on',
@@ -436,13 +441,13 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
   },
   adaptive: {
     eyebrow: '',
-    headline: 'One profile that adapts to every fan.',
+    headline: 'One adaptive profile. Four moments.',
     alternateHeadlines: [
       'One profile for every release moment.',
       'One link, tuned to what matters right now.',
       'The same link, different job.',
     ],
-    body: 'Link once. Capture the fan. Learn what converts. Close the moment. Before a drop, the profile becomes a countdown. On release day, fans route to the right service. On tour, nearby dates lead. At the merch table, one scan becomes support and capture.',
+    body: 'Keep the same link everywhere. Jovie changes the leading action as the moment changes.',
     contextCues: [
       'Release-aware',
       'Location-aware',
@@ -617,7 +622,7 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
   },
   outcomes: {
     headline: 'Built around fan outcomes.',
-    body: 'Link, capture, learn, convert — each profile state reduces friction and moves the fan to the next right action.',
+    body: 'Every state removes a choice and moves the fan toward one useful action.',
     cards: [
       {
         id: 'drive-streams',
@@ -646,25 +651,25 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     landingCards: [
       {
         id: 'straight-to-listen',
-        title: 'Straight to listen',
+        title: 'Listen',
         description:
           'Fans land on the right release and the right platform without hunting through a stack of links.',
       },
       {
         id: 'local-dates-first',
-        title: 'Local dates first',
+        title: 'Show Up',
         description:
           'Touring fans see the show that matters to them instead of scrolling through cities that do not.',
       },
       {
         id: 'support-without-friction',
-        title: 'Support without friction',
+        title: 'Support',
         description:
           'When someone is ready to support, the profile turns that moment into action fast.',
       },
       {
         id: 'capture-the-fan',
-        title: 'Capture the fan',
+        title: 'Stay Close',
         description:
           'A listen, a signup, or a support moment can become a real fan relationship instead of an anonymous click.',
       },
@@ -770,9 +775,9 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
   },
   opinionated: {
     eyebrow: 'Opinionated by design',
-    headline: 'Built to convert, not decorate.',
-    body: 'Jovie is intentionally constrained. No theme builder. No layout rabbit hole. No generic creator-site sprawl. Every profile teaches fans what to tap because the product is built around release moments, show moments, and conversion.',
-    principle: 'No template maze.',
+    headline: 'One clear action beats a wall of links.',
+    body: 'Fans should not have to choose from a wall of links. Jovie leads with the action that matters now.',
+    principle: 'One profile. One decision.',
     columns: ['Moment', 'Jovie reads', 'Primary action'],
     decisions: [
       {
@@ -934,9 +939,9 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     playLabel: 'Play pay flow',
   },
   capture: {
-    headline: 'Capture every fan, not just the click.',
-    subhead: 'One opt-in can become a lasting fan relationship.',
-    body: 'Fans opt in once. From there, Jovie can keep them close with release alerts and future follow-up. The profile is not just a destination. It is the start of an owned audience.',
+    headline: 'One fan moment. A relationship you keep.',
+    subhead: 'One opt-in can become the next release listen.',
+    body: 'When a fan opts in, the next release or nearby show has a direct path back to them. Their permission turns one moment into an audience you can reach again.',
     action: {
       title: 'Get updates',
       detail: 'Release and nearby-show alerts.',
@@ -1086,13 +1091,35 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     ],
   },
   specWall: {
-    headline: 'Built for artists.',
+    headline: 'Your music stays together. The right action leads.',
     subhead:
-      'The product truth behind one fast, music-native profile—kept compact on purpose.',
+      'Fans can listen, find shows, follow, and support you without leaving your profile.',
+    callouts: [
+      {
+        id: 'identity',
+        title: 'They Know It Is You',
+        body: 'Your name, image, and verified destinations make the profile unmistakably yours.',
+      },
+      {
+        id: 'release',
+        title: 'New Music Is Ready',
+        body: 'Your current release is ready to play without making fans search for it.',
+      },
+      {
+        id: 'action',
+        title: 'The Right Next Move',
+        body: 'Pre-save before release. Listen when it drops. Tickets when fans are nearby.',
+      },
+      {
+        id: 'navigation',
+        title: 'Everything Stays Close',
+        body: 'Music, shows, support, and updates stay in one place.',
+      },
+    ],
   },
   howItWorks: {
     headline: 'One link. Three steps.',
-    body: 'Claim the profile, connect the essentials, and keep the same URL everywhere.',
+    body: 'Claim your artist name, connect your catalog, and share one Jovie link everywhere.',
     steps: [
       {
         id: 'claim',
@@ -1155,11 +1182,12 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     },
   },
   socialProof: {
-    headline: 'Built for real artist workflows.',
-    intro: 'Real artist profiles. Real release moments.',
+    headline: 'One profile through the whole release cycle.',
+    intro:
+      'Pre-save before release. Nearby tickets on tour. Direct support in person.',
   },
   faq: {
-    headline: 'Questions, answered.',
+    headline: 'Questions',
     items: [
       {
         question: 'How is this different from Linktree?',
@@ -1177,15 +1205,15 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
           'Yes. Touring, tickets, QR sharing, and support flows all fit inside the same profile instead of living on separate links.',
       },
       {
-        question: 'How long does setup take?',
+        question: 'Is an Artist Profile free?',
         answer:
-          'Fast. Claim the profile, connect your music and links, and start sharing one URL.',
+          'Yes. Artist Profiles are free. Pro adds release tools when you need them.',
       },
     ],
   },
   finalCta: {
     headline: 'Claim your profile.',
-    subhead: 'One link for every release, show, and fan action.',
+    subhead: 'One adaptive profile for every release, show, and fan action.',
     ctaLabel: 'Claim your profile',
     signature: 'jov.ie/you',
   },

--- a/apps/web/tests/unit/marketing/artist-profile/ArtistProfileSpecWall.test.tsx
+++ b/apps/web/tests/unit/marketing/artist-profile/ArtistProfileSpecWall.test.tsx
@@ -15,13 +15,11 @@ describe('ArtistProfileSpecWall', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Built for artists.',
+        name: ARTIST_PROFILE_COPY.specWall.headline,
       })
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'The product truth behind one fast, music-native profile—kept compact on purpose.'
-      )
+      screen.getByText(ARTIST_PROFILE_COPY.specWall.subhead)
     ).toBeInTheDocument();
 
     expect(screen.getAllByTestId('artist-profile-truth-tile')).toHaveLength(10);

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -118,7 +118,8 @@ describe('artist profile landing family System B source contract', () => {
       ),
       'utf8'
     );
-    expect(outcomes).toContain('MarketingSnapRail');
+    expect(outcomes).toContain("aria-label='Fan Outcomes'");
+    expect(outcomes).not.toContain('MarketingSnapRail');
     expect(outcomes).not.toContain('scrollByDirection');
 
     const hero = readFileSync(


### PR DESCRIPTION
## Description

- Replace generic feature cards with a compact ledger of fan and artist outcomes.
- Tighten the copy to measurable product consequences and remove presentation-selling language.
- Stack 4 of 9.

## Type of Change

- [x] New feature

## Testing

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added or updated where applicable

Integrated stack evidence:

- Full normal pre-push gate passed: Biome, Tailwind guard, typecheck, component-ship gate, and all 8 unit-test shards.
- Component evidence: 21 changed components; 127 stories scanned; ratchet clean.
- Design and marketing guard sweep: 64 files / 238 tests passed.
- Artist Profiles Playwright contract: 10/10 passed.
- Production build: 469/469 static pages; /artist-profiles and /artist-profile generated.
- Screenshot-catalog integrity passed.
- Independent design reviews: clarity/conversion, reduction/craft, and product-callout system all PASS.

bug-to-test: not applicable — feature, documentation, or test-contract work.

## Design Skill Evidence

- [x] Design-read: public product landing page for independent artists, dark high-contrast Jovie System B language, product-first and editorial.
- [x] Dials: DESIGN_VARIANCE 4/10; MOTION_INTENSITY 2/10; VISUAL_DENSITY 5/10.
- [x] Before/after evidence: browser-verified at 1440px and 390px; canonical product captures included in the stack.
- [x] Narrow lint and typecheck output included in local verification.
- [x] design-canonical: PASS — contrast, states, layout, reduced motion, icons, anti-slop, and evidence.
- [x] No state transition introduces layout shift.
- [x] No external-data embedding or vectorization pipeline is created, populated, or deployed.

## Deployment Notes

- No migrations, environment variables, feature flags, billing, auth, or external-data embedding changes.
- Standard production controller may deploy after the exact final main SHA clears the native merge queue.

