### PR TITLE
fix(control-plane): replace deprecated Linear issue lookup

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -266,6 +266,75 @@ describe('reconciliation idempotency', () => {
 });
 
 describe('Linear transport', () => {
+  it('classifies Linear deprecated GraphQL responses distinctly', () => {
+    assert.equal(
+      linear.classifyGraphQLErrors([
+        {
+          message: 'deprecated',
+          extensions: { userPresentableMessage: 'This endpoint deprecated.' },
+        },
+      ]),
+      'DEPRECATED'
+    );
+    assert.equal(
+      linear.classifyGraphQLErrors([{ message: 'forbidden' }]),
+      'API'
+    );
+  });
+
+  it('classifies a deprecated GraphQL response as a deprecated API error', async () => {
+    process.env.LINEAR_API_KEY = 'deprecated-secret';
+    await assert.rejects(
+      linear.graphql(
+        'query Deprecated { viewer { id } }',
+        {},
+        {
+          /** @type {any} */
+          fetchImpl: async () => ({
+            json: async () => ({
+              errors: [
+                {
+                  message: 'deprecated',
+                  extensions: {
+                    userPresentableMessage: 'This endpoint deprecated.',
+                  },
+                },
+              ],
+            }),
+          }),
+        }
+      ),
+      error => {
+        const err = /** @type {any} */ (error);
+        return (
+          err?.code === 'DEPRECATED' &&
+          !String(err?.message ?? '').includes('deprecated-secret')
+        );
+      }
+    );
+  });
+
+  it('looks up issue keys with the supported team and number filter', async () => {
+    const previous = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = 'query-secret';
+    /** @type {any} */
+    let request;
+    const issue = { id: 'issue-4594', identifier: 'JOV-4594', project: null };
+    const result = await linear.fetchIssue('JOV-4594', {
+      fetchImpl: async (_url, options) => {
+        request = JSON.parse(options.body);
+        return { json: async () => ({ data: { issues: { nodes: [issue] } } }) };
+      },
+    });
+    assert.deepEqual(result, issue);
+    assert.ok(request);
+    assert.match(request.query, /issues\s*\(/);
+    assert.doesNotMatch(request.query, /issueSearch/);
+    assert.deepEqual(request.variables, { teamKey: 'JOV', number: 4594 });
+    if (previous === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = previous;
+  });
+
   it('retries transient fetch failures and preserves the raw Linear auth format', async () => {
     const previous = process.env.LINEAR_API_KEY;
     process.env.LINEAR_API_KEY = 'test-secret-that-must-not-leak';

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -51,6 +51,17 @@ function isTransientNetworkError(error) {
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+/** @param {any[]} errors */
+export function classifyGraphQLErrors(errors) {
+  return errors.some(error =>
+    [error?.message, error?.extensions?.userPresentableMessage]
+      .filter(Boolean)
+      .some(message => /deprecated/i.test(message))
+  )
+    ? 'DEPRECATED'
+    : 'API';
+}
+
 /**
  * Bounded, retrying GraphQL transport. Only the API key is sent as the
  * normal Linear `Authorization: <key>` header; it is never logged or exposed
@@ -84,9 +95,13 @@ export async function graphql(
       });
       const data = /** @type {any} */ (await resp.json());
       if (data.errors) {
-        throw new Error(
-          `Linear API error: ${data.errors.map(e => e.message).join('; ')}`
+        const error = /** @type {any} */ (
+          new Error(
+            `Linear API error: ${data.errors.map(e => e.message).join('; ')}`
+          )
         );
+        error.code = classifyGraphQLErrors(data.errors);
+        throw error;
       }
       return data.data;
     } catch (error) {
@@ -97,7 +112,9 @@ export async function graphql(
             ? 'TIMEOUT'
             : isTransientNetworkError(error)
               ? 'NETWORK'
-              : 'API';
+              : error?.code === 'DEPRECATED'
+                ? 'DEPRECATED'
+                : 'API';
         throw new LinearTransportError(
           `Linear GraphQL request failed (${code.toLowerCase()}, attempts=${attempt})`,
           { code, cause: error, attempts: attempt }
@@ -271,36 +288,51 @@ export async function fetchTeamInProgressIssues(teamId, maxResults = 1000) {
 /**
  * Fetch a single issue by identifier (e.g. "JOV-1234").
  */
-export async function fetchIssue(identifier) {
-  const data = await graphql(
-    `
-    query($identifier: String!) {
-      issueSearch(query: $identifier, first: 1) {
-        nodes {
-          id
-          identifier
-          title
-          description
-          url
-          createdAt
-          updatedAt
-          priority
-          estimate
-          assignee { id name }
-          creator { id name }
-          labels { nodes { id name } }
-          parent { id identifier title }
-          children { nodes { id identifier title } }
-          relations { nodes { type relatedIssue { id identifier title } } }
-          state { id name type }
-          comments { nodes { id body createdAt } }
-        }
-      }
-    }
-  `,
-    { identifier }
-  );
-  return data.issueSearch.nodes[0] || null;
+export async function fetchIssue(identifier, options = {}) {
+  const value = identifier.trim();
+  const issueFields = `
+    id identifier title description url createdAt updatedAt priority estimate
+    assignee { id name } creator { id name }
+    labels { nodes { id name } }
+    project { id name slugId }
+    parent { id identifier title }
+    children { nodes { id identifier title } }
+    relations { nodes { type relatedIssue { id identifier title } } }
+    state { id name type }
+    comments { nodes { id body createdAt } }
+  `;
+  const keyMatch = /^([A-Za-z][A-Za-z0-9]*)-(\d+)$/.exec(value);
+
+  // Linear removed issueSearch. Resolve human identifiers through the
+  // supported team+number filter, or use the stable UUID directly.
+  if (keyMatch) {
+    const data = await graphql(
+      `query($teamKey: String!, $number: Float!) {
+        issues(
+          filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+          first: 1
+        ) { nodes { ${issueFields} } }
+      }`,
+      { teamKey: keyMatch[1].toUpperCase(), number: Number(keyMatch[2]) },
+      options
+    );
+    return data.issues.nodes[0] || null;
+  }
+
+  if (
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value
+    )
+  ) {
+    const data = await graphql(
+      `query($id: String!) { issue(id: $id) { ${issueFields} } }`,
+      { id: value },
+      options
+    );
+    return data.issue || null;
+  }
+
+  throw new Error(`Invalid Linear issue identifier: ${identifier}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace deprecated Linear `issueSearch` with supported team-key + issue-number lookup.
- Support stable Linear UUID lookup through `issue(id: ...)`.
- Include current project, state, and label fields for admission/read-only validation.
- Classify deprecated GraphQL responses distinctly without changing auth or admission behavior.

## Linear evidence
The JOV-4594 dry-run reproduced:
`{"message":"deprecated","path":["issueSearch"],"extensions":{"type":"invalid input","code":"INPUT_ERROR","statusCode":400,"userError":true,"userPresentableMessage":"This endpoint deprecated."}}`

No Linear mutation, project assignment, comment, worker launch, concurrency change, credential change, or canary was performed.

## Test plan
- `pnpm backlog:test`
- `pnpm typecheck:scripts`
- `pnpm exec biome ci scripts/backlog-orchestrator/linear-client.mjs scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs`
- `pnpm test:bug-to-test`
- `pnpm security:scan-secrets`
- `pnpm security:verify-secret-scan`
- `git diff origin/main...HEAD --check`

<!-- linear-issue-id:JOV-4594 -->
