### PR TITLE
fix(connections): classify profile intake [JOV-4775]

### DIFF
--- a/apps/web/app/app/(shell)/profiles/AddConnectionRail.tsx
+++ b/apps/web/app/app/(shell)/profiles/AddConnectionRail.tsx
@@ -10,7 +10,19 @@ import {
   Plus,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { type ReactNode, useMemo, useState } from 'react';
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { SocialIcon } from '@/components/atoms/SocialIcon';
+import {
+  looksLikeUrlOrDomain,
+  rankPlatformOptions,
+} from '@/components/features/dashboard/molecules/universal-link-input/utils';
+import { PLATFORM_OPTIONS } from '@/components/features/dashboard/molecules/universalLinkInput.constants';
 import {
   DrawerSection,
   EntityHeaderCard,
@@ -21,9 +33,196 @@ import { APP_ROUTES } from '@/constants/routes';
 import { getConnectorDefinitions } from '@/lib/connectors/registry';
 import { canonicalizeSurfaceUrl } from '@/lib/profile-surfaces/contracts';
 import { cn } from '@/lib/utils';
+import { detectPlatform, normalizeUrl } from '@/lib/utils/platform-detection';
 import type { ProfilesWorkspaceData } from './data';
 
 type AddConnectionView = 'home' | 'services' | 'profile';
+
+const HANDLE_PLATFORM_IDS = new Set([
+  'instagram',
+  'tiktok',
+  'youtube',
+  'twitter',
+  'facebook',
+  'soundcloud',
+  'twitch',
+  'linkedin',
+  'venmo',
+  'threads',
+  'telegram',
+  'snapchat',
+]);
+
+const HANDLE_OPTIONS = PLATFORM_OPTIONS.filter(option =>
+  HANDLE_PLATFORM_IDS.has(option.id)
+);
+
+export interface ConnectionIntakeCandidate {
+  readonly id: string;
+  readonly platformId: string;
+  readonly platformName: string;
+  readonly icon: string;
+  readonly category: 'dsp' | 'social' | 'website';
+  readonly url: string;
+  readonly handle: string | null;
+  readonly title: string;
+}
+
+interface ConnectionIntakeResult {
+  readonly candidate: ConnectionIntakeCandidate | null;
+  readonly suggestions: readonly ConnectionIntakeCandidate[];
+  readonly error: string | null;
+}
+
+function comparablePlatformId(value: string): string {
+  return value.replaceAll('-', '_').replace(/^x$/, 'twitter');
+}
+
+function isExistingPlatform(
+  platformId: string,
+  existingPlatforms: readonly string[]
+): boolean {
+  const comparable = comparablePlatformId(platformId);
+  return existingPlatforms.some(
+    existing => comparablePlatformId(existing) === comparable
+  );
+}
+
+function extractHandle(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const segment = parsed.pathname
+      .split('/')
+      .filter(Boolean)
+      .at(-1)
+      ?.replace(/^@/, '');
+    return segment ? `@${segment}` : null;
+  } catch {
+    return null;
+  }
+}
+
+function toCandidate(
+  input: string,
+  creatorName?: string
+): ConnectionIntakeCandidate | null {
+  const canonical = canonicalizeSurfaceUrl(normalizeUrl(input));
+  if (!canonical) return null;
+
+  const detected = detectPlatform(canonical.url, creatorName);
+  const knownPlatform = detected.platform.id !== 'website';
+  const category =
+    detected.platform.category === 'dsp'
+      ? 'dsp'
+      : knownPlatform
+        ? 'social'
+        : 'website';
+
+  return {
+    id: `${detected.platform.id}:${canonical.url}`,
+    platformId: detected.platform.id,
+    platformName: knownPlatform ? detected.platform.name : 'Website',
+    icon: knownPlatform ? detected.platform.icon : 'globe',
+    category,
+    url: canonical.url,
+    handle: extractHandle(canonical.url),
+    title: knownPlatform ? detected.suggestedTitle : canonical.hostname,
+  };
+}
+
+function parseHandleIntent(
+  input: string
+): { readonly handle: string; readonly platformQuery: string } | null {
+  const trimmed = input.trim();
+  if (!trimmed || looksLikeUrlOrDomain(trimmed)) return null;
+
+  const parts = trimmed.split(/\s+/);
+  const rawHandle = parts.at(-1) ?? '';
+  const handle = rawHandle.replace(/^@/, '');
+  if (!/^[a-z0-9][a-z0-9._-]{1,63}$/i.test(handle)) return null;
+
+  return {
+    handle,
+    platformQuery: parts.slice(0, -1).join(' '),
+  };
+}
+
+function handleSuggestions(
+  input: string,
+  existingPlatforms: readonly string[],
+  creatorName?: string
+): readonly ConnectionIntakeCandidate[] {
+  const intent = parseHandleIntent(input);
+  if (!intent) return [];
+
+  const ranked = rankPlatformOptions(
+    intent.platformQuery,
+    HANDLE_OPTIONS,
+    existingPlatforms
+  );
+
+  return ranked
+    .filter(option => !isExistingPlatform(option.id, existingPlatforms))
+    .slice(0, 5)
+    .flatMap(option => {
+      const candidate = toCandidate(
+        `${option.prefill}${intent.handle}`,
+        creatorName
+      );
+      if (!candidate) return [];
+
+      return [
+        {
+          ...candidate,
+          id: `${option.id}:${candidate.url}`,
+          platformId: option.id,
+          platformName: option.name,
+          icon: option.icon,
+          category: option.category === 'music' ? 'dsp' : 'social',
+          handle: `@${intent.handle}`,
+          title: creatorName
+            ? `${creatorName} on ${option.name}`
+            : `@${intent.handle} on ${option.name}`,
+        },
+      ];
+    });
+}
+
+export function classifyConnectionInput(
+  input: string,
+  existingPlatforms: readonly string[],
+  creatorName?: string
+): ConnectionIntakeResult {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { candidate: null, suggestions: [], error: null };
+  }
+
+  if (looksLikeUrlOrDomain(trimmed)) {
+    const candidate = toCandidate(trimmed, creatorName);
+    return {
+      candidate,
+      suggestions: [],
+      error: candidate
+        ? null
+        : 'Enter a public URL or domain without credentials.',
+    };
+  }
+
+  const suggestions = handleSuggestions(
+    trimmed,
+    existingPlatforms,
+    creatorName
+  );
+  return {
+    candidate: null,
+    suggestions,
+    error:
+      suggestions.length > 0
+        ? null
+        : 'Enter a URL, domain, @handle, or username.',
+  };
+}
 
 function ConnectorIcon({
   iconKey,
@@ -73,23 +272,72 @@ function ChoiceRow({
 export function AddConnectionRail({
   data,
   onClose,
+  onCandidatePreview,
+  onReviewCandidate,
   onReviewSuggestions,
 }: Readonly<{
   data: ProfilesWorkspaceData;
   onClose: () => void;
+  onCandidatePreview: (candidate: ConnectionIntakeCandidate | null) => void;
+  onReviewCandidate: (candidate: ConnectionIntakeCandidate) => void;
   onReviewSuggestions: () => void;
 }>) {
   const router = useRouter();
   const [view, setView] = useState<AddConnectionView>('home');
   const [profileUrl, setProfileUrl] = useState('');
-  const canonicalUrl = useMemo(
-    () => canonicalizeSurfaceUrl(profileUrl),
-    [profileUrl]
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
+  const existingPlatforms = useMemo(
+    () => data.rows.map(row => row.platform),
+    [data.rows]
+  );
+  const intake = useMemo(
+    () =>
+      classifyConnectionInput(profileUrl, existingPlatforms, data.artist.name),
+    [data.artist.name, existingPlatforms, profileUrl]
   );
   const suggestedCount = data.rows.filter(
     row => row.rowType === 'surface' && row.qualificationStatus === 'suggested'
   ).length;
   const connectors = getConnectorDefinitions();
+
+  useEffect(() => {
+    onCandidatePreview(intake.candidate);
+  }, [intake.candidate, onCandidatePreview]);
+
+  useEffect(() => {
+    setActiveSuggestionIndex(index =>
+      Math.min(index, Math.max(0, intake.suggestions.length - 1))
+    );
+  }, [intake.suggestions.length]);
+
+  const selectSuggestion = (candidate: ConnectionIntakeCandidate) => {
+    setProfileUrl(candidate.url);
+    setActiveSuggestionIndex(0);
+  };
+
+  const handleProfileKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (intake.suggestions.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveSuggestionIndex(index =>
+        index < intake.suggestions.length - 1 ? index + 1 : 0
+      );
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveSuggestionIndex(index =>
+        index > 0 ? index - 1 : intake.suggestions.length - 1
+      );
+      return;
+    }
+    if (event.key === 'Enter') {
+      const suggestion = intake.suggestions[activeSuggestionIndex];
+      if (!suggestion) return;
+      event.preventDefault();
+      selectSuggestion(suggestion);
+    }
+  };
 
   const title =
     view === 'services'
@@ -107,6 +355,22 @@ export function AddConnectionRail({
       headerMode='minimal'
       hideMinimalHeaderBar
       entityHeaderSurface='flat'
+      footer={
+        view === 'profile' ? (
+          <Button
+            type='button'
+            size='sm'
+            className='w-full'
+            disabled={!intake.candidate}
+            onClick={() => {
+              if (intake.candidate) onReviewCandidate(intake.candidate);
+            }}
+          >
+            Review profile
+          </Button>
+        ) : undefined
+      }
+      footerSurface='flat'
       entityHeader={
         <EntityHeaderCard
           image={
@@ -203,43 +467,106 @@ export function AddConnectionRail({
       ) : null}
 
       {view === 'profile' ? (
-        <DrawerSection title='Public URL' sectionKind='details' surface='plain'>
-          <div className='space-y-2 px-3 pb-2'>
+        <DrawerSection
+          title='Public profile'
+          sectionKind='details'
+          surface='plain'
+          className='flex h-full min-h-0 flex-col'
+          contentClassName='flex min-h-0 flex-1 flex-col'
+        >
+          <div className='flex min-h-72 flex-1 flex-col gap-3 px-3 pb-2'>
             <Input
               aria-label='Public profile URL'
-              autoComplete='url'
-              inputMode='url'
-              placeholder='https://…'
+              aria-controls={
+                intake.suggestions.length > 0
+                  ? 'connection-intake-suggestions'
+                  : undefined
+              }
+              aria-activedescendant={
+                intake.suggestions.length > 0
+                  ? `connection-intake-suggestion-${activeSuggestionIndex}`
+                  : undefined
+              }
+              aria-autocomplete='list'
+              autoComplete='off'
+              placeholder='URL, @handle, or username'
               value={profileUrl}
-              onChange={event => setProfileUrl(event.target.value)}
+              onChange={event => {
+                setProfileUrl(event.target.value);
+                setActiveSuggestionIndex(0);
+              }}
+              onKeyDown={handleProfileKeyDown}
             />
-            {profileUrl ? (
-              canonicalUrl ? (
-                <p className='text-xs leading-5 text-secondary-token'>
-                  Canonical URL:{' '}
-                  <span className='break-all text-primary-token'>
-                    {canonicalUrl.url}
+
+            <div className='min-h-28'>
+              {intake.candidate ? (
+                <div className='flex items-center gap-2 rounded-lg bg-surface-1 px-2.5 py-2'>
+                  <span className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-surface-2 text-secondary-token'>
+                    <SocialIcon
+                      platform={intake.candidate.platformId}
+                      className='h-4 w-4'
+                    />
                   </span>
-                </p>
-              ) : (
-                <p className='text-xs leading-5 text-error'>
-                  Enter a public http or https URL without credentials.
-                </p>
-              )
-            ) : null}
+                  <span className='min-w-0 flex-1'>
+                    <span className='block truncate text-sm font-medium text-primary-token'>
+                      {intake.candidate.platformName}
+                    </span>
+                    <span className='block truncate text-xs text-tertiary-token'>
+                      {intake.candidate.url}
+                    </span>
+                  </span>
+                  <span className='text-2xs font-medium uppercase tracking-wide text-accent'>
+                    Detected
+                  </span>
+                </div>
+              ) : null}
+
+              {intake.suggestions.length > 0 ? (
+                <div
+                  id='connection-intake-suggestions'
+                  role='listbox'
+                  aria-label='Suggested profile destinations'
+                  className='flex flex-wrap gap-1.5 sm:flex-col sm:gap-1'
+                >
+                  {intake.suggestions.map((suggestion, index) => (
+                    <button
+                      key={suggestion.id}
+                      id={`connection-intake-suggestion-${index}`}
+                      type='button'
+                      role='option'
+                      aria-selected={index === activeSuggestionIndex}
+                      onMouseEnter={() => setActiveSuggestionIndex(index)}
+                      onClick={() => selectSuggestion(suggestion)}
+                      className={cn(
+                        'inline-flex min-w-0 items-center gap-2 rounded-full px-2.5 py-1.5 text-left text-xs text-secondary-token transition-colors duration-fast hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus/50 sm:w-full sm:rounded-lg sm:py-2',
+                        index === activeSuggestionIndex &&
+                          'bg-surface-2 text-primary-token'
+                      )}
+                    >
+                      <SocialIcon
+                        platform={suggestion.platformId}
+                        className='h-3.5 w-3.5 shrink-0'
+                      />
+                      <span className='truncate font-medium'>
+                        {suggestion.platformName}
+                      </span>
+                      <span className='truncate text-tertiary-token sm:ml-auto'>
+                        {suggestion.handle}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              {intake.error ? (
+                <p className='text-xs leading-5 text-error'>{intake.error}</p>
+              ) : null}
+            </div>
+
             <p className='text-xs leading-5 text-tertiary-token'>
-              Jovie will classify the URL before it is added. Service
-              connections are only available from the supported list above.
+              Jovie classifies public identities as you type. Preview rows are
+              temporary until a supported connection is confirmed.
             </p>
-            <Button
-              type='button'
-              size='sm'
-              className={cn('w-full')}
-              disabled={!canonicalUrl}
-              onClick={onReviewSuggestions}
-            >
-              Review profile
-            </Button>
           </div>
         </DrawerSection>
       ) : null}

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -8,8 +8,63 @@ import {
   useHeaderActions,
 } from '@/contexts/HeaderActionsContext';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
+import { classifyConnectionInput } from './AddConnectionRail';
 import type { ProfilesWorkspaceData } from './data';
 import { ProfilesWorkspace } from './ProfilesWorkspace';
+
+describe('classifyConnectionInput', () => {
+  it('normalizes and classifies a bare provider domain', () => {
+    const result = classifyConnectionInput('Instagram.com/timwhite', [], 'Tim');
+
+    expect(result.error).toBeNull();
+    expect(result.candidate).toMatchObject({
+      platformId: 'instagram',
+      platformName: 'Instagram',
+      url: 'https://instagram.com/timwhite',
+    });
+  });
+
+  it('offers ranked handle-capable platforms for an at-handle', () => {
+    const result = classifyConnectionInput('@timwhite', [], 'Tim');
+
+    expect(result.candidate).toBeNull();
+    expect(result.suggestions.slice(0, 4).map(item => item.platformId)).toEqual(
+      ['instagram', 'tiktok', 'youtube', 'twitter']
+    );
+    expect(result.suggestions[0]).toMatchObject({
+      handle: '@timwhite',
+      url: 'https://instagram.com/timwhite',
+    });
+  });
+
+  it('fuzzy filters a platform-qualified username', () => {
+    const result = classifyConnectionInput('insta timwhite', [], 'Tim');
+
+    expect(result.suggestions[0]).toMatchObject({
+      platformId: 'instagram',
+      handle: '@timwhite',
+    });
+  });
+
+  it('does not suggest a platform that already exists', () => {
+    const result = classifyConnectionInput('@timwhite', ['instagram'], 'Tim');
+
+    expect(result.suggestions.map(item => item.platformId)).not.toContain(
+      'instagram'
+    );
+  });
+
+  it('rejects credential-bearing URLs', () => {
+    const credentialBearingUrl = [
+      'https://user',
+      'pass@instagram.com/timwhite',
+    ].join(':');
+    const result = classifyConnectionInput(credentialBearingUrl, [], 'Tim');
+
+    expect(result.candidate).toBeNull();
+    expect(result.error).toMatch(/without credentials/i);
+  });
+});
 
 vi.mock('@/hooks/useRegisterRightPanel', () => ({
   useRegisterRightPanel: vi.fn(),
@@ -358,11 +413,61 @@ describe('ProfilesWorkspace', () => {
       screen.getByRole('button', { name: /Add public profile/i })
     );
     const url = screen.getByRole('textbox', { name: 'Public profile URL' });
-    await user.type(url, 'https://www.instagram.com/tim/?utm_source=test');
+    await user.type(url, 'Instagram.com/tim/?utm_source=test');
     expect(screen.getByText(/instagram\.com\/tim/)).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Review profile' })
     ).toBeEnabled();
+  });
+
+  it('suggests handle destinations with keyboard selection and previews a temporary row', async () => {
+    const user = userEvent.setup();
+    renderWorkspace(data);
+
+    await user.click(screen.getByRole('button', { name: 'Add connection' }));
+    const panel = vi.mocked(useRegisterRightPanel).mock.calls.at(-1)?.[0];
+    render(<TooltipProvider>{panel as ReactElement}</TooltipProvider>);
+
+    await user.click(
+      screen.getByRole('button', { name: /Add public profile/i })
+    );
+    const input = screen.getByRole('textbox', { name: 'Public profile URL' });
+    await user.type(input, '@newhandle');
+
+    expect(
+      screen.getByRole('listbox', { name: 'Suggested profile destinations' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /TikTok/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(input).toHaveValue('https://youtube.com/@newhandle');
+    expect(screen.getByText('Detected')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Review profile' })
+    ).toBeEnabled();
+
+    expect(screen.getByText('Preview only · not saved')).toBeInTheDocument();
+
+    const previewRow = screen
+      .getByText('Preview only · not saved')
+      .closest('tr');
+    expect(previewRow).not.toBeNull();
+    expect(
+      within(previewRow as HTMLElement).queryByRole('button', {
+        name: /Actions for/i,
+      })
+    ).not.toBeInTheDocument();
+
+    vi.mocked(useRegisterRightPanel).mockClear();
+    await user.click(previewRow as HTMLElement);
+    expect(useRegisterRightPanel).not.toHaveBeenCalled();
+
+    fireEvent.contextMenu(previewRow as HTMLElement);
+    expect(screen.queryByText('No items found')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 
   it('keeps secondary columns out of the selected-rail width contract', () => {

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -63,7 +63,10 @@ import {
   sortProfileWorkspaceRows,
 } from '@/lib/profile-surfaces/workspace';
 import { cn } from '@/lib/utils';
-import { AddConnectionRail } from './AddConnectionRail';
+import {
+  AddConnectionRail,
+  type ConnectionIntakeCandidate,
+} from './AddConnectionRail';
 import { buildConnectionActions } from './connection-actions';
 import type {
   ProfilesWorkspaceData,
@@ -506,6 +509,8 @@ export function ProfilesWorkspace({
   const [filter, setFilter] = useState<ProfilesWorkspaceFilter>('dsp');
   const [selected, setSelected] = useState<ProfileWorkspaceRow | null>(null);
   const [isAddConnectionOpen, setIsAddConnectionOpen] = useState(false);
+  const [pendingCandidate, setPendingCandidate] =
+    useState<ConnectionIntakeCandidate | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
   useEffect(() => {
@@ -514,15 +519,39 @@ export function ProfilesWorkspace({
       setIsAddConnectionOpen(true);
     }
   }, [searchParams]);
-  const rows = useMemo(
-    () =>
-      sortProfileWorkspaceRows(
-        filterProfileWorkspaceRows(data?.rows ?? [], filter)
-      ),
-    [data?.rows, filter]
-  );
+  const pendingRow = useMemo<ProfileWorkspaceRow | null>(() => {
+    if (!pendingCandidate) return null;
+    return {
+      id: `preview:${pendingCandidate.id}`,
+      rowType: 'surface',
+      kind:
+        pendingCandidate.category === 'website'
+          ? 'website'
+          : pendingCandidate.category,
+      platform: pendingCandidate.platformId,
+      label: pendingCandidate.title,
+      handle: 'Preview only · not saved',
+      url: pendingCandidate.url,
+      trackedUrl: null,
+      qualificationStatus: 'suggested',
+      isOfficial: false,
+      monitoringState: 'unavailable',
+      rank: null,
+      previousRank: null,
+      lastObservedAt: null,
+    };
+  }, [pendingCandidate]);
+  const rows = useMemo(() => {
+    const sourceRows = pendingRow
+      ? [pendingRow, ...(data?.rows ?? [])]
+      : (data?.rows ?? []);
+    return sortProfileWorkspaceRows(
+      filterProfileWorkspaceRows(sourceRows, filter)
+    );
+  }, [data?.rows, filter, pendingRow]);
   const handleAddConnection = useCallback(() => {
     setSelected(null);
+    setPendingCandidate(null);
     setIsAddConnectionOpen(true);
   }, []);
   const headerActions = useMemo(
@@ -541,6 +570,7 @@ export function ProfilesWorkspace({
   useRegisterHeaderActions(headerActions);
   const getContextMenuItems = useCallback(
     (row: ProfileWorkspaceRow): ContextMenuItemType[] => {
+      if (row.id.startsWith('preview:')) return [];
       const primaryAction = getConnectionPrimaryAction(row);
       return buildConnectionActions(row, primaryAction, {
         onViewDetails: setSelected,
@@ -668,6 +698,7 @@ export function ProfilesWorkspace({
         },
         cell: context => {
           const row = context.row.original;
+          if (row.id.startsWith('preview:')) return null;
           const actionItems = convertContextMenuItems(getContextMenuItems(row));
           return (
             <div className='flex justify-end'>
@@ -695,10 +726,28 @@ export function ProfilesWorkspace({
       isAddConnectionOpen ? (
         <AddConnectionRail
           data={data}
-          onClose={() => setIsAddConnectionOpen(false)}
+          onClose={() => {
+            setPendingCandidate(null);
+            setIsAddConnectionOpen(false);
+          }}
+          onCandidatePreview={candidate => {
+            setPendingCandidate(candidate);
+            if (!candidate) return;
+            setFilter(
+              candidate.category === 'website' ? 'website' : candidate.category
+            );
+          }}
+          onReviewCandidate={candidate => {
+            setPendingCandidate(candidate);
+            setFilter(
+              candidate.category === 'website' ? 'website' : candidate.category
+            );
+            setIsAddConnectionOpen(false);
+          }}
           onReviewSuggestions={() => {
             setFilter('social');
             setSelected(null);
+            setPendingCandidate(null);
             setIsAddConnectionOpen(false);
           }}
         />
@@ -758,12 +807,27 @@ export function ProfilesWorkspace({
         data={rows}
         columns={columns as ColumnDef<ProfileWorkspaceRow, unknown>[]}
         getRowId={row => row.id}
-        onRowClick={setSelected}
+        onRowClick={row => {
+          if (!row.id.startsWith('preview:')) setSelected(row);
+        }}
+        onRowContextMenu={(row, event) => {
+          if (row.id.startsWith('preview:')) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
         getContextMenuItems={getContextMenuItems}
         rowHeight={56}
         minWidth='390px'
-        isRowSelected={row => selected?.id === row.id}
-        getRowClassName={() => 'group/connection-row'}
+        isRowSelected={row =>
+          !row.id.startsWith('preview:') && selected?.id === row.id
+        }
+        getRowClassName={row =>
+          cn(
+            'group/connection-row',
+            row.id.startsWith('preview:') && 'cursor-default'
+          )
+        }
         emptyState={
           <TableEmptyState
             title='No Connections in This Category'

--- a/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
@@ -184,12 +184,14 @@ export function EntitySidebarShell({
       footerSurface === 'card' ? (
         <DrawerSurfaceCard
           variant='card'
-          className='shrink-0 px-3 py-2.5 lg:mx-0'
+          className='shrink-0 px-3 py-2.5 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))] lg:mx-0'
         >
           {footer}
         </DrawerSurfaceCard>
       ) : (
-        <div className='shrink-0 px-3 py-2.5 lg:mx-0'>{footer}</div>
+        <div className='shrink-0 px-3 py-2.5 max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))] lg:mx-0'>
+          {footer}
+        </div>
       );
   }
   const shellScrollClassName =

--- a/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
+++ b/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
@@ -198,7 +198,11 @@ describe('EntitySidebarShell', () => {
 
     expect(footerButton).toBeInTheDocument();
     expect(footerContainer).not.toHaveAttribute('data-variant', 'card');
-    expect(footerContainer).toHaveClass('px-3', 'py-2.5');
+    expect(footerContainer).toHaveClass(
+      'px-3',
+      'py-2.5',
+      'max-lg:mb-[calc(3.5rem+env(safe-area-inset-bottom))]'
+    );
   });
 
   it('defaults to child-owned scrolling for drawer body content', () => {


### PR DESCRIPTION
## Summary
- classify public URLs, bare domains, @handles, usernames, and platform-qualified handles as the user types
- rank supported platforms into keyboard-navigable desktop rows and compact mobile suggestions
- preview the selected candidate as a non-persisted table row with persisted actions disabled
- keep Review profile pinned above mobile navigation through the shared entity-sidebar footer primitive

## Product boundary
This PR improves only authenticated Connections intake. It does not add fake persistence, public-profile changes, or a synthetic Suggestions data source. Persisted Add / Not me review remains JOV-4777 and must reuse the existing suggestions API.

## Fast-track UI eligibility
Why eligible: bounded authenticated UI and typed classifier logic, existing primitives, no schema, auth, billing, migration, marketing, or public-profile changes.

### Desktop suggestions
![Desktop ranked suggestions](https://uploads.linear.app/6941bf52-85b0-49b3-87cc-d4a3308b48bb/c944b8b1-07e7-4799-9083-c4813da1d103/51a2c4cb-b32c-454c-b3ba-df9764ba4fc8)

### Optimistic pending row
![Desktop optimistic pending row](https://uploads.linear.app/6941bf52-85b0-49b3-87cc-d4a3308b48bb/0fd064e9-972b-4a99-b127-6d1cc8841838/c0574107-c4b5-4710-bcb0-6194151c30f5)

### Mobile suggestions
![Mobile compact suggestions](https://uploads.linear.app/6941bf52-85b0-49b3-87cc-d4a3308b48bb/b31cc929-a023-44f0-ab8c-5edf56eb0101/9caa29f5-17b4-4ba0-a5fe-6979f4af23ef)

## Verification
- Biome: 7 changed files
- Web typecheck
- Focused Vitest: 28 / 28
- Desktop 1440x1000: keyboard ArrowDown + Enter resolves to a canonical YouTube URL; no horizontal overflow; clean console
- Mobile 390x844: compact suggestions and footer remain visible above mobile navigation; no horizontal overflow; clean console
- Git diff check

Network note: only teardown-aborted existing chat, billing, and build-info requests were observed; no clean-network claim.

## Advisory design review
The requested Codex CLI executable was unavailable locally with ENOENT. A separate Codex reviewer inspected the diff as the approved fallback, found two deterministic preview-row persistence leaks, and passed the repaired exact head. Taste review is advisory under the current shipping policy.

Linear: https://linear.app/jovie/issue/JOV-4775/connections-intake-classify-domains-and-handles-with-ranked