### PR TITLE
fix(profile): harden release integrity and initial payload

### DIFF
--- a/apps/web/app/[username]/_components/PublicProfileErrorState.tsx
+++ b/apps/web/app/[username]/_components/PublicProfileErrorState.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+
+interface PublicProfileErrorStateProps {
+  readonly retryHref: string;
+}
+
+/**
+ * Server-rendered recovery state for a transient public-profile read failure.
+ * Keeping this path server-only prevents the general interactive ErrorBanner
+ * (clipboard, toast, disclosure, and button dependencies) from joining every
+ * successful profile's initial client graph.
+ */
+export function PublicProfileErrorState({
+  retryHref,
+}: PublicProfileErrorStateProps) {
+  return (
+    <main className='px-4 py-8'>
+      <section
+        role='alert'
+        aria-live='assertive'
+        aria-labelledby='public-profile-error-title'
+        data-testid='public-profile-error'
+        className='mx-auto max-w-lg rounded-2xl border border-error/30 bg-error-subtle px-5 py-4 text-error-foreground shadow-xl backdrop-blur-sm dark:border-error/40'
+      >
+        <div className='flex gap-3'>
+          <span
+            className='mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-red-500/40 bg-red-500/15 text-red-200 shadow-inner dark:border-red-700/60 dark:bg-red-900/40'
+            aria-hidden='true'
+          >
+            <svg
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+              className='h-5 w-5'
+            >
+              <title>Warning</title>
+              <path d='M21.73 18 13.73 4a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z' />
+              <path d='M12 9v4' />
+              <path d='M12 17h.01' />
+            </svg>
+          </span>
+
+          <div className='min-w-0 flex-1'>
+            <h1
+              id='public-profile-error-title'
+              className='text-sm font-semibold leading-snug tracking-tight'
+            >
+              Profile Is Temporarily Unavailable
+            </h1>
+            <p className='mt-1.5 text-sm leading-snug text-red-100/90 dark:text-red-100/80'>
+              We could not load this profile right now, so please refresh or try
+              again in a few minutes.
+            </p>
+            <div className='mt-4 flex flex-col gap-2 sm:flex-row'>
+              <Link
+                href={retryHref}
+                className='inline-flex min-h-11 items-center justify-center rounded-full bg-white px-4 text-sm font-semibold text-black transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-950 dark:bg-white dark:text-black'
+              >
+                Try Again
+              </Link>
+              <Link
+                href='/'
+                className='inline-flex min-h-11 items-center justify-center rounded-full border border-red-100/20 px-4 text-sm font-semibold text-red-50 transition-colors hover:bg-red-100/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-950'
+              >
+                Go Home
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -8,7 +8,6 @@ import { Suspense } from 'react';
 
 import type { PublicRelease } from '@/components/features/profile/releases/types';
 import { BASE_URL } from '@/constants/app';
-import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { DesktopQrOverlayClient } from '@/features/profile/DesktopQrOverlayClient';
 import { ProfileAeoContent } from '@/features/profile/ProfileAeoContent';
 import { ProfileViewTracker } from '@/features/profile/ProfileViewTracker';
@@ -59,8 +58,12 @@ import type { PublicContact } from '@/types/contacts';
 import { convertCreatorProfileToArtist } from '@/types/db';
 import { ProfileLoading } from './_components/ProfileLoading';
 import { PublicClaimBanner } from './_components/PublicClaimBanner';
+import { PublicProfileErrorState } from './_components/PublicProfileErrorState';
 import { getProfileStaticParams } from './_lib/profile-static-params';
-import { getProfileAndLinks } from './_lib/public-profile-loader';
+import {
+  getProfileAndLinks,
+  type PublicProfileLoaderResult,
+} from './_lib/public-profile-loader';
 
 // Profile loader (fetch + cache + per-request memo) lives in
 // _lib/public-profile-loader.ts so per-mode routes (plan PR 3a-2b) can
@@ -78,6 +81,22 @@ interface Props {
   readonly params: Promise<{
     readonly username: string;
   }>;
+}
+
+interface ArtistPageContentProps {
+  readonly username: string;
+  readonly profileResult: PublicProfileLoaderResult;
+}
+
+function assertValidProfileUsername(username: string) {
+  if (
+    username.length < USERNAME_MIN_LENGTH ||
+    username.length > USERNAME_MAX_LENGTH ||
+    !USERNAME_PATTERN.test(username) ||
+    isReservedUsername(username)
+  ) {
+    notFound();
+  }
 }
 
 async function getPublicTourDates(
@@ -161,19 +180,11 @@ async function getCreditedArtistsForMentions(profileId: string) {
   }
 }
 
-async function ArtistPageContent({ params }: Readonly<Props>) {
-  const { username } = await params;
+async function ArtistPageContent({
+  username,
+  profileResult,
+}: Readonly<ArtistPageContentProps>) {
   const initialMode = 'profile';
-
-  // Early reject obviously invalid or reserved usernames before hitting the database
-  if (
-    username.length < USERNAME_MIN_LENGTH ||
-    username.length > USERNAME_MAX_LENGTH ||
-    !USERNAME_PATTERN.test(username) ||
-    isReservedUsername(username)
-  ) {
-    notFound();
-  }
 
   const isPublicNoAuthSmoke = process.env.PUBLIC_NOAUTH_SMOKE === '1';
   const viewerCountryCode = null;
@@ -185,7 +196,6 @@ async function ArtistPageContent({ params }: Readonly<Props>) {
   // renders AnonCookieBootstrap which resolves the per-user variant client-side
   // via /api/profile/audience-anon-cookie and updates its own state.
 
-  const profileResult = await getProfileAndLinks(username);
   const {
     profile,
     links,
@@ -199,19 +209,7 @@ async function ArtistPageContent({ params }: Readonly<Props>) {
   } = profileResult;
 
   if (status === 'error') {
-    return (
-      <div className='px-4 py-8'>
-        <ErrorBanner
-          title='Profile is temporarily unavailable'
-          description='We could not load this profile right now, so please refresh or try again in a few minutes.'
-          actions={[
-            { label: 'Try Again', href: `/${username.toLowerCase()}` },
-            { label: 'Go Home', href: '/' },
-          ]}
-          testId='public-profile-error'
-        />
-      </div>
-    );
+    return <PublicProfileErrorState retryHref={`/${username.toLowerCase()}`} />;
   }
 
   if (!profile) {
@@ -427,10 +425,24 @@ async function ArtistPageContent({ params }: Readonly<Props>) {
   );
 }
 
-export default function ArtistPage(props: Readonly<Props>) {
+export default async function ArtistPage({ params }: Readonly<Props>) {
+  const { username } = await params;
+  assertValidProfileUsername(username);
+
+  // Resolve a missing/private profile before the page-level Suspense boundary
+  // can stream its loading shell. This preserves the segment's profile-specific
+  // not-found UI and a real HTTP 404 instead of streaming that UI with HTTP 200.
+  // Only this identity lookup is pre-stream: tour, release, merch, and entity
+  // reads remain inside ArtistPageContent, so valid profiles still use the
+  // existing loading fallback while those independent reads settle.
+  const profileResult = await getProfileAndLinks(username);
+  if (profileResult.status === 'not_found') {
+    notFound();
+  }
+
   return (
     <Suspense fallback={<ProfileLoading />}>
-      <ArtistPageContent {...props} />
+      <ArtistPageContent username={username} profileResult={profileResult} />
     </Suspense>
   );
 }
@@ -441,15 +453,7 @@ export default function ArtistPage(props: Readonly<Props>) {
 // every public-profile route.
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { username } = await params;
-
-  if (
-    username.length < USERNAME_MIN_LENGTH ||
-    username.length > USERNAME_MAX_LENGTH ||
-    !USERNAME_PATTERN.test(username) ||
-    isReservedUsername(username)
-  ) {
-    notFound();
-  }
+  assertValidProfileUsername(username);
 
   const profileResult = await getProfileAndLinks(username);
   const { profile, genres, status } = profileResult;

--- a/apps/web/components/features/profile/DesktopQrOverlay.tsx
+++ b/apps/web/components/features/profile/DesktopQrOverlay.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import { Smartphone, X } from 'lucide-react';
-import { motion } from 'motion/react';
 import { useEffect, useMemo, useState } from 'react';
 import { CircleIconButton } from '@/components/atoms/CircleIconButton';
 import { getQrCodeUrl, QRCode } from '@/components/molecules/QRCode';
-import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 
 interface DesktopQrOverlayProps {
@@ -15,7 +13,6 @@ interface DesktopQrOverlayProps {
 export function DesktopQrOverlay({ handle }: Readonly<DesktopQrOverlayProps>) {
   const [mode, setMode] = useState<'hidden' | 'icon' | 'open'>('hidden');
   const [url, setUrl] = useState('');
-  const prefersReducedMotion = useReducedMotion();
   const qrUrl = useMemo(() => {
     if (!url) return '';
     return getQrCodeUrl(url, 120);
@@ -114,36 +111,26 @@ export function DesktopQrOverlay({ handle }: Readonly<DesktopQrOverlayProps>) {
   return (
     <>
       {mode === 'open' && (
-        <motion.div
+        <div
           key='qr'
-          initial={
-            prefersReducedMotion
-              ? { opacity: 1 }
-              : { opacity: 0, y: 16, scale: 0.98 }
-          }
-          animate={
-            prefersReducedMotion
-              ? { opacity: 1 }
-              : { opacity: 1, y: 0, scale: 1 }
-          }
-          transition={
-            prefersReducedMotion
-              ? { duration: 0 }
-              : { duration: 0.2, ease: 'easeOut' }
-          }
-          className={`group fixed bottom-4 right-4 ${PROFILE_Z.DRAWER_CONTENT} flex flex-col items-center rounded-xl p-4 ring-1 ring-(--color-border-subtle) shadow-xl bg-surface-0 backdrop-blur-md overflow-hidden`}
+          className={`group fixed bottom-4 right-4 ${PROFILE_Z.DRAWER_CONTENT} flex flex-col items-center overflow-hidden rounded-xl bg-surface-0 p-3 shadow-xl ring-1 ring-(--color-border-subtle) backdrop-blur-md animate-in fade-in slide-in-from-bottom-4 zoom-in-95 duration-cinematic ease-out motion-reduce:animate-none`}
         >
           <div className='pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-slower group-hover:opacity-100'>
             <div className='absolute inset-0 bg-[radial-gradient(80%_60%_at_50%_0%,rgba(255,255,255,0.35),transparent_60%)]' />
           </div>
-          <button
-            type='button'
-            onClick={close}
-            aria-label='Close'
-            className='absolute top-1 right-1 text-tertiary-token hover:text-secondary-token'
-          >
-            <X className='h-4 w-4' />
-          </button>
+          <div className='relative mb-1 flex w-full items-center justify-between gap-2'>
+            <p className='pl-1 text-xs font-medium text-secondary-token'>
+              Open On Phone
+            </p>
+            <button
+              type='button'
+              onClick={close}
+              aria-label='Close'
+              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus'
+            >
+              <X className='h-4 w-4' aria-hidden='true' />
+            </button>
+          </div>
           {url && (
             <QRCode
               data={url}
@@ -151,26 +138,16 @@ export function DesktopQrOverlay({ handle }: Readonly<DesktopQrOverlayProps>) {
               label='Scan To Open This Profile On Your Phone'
             />
           )}
-          <p className='mt-2 text-xs text-secondary-token'>Open On Phone</p>
-        </motion.div>
+        </div>
       )}
 
       {mode === 'icon' && (
-        <motion.div
+        <div
           key='reopen'
-          initial={
-            prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 12 }
-          }
-          animate={prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
-          transition={
-            prefersReducedMotion
-              ? { duration: 0 }
-              : { duration: 0.2, ease: 'easeOut' }
-          }
-          className={`fixed bottom-4 right-4 ${PROFILE_Z.DRAWER_CONTENT}`}
+          className={`fixed bottom-4 right-4 ${PROFILE_Z.DRAWER_CONTENT} animate-in fade-in slide-in-from-bottom-3 duration-cinematic ease-out motion-reduce:animate-none`}
         >
           <CircleIconButton
-            size='md'
+            size='lg'
             variant='surface'
             onClick={reopen}
             ariaLabel='Open On Phone'
@@ -179,7 +156,7 @@ export function DesktopQrOverlay({ handle }: Readonly<DesktopQrOverlayProps>) {
             <span className='pointer-events-none absolute inset-0 rounded-full opacity-0 transition-opacity duration-slower group-hover:opacity-100 bg-[radial-gradient(80%_60%_at_50%_0%,rgba(255,255,255,0.35),transparent_60%)]' />
             <Smartphone className='relative h-5 w-5' aria-hidden='true' />
           </CircleIconButton>
-        </motion.div>
+        </div>
       )}
     </>
   );

--- a/apps/web/tests/e2e/profile.spec.ts
+++ b/apps/web/tests/e2e/profile.spec.ts
@@ -180,10 +180,11 @@ describeProfile('Profile - 404 Page', () => {
   test('shows 404 with navigation for non-existent profile', async ({
     page,
   }) => {
-    await page.goto('/nonexistent-artist', {
+    const response = await page.goto('/nonexistent-artist', {
       timeout: 120_000,
       waitUntil: 'domcontentloaded',
     });
+    expect(response?.status()).toBe(404);
 
     const h1 = page.locator('h1');
     const isH1Visible = await h1

--- a/apps/web/tests/e2e/public-profile-smoke.spec.ts
+++ b/apps/web/tests/e2e/public-profile-smoke.spec.ts
@@ -24,6 +24,11 @@ import { expect, test } from '@playwright/test';
  */
 
 test.use({ storageState: { cookies: [], origins: [] } });
+// Keep the latency assertion isolated from the status-semantics requests added
+// below. With fullyParallel enabled globally, three simultaneous cold profile
+// renders contend for the same standalone server and turn this browser budget
+// into a worker-count benchmark rather than a visitor-load measurement.
+test.describe.configure({ mode: 'serial' });
 
 const PROFILE_HANDLE = process.env.SMOKE_PROFILE_HANDLE ?? 'timwhite';
 const LOAD_BUDGET_MS = Number(process.env.SMOKE_LOAD_BUDGET_MS ?? '3000');

--- a/apps/web/tests/e2e/public-profile-smoke.spec.ts
+++ b/apps/web/tests/e2e/public-profile-smoke.spec.ts
@@ -27,6 +27,9 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 const PROFILE_HANDLE = process.env.SMOKE_PROFILE_HANDLE ?? 'timwhite';
 const LOAD_BUDGET_MS = Number(process.env.SMOKE_LOAD_BUDGET_MS ?? '3000');
+const hasDatabase = Boolean(
+  process.env.DATABASE_URL && !process.env.DATABASE_URL.includes('dummy')
+);
 
 test('public profile renders core elements within budget', async ({ page }) => {
   test.setTimeout(60_000);
@@ -111,5 +114,44 @@ test('public profile renders core elements within budget', async ({ page }) => {
   await page.screenshot({
     path: `test-results/public-profile-smoke-${PROFILE_HANDLE}.png`,
     fullPage: true,
+  });
+});
+
+test.describe('public profile document semantics @regression', () => {
+  test.skip(!hasDatabase, 'Profile document semantics require a real database');
+
+  test('a seeded public profile remains a successful document', async ({
+    page,
+  }) => {
+    const response = await page.goto('/dualipa', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByRole('heading', { name: 'Dua Lipa', level: 1 })
+    ).toBeVisible();
+    await expect(page.getByTestId('not-found')).toHaveCount(0);
+  });
+
+  test('a missing valid handle returns the branded profile 404', async ({
+    page,
+  }) => {
+    const response = await page.goto('/nonexistent-artist', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    expect(response?.status()).toBe(404);
+    await expect(
+      page.getByRole('heading', { name: 'Profile not found' })
+    ).toBeVisible();
+    await expect(page.getByTestId('not-found')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Go home' })).toHaveAttribute(
+      'href',
+      '/'
+    );
+    await expect(
+      page.locator('meta[name="robots"][content*="noindex"]')
+    ).toHaveCount(1);
   });
 });

--- a/apps/web/tests/unit/DesktopQrOverlay.test.tsx
+++ b/apps/web/tests/unit/DesktopQrOverlay.test.tsx
@@ -38,7 +38,13 @@ describe('DesktopQrOverlay', () => {
 
   it('starts as icon on desktop (hidden by default)', () => {
     render(<DesktopQrOverlay handle='tim' />);
-    expect(screen.getByLabelText('Open On Phone')).toBeInTheDocument();
+    const trigger = screen.getByLabelText('Open On Phone');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.parentElement).toHaveClass(
+      'animate-in',
+      'motion-reduce:animate-none'
+    );
+    expect(trigger).toHaveClass('h-11', 'w-11');
     expect(
       screen.queryByAltText('Scan To Open This Profile On Your Phone')
     ).toBeNull();
@@ -56,9 +62,14 @@ describe('DesktopQrOverlay', () => {
   it('opens QR code when icon is clicked', async () => {
     render(<DesktopQrOverlay handle='tim' />);
     fireEvent.click(screen.getByLabelText('Open On Phone'));
-    expect(
-      await screen.findByAltText('Scan To Open This Profile On Your Phone')
-    ).toBeInTheDocument();
+    const qrCode = await screen.findByAltText(
+      'Scan To Open This Profile On Your Phone'
+    );
+    expect(qrCode).toBeInTheDocument();
+    expect(qrCode.closest('.animate-in')).toHaveClass(
+      'motion-reduce:animate-none'
+    );
+    expect(screen.getByLabelText('Close')).toHaveClass('h-11', 'w-11');
   });
 
   it('closes back to icon when dismiss is clicked', async () => {

--- a/apps/web/tests/unit/profile/public-profile-page.test.ts
+++ b/apps/web/tests/unit/profile/public-profile-page.test.ts
@@ -7,13 +7,16 @@
  * - generateMetadata (SEO metadata generation)
  * - getCachedProfileAndLinks (only caches successful results)
  *
- * These are pure logic tests that don't render React components.
+ * Includes the small server-rendered recovery surface used by the page.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
 import { describe, expect, it } from 'vitest';
+import { PublicProfileErrorState } from '@/app/[username]/_components/PublicProfileErrorState';
 import {
   getLegacyProfileModeRedirectHref,
   getProfileModeRedirectHref,
@@ -33,6 +36,10 @@ const TEST_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const WEB_ROOT = path.resolve(TEST_FILE_DIR, '../../..');
 const PUBLIC_PROFILE_PAGE_SOURCE = readFileSync(
   path.join(WEB_ROOT, 'app/[username]/page.tsx'),
+  'utf8'
+);
+const PUBLIC_PROFILE_LAYOUT_SOURCE = readFileSync(
+  path.join(WEB_ROOT, 'app/[username]/layout.tsx'),
   'utf8'
 );
 // Profile loader (cache + error class + TTL) was extracted to its own file
@@ -136,6 +143,59 @@ describe('Public Profile Page Logic', () => {
       ).toBe(false);
       expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
         '<Suspense fallback={<ProfileLoading />}>'
+      );
+    });
+
+    it('resolves missing profiles before the streamed page boundary', () => {
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
+        "import { notFound } from 'next/navigation'"
+      );
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
+        'const profileResult = await getProfileAndLinks(username)'
+      );
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
+        "profileResult.status === 'not_found'"
+      );
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain('notFound()');
+      expect(
+        PUBLIC_PROFILE_PAGE_SOURCE.indexOf("status === 'not_found'")
+      ).toBeLessThan(
+        PUBLIC_PROFILE_PAGE_SOURCE.indexOf(
+          '<Suspense fallback={<ProfileLoading />}>'
+        )
+      );
+      expect(PUBLIC_PROFILE_LAYOUT_SOURCE).not.toContain('notFound()');
+    });
+
+    it('keeps the transient profile error state out of the client graph', () => {
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).not.toContain(
+        '@/features/feedback/ErrorBanner'
+      );
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
+        '<PublicProfileErrorState retryHref={`/${username.toLowerCase()}`} />'
+      );
+    });
+
+    it('renders a full-size accessible recovery surface for transient errors', () => {
+      render(createElement(PublicProfileErrorState, { retryHref: '/dualipa' }));
+
+      expect(screen.getByRole('main')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveAccessibleName(
+        'Profile Is Temporarily Unavailable'
+      );
+      expect(screen.getByRole('link', { name: 'Try Again' })).toHaveAttribute(
+        'href',
+        '/dualipa'
+      );
+      expect(screen.getByRole('link', { name: 'Try Again' })).toHaveClass(
+        'min-h-11'
+      );
+      expect(screen.getByRole('link', { name: 'Go Home' })).toHaveAttribute(
+        'href',
+        '/'
+      );
+      expect(screen.getByRole('link', { name: 'Go Home' })).toHaveClass(
+        'min-h-11'
       );
     });
 


### PR DESCRIPTION
## Outcome

Hardens the public artist-profile release boundary while preserving the Apple-quality mobile surface already landed on main.

- Returns a real HTTP 404 with the branded profile-not-found experience for missing/private handles; valid profiles remain 200.
- Keeps only the identity lookup before the profile Suspense boundary, so releases, merch, events, and entity data continue streaming independently.
- Adds an accessible, server-rendered transient recovery surface instead of shipping the generic client error-banner graph.
- Removes the desktop QR overlay's motion runtime and replaces it with reduced-motion-safe CSS while preserving 44px controls.
- Adds non-vacuous runtime and browser assertions for valid/missing status semantics and error-state actions.

## Verification

- Pre-commit and pre-push gates passed: secrets, repo hygiene, typecheck, Biome, ESLint, component ship gate, affected tests, CI harness.
- Unit/affected suite: 85/85 passed during pre-push.
- Optimized build: 469/469 static pages generated on the implementation candidate; a final exact-commit build and standalone browser smoke run are being attached before ready-for-review.
- Earlier exhaustive profile lane evidence: Chromium 107/107 core, 54/54 responsive; WebKit 61/61; accessibility 35/35; unit 626; all profile/detail surfaces; 72 viewport/mode screenshots.

## Performance evidence

For the root profile, JavaScript fell from 1120.6 KB to 913.0 KB and the 1200 KB total-resource gate now passes at 1183.4 KB. The inherited global CSS chunk remains 139.1 KB against the existing 100 KB absolute target; profile-owned CSS is only about 8.4 KB, so this system-level gap is kept visible rather than weakening the threshold. Detail-route payload and a true warm-interaction contract are tracked separately from this release-integrity change.

No external data embedding was added.
