### PR TITLE
feat(marketing): clarify artist fan relationship loop

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.css
@@ -7,3 +7,67 @@
     transparent
   );
 }
+
+.ap-capture-loop__visual {
+  isolation: isolate;
+}
+
+.ap-capture-loop__ring {
+  position: absolute;
+  width: min(30rem, 90%);
+  aspect-ratio: 1;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-pill);
+}
+
+.ap-capture-loop__phone {
+  position: relative;
+  z-index: 2;
+  width: min(18rem, 62vw);
+  max-width: none;
+}
+
+.ap-capture-loop__node {
+  position: absolute;
+  z-index: 3;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-surface-0);
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-semibold);
+}
+
+.ap-capture-loop__node--act {
+  top: 9%;
+  left: 12%;
+}
+
+.ap-capture-loop__node--opt-in {
+  top: 42%;
+  right: 2%;
+}
+
+.ap-capture-loop__node--return {
+  bottom: 8%;
+  left: 3%;
+}
+
+@media (max-width: 47.99rem) {
+  .ap-capture-loop__visual {
+    min-height: 31rem;
+  }
+
+  .ap-capture-loop__node--act {
+    left: 2%;
+  }
+
+  .ap-capture-loop__node--opt-in {
+    right: 0;
+  }
+
+  .ap-capture-loop__node--return {
+    left: 0;
+  }
+}

--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
@@ -1,9 +1,11 @@
-import { ArrowRight, BellRing, Check } from 'lucide-react';
+import Image from 'next/image';
 import type {
   ArtistProfileCaptureVisualCopy,
   ArtistProfileLandingCopy,
 } from '@/data/artistProfileCopy';
+import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { ArtistProfileCaptureVisual } from '../MarketingStoryPrimitives';
+import { ArtistProfilePhoneFrame } from './ArtistProfilePhoneFrame';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 import './ArtistProfileCaptureSection.css';
@@ -14,6 +16,10 @@ interface ArtistProfileCaptureSectionProps {
     | ArtistProfileCaptureVisualCopy
     | ArtistProfileLandingCopy['capture'];
 }
+
+const SUBSCRIBE_PROFILE = getMarketingExportImage(
+  'tim-white-profile-subscribe-mobile'
+);
 
 function isEditorialCapture(
   capture: ArtistProfileCaptureSectionProps['capture']
@@ -44,115 +50,66 @@ export function ArtistProfileCaptureSection({
   }
 
   return (
-    <ArtistProfileSectionShell className='bg-surface-0' id={id}>
-      <div className='mx-auto max-w-280'>
-        <ArtistProfileSectionHeader
-          align='left'
-          headline={capture.headline}
-          body={capture.body}
-          className='max-w-3xl'
-          bodyClassName='max-w-2xl'
-        />
-
-        <div
-          className='mt-12 grid items-stretch gap-4 lg:grid-cols-[minmax(0,1fr)_3rem_minmax(0,1fr)] lg:gap-6'
-          data-testid='artist-profile-capture-demo'
-        >
-          <article
-            role='img'
-            aria-label={capture.journey.inputPreviewLabel}
-            className='flex min-h-64 flex-col justify-between rounded-2xl border border-subtle bg-surface-1 p-5 sm:p-6'
-          >
-            <div>
-              <p className='text-xs font-semibold text-secondary-token'>
-                {capture.journey.inputEyebrow}
-              </p>
-              <h3 className='mt-3 text-2xl font-semibold tracking-tight text-primary-token'>
-                {capture.action.title}
-              </h3>
-              <p className='mt-2 text-app leading-relaxed text-secondary-token'>
-                {capture.action.detail}
-              </p>
-            </div>
-
-            <div
-              aria-hidden='true'
-              className='mt-8 rounded-xl border border-subtle bg-surface-0 p-2'
-            >
-              <div className='flex items-center gap-2'>
-                <div className='min-w-0 flex-1 rounded-lg border border-subtle bg-surface-1 px-3 py-3 font-mono text-xs text-tertiary-token'>
-                  {capture.action.inputPlaceholder}
-                </div>
-                <span className='inline-flex min-h-11 shrink-0 items-center rounded-lg bg-primary-token px-4 text-xs font-semibold text-surface-1'>
-                  {capture.action.ctaLabel}
+    <ArtistProfileSectionShell className='ap-capture-loop bg-surface-0' id={id}>
+      <div className='ap-capture-loop__layout mx-auto grid max-w-public-content items-center gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(30rem,1.2fr)] lg:gap-20'>
+        <div>
+          <ArtistProfileSectionHeader
+            align='left'
+            headline={capture.headline}
+            body={capture.body}
+            className='max-w-3xl'
+            bodyClassName='max-w-xl'
+          />
+          <ol className='mt-9 border-t border-subtle'>
+            {capture.benefits.map((benefit, index) => (
+              <li
+                key={benefit.id}
+                className='grid grid-cols-[2rem_minmax(0,1fr)] gap-3 border-b border-subtle py-4'
+              >
+                <span className='font-mono text-3xs text-tertiary-token'>
+                  0{index + 1}
                 </span>
-              </div>
-              <p className='mt-3 flex items-center gap-2 px-1 pb-1 text-xs font-medium text-secondary-token'>
-                <Check
-                  className='h-3.5 w-3.5 text-success'
-                  aria-hidden='true'
-                />
-                {capture.action.confirmedLabel}
-              </p>
-            </div>
-          </article>
-
-          <div className='flex items-center justify-center' aria-hidden='true'>
-            <ArrowRight className='h-5 w-5 rotate-90 text-tertiary-token lg:rotate-0' />
-          </div>
-
-          <article className='flex min-h-64 flex-col justify-between rounded-2xl border border-subtle bg-surface-1 p-5 sm:p-6'>
-            <div>
-              <p className='text-xs font-semibold text-secondary-token'>
-                {capture.journey.notificationEyebrow}
-              </p>
-              <h3 className='mt-3 text-2xl font-semibold tracking-tight text-primary-token'>
-                {capture.journey.notificationHeadline}
-              </h3>
-              <p className='mt-2 text-app leading-relaxed text-secondary-token'>
-                {capture.journey.notificationBody}
-              </p>
-            </div>
-
-            <div className='mt-8 rounded-xl border border-subtle bg-surface-0 p-4'>
-              <div className='flex items-start gap-3'>
-                <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary-token text-surface-1'>
-                  <BellRing className='h-4 w-4' aria-hidden='true' />
-                </span>
-                <div className='min-w-0'>
-                  <div className='flex items-center gap-2 text-2xs text-tertiary-token'>
-                    <span className='font-semibold text-secondary-token'>
-                      {capture.notification.appName}
-                    </span>
-                    <span>{capture.notification.timeLabel}</span>
-                  </div>
-                  <p className='mt-2 text-sm font-semibold text-primary-token'>
-                    {capture.notification.title}
+                <div>
+                  <p className='text-sm font-semibold text-primary-token'>
+                    {benefit.label}
                   </p>
-                  <p className='mt-1.5 text-xs leading-relaxed text-secondary-token'>
-                    {capture.notification.detail}
+                  <p className='mt-1.5 text-app leading-relaxed text-secondary-token'>
+                    {benefit.detail}
                   </p>
                 </div>
-              </div>
-            </div>
-          </article>
+              </li>
+            ))}
+          </ol>
         </div>
 
-        <ol className='mt-8 grid gap-3 md:grid-cols-3'>
-          {capture.benefits.map((benefit, index) => (
-            <li key={benefit.id} className='border-t border-subtle pt-4'>
-              <p className='font-mono text-3xs text-tertiary-token'>
-                0{index + 1}
-              </p>
-              <p className='mt-3 text-sm font-semibold text-primary-token'>
-                {benefit.label}
-              </p>
-              <p className='mt-2 text-app leading-relaxed text-secondary-token'>
-                {benefit.detail}
-              </p>
-            </li>
-          ))}
-        </ol>
+        <figure
+          className='ap-capture-loop__visual relative flex min-h-128 items-center justify-center'
+          data-testid='artist-profile-capture-demo'
+        >
+          <figcaption className='sr-only'>
+            Fan relationship loop: a fan acts, opts in, and hears from the
+            artist again.
+          </figcaption>
+          <div className='ap-capture-loop__ring' aria-hidden='true' />
+          <span className='ap-capture-loop__node ap-capture-loop__node--act'>
+            Fan Acts
+          </span>
+          <span className='ap-capture-loop__node ap-capture-loop__node--opt-in'>
+            Opts In
+          </span>
+          <span className='ap-capture-loop__node ap-capture-loop__node--return'>
+            Hears From You Again
+          </span>
+          <ArtistProfilePhoneFrame className='ap-capture-loop__phone'>
+            <Image
+              fill
+              src={SUBSCRIBE_PROFILE.publicUrl}
+              alt='Jovie artist profile showing a fan email and SMS opt-in.'
+              className='object-cover object-top'
+              sizes='(min-width: 1024px) 18rem, 16rem'
+            />
+          </ArtistProfilePhoneFrame>
+        </figure>
       </div>
     </ArtistProfileSectionShell>
   );

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css
@@ -1,13 +1,72 @@
-/*
- * Artist-profile opinionated section (System B).
- *
- * Only the ch measure limit that Tailwind utilities cannot express lives
- * here; everything else stays on token utilities and the shared SHELL_*
- * type classes in the TSX.
- *
- * Scoped to the `ap-opinionated` prefix.
- */
-
 .ap-opinionated__headline {
   max-width: 12ch;
+}
+
+.ap-opinionated__comparison {
+  scrollbar-width: none;
+  scroll-snap-type: x mandatory;
+}
+
+.ap-opinionated__comparison::-webkit-scrollbar {
+  display: none;
+}
+
+.ap-opinionated__comparison-pane {
+  scroll-snap-align: start;
+}
+
+.ap-opinionated__comparison-media {
+  position: relative;
+  height: clamp(22rem, 42vw, 34rem);
+  overflow: hidden;
+  background: var(--color-bg-surface-0);
+}
+
+.ap-opinionated__menu-preview {
+  width: min(20rem, 72%);
+  margin: 0 auto;
+  padding-top: clamp(2rem, 6vw, 4rem);
+}
+
+.ap-opinionated__menu-avatar {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-surface-2);
+}
+
+.ap-opinionated__menu-name {
+  width: 7rem;
+  height: 0.6rem;
+  margin: var(--space-4) auto var(--space-8);
+  border-radius: var(--radius-pill);
+  background: var(--color-border-default);
+}
+
+.ap-opinionated__menu-links {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.ap-opinionated__menu-link {
+  display: flex;
+  min-height: 3.25rem;
+  align-items: center;
+  justify-content: space-between;
+  padding-inline: var(--space-4);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-xs);
+}
+
+@media (max-width: 47.99rem) {
+  .ap-opinionated__comparison-track {
+    width: 164vw;
+  }
+
+  .ap-opinionated__comparison-media {
+    height: 21rem;
+  }
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
@@ -1,5 +1,7 @@
-import { ArrowRight, MapPin, Music2, QrCode } from 'lucide-react';
+import { ArrowUpRight } from 'lucide-react';
+import Image from 'next/image';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
+import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { cn } from '@/lib/utils';
 import { SHELL_H2_CLASS, SHELL_LEAD_CLASS } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
@@ -9,83 +11,93 @@ interface ArtistProfileOpinionatedSectionProps {
   readonly opinionated: ArtistProfileLandingCopy['opinionated'];
 }
 
-const DECISION_ICONS = {
-  release: Music2,
-  tour: MapPin,
-  support: QrCode,
-} as const;
+const LIVE_PROFILE = getMarketingExportImage('tim-white-profile-live-mobile');
+
+function StaticMenuPreview() {
+  const links = [
+    'Latest Release',
+    'Tour Dates',
+    'Merch',
+    'Subscribe',
+    'Contact',
+  ];
+
+  return (
+    <div
+      className='ap-opinionated__menu-preview'
+      role='img'
+      aria-label='Static Link Menu Giving Every Destination Equal Weight.'
+    >
+      <div className='ap-opinionated__menu-avatar' />
+      <div className='ap-opinionated__menu-name' />
+      <div className='ap-opinionated__menu-links'>
+        {links.map(link => (
+          <div key={link} className='ap-opinionated__menu-link'>
+            <span>{link}</span>
+            <ArrowUpRight aria-hidden='true' size={14} strokeWidth={1.6} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export function ArtistProfileOpinionatedSection({
   opinionated,
 }: Readonly<ArtistProfileOpinionatedSectionProps>) {
   return (
     <ArtistProfileSectionShell>
-      <div className='grid items-start gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(30rem,1.2fr)] lg:gap-20'>
-        <div className='max-w-xl lg:sticky lg:top-32'>
-          {/* ui-casing-allow: marketing display headline */}
+      <div className='mx-auto max-w-public-content'>
+        <div className='grid items-end gap-8 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1fr)]'>
           <h2 className={cn(SHELL_H2_CLASS, 'ap-opinionated__headline')}>
             {opinionated.headline}
           </h2>
-          <p className={cn(SHELL_LEAD_CLASS, 'mt-6')}>{opinionated.body}</p>
-          <p className='mt-7 inline-flex rounded-full border border-subtle bg-surface-0 px-4 py-2 font-mono text-xs text-secondary-token'>
-            {opinionated.principle}
+          <p className={cn(SHELL_LEAD_CLASS, 'max-w-xl lg:justify-self-end')}>
+            {opinionated.body}
           </p>
         </div>
 
-        <div className='overflow-hidden rounded-2xl border border-subtle bg-surface-0'>
-          <div
-            aria-hidden='true'
-            className='hidden grid-cols-[1fr_1fr_auto] gap-6 border-b border-subtle px-5 py-4 text-3xs font-semibold text-tertiary-token sm:grid'
-          >
-            {opinionated.columns.map(column => (
-              <span key={column}>{column}</span>
-            ))}
-          </div>
+        <div className='ap-opinionated__comparison mt-12 overflow-x-auto'>
+          <div className='ap-opinionated__comparison-track grid min-w-168 grid-cols-2 border-y border-subtle'>
+            <figure className='ap-opinionated__comparison-pane py-5 pr-5 sm:py-7 sm:pr-7'>
+              <figcaption className='mb-5 flex items-baseline justify-between gap-4'>
+                <strong className='text-sm font-semibold text-primary-token'>
+                  Static Menu
+                </strong>
+                <span className='text-xs text-tertiary-token'>
+                  Every option at once
+                </span>
+              </figcaption>
+              <div className='ap-opinionated__comparison-media'>
+                <StaticMenuPreview />
+              </div>
+            </figure>
 
-          <div className='divide-y divide-subtle'>
-            {opinionated.decisions.map(decision => {
-              const Icon = DECISION_ICONS[decision.id];
-
-              return (
-                <article key={decision.id} className='px-5 py-6'>
-                  <dl className='grid gap-5 sm:grid-cols-[1fr_1fr_auto] sm:items-center sm:gap-6'>
-                    <div>
-                      <dt className='sr-only'>{opinionated.columns[0]}</dt>
-                      <dd className='flex items-center gap-3'>
-                        <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-1 text-secondary-token'>
-                          <Icon className='h-4 w-4' aria-hidden='true' />
-                        </span>
-                        <span className='text-sm font-semibold text-primary-token'>
-                          {decision.context}
-                        </span>
-                      </dd>
-                    </div>
-
-                    <div>
-                      <dt className='sr-only'>{opinionated.columns[1]}</dt>
-                      <dd className='text-app text-secondary-token'>
-                        {decision.signal}
-                      </dd>
-                    </div>
-
-                    <div>
-                      <dt className='sr-only'>{opinionated.columns[2]}</dt>
-                      <dd className='flex items-center gap-3 sm:justify-end'>
-                        <ArrowRight
-                          className='h-4 w-4 text-tertiary-token'
-                          aria-hidden='true'
-                        />
-                        <span className='font-mono text-xs font-semibold text-primary-token'>
-                          {decision.action}
-                        </span>
-                      </dd>
-                    </div>
-                  </dl>
-                </article>
-              );
-            })}
+            <figure className='ap-opinionated__comparison-pane border-l border-subtle py-5 pl-5 sm:py-7 sm:pl-7'>
+              <figcaption className='mb-5 flex items-baseline justify-between gap-4'>
+                <strong className='text-sm font-semibold text-primary-token'>
+                  Adaptive Lead
+                </strong>
+                <span className='text-xs text-tertiary-token'>
+                  One clear move
+                </span>
+              </figcaption>
+              <div className='ap-opinionated__comparison-media'>
+                <Image
+                  fill
+                  src={LIVE_PROFILE.publicUrl}
+                  alt='Jovie artist profile leading with one clear Listen action.'
+                  className='object-contain object-top'
+                  sizes='(min-width: 1024px) 36rem, 78vw'
+                />
+              </div>
+            </figure>
           </div>
         </div>
+
+        <p className='mt-5 font-mono text-xs text-tertiary-token'>
+          {opinionated.principle}
+        </p>
       </div>
     </ArtistProfileSectionShell>
   );

--- a/apps/web/components/marketing/storybook/MarketingSections.stories.tsx
+++ b/apps/web/components/marketing/storybook/MarketingSections.stories.tsx
@@ -19,6 +19,7 @@ import { ArtistProfileHeroAdaptiveIntro } from '@/components/marketing/artist-pr
 import { ArtistProfileHowItWorks } from '@/components/marketing/artist-profile/ArtistProfileHowItWorks';
 import { ArtistProfileModeSwitcher } from '@/components/marketing/artist-profile/ArtistProfileModeSwitcher';
 import { ArtistProfileMonetizationSection } from '@/components/marketing/artist-profile/ArtistProfileMonetizationSection';
+import { ArtistProfileOpinionatedSection } from '@/components/marketing/artist-profile/ArtistProfileOpinionatedSection';
 import { ArtistProfileOutcomesCarousel } from '@/components/marketing/artist-profile/ArtistProfileOutcomesCarousel';
 import { ArtistProfileSectionShell } from '@/components/marketing/artist-profile/ArtistProfileSectionShell';
 import { ArtistProfileSocialProof } from '@/components/marketing/artist-profile/ArtistProfileSocialProof';
@@ -377,6 +378,9 @@ export const capture: Story = {
       <ArtistProfileCaptureSection
         capture={ARTIST_PROFILE_COPY.capture}
         id='storybook-capture'
+      />
+      <ArtistProfileOpinionatedSection
+        opinionated={ARTIST_PROFILE_COPY.opinionated}
       />
     </SectionFrame>
   ),

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -147,6 +147,28 @@ describe('artist profile landing family System B source contract', () => {
     expect(intro).toContain('HomeTrustSection');
     expect(intro).toContain("presentation='inline-strip'");
 
+    const capture = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/artist-profile/ArtistProfileCaptureSection.tsx'
+      ),
+      'utf8'
+    );
+    expect(capture).toContain('ap-capture-loop');
+    expect(capture).toContain('ArtistProfilePhoneFrame');
+    expect(capture).toContain("'tim-white-profile-subscribe-mobile'");
+
+    const opinionated = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx'
+      ),
+      'utf8'
+    );
+    expect(opinionated).toContain('StaticMenuPreview');
+    expect(opinionated).toContain('ap-opinionated__comparison-track');
+    expect(opinionated).toContain("'tim-white-profile-live-mobile'");
+
     const finalCta = readFileSync(
       resolve(
         process.cwd(),


### PR DESCRIPTION
## Description

- Turn capture into a truthful relationship loop with an explicit illustrative-data disclosure.
- Reframe the opinionated section as menu versus decision, with clearer information hierarchy.
- Stack 5 of 9.

## Type of Change

- [x] New feature

## Testing

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added or updated where applicable

Integrated stack evidence:

- Full normal pre-push gate passed: Biome, Tailwind guard, typecheck, component-ship gate, and all 8 unit-test shards.
- Component evidence: 21 changed components; 127 stories scanned; ratchet clean.
- Design and marketing guard sweep: 64 files / 238 tests passed.
- Artist Profiles Playwright contract: 10/10 passed.
- Production build: 469/469 static pages; /artist-profiles and /artist-profile generated.
- Screenshot-catalog integrity passed.
- Independent design reviews: clarity/conversion, reduction/craft, and product-callout system all PASS.

bug-to-test: not applicable — feature, documentation, or test-contract work.

## Design Skill Evidence

- [x] Design-read: public product landing page for independent artists, dark high-contrast Jovie System B language, product-first and editorial.
- [x] Dials: DESIGN_VARIANCE 4/10; MOTION_INTENSITY 2/10; VISUAL_DENSITY 5/10.
- [x] Before/after evidence: browser-verified at 1440px and 390px; canonical product captures included in the stack.
- [x] Narrow lint and typecheck output included in local verification.
- [x] design-canonical: PASS — contrast, states, layout, reduced motion, icons, anti-slop, and evidence.
- [x] No state transition introduces layout shift.
- [x] No external-data embedding or vectorization pipeline is created, populated, or deployed.

## Deployment Notes

- No migrations, environment variables, feature flags, billing, auth, or external-data embedding changes.
- Standard production controller may deploy after the exact final main SHA clears the native merge queue.

