### PR TITLE
fix(ci): restore CodeQL bundle coherence

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Summary

- Align `github/codeql-action/analyze` to the same immutable v4.37.3 bundle commit already used by `init`.
- Restore the coherence invariant previously established by #14698 after the component-only Dependabot update in #14944 regressed it.
- Keep the exact trigger, permissions, language matrix, query set, and security-event upload behavior unchanged.

## Release-gate incident

Exact-main CodeQL run 30791773297 failed for both Actions and JavaScript/TypeScript with: `Loaded a configuration file for version 4.37.3, but running version 4.37.1`. The separate Security Scanning workflow was green; this is action-bundle version skew, not a vulnerability finding.

## Bug-to-test

Satisfied by `scripts/lib/__tests__/codeql-workflow-contract.test.mjs`: red before the patch (two revisions), green after (3/3).

## Verification

- [x] CodeQL workflow contract: 3/3
- [x] `actionlint .github/workflows/codeql.yml`
- [x] `git diff --check`
- [x] CI harness validation and generated-doc freshness
- [x] Non-bypassed pre-push hook: typecheck, lint, component ship gate, affected verification, secret scans
- [x] Manual CodeQL workflow on this exact branch: 30792416354
- [x] Source CI gates on exact head: 30792410697 (attempt 3)
- [ ] Native merge-queue gates
- [ ] Exact descendant-main CodeQL run

## Scope

One workflow line. No product runtime, profile behavior, external-data embedding, release trigger, permission, or security policy changes.
