### PR TITLE
test(profile): measure real warm tab transitions [JOV-4780]

### DIFF
--- a/apps/web/scripts/performance-budgets-guard.test.ts
+++ b/apps/web/scripts/performance-budgets-guard.test.ts
@@ -19,6 +19,7 @@ import type {
   ViolationResult,
 } from './performance-budgets-guard';
 import {
+  applyProfileWarmTransitionTimings,
   buildConfirmedPageResult,
   confirmTimingViolations,
   evaluateTimingConfirmation,
@@ -26,6 +27,7 @@ import {
   measureSameRouteInteraction,
   measureWarmNavigationRoute,
   parseGuardCliArgs,
+  resolveWarmNavigationStartPath,
   runPerformanceBudgetsGuard,
   selectGuardRoutes,
   waitForWarmDestinationReady,
@@ -201,6 +203,7 @@ function createInteractivePage({
   trigger.nth.mockReturnValue(trigger);
 
   const page = {
+    addInitScript: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn(async () => {
       const elapsed = elapsedValues.shift();
       if (elapsed === undefined) {
@@ -579,6 +582,79 @@ describe('performance budgets guard', () => {
     expect(fixture.events.indexOf('elapsed:12')).toBeLessThan(
       fixture.events.indexOf(`visible:${fixture.contentSelector}`)
     );
+  });
+
+  it('resolves dynamic profile starts and clicks the visible mobile tab', async () => {
+    const triggerSelector =
+      '[data-testid="profile-bottom-nav"] button[aria-label="Music"]';
+    const fixture = createInteractivePage({
+      contentSelector: '[data-testid="profile-primary-tab-listen"]',
+      finalUrl: 'http://127.0.0.1:4100/dualipa?mode=listen',
+      triggerSelector,
+    });
+    const route = {
+      id: 'public-profile-mode-listen',
+      path: '/[username]?mode=listen',
+      warmNavigationStartPath: '/[username]',
+      measureMode: 'profile-warm-transition',
+      readySelectors: {
+        content: [fixture.contentSelector],
+        navTrigger: [triggerSelector],
+      },
+      timings: [
+        { metric: 'interactive-shell-ready', budget: 100 },
+        { metric: 'warm-shell-response', budget: 100 },
+      ],
+    } as PerfRouteDefinition;
+
+    expect(resolveWarmNavigationStartPath(route, '/dualipa?mode=listen')).toBe(
+      '/dualipa'
+    );
+
+    const result = await measureWarmNavigationRoute(
+      fixture.page,
+      route,
+      'http://127.0.0.1:4100',
+      'http://127.0.0.1:4100/dualipa?mode=listen'
+    );
+
+    expect(result).toEqual({
+      warmShellResponse: 12,
+      skeletonToContent: 64,
+    });
+    expect(fixture.page.addInitScript).toHaveBeenCalledOnce();
+    expect(fixture.page.goto).toHaveBeenCalledWith(
+      'http://127.0.0.1:4100/dualipa',
+      expect.objectContaining({ waitUntil: 'domcontentloaded' })
+    );
+    expect(fixture.events).toContain('click');
+  });
+
+  it('maps warm profile readiness without replacing cold-load metrics', () => {
+    const timingValues = {
+      'cumulative-layout-shift': 0,
+      'first-contentful-paint': 96,
+      'first-input-delay': 1,
+      'interactive-shell-ready': 0,
+      'largest-contentful-paint': 96,
+      'redirect-complete': 0,
+      'skeleton-to-content': 0,
+      'time-to-first-byte': 7,
+      'warm-shell-response': 0,
+    } satisfies Record<PerfTimingMetricName, number>;
+
+    applyProfileWarmTransitionTimings(timingValues, {
+      warmShellResponse: 12,
+      skeletonToContent: 64,
+    });
+
+    expect(timingValues).toMatchObject({
+      'first-contentful-paint': 96,
+      'interactive-shell-ready': 64,
+      'largest-contentful-paint': 96,
+      'time-to-first-byte': 7,
+      'warm-shell-response': 12,
+    });
   });
 
   it('executes a same-route profile-rail interaction through deterministic markers', async () => {

--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -7,6 +7,7 @@ import {
   type Locator,
   type Page,
 } from '@playwright/test';
+import { PAC_TAB_BAR_RETURN_VISIT_KEY } from '../lib/profile/pac-tab-bar-experiment';
 import {
   assertResolvedPerfRoutePath,
   assertValidPerfRouteManifest,
@@ -435,6 +436,22 @@ function resolveExpectedDynamicPath(
   return expectedPath;
 }
 
+export function resolveWarmNavigationStartPath(
+  route: PerfRouteDefinition,
+  resolvedPath: string
+) {
+  const startPath = route.warmNavigationStartPath;
+  if (!startPath) {
+    throw new TypeError(
+      `Warm-navigation route "${route.id}" is missing warmNavigationStartPath.`
+    );
+  }
+
+  const resolvedStartPath = resolveExpectedDynamicPath(startPath, resolvedPath);
+  assertResolvedPerfRoutePath(route, resolvedStartPath);
+  return resolvedStartPath;
+}
+
 function expectedRoutePaths(route: PerfRouteDefinition, resolvedPath: string) {
   const redirectDestinations = (
     (route.readySelectors.redirectDestinations ?? []) as readonly string[]
@@ -676,11 +693,20 @@ export async function measureWarmNavigationRoute(
   baseUrl: string,
   url: string
 ) {
-  const startPath = route.warmNavigationStartPath;
-  if (!startPath) {
-    throw new TypeError(
-      `Warm-navigation route "${route.id}" is missing warmNavigationStartPath.`
-    );
+  const parsedUrl = new URL(url);
+  const resolvedDestinationPath = `${parsedUrl.pathname}${parsedUrl.search}`;
+  const startPath = resolveWarmNavigationStartPath(
+    route,
+    resolvedDestinationPath
+  );
+
+  if (route.measureMode === 'profile-warm-transition') {
+    // The profile tab-bar experiment intentionally hides navigation for some
+    // first-time visitors. This contract measures the warmed/returning state
+    // named in JOV-4780, where the real visible controls are available.
+    await page.addInitScript(storageKey => {
+      globalThis.localStorage.setItem(storageKey, '1');
+    }, PAC_TAB_BAR_RETURN_VISIT_KEY);
   }
 
   await page.goto(resolveRouteUrl(baseUrl, startPath), {
@@ -700,18 +726,18 @@ export async function measureWarmNavigationRoute(
   }
 
   const startedAt = Date.now();
-  const parsedUrl = new URL(url);
-  const expectedPaths = expectedRoutePaths(
-    route,
-    `${parsedUrl.pathname}${parsedUrl.search}`
-  );
+  const expectedPaths = expectedRoutePaths(route, resolvedDestinationPath);
   await armWarmNavigationStart(visibleTrigger);
   const routeReadyPromise = waitForExpectedUrl(page, expectedPaths);
   await visibleTrigger.click({ noWaitAfter: true });
 
   await routeReadyPromise;
   const warmShellResponse = await readWarmNavigationElapsed(page);
-  const skeletonToContent = hasTimingBudget(route, 'skeleton-to-content')
+  const shouldMeasureDestinationContent =
+    hasTimingBudget(route, 'skeleton-to-content') ||
+    (route.measureMode === 'profile-warm-transition' &&
+      hasTimingBudget(route, 'interactive-shell-ready'));
+  const skeletonToContent = shouldMeasureDestinationContent
     ? await waitForContentReady(page, route, startedAt, true)
     : 0;
 
@@ -919,6 +945,7 @@ function createContextOptions(
           origins: [],
         }
       : undefined,
+    viewport: route.viewport,
   };
 }
 
@@ -930,6 +957,17 @@ async function createContext(
   const options = createContextOptions(route, cookies);
   const context = await browser.newContext(options);
   return context;
+}
+
+export function applyProfileWarmTransitionTimings(
+  timingValues: Record<PerfTimingMetricName, number>,
+  interaction: {
+    readonly skeletonToContent: number;
+    readonly warmShellResponse: number;
+  }
+) {
+  timingValues['warm-shell-response'] = interaction.warmShellResponse;
+  timingValues['interactive-shell-ready'] = interaction.skeletonToContent;
 }
 
 async function warmRoute(
@@ -988,6 +1026,9 @@ async function measureRouteSample(
   try {
     const page = await context.newPage();
     await page.addInitScript(PERF_INIT_SCRIPT);
+    let browserMetrics:
+      | Awaited<ReturnType<typeof collectBrowserMetrics>>
+      | undefined;
 
     const timingValues: Record<PerfTimingMetricName, number> = {
       'cumulative-layout-shift': 0,
@@ -1001,7 +1042,31 @@ async function measureRouteSample(
       'warm-shell-response': 0,
     };
 
-    if (
+    if (route.measureMode === 'profile-warm-transition') {
+      // Keep cold target-load evidence independent from the warmed user
+      // action. The first leg owns FCP/LCP/CLS/FID/TTFB and resources; the
+      // second leg starts from a real profile state and clicks a visible tab.
+      await page.goto(url, {
+        timeout: NAVIGATION_TIMEOUT_MS,
+        waitUntil: 'domcontentloaded',
+      });
+      await waitForAnyVisible(page, route.readySelectors.content);
+      browserMetrics = await collectBrowserMetrics(page, devMode);
+
+      const interactionPage = await context.newPage();
+      try {
+        await interactionPage.addInitScript(PERF_INIT_SCRIPT);
+        const interaction = await measureWarmNavigationRoute(
+          interactionPage,
+          route,
+          baseUrl,
+          url
+        );
+        applyProfileWarmTransitionTimings(timingValues, interaction);
+      } finally {
+        await interactionPage.close();
+      }
+    } else if (
       route.measureMode === 'warm-navigation' ||
       route.measureMode === 'same-route-interaction'
     ) {
@@ -1056,7 +1121,7 @@ async function measureRouteSample(
       }
     }
 
-    const browserMetrics = await collectBrowserMetrics(page, devMode);
+    browserMetrics ??= await collectBrowserMetrics(page, devMode);
     timingValues['cumulative-layout-shift'] =
       browserMetrics.timingValues['cumulative-layout-shift'];
     timingValues['first-contentful-paint'] =

--- a/apps/web/scripts/performance-route-manifest.test.ts
+++ b/apps/web/scripts/performance-route-manifest.test.ts
@@ -206,6 +206,134 @@ describe('performance route manifest', () => {
     ).toBe(75);
   });
 
+  it('measures the four public profile mobile tabs through real 100ms controls', () => {
+    const routes = getEndUserPerfRouteManifest();
+    const warmProfileRoutes = routes.filter(
+      route => route.measureMode === 'profile-warm-transition'
+    );
+
+    expect(warmProfileRoutes.map(route => route.id)).toEqual([
+      'public-profile-main',
+      'public-profile-mode-listen',
+      'public-profile-mode-subscribe',
+      'public-profile-mode-tour',
+    ]);
+
+    for (const route of warmProfileRoutes) {
+      expect(route.viewport).toEqual({ width: 390, height: 844 });
+      expect(route.warmNavigationStartPath).toContain('[username]');
+      expect(route.readySelectors.navTrigger).toHaveLength(1);
+      expect(route.readySelectors.navTrigger?.[0]).toContain(
+        '[data-testid="profile-bottom-nav"] button[aria-label='
+      );
+      expect(route.readySelectors.content).not.toContain(
+        '[data-testid="profile-header"]'
+      );
+      expect(
+        getRouteTimingBudgets(route).find(
+          timing => timing.metric === 'interactive-shell-ready'
+        )?.budget
+      ).toBe(100);
+      expect(
+        getRouteTimingBudgets(route).find(
+          timing => timing.metric === 'warm-shell-response'
+        )?.budget
+      ).toBe(100);
+    }
+
+    const root = warmProfileRoutes.find(
+      route => route.id === 'public-profile-main'
+    );
+    expect(root?.warmNavigationStartPath).toBe('/[username]?mode=listen');
+    expect(root?.readySelectors.content).toEqual([
+      '[data-testid="profile-home-rail"]',
+    ]);
+    expect(getRouteTimingBudgets(root!).map(timing => timing.metric)).toEqual(
+      expect.arrayContaining([
+        'first-contentful-paint',
+        'largest-contentful-paint',
+        'cumulative-layout-shift',
+        'first-input-delay',
+        'time-to-first-byte',
+      ])
+    );
+  });
+
+  it('keeps non-tab profile modes as honest page-load contracts', () => {
+    const pageLoadModeIds = [
+      'public-profile-mode-pay',
+      'public-profile-mode-about',
+      'public-profile-mode-contact',
+      'public-profile-mode-releases',
+    ];
+    const routes = getEndUserPerfRouteManifest().filter(route =>
+      pageLoadModeIds.includes(route.id)
+    );
+
+    expect(routes.map(route => route.id)).toEqual(pageLoadModeIds);
+    for (const route of routes) {
+      expect(route.measureMode).toBe('page-load');
+      expect(route.readySelectors.navTrigger).toBeUndefined();
+      expect(
+        getRouteTimingBudgets(route).some(
+          timing => timing.metric === 'interactive-shell-ready'
+        )
+      ).toBe(false);
+      expect(getRouteTimingBudgets(route).map(timing => timing.metric)).toEqual(
+        expect.arrayContaining([
+          'first-contentful-paint',
+          'largest-contentful-paint',
+          'cumulative-layout-shift',
+          'time-to-first-byte',
+        ])
+      );
+    }
+  });
+
+  it('rejects profile warm transitions that weaken the mobile eval', () => {
+    const route = {
+      id: 'profile-warm-fixture',
+      group: 'public-profile-mode-shell',
+      surface: 'public-profile',
+      path: '/[username]?mode=listen',
+      warmNavigationStartPath: '/[username]',
+      resolvePath: async () => '/tim?mode=listen',
+      requiresAuth: false,
+      warmupStrategy: 'public-route',
+      measureMode: 'profile-warm-transition',
+      readySelectors: {
+        content: ['[data-testid="profile-primary-tab-listen"]'],
+        navTrigger: [
+          '[data-testid="profile-bottom-nav"] button[aria-label="Music"]',
+        ],
+      },
+      viewport: { width: 390, height: 844 },
+      timings: [
+        { metric: 'interactive-shell-ready', budget: 100 },
+        { metric: 'warm-shell-response', budget: 100 },
+      ],
+      resourceSizes: [{ resourceType: 'total', budget: 1200 }],
+      priority: 1,
+    } as const satisfies PerfRouteDefinition;
+
+    expect(() => assertValidPerfRouteDefinition(route)).not.toThrow();
+    expect(() =>
+      assertValidPerfRouteDefinition({
+        ...route,
+        viewport: { width: 375, height: 812 },
+      })
+    ).toThrow('must use the 390x844 mobile viewport');
+    expect(() =>
+      assertValidPerfRouteDefinition({
+        ...route,
+        timings: [
+          { metric: 'interactive-shell-ready', budget: 101 },
+          { metric: 'warm-shell-response', budget: 100 },
+        ],
+      })
+    ).toThrow('must preserve 100ms');
+  });
+
   it('rejects empty locators and redirect loops with route-specific errors', () => {
     const baseRoute = {
       id: 'fixture-route',

--- a/apps/web/scripts/performance-route-manifest.ts
+++ b/apps/web/scripts/performance-route-manifest.ts
@@ -62,7 +62,13 @@ export type PerfMeasureMode =
   | 'interactive-shell'
   | 'redirect'
   | 'same-route-interaction'
-  | 'warm-navigation';
+  | 'warm-navigation'
+  | 'profile-warm-transition';
+
+export interface PerfViewport {
+  readonly width: number;
+  readonly height: number;
+}
 
 export interface PerfTimingBudget {
   readonly metric: PerfTimingMetricName;
@@ -110,6 +116,7 @@ export interface PerfRouteDefinition {
   readonly warmupStrategy: PerfWarmupStrategy;
   readonly measureMode: PerfMeasureMode;
   readonly readySelectors: PerfReadySelectors;
+  readonly viewport?: PerfViewport;
   readonly timingBudgets?: readonly PerfTimingBudget[];
   readonly resourceBudgets?: readonly PerfResourceBudget[];
   readonly timings?: readonly PerfTimingBudget[];
@@ -185,7 +192,10 @@ export function assertValidPerfRouteDefinition(route: PerfRouteDefinition) {
     );
   }
 
-  if (route.measureMode === 'warm-navigation') {
+  if (
+    route.measureMode === 'warm-navigation' ||
+    route.measureMode === 'profile-warm-transition'
+  ) {
     if (!route.readySelectors.content?.length) {
       throw new TypeError(
         `Warm-navigation route "${route.id}" must define destination-specific content readiness.`
@@ -204,6 +214,32 @@ export function assertValidPerfRouteDefinition(route: PerfRouteDefinition) {
     if (route.warmNavigationStartPath === route.path) {
       throw new TypeError(
         `Warm-navigation route "${route.id}" cannot start from its destination path "${route.path}".`
+      );
+    }
+  }
+
+  if (route.measureMode === 'profile-warm-transition') {
+    const timingBudgets = getRouteTimingBudgets(route);
+    const interactiveBudget = timingBudgets.find(
+      timing => timing.metric === 'interactive-shell-ready'
+    );
+    const shellBudget = timingBudgets.find(
+      timing => timing.metric === 'warm-shell-response'
+    );
+
+    if (route.surface !== 'public-profile') {
+      throw new TypeError(
+        `Profile warm-transition route "${route.id}" must use the public-profile surface.`
+      );
+    }
+    if (route.viewport?.width !== 390 || route.viewport.height !== 844) {
+      throw new TypeError(
+        `Profile warm-transition route "${route.id}" must use the 390x844 mobile viewport.`
+      );
+    }
+    if (interactiveBudget?.budget !== 100 || shellBudget?.budget !== 100) {
+      throw new TypeError(
+        `Profile warm-transition route "${route.id}" must preserve 100ms interactive-shell-ready and warm-shell-response budgets.`
       );
     }
   }
@@ -456,16 +492,22 @@ const PUBLIC_PROFILE_CORE_ROUTES = [
     group: 'public-profile-core',
     surface: 'public-profile',
     path: '/[username]',
+    warmNavigationStartPath: '/[username]?mode=listen',
     resolvePath: resolveSeededProfilePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'profile-warm-transition',
     readySelectors: {
       shell: ['[data-testid="profile-header"]'],
-      content: ['main h1', '[data-testid="profile-header"]'],
+      content: ['[data-testid="profile-home-rail"]'],
+      navTrigger: [
+        '[data-testid="profile-bottom-nav"] button[aria-label="Home"]',
+      ],
     },
+    viewport: { width: 390, height: 844 },
     timings: [
       { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'warm-shell-response', budget: 100 },
       // Gmail rule targets: 100ms perceived, 500ms hard budget
       { metric: 'first-contentful-paint', budget: 800 },
       { metric: 'largest-contentful-paint', budget: 1500 },
@@ -699,21 +741,25 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     group: 'public-profile-mode-shell',
     surface: 'public-profile',
     path: '/[username]?mode=listen',
+    warmNavigationStartPath: '/[username]',
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'profile-warm-transition',
     readySelectors: {
       shell: ['[data-testid="profile-header"]'],
       content: [
         '[data-testid="profile-primary-tab-releases"]',
         '[data-testid="profile-primary-tab-listen"]',
-        '[data-testid="profile-mode-drawer-listen"]',
-        '[data-testid="profile-header"]',
+      ],
+      navTrigger: [
+        '[data-testid="profile-bottom-nav"] button[aria-label="Music"]',
       ],
     },
+    viewport: { width: 390, height: 844 },
     timings: [
       { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'warm-shell-response', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,
@@ -728,16 +774,15 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'page-load',
     readySelectors: {
-      shell: ['[data-testid="profile-header"]'],
-      content: [
-        '[data-testid="profile-mode-drawer-pay"]',
-        '[data-testid="profile-header"]',
-      ],
+      content: ['[data-testid="profile-mode-drawer-pay"]'],
     },
     timings: [
-      { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'first-contentful-paint', budget: 2800 },
+      { metric: 'largest-contentful-paint', budget: 3300 },
+      { metric: 'cumulative-layout-shift', budget: 0.1 },
+      { metric: 'first-input-delay', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,
@@ -749,22 +794,22 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     group: 'public-profile-mode-shell',
     surface: 'public-profile',
     path: '/[username]?mode=subscribe',
+    warmNavigationStartPath: '/[username]',
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'profile-warm-transition',
     readySelectors: {
       shell: ['[data-testid="profile-header"]'],
-      content: [
-        '[data-testid="profile-primary-tab-subscribe"]',
-        '[data-testid="notifications-page"]',
-        '[data-testid="notifications-flow"]',
-        '[data-testid="profile-mode-drawer-subscribe"]',
-        '[data-testid="profile-header"]',
+      content: ['[data-testid="profile-primary-tab-subscribe"]'],
+      navTrigger: [
+        '[data-testid="profile-bottom-nav"] button[aria-label="Alerts"]',
       ],
     },
+    viewport: { width: 390, height: 844 },
     timings: [
       { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'warm-shell-response', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,
@@ -779,17 +824,18 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'page-load',
     readySelectors: {
-      shell: ['[data-testid="profile-header"]'],
       content: [
         '[data-testid="profile-primary-tab-about"]',
         '[data-testid="profile-mode-drawer-about"]',
-        '[data-testid="profile-header"]',
       ],
     },
     timings: [
-      { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'first-contentful-paint', budget: 2800 },
+      { metric: 'largest-contentful-paint', budget: 3300 },
+      { metric: 'cumulative-layout-shift', budget: 0.1 },
+      { metric: 'first-input-delay', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,
@@ -804,16 +850,15 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'page-load',
     readySelectors: {
-      shell: ['[data-testid="profile-header"]'],
-      content: [
-        '[data-testid="profile-mode-drawer-contact"]',
-        '[data-testid="profile-header"]',
-      ],
+      content: ['[data-testid="profile-mode-drawer-contact"]'],
     },
     timings: [
-      { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'first-contentful-paint', budget: 2800 },
+      { metric: 'largest-contentful-paint', budget: 3300 },
+      { metric: 'cumulative-layout-shift', budget: 0.1 },
+      { metric: 'first-input-delay', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,
@@ -825,20 +870,22 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     group: 'public-profile-mode-shell',
     surface: 'public-profile',
     path: '/[username]?mode=tour',
+    warmNavigationStartPath: '/[username]',
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'profile-warm-transition',
     readySelectors: {
       shell: ['[data-testid="profile-header"]'],
-      content: [
-        '[data-testid="profile-primary-tab-tour"]',
-        '[data-testid="profile-mode-drawer-tour"]',
-        '[data-testid="profile-header"]',
+      content: ['[data-testid="profile-primary-tab-tour"]'],
+      navTrigger: [
+        '[data-testid="profile-bottom-nav"] button[aria-label="Events"]',
       ],
     },
+    viewport: { width: 390, height: 844 },
     timings: [
       { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'warm-shell-response', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,
@@ -853,16 +900,15 @@ const PUBLIC_PROFILE_MODE_SHELL_ROUTES = [
     resolvePath: resolveSeededProfileModePath,
     requiresAuth: false,
     warmupStrategy: 'public-route',
-    measureMode: 'interactive-shell',
+    measureMode: 'page-load',
     readySelectors: {
-      shell: ['[data-testid="profile-header"]'],
-      content: [
-        '[data-testid="profile-mode-drawer-releases"]',
-        '[data-testid="profile-header"]',
-      ],
+      content: ['[data-testid="profile-mode-drawer-releases"]'],
     },
     timings: [
-      { metric: 'interactive-shell-ready', budget: 100 },
+      { metric: 'first-contentful-paint', budget: 2800 },
+      { metric: 'largest-contentful-paint', budget: 3300 },
+      { metric: 'cumulative-layout-shift', budget: 0.1 },
+      { metric: 'first-input-delay', budget: 100 },
       { metric: 'time-to-first-byte', budget: 2400 },
     ],
     resourceSizes: DEFAULT_PUBLIC_RESOURCE_BUDGETS,


### PR DESCRIPTION
## Summary

- replace synthetic public-profile interaction timing with real visible mobile tab clicks at the canonical 390 x 844 viewport
- require both exact URL arrival and destination-owned content readiness for Home, Music, Alerts, and Events
- retain cold-load vitals and resource budgets, and classify Pay, About, Contact, and Releases as page-load routes instead of fake warm interactions
- add fail-closed tests that reject viewport or 100 ms budget weakening

No public-profile runtime behavior changes and no external-data embedding.

## Strict performance evidence

Optimized standalone build, real development database, three samples per warm transition:

| Destination | content-ready median | URL median | content-ready samples |
| --- | ---: | ---: | --- |
| Home | 62.7 ms | 53.9 ms | 62.7, 58.2, 71.2 ms |
| Music | 57.8 ms | 53.6 ms | 57.8, 76.7, 57.7 ms |
| Alerts | 85.2 ms | 73.2 ms | 85.2, 85.2, 76.2 ms |
| Events | 59.1 ms | 53.5 ms | 58.7, 59.1, 60.9 ms |

All warm medians pass the strict 100 ms budget. Cold CLS remained 0. Scripts were 924.125 KB against 1050 KB and total transfer was 1114 to 1115 KB against 1200 KB.

## Verification

- targeted performance contract tests: 50 passed
- web typecheck: passed
- optimized production build: passed, 752 of 752 static pages generated
- protected pre-push: Biome, full web typecheck, proxy and Tailwind validation, component ship gate with 129 stories, lint across 7488 files, all sharded web unit suites, CI harness validation

## Known independent budget

Global CSS is 139.099 KB against the existing 100 KB budget. This PR preserves that red guard and does not weaken it. The independent remediation is tracked in JOV-2269; route and detail bundle work remains tracked in JOV-2443.

Closes JOV-4780.