### PR TITLE
feat(marketing): add reusable product callout system

### DIFF
--- a/apps/web/components/marketing/MarketingSnapRail.tsx
+++ b/apps/web/components/marketing/MarketingSnapRail.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { type ReactNode, useCallback, useId, useRef } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 import './MarketingSnapRail.css';
@@ -18,6 +25,8 @@ export interface MarketingSnapRailProps {
   readonly scrollerTestId?: string;
   /** When true, desktop prev/next float over the rail. Mobile always uses native swipe. */
   readonly overlayControlsOnDesktop?: boolean;
+  readonly showMobileControls?: boolean;
+  readonly showDesktopControls?: boolean;
   readonly previousLabel?: string;
   readonly nextLabel?: string;
 }
@@ -40,6 +49,8 @@ export function MarketingSnapRail({
   testId = 'marketing-snap-rail',
   scrollerTestId,
   overlayControlsOnDesktop = false,
+  showMobileControls = false,
+  showDesktopControls = true,
   previousLabel = 'Scroll Left',
   nextLabel = 'Scroll Right',
 }: Readonly<MarketingSnapRailProps>) {
@@ -48,6 +59,55 @@ export function MarketingSnapRail({
   const describedBy = instructionsId ?? `${railId}-instructions`;
   const scrollerRef = useRef<HTMLElement | null>(null);
   const reducedMotion = useReducedMotion();
+  const [scrollState, setScrollState] = useState({
+    ready: false,
+    canScrollPrevious: false,
+    canScrollNext: false,
+  });
+
+  const measureScrollState = useCallback(() => {
+    const rail = scrollerRef.current;
+    if (!rail) {
+      return;
+    }
+
+    const maximumScrollLeft = Math.max(rail.scrollWidth - rail.clientWidth, 0);
+    const boundaryTolerance = 2;
+    const nextScrollState = {
+      ready: true,
+      canScrollPrevious: rail.scrollLeft > boundaryTolerance,
+      canScrollNext:
+        maximumScrollLeft > boundaryTolerance &&
+        rail.scrollLeft < maximumScrollLeft - boundaryTolerance,
+    };
+    setScrollState(previousScrollState =>
+      previousScrollState.ready === nextScrollState.ready &&
+      previousScrollState.canScrollPrevious ===
+        nextScrollState.canScrollPrevious &&
+      previousScrollState.canScrollNext === nextScrollState.canScrollNext
+        ? previousScrollState
+        : nextScrollState
+    );
+  }, []);
+
+  useEffect(() => {
+    const rail = scrollerRef.current;
+    if (!rail) {
+      return;
+    }
+
+    measureScrollState();
+    rail.addEventListener('scroll', measureScrollState, { passive: true });
+    window.addEventListener('resize', measureScrollState);
+    const resizeObserver = new ResizeObserver(measureScrollState);
+    resizeObserver.observe(rail);
+
+    return () => {
+      rail.removeEventListener('scroll', measureScrollState);
+      window.removeEventListener('resize', measureScrollState);
+      resizeObserver.disconnect();
+    };
+  }, [measureScrollState]);
 
   const scrollByDirection = useCallback(
     (direction: 'prev' | 'next') => {
@@ -69,23 +129,25 @@ export function MarketingSnapRail({
     <>
       <button
         type='button'
+        disabled={!scrollState.canScrollPrevious}
         aria-controls={railId}
         aria-label={previousLabel}
         onClick={() => {
           scrollByDirection('prev');
         }}
-        className='marketing-snap-rail__nav-btn pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full backdrop-blur-xl transition-colors'
+        className='marketing-snap-rail__nav-btn pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full backdrop-blur-xl transition-colors disabled:cursor-default disabled:opacity-35'
       >
         <ChevronLeft className='h-4 w-4' aria-hidden='true' />
       </button>
       <button
         type='button'
+        disabled={!scrollState.canScrollNext}
         aria-controls={railId}
         aria-label={nextLabel}
         onClick={() => {
           scrollByDirection('next');
         }}
-        className='marketing-snap-rail__nav-btn pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full backdrop-blur-xl transition-colors'
+        className='marketing-snap-rail__nav-btn pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full backdrop-blur-xl transition-colors disabled:cursor-default disabled:opacity-35'
       >
         <ChevronRight className='h-4 w-4' aria-hidden='true' />
       </button>
@@ -102,42 +164,77 @@ export function MarketingSnapRail({
 
       <div className='marketing-snap-rail__frame relative w-full overflow-x-hidden'>
         {/* Desktop: default controls sit in-flow and push the rail down (no card overlay). */}
-        {!overlayControlsOnDesktop ? (
-          <div className='marketing-snap-rail__controls pointer-events-none mb-4 hidden items-center justify-end gap-2 pr-5 sm:pr-6 lg:flex lg:pr-[max(1.5rem,calc((100vw-var(--public-content-max-page))/2))]'>
+        {showDesktopControls && !overlayControlsOnDesktop ? (
+          <div
+            className={cn(
+              'marketing-snap-rail__controls pointer-events-none mb-4 hidden items-center justify-end gap-2 pr-5 sm:pr-6 lg:flex lg:pr-[max(1.5rem,calc((100vw-var(--public-content-max-page))/2))]',
+              !scrollState.ready ||
+                (!scrollState.canScrollPrevious && !scrollState.canScrollNext)
+                ? 'invisible'
+                : null
+            )}
+          >
             {navButtons}
           </div>
-        ) : (
-          <div className='marketing-snap-rail__controls marketing-snap-rail__controls--overlay pointer-events-none absolute right-[max(1.25rem,calc((100vw-var(--public-content-max-page))/2))] top-4 z-20 hidden items-center gap-2 lg:flex'>
+        ) : showDesktopControls ? (
+          <div
+            className={cn(
+              'marketing-snap-rail__controls marketing-snap-rail__controls--overlay pointer-events-none absolute right-[max(1.25rem,calc((100vw-var(--public-content-max-page))/2))] top-4 z-20 hidden items-center gap-2 lg:flex',
+              !scrollState.ready ||
+                (!scrollState.canScrollPrevious && !scrollState.canScrollNext)
+                ? 'invisible'
+                : null
+            )}
+          >
             {navButtons}
           </div>
-        )}
+        ) : null}
 
-        <div className='hidden sm:block lg:hidden'>
-          <div className='sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-6 focus-within:top-4 focus-within:z-20 focus-within:flex focus-within:gap-2'>
-            <button
-              type='button'
-              aria-controls={railId}
-              aria-label={previousLabel}
-              onClick={() => {
-                scrollByDirection('prev');
-              }}
-              className='marketing-snap-rail__rail-btn min-h-11 min-w-11 rounded-full bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold'
-            >
-              Prev
-            </button>
-            <button
-              type='button'
-              aria-controls={railId}
-              aria-label={nextLabel}
-              onClick={() => {
-                scrollByDirection('next');
-              }}
-              className='marketing-snap-rail__rail-btn min-h-11 min-w-11 rounded-full bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold'
-            >
-              Next
-            </button>
+        {showMobileControls ? (
+          <div
+            className={cn(
+              'marketing-snap-rail__mobile-controls mb-4 flex items-center justify-end gap-2',
+              showDesktopControls ? 'lg:hidden' : 'md:hidden',
+              !scrollState.ready ||
+                (!scrollState.canScrollPrevious && !scrollState.canScrollNext)
+                ? 'invisible'
+                : null
+            )}
+          >
+            {navButtons}
           </div>
-        </div>
+        ) : null}
+
+        {!showMobileControls ? (
+          <div className='hidden sm:block lg:hidden'>
+            <div className='sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-6 focus-within:top-4 focus-within:z-20 focus-within:flex focus-within:gap-2'>
+              <button
+                type='button'
+                disabled={!scrollState.canScrollPrevious}
+                aria-controls={railId}
+                aria-label={previousLabel}
+                onClick={() => {
+                  scrollByDirection('prev');
+                }}
+                className='marketing-snap-rail__rail-btn min-h-11 min-w-11 rounded-full bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold'
+              >
+                Prev
+              </button>
+              <button
+                type='button'
+                disabled={!scrollState.canScrollNext}
+                aria-controls={railId}
+                aria-label={nextLabel}
+                onClick={() => {
+                  scrollByDirection('next');
+                }}
+                className='marketing-snap-rail__rail-btn min-h-11 min-w-11 rounded-full bg-(--color-cell-hover) px-3 py-2 text-xs font-semibold'
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        ) : null}
 
         <section
           ref={scrollerRef}

--- a/apps/web/components/marketing/MarketingStoryPrimitives.tsx
+++ b/apps/web/components/marketing/MarketingStoryPrimitives.tsx
@@ -22,7 +22,6 @@ import { cn } from '@/lib/utils';
 import type { CapturePhase } from './artist-profile/captureShared';
 import {
   AudienceRail,
-  CAPTURE_ANIMATION_STYLES,
   CaptureActionPill,
 } from './artist-profile/captureShared';
 
@@ -188,27 +187,11 @@ export function ArtistProfileCaptureVisual({
     };
   }, [activated, phase, reducedMotion]);
 
-  useEffect(() => {
-    if (!activated || reducedMotion || phase !== 'done') {
-      return;
-    }
-
-    const loopTimer = globalThis.setTimeout(() => {
-      setPhase('typing');
-    }, 2600);
-
-    return () => {
-      globalThis.clearTimeout(loopTimer);
-    };
-  }, [activated, phase, reducedMotion]);
-
   return (
     <div
       ref={rootRef}
       className={cn('artist-profile-capture-shell', className)}
     >
-      <style>{CAPTURE_ANIMATION_STYLES}</style>
-
       <div className='mx-auto flex max-w-lg justify-center'>
         <CaptureActionPill capture={capture} phase={phase} />
       </div>

--- a/apps/web/components/marketing/MarketingSurfaceCard.tsx
+++ b/apps/web/components/marketing/MarketingSurfaceCard.tsx
@@ -1,8 +1,12 @@
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
 
-export type MarketingSurfaceVariant = 'floating' | 'panel' | 'phone-inset';
-export type MarketingGlowTone = 'violet' | 'blue' | 'amber' | 'none';
+export type MarketingSurfaceVariant =
+  | 'floating'
+  | 'panel'
+  | 'phone-inset'
+  | 'product-callout';
+export type MarketingGlowTone = 'violet' | 'blue' | 'teal' | 'amber' | 'none';
 export type MarketingSurfaceChrome = 'framed' | 'full-bleed';
 
 export interface MarketingSurfaceCardProps {
@@ -17,8 +21,13 @@ export interface MarketingSurfaceCardProps {
   readonly chrome?: MarketingSurfaceChrome;
   readonly className?: string;
   readonly imageClassName?: string;
+  readonly contentClassName?: string;
   /** Override the default sizes hint for the inner next/image. */
   readonly imageSizes?: string;
+  /** Product-language label shown in the shared callout chrome. */
+  readonly label?: string;
+  /** Optional current-state label, for example "Release Alerts". */
+  readonly stateLabel?: string;
   readonly children?: React.ReactNode;
 }
 
@@ -29,12 +38,14 @@ const VARIANT_CLASS_NAMES: Record<MarketingSurfaceVariant, string> = {
     'rounded-[1.5rem] border-white/10 bg-[linear-gradient(180deg,rgba(18,20,27,0.96),rgba(11,13,18,0.94))] shadow-[0_28px_90px_rgba(0,0,0,0.38),0_8px_24px_rgba(0,0,0,0.24)]',
   'phone-inset':
     'rounded-[2rem] border-white/14 bg-[linear-gradient(180deg,rgba(17,18,24,0.98),rgba(9,10,15,0.98))] shadow-[0_30px_90px_rgba(0,0,0,0.48),0_10px_30px_rgba(0,0,0,0.28)]',
+  'product-callout': 'rounded-3xl border-subtle bg-surface-0 shadow-card',
 };
 
 const GLOW_CLASS_NAMES: Record<MarketingGlowTone, string> = {
   violet:
     'bg-[radial-gradient(circle_at_top,rgba(129,140,248,0.24),transparent_58%)]',
   blue: 'bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.18),transparent_58%)]',
+  teal: 'bg-[radial-gradient(circle_at_top,color-mix(in_oklab,var(--color-accent-teal)_16%,transparent),transparent_58%)]',
   amber:
     'bg-[radial-gradient(circle_at_top,rgba(251,191,36,0.18),transparent_58%)]',
   none: '',
@@ -53,6 +64,9 @@ export function MarketingSurfaceCard({
   className,
   imageSizes,
   imageClassName,
+  contentClassName,
+  label,
+  stateLabel,
   children,
 }: Readonly<MarketingSurfaceCardProps>) {
   const resolvedChrome = chrome ?? (src ? 'full-bleed' : 'framed');
@@ -60,6 +74,9 @@ export function MarketingSurfaceCard({
   return (
     <div
       data-testid={testId}
+      data-marketing-product-callout={
+        variant === 'product-callout' ? 'true' : undefined
+      }
       className={cn(
         'relative overflow-hidden',
         resolvedChrome === 'framed' && 'border backdrop-blur-sm',
@@ -88,6 +105,23 @@ export function MarketingSurfaceCard({
         </>
       ) : null}
 
+      {label || stateLabel ? (
+        <div className='relative z-20 flex min-h-12 items-center justify-between gap-4 border-b border-subtle px-5 py-3 sm:px-6'>
+          {label ? (
+            <p className='text-xs font-semibold tracking-tight text-primary-token'>
+              {label}
+            </p>
+          ) : (
+            <span />
+          )}
+          {stateLabel ? (
+            <span className='font-mono text-3xs tracking-tight text-tertiary-token'>
+              {stateLabel}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
       {src ? (
         <Image
           src={src}
@@ -101,7 +135,14 @@ export function MarketingSurfaceCard({
       ) : null}
 
       {children ? (
-        <div className='relative z-20 h-full w-full'>{children}</div>
+        <div
+          className={cn(
+            'relative z-20 h-full w-full min-w-0',
+            contentClassName
+          )}
+        >
+          {children}
+        </div>
       ) : null}
 
       <div

--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.css
@@ -10,64 +10,28 @@
 
 .ap-capture-loop__visual {
   isolation: isolate;
+  min-width: 0;
 }
 
-.ap-capture-loop__ring {
-  position: absolute;
-  width: min(30rem, 90%);
-  aspect-ratio: 1;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-pill);
+.ap-capture-loop__callout {
+  width: 100%;
+  min-height: 34rem;
 }
 
-.ap-capture-loop__phone {
-  position: relative;
-  z-index: 2;
-  width: min(18rem, 62vw);
-  max-width: none;
+.ap-capture-loop__callout-content {
+  display: flex;
+  min-height: 30rem;
+  align-items: center;
+  padding-block: clamp(var(--space-8), 6vw, var(--space-16));
 }
 
-.ap-capture-loop__node {
-  position: absolute;
-  z-index: 3;
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-pill);
-  background: var(--color-bg-surface-0);
-  color: var(--color-text-secondary-token);
-  font-size: var(--text-xs);
-  font-weight: var(--font-weight-semibold);
-}
-
-.ap-capture-loop__node--act {
-  top: 9%;
-  left: 12%;
-}
-
-.ap-capture-loop__node--opt-in {
-  top: 42%;
-  right: 2%;
-}
-
-.ap-capture-loop__node--return {
-  bottom: 8%;
-  left: 3%;
+.ap-capture-loop__callout-content > * {
+  width: 100%;
 }
 
 @media (max-width: 47.99rem) {
-  .ap-capture-loop__visual {
-    min-height: 31rem;
-  }
-
-  .ap-capture-loop__node--act {
-    left: 2%;
-  }
-
-  .ap-capture-loop__node--opt-in {
-    right: 0;
-  }
-
-  .ap-capture-loop__node--return {
-    left: 0;
+  .ap-capture-loop__callout,
+  .ap-capture-loop__callout-content {
+    min-height: 0;
   }
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
@@ -1,11 +1,9 @@
-import Image from 'next/image';
 import type {
   ArtistProfileCaptureVisualCopy,
   ArtistProfileLandingCopy,
 } from '@/data/artistProfileCopy';
-import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { ArtistProfileCaptureVisual } from '../MarketingStoryPrimitives';
-import { ArtistProfilePhoneFrame } from './ArtistProfilePhoneFrame';
+import { MarketingSurfaceCard } from '../MarketingSurfaceCard';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 import './ArtistProfileCaptureSection.css';
@@ -16,10 +14,6 @@ interface ArtistProfileCaptureSectionProps {
     | ArtistProfileCaptureVisualCopy
     | ArtistProfileLandingCopy['capture'];
 }
-
-const SUBSCRIBE_PROFILE = getMarketingExportImage(
-  'tim-white-profile-subscribe-mobile'
-);
 
 function isEditorialCapture(
   capture: ArtistProfileCaptureSectionProps['capture']
@@ -83,32 +77,24 @@ export function ArtistProfileCaptureSection({
         </div>
 
         <figure
-          className='ap-capture-loop__visual relative flex min-h-128 items-center justify-center'
+          className='ap-capture-loop__visual relative'
           data-testid='artist-profile-capture-demo'
         >
           <figcaption className='sr-only'>
-            Fan relationship loop: a fan acts, opts in, and hears from the
-            artist again.
+            A focused Jovie fan opt-in accepts an email, confirms the fan, and
+            turns that moment into an audience the artist can reach again.
           </figcaption>
-          <div className='ap-capture-loop__ring' aria-hidden='true' />
-          <span className='ap-capture-loop__node ap-capture-loop__node--act'>
-            Fan Acts
-          </span>
-          <span className='ap-capture-loop__node ap-capture-loop__node--opt-in'>
-            Opts In
-          </span>
-          <span className='ap-capture-loop__node ap-capture-loop__node--return'>
-            Hears From You Again
-          </span>
-          <ArtistProfilePhoneFrame className='ap-capture-loop__phone'>
-            <Image
-              fill
-              src={SUBSCRIBE_PROFILE.publicUrl}
-              alt='Jovie artist profile showing a fan email and SMS opt-in.'
-              className='object-cover object-top'
-              sizes='(min-width: 1024px) 18rem, 16rem'
-            />
-          </ArtistProfilePhoneFrame>
+          <MarketingSurfaceCard
+            variant='product-callout'
+            glowTone='teal'
+            chrome='framed'
+            label='Fan Opt-in'
+            stateLabel='Release Alerts'
+            className='ap-capture-loop__callout'
+            contentClassName='ap-capture-loop__callout-content'
+          >
+            <ArtistProfileCaptureVisual capture={capture} />
+          </MarketingSurfaceCard>
         </figure>
       </div>
     </ArtistProfileSectionShell>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css
@@ -2,12 +2,15 @@
   max-width: 12ch;
 }
 
-.ap-opinionated__comparison {
+.marketing-snap-rail__scroller.ap-opinionated__comparison {
+  display: block;
+  padding-inline: 0;
+  overflow-x: auto;
   scrollbar-width: none;
   scroll-snap-type: x mandatory;
 }
 
-.ap-opinionated__comparison::-webkit-scrollbar {
+.marketing-snap-rail__scroller.ap-opinionated__comparison::-webkit-scrollbar {
   display: none;
 }
 

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
 import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { cn } from '@/lib/utils';
+import { MarketingSnapRail } from '../MarketingSnapRail';
 import { SHELL_H2_CLASS, SHELL_LEAD_CLASS } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 import './ArtistProfileOpinionatedSection.css';
@@ -57,7 +58,16 @@ export function ArtistProfileOpinionatedSection({
           </p>
         </div>
 
-        <div className='ap-opinionated__comparison mt-12 overflow-x-auto'>
+        <MarketingSnapRail
+          ariaLabel='Static Menu And Adaptive Profile Comparison'
+          instructions='Use the previous and next buttons, or swipe, to compare both approaches.'
+          className='mt-12'
+          railClassName='ap-opinionated__comparison'
+          previousLabel='Show Static Menu Comparison'
+          nextLabel='Show Adaptive Profile Comparison'
+          showMobileControls
+          showDesktopControls={false}
+        >
           <div className='ap-opinionated__comparison-track grid min-w-168 grid-cols-2 border-y border-subtle'>
             <figure className='ap-opinionated__comparison-pane py-5 pr-5 sm:py-7 sm:pr-7'>
               <figcaption className='mb-5 flex items-baseline justify-between gap-4'>
@@ -93,7 +103,7 @@ export function ArtistProfileOpinionatedSection({
               </div>
             </figure>
           </div>
-        </div>
+        </MarketingSnapRail>
 
         <p className='mt-5 font-mono text-xs text-tertiary-token'>
           {opinionated.principle}

--- a/apps/web/components/marketing/artist-profile/captureShared.css
+++ b/apps/web/components/marketing/artist-profile/captureShared.css
@@ -116,8 +116,11 @@
     var(--color-text-primary-token) 3.5%,
     transparent
   );
-  box-shadow: 0 18px 40px
-    color-mix(in oklab, var(--system-b-cinematic-black) 18%, transparent);
+  box-shadow:
+    inset 0 1px 0
+    color-mix(in oklab, var(--color-text-primary-token) 6%, transparent),
+    0 28px 72px
+    color-mix(in oklab, var(--system-b-cinematic-black) 28%, transparent);
 }
 
 .ap-capture-action__inner--idle {
@@ -146,6 +149,20 @@
   );
   box-shadow: inset 0 1px 0
     color-mix(in oklab, var(--color-text-primary-token) 3%, transparent);
+}
+
+.ap-capture-action[data-phase="typing"] .ap-capture-action__field,
+.ap-capture-action[data-phase="submitting"] .ap-capture-action__field {
+  border-color: color-mix(
+    in oklab,
+    var(--color-accent-teal) 68%,
+    var(--color-accent-blue)
+  );
+  box-shadow:
+    inset 0 1px 0
+    color-mix(in oklab, var(--color-text-primary-token) 5%, transparent),
+    0 0 0 2px color-mix(in oklab, var(--color-accent-teal) 24%, transparent),
+    0 0 28px color-mix(in oklab, var(--color-accent-blue) 16%, transparent);
 }
 
 .ap-capture-action__caret {

--- a/apps/web/components/marketing/artist-profile/captureShared.tsx
+++ b/apps/web/components/marketing/artist-profile/captureShared.tsx
@@ -47,14 +47,6 @@ export type PillAccentStyle = CSSProperties & {
   readonly '--pill-accent': string;
 };
 
-/**
- * @deprecated The animation/effect styles now live in `./captureShared.css`,
- * which this module imports for side effects. Kept as an empty string so the
- * existing `<style>` injection in MarketingStoryPrimitives keeps typechecking
- * until that consumer migrates.
- */
-export const CAPTURE_ANIMATION_STYLES = '';
-
 export function CaptureActionPill({
   capture,
   phase,
@@ -69,6 +61,7 @@ export function CaptureActionPill({
   return (
     <div
       className='ap-capture-action w-full max-w-108 rounded-full p-1.5 backdrop-blur-xl'
+      data-phase={phase}
       aria-live='polite'
     >
       <div

--- a/apps/web/components/marketing/storybook/MarketingSections.stories.tsx
+++ b/apps/web/components/marketing/storybook/MarketingSections.stories.tsx
@@ -25,7 +25,11 @@ import { ArtistProfileOutcomesCarousel } from '@/components/marketing/artist-pro
 import { ArtistProfileSectionShell } from '@/components/marketing/artist-profile/ArtistProfileSectionShell';
 import { ArtistProfileSocialProof } from '@/components/marketing/artist-profile/ArtistProfileSocialProof';
 import { ArtistProfileSpecWall } from '@/components/marketing/artist-profile/ArtistProfileSpecWall';
+import { CaptureActionPill } from '@/components/marketing/artist-profile/captureShared';
 import { HomepageV2FinalCta } from '@/components/marketing/homepage-v2/HomepageV2Ctas';
+import { MarketingSnapRail } from '@/components/marketing/MarketingSnapRail';
+import { ArtistProfileCaptureVisual } from '@/components/marketing/MarketingStoryPrimitives';
+import { MarketingSurfaceCard } from '@/components/marketing/MarketingSurfaceCard';
 import { MarketingFooterCta } from '@/components/site/MarketingFooterCta';
 import { APP_ROUTES } from '@/constants/routes';
 import { getComparison } from '@/content/comparisons';
@@ -396,6 +400,56 @@ export const capture: Story = {
       <ArtistProfileOpinionatedSection
         opinionated={ARTIST_PROFILE_COPY.opinionated}
       />
+    </SectionFrame>
+  ),
+};
+
+export const artistProfileCalloutSystem: Story = {
+  name: 'artist-profile-callout-system',
+  parameters: {
+    jovie: {
+      uncoveredPropsByComponent: {
+        MarketingSnapRail: ['disabled'],
+      },
+    },
+    docs: {
+      description: {
+        story:
+          'Reusable Artist Profiles callout primitives showing a truthful focused fan-capture moment and restrained typing state.',
+      },
+    },
+  },
+  render: () => (
+    <SectionFrame sectionId='capture'>
+      <MarketingSnapRail
+        ariaLabel='Artist Profile Product Moments'
+        instructions='Use the previous and next buttons, or swipe, to inspect each product moment.'
+        showMobileControls
+      >
+        <div className='grid min-w-168 grid-cols-2 gap-4'>
+          <MarketingSurfaceCard
+            variant='product-callout'
+            glowTone='teal'
+            label='Fan Opt-in'
+            stateLabel='Focused'
+            contentClassName='p-6'
+          >
+            <ArtistProfileCaptureVisual capture={ARTIST_PROFILE_COPY.capture} />
+          </MarketingSurfaceCard>
+          <MarketingSurfaceCard
+            variant='product-callout'
+            glowTone='none'
+            label='Input State'
+            stateLabel='Typing'
+            contentClassName='p-6'
+          >
+            <CaptureActionPill
+              capture={ARTIST_PROFILE_COPY.capture}
+              phase='typing'
+            />
+          </MarketingSurfaceCard>
+        </div>
+      </MarketingSnapRail>
     </SectionFrame>
   ),
 };

--- a/apps/web/tests/unit/marketing/MarketingSnapRail.test.tsx
+++ b/apps/web/tests/unit/marketing/MarketingSnapRail.test.tsx
@@ -49,13 +49,56 @@ describe('MarketingSnapRail', () => {
       configurable: true,
       value: 400,
     });
+    Object.defineProperty(scroller, 'scrollWidth', {
+      configurable: true,
+      value: 800,
+    });
     scroller.scrollBy = scrollBy as typeof scroller.scrollBy;
+    fireEvent(window, new Event('resize'));
 
-    fireEvent.click(screen.getAllByLabelText('Next cards')[0]!);
+    const previousButton = screen.getAllByLabelText('Scroll Left')[0]!;
+    const nextButton = screen.getAllByLabelText('Next cards')[0]!;
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeEnabled();
+
+    fireEvent.click(nextButton);
 
     expect(scrollBy).toHaveBeenCalledWith({
       left: 320,
       behavior: 'auto',
     });
+
+    Object.defineProperty(scroller, 'scrollLeft', {
+      configurable: true,
+      value: 400,
+    });
+    fireEvent.scroll(scroller);
+
+    expect(previousButton).toBeEnabled();
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('exposes visible compact controls below desktop when requested', () => {
+    render(
+      <MarketingSnapRail
+        ariaLabel='Adaptive Profile Comparison'
+        nextLabel='Show Next Profile State'
+        previousLabel='Show Previous Profile State'
+        showMobileControls
+        showDesktopControls={false}
+      >
+        <article>Profile state</article>
+      </MarketingSnapRail>
+    );
+
+    expect(
+      screen.getAllByLabelText('Show Previous Profile State')
+    ).toHaveLength(1);
+    expect(screen.getAllByLabelText('Show Next Profile State')).toHaveLength(1);
+    expect(
+      screen
+        .getByLabelText('Show Next Profile State')
+        ?.closest('.marketing-snap-rail__mobile-controls')
+    ).toHaveClass('md:hidden');
   });
 });

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -122,6 +122,21 @@ describe('artist profile landing family System B source contract', () => {
     expect(outcomes).not.toContain('MarketingSnapRail');
     expect(outcomes).not.toContain('scrollByDirection');
 
+    const opinionated = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx'
+      ),
+      'utf8'
+    );
+    expect(opinionated).toContain(
+      "ariaLabel='Static Menu And Adaptive Profile Comparison'"
+    );
+    expect(opinionated).toContain('showMobileControls');
+    expect(opinionated).toContain(
+      "instructions='Use the previous and next buttons, or swipe, to compare both approaches.'"
+    );
+
     const hero = readFileSync(
       resolve(
         process.cwd(),
@@ -154,20 +169,36 @@ describe('artist profile landing family System B source contract', () => {
       ),
       'utf8'
     );
-    expect(capture).toContain('ap-capture-loop');
-    expect(capture).toContain('ArtistProfilePhoneFrame');
-    expect(capture).toContain("'tim-white-profile-subscribe-mobile'");
+    expect(capture).toContain('<MarketingSurfaceCard');
+    expect(capture).toContain("variant='product-callout'");
+    expect(capture).toContain("glowTone='teal'");
+    expect(capture).toContain('<ArtistProfileCaptureVisual');
+    expect(capture).not.toContain('ArtistProfilePhoneFrame');
 
-    const opinionated = readFileSync(
+    const captureShared = readFileSync(
       resolve(
         process.cwd(),
-        'components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx'
+        'components/marketing/artist-profile/captureShared.tsx'
       ),
       'utf8'
     );
-    expect(opinionated).toContain('StaticMenuPreview');
-    expect(opinionated).toContain('ap-opinionated__comparison-track');
-    expect(opinionated).toContain("'tim-white-profile-live-mobile'");
+    expect(captureShared).toContain('data-phase={phase}');
+
+    const captureVisual = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/MarketingStoryPrimitives.tsx'
+      ),
+      'utf8'
+    );
+    expect(captureVisual).not.toContain('loopTimer');
+
+    const surfaceCard = readFileSync(
+      resolve(process.cwd(), 'components/marketing/MarketingSurfaceCard.tsx'),
+      'utf8'
+    );
+    expect(surfaceCard).toContain("| 'product-callout';");
+    expect(surfaceCard).toContain('data-marketing-product-callout');
 
     const howItWorks = readFileSync(
       resolve(

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -100,6 +100,31 @@ modes, neverUse rules.
 - Content budgets: over-budget slot = check failure. Use `text-wrap: balance`.
 - CTA: `primaryCtaLabel` repeated verbatim throughout the page (one primary).
 
+### Product callout assembly
+
+Use the shared callout library instead of creating one-off marketing chrome:
+
+- **Canvas:** `MarketingSurfaceCard variant="product-callout"` owns the
+  editorial surface, frame, material, lighting, and optional product-state
+  labels.
+- **Stable state:** render a registry-backed `MarketingScreenshot` or
+  `ProductScreenshotFrame` by default.
+- **Active state:** reuse an existing dependency-safe product component only
+  when its focused, typing, submitting, or completed state directly explains
+  the feature. Keep the fixture read-only and side-effect free.
+- **Interaction language:** elevated pills, teal-blue focus, and input motion
+  are optional proof cues. Apply them only to the active control, run motion
+  once, preserve layout, and resolve reduced motion to the completed state.
+- **Responsive/accessibility:** one product state per callout, one frame
+  hierarchy, page-grid alignment, no horizontal page overflow, meaningful alt
+  text, figure caption, or group name, 44px interactive targets, and non-color
+  status cues.
+
+The existing product component language leads. Do not invent controls, chrome,
+or decorative interaction states for a marketing page. See
+[`COMPOSITION_RULES.md`](./COMPOSITION_RULES.md#law-8--product-callouts-prove-one-real-state)
+for the selection order and rationale.
+
 ## Inherited invariants (NOT restated in the registry)
 
 These apply to EVERY composition; the registry does not restate them:

--- a/docs/marketing/COMPOSITION_RULES.md
+++ b/docs/marketing/COMPOSITION_RULES.md
@@ -10,7 +10,7 @@ doc-freshness: docs/marketing/COMPOSITION_RULES.md
 > `maxContent`), and `composition.ts` (the filter pipeline). This file owns
 > the rationale. Agents: start at [`AGENT_GUIDE.md`](./AGENT_GUIDE.md).
 
-The composition rules cluster into seven laws, each with a reason and a
+The composition rules cluster into eight laws, each with a reason and a
 machine-checkable home.
 
 ## Law 1 — Hero is always first
@@ -113,6 +113,40 @@ selection.
 already has, not as a fix for a deficiency (creator-economy research §3).
 
 **Home:** `recipes.ts` `arc` + `sections.ts` `audienceLegality` + `composition.ts` audience-legality filter.
+
+## Law 8 — Product callouts prove one real state
+
+A product callout is a composed editorial surface around one truthful product
+state. Start with `MarketingSurfaceCard variant="product-callout"` for the
+canvas, shared chrome, token-led material, and controlled lighting. Put either
+a registry-backed `MarketingScreenshot` / `ProductScreenshotFrame` or an
+existing dependency-safe product component inside it. Do not invent interface
+chrome to make a marketing composition feel more impressive.
+
+Choose the proof mode in this order:
+
+1. Use a registry screenshot for a stable capability or overview.
+2. Use a real product component in a read-only fixture when the active state is
+   the feature being explained.
+3. Add a device frame only when device context materially changes the story.
+
+Active treatments are optional and state-specific. An elevated interaction pill
+is appropriate for a compact action. A teal-blue focus ring appears only on the
+field that is actually focused. Typing or input-state motion runs once, settles
+into the truthful completed state, reserves its dimensions, and renders the
+stable result immediately under reduced motion. These treatments are never
+ambient decoration and never repeated across every callout.
+
+Composition stays on the page grid: one primary product state per section, one
+frame hierarchy, 8-point spacing, and the shared page container. Labels name
+the product surface or state, not the design artifact. Responsive callouts must
+remain legible without horizontal page overflow; interactive controls keep a
+44px target; status cannot rely on color alone; composed states need an
+accessible figure caption, group name, or meaningful image alt.
+
+**Home:** `MarketingSurfaceCard`, `MarketingScreenshot`,
+`ProductScreenshotFrame`, `MarketingStoryPrimitives`, screenshot registry, and
+the route's colocated responsive CSS.
 
 ## Page-class rules
 


### PR DESCRIPTION
## Description

- Add reusable premium marketing-callout primitives for surfaces, frames, rails, focus states, and responsive composition.
- Document when authentic active product states should be used and when motion should stay quiet.
- Demonstrate the system on the Artist Profiles page rather than documenting it only.
- Stack 7 of 9.

## Type of Change

- [x] New feature

## Testing

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added or updated where applicable

Integrated stack evidence:

- Full normal pre-push gate passed: Biome, Tailwind guard, typecheck, component-ship gate, and all 8 unit-test shards.
- Component evidence: 21 changed components; 127 stories scanned; ratchet clean.
- Design and marketing guard sweep: 64 files / 238 tests passed.
- Artist Profiles Playwright contract: 10/10 passed.
- Production build: 469/469 static pages; /artist-profiles and /artist-profile generated.
- Screenshot-catalog integrity passed.
- Independent design reviews: clarity/conversion, reduction/craft, and product-callout system all PASS.

bug-to-test: not applicable — feature, documentation, or test-contract work.

## Design Skill Evidence

- [x] Design-read: public product landing page for independent artists, dark high-contrast Jovie System B language, product-first and editorial.
- [x] Dials: DESIGN_VARIANCE 4/10; MOTION_INTENSITY 2/10; VISUAL_DENSITY 5/10.
- [x] Before/after evidence: browser-verified at 1440px and 390px; canonical product captures included in the stack.
- [x] Narrow lint and typecheck output included in local verification.
- [x] design-canonical: PASS — contrast, states, layout, reduced motion, icons, anti-slop, and evidence.
- [x] No state transition introduces layout shift.
- [x] No external-data embedding or vectorization pipeline is created, populated, or deployed.

## Deployment Notes

- No migrations, environment variables, feature flags, billing, auth, or external-data embedding changes.
- Standard production controller may deploy after the exact final main SHA clears the native merge queue.

