### PR TITLE
feat(marketing): annotate profile product truth

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
@@ -1,171 +1,74 @@
-import { CheckCircle2, QrCode, Search } from 'lucide-react';
-import { ProviderIcon } from '@/components/atoms/ProviderIcon';
+import Image from 'next/image';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
-import { cn } from '@/lib/utils';
+import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
-
-function getProviderLabel(provider: string): string {
-  if (provider === 'apple_music') return 'Apple Music';
-  if (provider === 'deezer') return 'Deezer';
-  return 'Spotify';
-}
 
 interface ArtistProfileHowItWorksProps {
   readonly howItWorks: ArtistProfileLandingCopy['howItWorks'];
 }
 
+const SYNC_SETTINGS = getMarketingExportImage(
+  'artist-spec-sync-settings-desktop'
+);
+
 export function ArtistProfileHowItWorks({
   howItWorks,
 }: Readonly<ArtistProfileHowItWorksProps>) {
   return (
-    <ArtistProfileSectionShell className='bg-surface-0'>
-      <div className='mx-auto max-w-280'>
-        <ArtistProfileSectionHeader
-          align='left'
-          headline={howItWorks.headline}
-          body={howItWorks.body}
-          className='max-w-3xl'
-          bodyClassName='max-w-xl'
-        />
+    <ArtistProfileSectionShell>
+      <div className='mx-auto grid max-w-public-content items-start gap-12 lg:grid-cols-[minmax(18rem,0.72fr)_minmax(36rem,1.28fr)] lg:gap-16'>
+        <div>
+          <ArtistProfileSectionHeader
+            align='left'
+            headline={howItWorks.headline}
+            body={howItWorks.body}
+            className='max-w-xl'
+            bodyClassName='max-w-md'
+          />
 
-        <ol className='mt-10 grid gap-4 lg:grid-cols-3'>
-          {howItWorks.steps.map((step, index) => (
-            <li
-              key={step.id}
-              className='flex min-h-96 flex-col rounded-2xl border border-subtle bg-surface-1 p-5 sm:p-6'
-            >
-              <p className='font-mono text-3xs text-tertiary-token'>
-                0{index + 1}
-              </p>
+          <ol className='mt-9 border-t border-subtle'>
+            {howItWorks.steps.map((step, index) => (
+              <li
+                key={step.id}
+                className='grid grid-cols-[2rem_minmax(0,1fr)] gap-3 border-b border-subtle py-5'
+              >
+                <span className='font-mono text-3xs text-tertiary-token'>
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <div>
+                  <h3 className='text-sm font-semibold text-primary-token'>
+                    {step.title}
+                  </h3>
+                  <p className='mt-2 text-app leading-relaxed text-secondary-token'>
+                    {step.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
 
-              <div className='mt-8 flex-1'>
-                {step.id === 'claim' ? (
-                  <ClaimPreview howItWorks={howItWorks} />
-                ) : null}
-                {step.id === 'connect' ? (
-                  <ConnectPreview howItWorks={howItWorks} />
-                ) : null}
-                {step.id === 'share' ? (
-                  <SharePreview howItWorks={howItWorks} />
-                ) : null}
-              </div>
-
-              <h3 className='mt-8 text-lg font-semibold tracking-tight text-primary-token'>
-                {step.title}
-              </h3>
-              <p className='mt-3 text-app leading-relaxed text-secondary-token'>
-                {step.description}
-              </p>
-            </li>
-          ))}
-        </ol>
+        <figure className='ap-how-it-works__product-window relative overflow-hidden border border-subtle bg-surface-0'>
+          <div className='ap-how-it-works__window-bar flex items-center gap-2 border-b border-subtle px-4 py-3'>
+            <span aria-hidden='true' />
+            <span aria-hidden='true' />
+            <span aria-hidden='true' />
+            <figcaption className='ml-2 font-mono text-3xs text-tertiary-token'>
+              Connect Music
+            </figcaption>
+          </div>
+          <div className='relative aspect-[1.2875]'>
+            <Image
+              fill
+              src={SYNC_SETTINGS.publicUrl}
+              alt='Jovie settings showing music services connected to an artist profile.'
+              className='object-cover object-top'
+              sizes='(min-width: 1024px) 48rem, 100vw'
+            />
+          </div>
+        </figure>
       </div>
     </ArtistProfileSectionShell>
-  );
-}
-
-function ClaimPreview({
-  howItWorks,
-}: Readonly<{ howItWorks: ArtistProfileLandingCopy['howItWorks'] }>) {
-  return (
-    <div className='space-y-3'>
-      <div className='flex min-h-11 items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-3.5'>
-        <Search className='h-4 w-4 text-tertiary-token' aria-hidden='true' />
-        <span className='text-app font-medium text-primary-token'>
-          {howItWorks.claim.searchValue}
-        </span>
-      </div>
-      <div className='flex items-center gap-3 rounded-xl border border-subtle bg-surface-0 p-3'>
-        <span className='flex h-10 w-10 items-center justify-center rounded-full border border-subtle bg-surface-1'>
-          <ProviderIcon provider='spotify' className='h-4 w-4' />
-        </span>
-        <div className='min-w-0 flex-1'>
-          <p className='truncate text-app font-semibold text-primary-token'>
-            {howItWorks.claim.resultName}
-          </p>
-          <p className='mt-1 text-2xs text-secondary-token'>
-            {howItWorks.claim.resultSubtitle}
-          </p>
-        </div>
-        <span className='rounded-full bg-primary-token px-3 py-1.5 text-3xs font-semibold text-surface-1'>
-          {howItWorks.claim.ctaLabel}
-        </span>
-      </div>
-      <p className='flex items-center justify-between rounded-lg border border-subtle bg-surface-0 px-3.5 py-3 font-mono text-xs text-secondary-token'>
-        {howItWorks.claim.profilePath}
-        <CheckCircle2 className='h-4 w-4 text-success' aria-hidden='true' />
-      </p>
-    </div>
-  );
-}
-
-function ConnectPreview({
-  howItWorks,
-}: Readonly<{ howItWorks: ArtistProfileLandingCopy['howItWorks'] }>) {
-  return (
-    <div className='rounded-xl border border-subtle bg-surface-0 p-3.5'>
-      <p className='text-app font-semibold text-primary-token'>
-        {howItWorks.sync.title}
-      </p>
-      <p className='mt-1 text-2xs text-secondary-token'>
-        {howItWorks.sync.detail}
-      </p>
-      <div className='mt-4 space-y-2'>
-        {howItWorks.sync.providers.map(provider => (
-          <div
-            key={provider.provider}
-            className='flex items-center justify-between rounded-lg border border-subtle bg-surface-1 px-3 py-2.5'
-          >
-            <span className='flex items-center gap-2.5 text-xs font-medium text-primary-token'>
-              <ProviderIcon provider={provider.provider} className='h-4 w-4' />
-              {getProviderLabel(provider.provider)}
-            </span>
-            <span
-              className={cn(
-                'text-3xs font-semibold',
-                provider.status === 'Matched'
-                  ? 'text-success'
-                  : 'text-secondary-token'
-              )}
-            >
-              {provider.status}
-            </span>
-          </div>
-        ))}
-      </div>
-      <p className='mt-3 text-2xs text-tertiary-token'>
-        {howItWorks.sync.otherProvidersLabel}
-      </p>
-    </div>
-  );
-}
-
-function SharePreview({
-  howItWorks,
-}: Readonly<{ howItWorks: ArtistProfileLandingCopy['howItWorks'] }>) {
-  return (
-    <div className='rounded-xl border border-subtle bg-surface-0 p-4'>
-      <div className='flex items-center justify-between gap-3'>
-        <p className='font-mono text-xs text-primary-token'>
-          {howItWorks.share.displayValue}
-        </p>
-        <span className='flex h-10 w-10 items-center justify-center rounded-lg border border-subtle bg-surface-1 text-secondary-token'>
-          <QrCode className='h-4 w-4' aria-hidden='true' />
-        </span>
-      </div>
-      <div className='mt-5 border-t border-subtle pt-4'>
-        <p className='text-3xs font-semibold text-tertiary-token'>
-          {howItWorks.share.deepLinksLabel}
-        </p>
-        <div className='mt-3 space-y-2'>
-          {howItWorks.share.deepLinks.slice(0, 3).map(link => (
-            <p key={link} className='font-mono text-2xs text-secondary-token'>
-              {link}
-            </p>
-          ))}
-        </div>
-      </div>
-    </div>
   );
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileLandingPage.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileLandingPage.css
@@ -64,3 +64,123 @@
     padding-block: var(--space-10) var(--space-8);
   }
 }
+
+.ap-annotated-truth__product-stage {
+  background:
+    linear-gradient(var(--color-border-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--color-border-subtle) 1px, transparent 1px);
+  background-size: 4rem 4rem;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    black 15%,
+    black 85%,
+    transparent
+  );
+}
+
+.ap-annotated-truth__phone {
+  position: relative;
+  z-index: 2;
+  width: min(21rem, 70vw);
+  max-width: none;
+}
+
+.ap-annotated-truth__marker {
+  position: absolute;
+  z-index: 3;
+  display: flex;
+  width: 1.75rem;
+  height: 1.75rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-text-secondary-token);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-base);
+  color: var(--color-text-primary-token);
+  font-family: var(--font-mono);
+  font-size: var(--text-3xs);
+  box-shadow: 0 0 0 var(--space-2)
+    color-mix(in oklab, var(--color-bg-base) 68%, transparent);
+}
+
+.ap-annotated-truth__marker--identity {
+  top: 20%;
+  left: 23%;
+}
+
+.ap-annotated-truth__marker--release {
+  top: 39%;
+  right: 20%;
+}
+
+.ap-annotated-truth__marker--action {
+  right: 24%;
+  bottom: 27%;
+}
+
+.ap-annotated-truth__marker--navigation {
+  bottom: 13%;
+  left: 24%;
+}
+
+.ap-how-it-works__product-window {
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-card);
+}
+
+.ap-how-it-works__window-bar span[aria-hidden="true"] {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-border-default);
+}
+
+@media (max-width: 63.99rem) {
+  .ap-annotated-truth__product-stage {
+    min-height: 36rem;
+  }
+
+  .ap-annotated-truth__marker--identity {
+    left: 14%;
+  }
+
+  .ap-annotated-truth__marker--release {
+    right: 12%;
+  }
+
+  .ap-annotated-truth__marker--action {
+    right: 15%;
+  }
+
+  .ap-annotated-truth__marker--navigation {
+    left: 15%;
+  }
+}
+
+.ap-profile-gallery {
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin;
+}
+
+.ap-profile-gallery__frame {
+  height: clamp(28rem, 48vw, 40rem);
+  border-radius: var(--radius-xl);
+}
+
+@media (min-width: 48rem) {
+  .ap-profile-gallery {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    overflow-x: visible;
+  }
+}
+
+@media (max-width: 47.99rem) {
+  .ap-profile-gallery {
+    grid-template-columns: repeat(3, minmax(16.5rem, 78vw));
+  }
+
+  .ap-profile-gallery__frame {
+    height: 34rem;
+  }
+}

--- a/apps/web/components/marketing/artist-profile/ArtistProfileLandingPage.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileLandingPage.tsx
@@ -1,8 +1,9 @@
+import Image from 'next/image';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
-import type { ArtistProfileTruthTile } from '@/data/artistProfileFeatures';
 import { ARTIST_PROFILE_SECTION_TEST_IDS } from '@/data/artistProfilePageOrder';
 import type { ArtistProfileSocialProofData } from '@/data/socialProof';
 import type { ArtistProfileSectionFlags } from '@/lib/featureFlags';
+import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { ArtistProfileCaptureSection } from './ArtistProfileCaptureSection';
 import { ArtistProfileFaq } from './ArtistProfileFaq';
 import { ArtistProfileFinalCta } from './ArtistProfileFinalCta';
@@ -11,19 +12,109 @@ import { ArtistProfileHeroAdaptiveIntro } from './ArtistProfileHeroAdaptiveIntro
 import { ArtistProfileHowItWorks } from './ArtistProfileHowItWorks';
 import { ArtistProfileOpinionatedSection } from './ArtistProfileOpinionatedSection';
 import { ArtistProfileOutcomesCarousel } from './ArtistProfileOutcomesCarousel';
+import { ArtistProfilePhoneFrame } from './ArtistProfilePhoneFrame';
+import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
+import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 import { ArtistProfileSocialProof } from './ArtistProfileSocialProof';
-import { ArtistProfileSpecWall } from './ArtistProfileSpecWall';
+
+const LIVE_PROFILE = getMarketingExportImage('tim-white-profile-live-mobile');
+
+const DEFAULT_CALLOUTS = [
+  {
+    id: 'identity',
+    title: 'Your Identity',
+    body: 'Artwork, artist name, and verified destinations stay unmistakably yours.',
+  },
+  {
+    id: 'release',
+    title: 'What Is Current',
+    body: 'The newest release leads without asking fans to search for it.',
+  },
+  {
+    id: 'action',
+    title: 'The Right Next Move',
+    body: 'Listen, pre-save, find tickets, or support—the action follows the moment.',
+  },
+  {
+    id: 'navigation',
+    title: 'Everything Else',
+    body: 'Music-native navigation keeps the rest close without competing for attention.',
+  },
+] as const;
+
+function ArtistProfileAnnotatedTruth({
+  specWall,
+}: Readonly<{ specWall: ArtistProfileLandingCopy['specWall'] }>) {
+  const callouts = specWall.callouts ?? DEFAULT_CALLOUTS;
+
+  return (
+    <ArtistProfileSectionShell className='ap-annotated-truth bg-surface-0'>
+      <div className='mx-auto max-w-public-content'>
+        <ArtistProfileSectionHeader
+          align='left'
+          headline={specWall.headline}
+          body={specWall.subhead}
+          className='max-w-3xl'
+          bodyClassName='max-w-xl'
+        />
+
+        <div className='ap-annotated-truth__composition mt-12 grid items-center gap-10 border-y border-subtle py-8 lg:grid-cols-[minmax(28rem,1.15fr)_minmax(20rem,0.85fr)] lg:gap-16 lg:py-12'>
+          <div className='ap-annotated-truth__product-stage relative flex min-h-144 items-center justify-center'>
+            <ArtistProfilePhoneFrame className='ap-annotated-truth__phone'>
+              <Image
+                fill
+                src={LIVE_PROFILE.publicUrl}
+                alt="Tim White's live Jovie artist profile."
+                className='object-cover object-top'
+                sizes='(min-width: 1024px) 21rem, 18rem'
+              />
+            </ArtistProfilePhoneFrame>
+            {callouts.map((callout, index) => (
+              <span
+                key={callout.id}
+                aria-hidden='true'
+                className={`ap-annotated-truth__marker ap-annotated-truth__marker--${callout.id}`}
+              >
+                {index + 1}
+              </span>
+            ))}
+          </div>
+
+          <ol className='ap-annotated-truth__callouts border-t border-subtle'>
+            {callouts.map((callout, index) => (
+              <li
+                key={callout.id}
+                data-testid='artist-profile-truth-tile'
+                className='grid grid-cols-[2rem_minmax(0,1fr)] gap-3 border-b border-subtle py-5'
+              >
+                <span className='font-mono text-3xs text-tertiary-token'>
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <div>
+                  <h3 className='text-sm font-semibold text-primary-token'>
+                    {callout.title}
+                  </h3>
+                  <p className='mt-2 text-app leading-relaxed text-secondary-token'>
+                    {callout.body}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </ArtistProfileSectionShell>
+  );
+}
 
 interface ArtistProfileLandingPageProps {
   readonly copy: ArtistProfileLandingCopy;
-  readonly truthTiles: readonly ArtistProfileTruthTile[];
   readonly socialProof: ArtistProfileSocialProofData;
   readonly flags: ArtistProfileSectionFlags;
 }
 
 export function ArtistProfileLandingPage({
   copy,
-  truthTiles,
   socialProof,
   flags,
 }: Readonly<ArtistProfileLandingPageProps>) {
@@ -54,10 +145,7 @@ export function ArtistProfileLandingPage({
         <ArtistProfileOpinionatedSection opinionated={copy.opinionated} />
       </div>
       <div data-testid={ARTIST_PROFILE_SECTION_TEST_IDS.specWall}>
-        <ArtistProfileSpecWall
-          specWall={copy.specWall}
-          truthTiles={truthTiles}
-        />
+        <ArtistProfileAnnotatedTruth specWall={copy.specWall} />
       </div>
       <div data-testid={ARTIST_PROFILE_SECTION_TEST_IDS.howItWorks}>
         <ArtistProfileHowItWorks howItWorks={copy.howItWorks} />
@@ -76,7 +164,7 @@ export function ArtistProfileLandingPage({
         </div>
       ) : null}
       <div data-testid={ARTIST_PROFILE_SECTION_TEST_IDS.finalCta}>
-        <ArtistProfileFinalCta finalCta={copy.finalCta} roomy showSignature />
+        <ArtistProfileFinalCta finalCta={copy.finalCta} />
       </div>
     </>
   );

--- a/apps/web/components/marketing/artist-profile/ArtistProfileLandingRoute.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileLandingRoute.tsx
@@ -1,6 +1,5 @@
 import { MarketingPageShell } from '@/components/marketing';
 import { ARTIST_PROFILE_COPY } from '@/data/artistProfileCopy';
-import { ARTIST_PROFILE_TRUTH_TILES } from '@/data/artistProfileFeatures';
 import { ARTIST_PROFILE_SOCIAL_PROOF } from '@/data/socialProof';
 import { ARTIST_PROFILE_FLAGS } from '@/lib/featureFlags';
 import { ArtistProfileLandingPage } from './ArtistProfileLandingPage';
@@ -11,7 +10,6 @@ export function ArtistProfileLandingRoute() {
     <MarketingPageShell className='artist-profiles-home-system'>
       <ArtistProfileLandingPage
         copy={ARTIST_PROFILE_COPY}
-        truthTiles={ARTIST_PROFILE_TRUTH_TILES}
         socialProof={ARTIST_PROFILE_SOCIAL_PROOF}
         flags={ARTIST_PROFILE_FLAGS}
       />

--- a/apps/web/components/marketing/storybook/MarketingSections.stories.tsx
+++ b/apps/web/components/marketing/storybook/MarketingSections.stories.tsx
@@ -17,6 +17,7 @@ import { ArtistProfileFinalCta } from '@/components/marketing/artist-profile/Art
 import { ArtistProfileHero } from '@/components/marketing/artist-profile/ArtistProfileHero';
 import { ArtistProfileHeroAdaptiveIntro } from '@/components/marketing/artist-profile/ArtistProfileHeroAdaptiveIntro';
 import { ArtistProfileHowItWorks } from '@/components/marketing/artist-profile/ArtistProfileHowItWorks';
+import { ArtistProfileLandingPage } from '@/components/marketing/artist-profile/ArtistProfileLandingPage';
 import { ArtistProfileModeSwitcher } from '@/components/marketing/artist-profile/ArtistProfileModeSwitcher';
 import { ArtistProfileMonetizationSection } from '@/components/marketing/artist-profile/ArtistProfileMonetizationSection';
 import { ArtistProfileOpinionatedSection } from '@/components/marketing/artist-profile/ArtistProfileOpinionatedSection';
@@ -186,6 +187,19 @@ export const howItWorks: Story = {
   render: () => (
     <SectionFrame sectionId='how-it-works'>
       <ArtistProfileHowItWorks howItWorks={ARTIST_PROFILE_COPY.howItWorks} />
+    </SectionFrame>
+  ),
+};
+
+export const artistProfileAssembly: Story = {
+  name: 'artist-profile-assembly',
+  render: () => (
+    <SectionFrame sectionId='feature-split'>
+      <ArtistProfileLandingPage
+        copy={ARTIST_PROFILE_COPY}
+        socialProof={ARTIST_PROFILE_SOCIAL_PROOF}
+        flags={{ FULL_PAGE: false, SOCIAL_PROOF: false, FAQ: false }}
+      />
     </SectionFrame>
   ),
 };

--- a/apps/web/tests/unit/app/artist-profiles-page.test.tsx
+++ b/apps/web/tests/unit/app/artist-profiles-page.test.tsx
@@ -326,7 +326,7 @@ describe('ArtistProfilesPage', () => {
     expect(screen.getAllByTestId('artist-profile-outcome-card')).toHaveLength(
       5
     );
-    expect(screen.getAllByTestId('artist-profile-truth-tile')).toHaveLength(10);
+    expect(screen.getAllByTestId('artist-profile-truth-tile')).toHaveLength(4);
     expect(ARTIST_PROFILE_COPY.faq.items).toHaveLength(4);
     expect(
       screen.queryByTestId(ARTIST_PROFILE_SECTION_TEST_IDS.socialProof)

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -48,7 +48,7 @@ const sectionComponents = [
   'ArtistProfileOutcomesCarousel',
   'ArtistProfileCaptureSection',
   'ArtistProfileOpinionatedSection',
-  'ArtistProfileSpecWall',
+  'ArtistProfileAnnotatedTruth',
   'ArtistProfileHowItWorks',
   'ArtistProfileSocialProof',
   'ArtistProfileFaq',
@@ -168,6 +168,16 @@ describe('artist profile landing family System B source contract', () => {
     expect(opinionated).toContain('StaticMenuPreview');
     expect(opinionated).toContain('ap-opinionated__comparison-track');
     expect(opinionated).toContain("'tim-white-profile-live-mobile'");
+
+    const howItWorks = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/marketing/artist-profile/ArtistProfileHowItWorks.tsx'
+      ),
+      'utf8'
+    );
+    expect(howItWorks).toContain("'artist-spec-sync-settings-desktop'");
+    expect(howItWorks).toContain('<Image');
 
     const finalCta = readFileSync(
       resolve(


### PR DESCRIPTION
## Description

- Annotate the actual artist-profile product surface with precise callouts.
- Replace disconnected setup steps with one continuous onboarding story using real Jovie states.
- Stack 6 of 9.

## Type of Change

- [x] New feature

## Testing

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added or updated where applicable

Integrated stack evidence:

- Full normal pre-push gate passed: Biome, Tailwind guard, typecheck, component-ship gate, and all 8 unit-test shards.
- Component evidence: 21 changed components; 127 stories scanned; ratchet clean.
- Design and marketing guard sweep: 64 files / 238 tests passed.
- Artist Profiles Playwright contract: 10/10 passed.
- Production build: 469/469 static pages; /artist-profiles and /artist-profile generated.
- Screenshot-catalog integrity passed.
- Independent design reviews: clarity/conversion, reduction/craft, and product-callout system all PASS.

bug-to-test: not applicable — feature, documentation, or test-contract work.

## Design Skill Evidence

- [x] Design-read: public product landing page for independent artists, dark high-contrast Jovie System B language, product-first and editorial.
- [x] Dials: DESIGN_VARIANCE 4/10; MOTION_INTENSITY 2/10; VISUAL_DENSITY 5/10.
- [x] Before/after evidence: browser-verified at 1440px and 390px; canonical product captures included in the stack.
- [x] Narrow lint and typecheck output included in local verification.
- [x] design-canonical: PASS — contrast, states, layout, reduced motion, icons, anti-slop, and evidence.
- [x] No state transition introduces layout shift.
- [x] No external-data embedding or vectorization pipeline is created, populated, or deployed.

## Deployment Notes

- No migrations, environment variables, feature flags, billing, auth, or external-data embedding changes.
- Standard production controller may deploy after the exact final main SHA clears the native merge queue.

