### PR TITLE
fix(backlog): count only active machine leases

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -98,15 +98,123 @@ describe('classifier', () => {
     assert.equal(scorer.scoreIssue(c).score, 0);
   });
 
-  it('counts only Linear In Progress issues as active shipping leases', () => {
+  it('counts only fresh active machine leases, not ordinary In Progress work', () => {
+    const now = '2026-08-03T12:00:00.000Z';
+    const activeMachineLease = makeIssue({
+      state: 'In Progress',
+      comments: [
+        {
+          body: 'machine-agent running process: 123 workspace: /tmp/jovie branch: fix/JOV-1',
+          createdAt: '2026-08-03T11:00:00.000Z',
+        },
+      ],
+    });
     assert.deepEqual(
-      scorer.currentShippingLoad([
-        makeIssue({ state: 'Todo' }),
-        makeIssue({ state: 'In Progress' }),
-      ]),
+      scorer.currentShippingLoad(
+        [
+          makeIssue({ state: 'Todo' }),
+          makeIssue({ state: 'In Progress' }),
+          activeMachineLease,
+        ],
+        { now }
+      ),
       { healthy: true, count: 1 }
     );
-    assert.deepEqual(scorer.currentShippingLoad([]), {
+  });
+
+  it('excludes Tim-owned and protected machine-looking work', () => {
+    const evidence = [
+      {
+        body: 'machine-agent running process: 123 workspace: /tmp/jovie branch: fix/JOV-1',
+        createdAt: '2026-08-03T11:00:00.000Z',
+      },
+    ];
+    const now = '2026-08-03T12:00:00.000Z';
+    assert.deepEqual(
+      scorer.currentShippingLoad(
+        [
+          makeIssue({
+            assignee: { id: 'tim', name: 'Tim White' },
+            state: 'In Progress',
+            comments: evidence,
+          }),
+          makeIssue({
+            labels: ['needs-human'],
+            state: 'In Progress',
+            comments: evidence,
+          }),
+        ],
+        { now }
+      ),
+      { healthy: true, count: 0 }
+    );
+  });
+
+  it('fails closed for stale, terminal, and ambiguous machine evidence', () => {
+    const now = '2026-08-03T12:00:00.000Z';
+    const base = (body, createdAt = '2026-08-03T11:00:00.000Z') => ({
+      body,
+      createdAt,
+    });
+    assert.deepEqual(
+      scorer.currentShippingLoad(
+        [
+          makeIssue({
+            state: 'In Progress',
+            comments: [
+              base(
+                'machine-agent running process: 1 workspace: /tmp/x branch: fix/x'
+              ),
+            ],
+          }),
+          makeIssue({
+            state: 'In Progress',
+            comments: [
+              base(
+                'machine-agent completed process: 2 workspace: /tmp/x branch: fix/y'
+              ),
+            ],
+          }),
+          makeIssue({
+            state: 'In Progress',
+            comments: [
+              base('machine-agent running process: 3 workspace: /tmp/x'),
+            ],
+          }),
+          makeIssue({
+            state: 'In Progress',
+            comments: [
+              base(
+                'machine-agent running process: 4 workspace: /tmp/x branch: fix/stale',
+                '2026-08-01T00:00:00.000Z'
+              ),
+            ],
+          }),
+        ],
+        { now }
+      ),
+      { healthy: true, count: 1 }
+    );
+  });
+
+  it('returns a stable zero-load read-back when no valid lease is present', () => {
+    const now = '2026-08-03T12:00:00.000Z';
+    const snapshot = [
+      makeIssue({
+        state: 'In Progress',
+        comments: [
+          {
+            body: 'machine-agent running',
+            createdAt: '2026-08-03T11:00:00.000Z',
+          },
+        ],
+      }),
+    ];
+    assert.deepEqual(scorer.currentShippingLoad(snapshot, { now }), {
+      healthy: true,
+      count: 0,
+    });
+    assert.deepEqual(scorer.currentShippingLoad(snapshot, { now }), {
       healthy: true,
       count: 0,
     });

--- a/scripts/backlog-orchestrator/scorer.mjs
+++ b/scripts/backlog-orchestrator/scorer.mjs
@@ -97,15 +97,130 @@ export async function isProductionRed() {
 }
 
 /**
- * Count active shipping leases from the authoritative Linear state snapshot.
- *
- * A production version endpoint proves reachability, not whether Symphony has
- * an active shipment. The orchestrator already fetches the active Linear issue
- * set, so use its In Progress issues as the lease source instead.
+ * Count active machine-owned shipping leases from the authoritative Linear
+ * snapshot. Ordinary In Progress state is not a lease: human-owned,
+ * protected, stale, terminal, malformed, and ambiguous evidence all fail
+ * closed and contribute zero capacity.
  */
-export function currentShippingLoad(activeIssues = []) {
-  const count = activeIssues.filter(
-    issue => (issue.state?.name || issue.state) === 'In Progress'
+const PROTECTED_LEASE_LABELS = new Set([
+  'blocked',
+  'codex-blocked',
+  'founder-fast-track',
+  'human-review-required',
+  'incident',
+  'needs-human',
+  'no-auto',
+  'protected',
+  'risk:high',
+  'tim-approved',
+  'tim-owned',
+]);
+const MACHINE_AGENT_PATTERN =
+  /jovie agent|codex issue shipper|machine-agent|machine agent/i;
+const TERMINAL_MACHINE_PATTERN =
+  /released|stopped|completed|finished|terminal|exited\s+(?:0|without|with)/i;
+const LEASE_FIELD_PATTERN =
+  /(?:process|pid|workspace|worktree|branch)\s*(?:id|name|path)?\s*[:=]\s*([^\s,;]+)/i;
+const MAX_MACHINE_EVIDENCE_AGE_HOURS = 24;
+
+function labelsOf(issue) {
+  return (issue?.labels?.nodes || issue?.labels || [])
+    .map(label => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean)
+    .map(label => label.toLowerCase());
+}
+
+function commentsOf(issue) {
+  return (issue?.comments?.nodes || issue?.comments || [])
+    .filter(comment => comment && typeof (comment.body || comment) === 'string')
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt || 0).getTime() -
+        new Date(a.createdAt || 0).getTime()
+    );
+}
+
+function latestMachineEvidence(issue) {
+  return commentsOf(issue).find(comment => {
+    const body = typeof comment === 'string' ? comment : comment.body || '';
+    const author = `${comment.author?.name || ''} ${comment.author?.email || ''}`;
+    return (
+      comment.machineAgent === true ||
+      comment.source === 'machine-agent' ||
+      MACHINE_AGENT_PATTERN.test(`${author} ${body}`)
+    );
+  });
+}
+
+function evidenceBody(evidence) {
+  return typeof evidence === 'string'
+    ? evidence
+    : [evidence?.body, evidence?.event, evidence?.status, evidence?.type]
+        .filter(Boolean)
+        .join(' ');
+}
+
+function isFreshEvidence(evidence, now) {
+  const createdAt = new Date(
+    typeof evidence === 'string' ? 0 : evidence?.createdAt || 0
+  ).getTime();
+  const current = new Date(now).getTime();
+  return (
+    Number.isFinite(createdAt) &&
+    Number.isFinite(current) &&
+    current >= createdAt &&
+    (current - createdAt) / 3_600_000 <= MAX_MACHINE_EVIDENCE_AGE_HOURS
+  );
+}
+
+/**
+ * Return true only when the latest machine evidence explicitly identifies an
+ * active lease. Requiring a live process/workspace/branch handle prevents old
+ * machine comments from occupying the cap; malformed or ambiguous evidence is
+ * deliberately not interpreted optimistically.
+ */
+export function hasValidActiveMachineLease(
+  issue,
+  { now = new Date().toISOString() } = {}
+) {
+  if ((issue?.state?.name || issue?.state) !== 'In Progress') return false;
+  if (labelsOf(issue).some(label => PROTECTED_LEASE_LABELS.has(label))) {
+    return false;
+  }
+  const assignee = `${issue?.assignee?.id || ''} ${issue?.assignee?.name || ''} ${issue?.assignee?.email || ''}`;
+  if (/tim(?:\s|-|_)*white|itstimwhite|^tim(?:\s|$)/i.test(assignee)) {
+    return false;
+  }
+
+  const evidence = latestMachineEvidence(issue);
+  if (!evidence || !isFreshEvidence(evidence, now)) return false;
+  const body = evidenceBody(evidence);
+  if (TERMINAL_MACHINE_PATTERN.test(body)) return false;
+
+  // A non-terminal machine comment without all three active handles is
+  // ambiguous: do not let it consume or release capacity.
+  const handles = [
+    ...body.matchAll(new RegExp(LEASE_FIELD_PATTERN.source, 'gi')),
+  ].map(match =>
+    match[0]
+      .split(/\s*[:=]/)[0]
+      .toLowerCase()
+      .trim()
+  );
+  const hasProcess = handles.some(handle => /process|pid/.test(handle));
+  const hasWorkspace = handles.some(handle =>
+    /workspace|worktree/.test(handle)
+  );
+  const hasBranch = handles.some(handle => /branch/.test(handle));
+  return hasProcess && hasWorkspace && hasBranch;
+}
+
+export function currentShippingLoad(
+  activeIssues = [],
+  { now = new Date().toISOString() } = {}
+) {
+  const count = activeIssues.filter(issue =>
+    hasValidActiveMachineLease(issue, { now })
   ).length;
   return { healthy: true, count };
 }


### PR DESCRIPTION
## Summary
- Count shipping capacity only for fresh, machine-owned `In Progress` leases with explicit non-terminal process/workspace/branch evidence.
- Exclude Tim-owned, protected, ordinary human, stale, terminal, malformed, and ambiguous work; fail closed.
- Add focused accounting and idempotent read-back regression coverage.

## Scope / coordination
- Ad-hoc control-plane fix; no Linear issue was created or mutated.
- Does not mutate Tim-owned/protected issues, change the cap (remains `1`), credentials, or canary dispatch.
- Preserve existing stale-lease recovery guard unchanged.

## Local verification
- `node --test scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` — 31 passed.
- `pnpm biome check --write scripts/backlog-orchestrator/scorer.mjs scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` — passed.
- `pnpm run typecheck:scripts` — passed; 197 pre-existing baseline errors, 0 new.
- `./scripts/security/scan-secrets.sh ci-pr origin/main` — passed (gitleaks + trufflehog, no findings).
- `git diff --check` — passed.
- Read-only live admission dry-run before PR: `pnpm backlog:admit-next --dry-run` — no mutation; old cache was `at capacity (1/1)`, current live read-back under this predicate was 0 valid active leases / 80 In Progress.

## Ship policy
Keep `MAX_CONCURRENT_SHIPPING = 1`. Do not merge/deploy or dispatch JOV-4594 until native CI/security gates and native MQ produce receipts. After deploy, verify Gem SHA and rerun dry-run admission; only then may exactly one canary be launched if capacity is genuinely available.
