### PR TITLE
fix(control-plane): expose backlog dependency closure

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -667,7 +667,24 @@ describe('entrypoint contract', () => {
     const wrapperSource = await readFile(wrapper, 'utf8');
     assert.match(wrapperSource, /cd \"\$\(dirname \"\$0\"\)\"/);
     assert.match(wrapperSource, /exec node backlog-orchestrator\.mjs \"\$@\"/);
-    assert.match(await readFile(executable, 'utf8'), /Deterministic-first/);
+    const executableSource = await readFile(executable, 'utf8');
+    assert.match(executableSource, /Deterministic-first/);
+    for (const dependency of [
+      'linear-client.mjs',
+      'classifier.mjs',
+      'reconcile.mjs',
+      'scorer.mjs',
+      'workstreamer.mjs',
+      'admitter.mjs',
+      'reporter.mjs',
+      'stale-lease-guard.mjs',
+    ]) {
+      assert.match(
+        executableSource,
+        new RegExp(`from ['"]\\./${dependency}['"]`),
+        `entrypoint must declare ${dependency} in its static dependency closure`
+      );
+    }
     assert.equal(JSON.parse(await readFile(config, 'utf8')).version, 1);
   });
 

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -23,17 +23,16 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// ----- Local imports -----
-const linear = await import(resolve(__dirname, 'linear-client.mjs'));
-const classifier = await import(resolve(__dirname, 'classifier.mjs'));
-const reconciler = await import(resolve(__dirname, 'reconcile.mjs'));
-const scorer = await import(resolve(__dirname, 'scorer.mjs'));
-const workstreamer = await import(resolve(__dirname, 'workstreamer.mjs'));
-const admitter = await import(resolve(__dirname, 'admitter.mjs'));
-const reporter = await import(resolve(__dirname, 'reporter.mjs'));
-const staleLeaseGuard = await import(
-  resolve(__dirname, 'stale-lease-guard.mjs')
-);
+// Keep the complete control-plane dependency closure visible to source sync and
+// module tooling. These are canonical sibling modules, not host-only copies.
+import * as admitter from './admitter.mjs';
+import * as classifier from './classifier.mjs';
+import * as linear from './linear-client.mjs';
+import * as reconciler from './reconcile.mjs';
+import * as reporter from './reporter.mjs';
+import * as scorer from './scorer.mjs';
+import * as staleLeaseGuard from './stale-lease-guard.mjs';
+import * as workstreamer from './workstreamer.mjs';
 
 // ----- Config -----
 const CACHE_FILE = resolve(__dirname, '.orchestrator-cache.json');

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -213,7 +213,7 @@ async function runAdmitNext(cache, isDryRun) {
     const stored = classifier.parseStoredClassification(issue);
     const c = classifier.classifyDeterministic(issue, allIssues);
     if (stored) c.preexisting = stored;
-    c.issue = issue;
+    /** @type {typeof c & { issue: typeof issue }} */ (c).issue = issue;
     classifications.push(c);
   }
 


### PR DESCRIPTION
## Summary
- Replace runtime-resolved sibling imports in `backlog-orchestrator.mjs` with static ESM imports.
- Keep canonical `reconcile.mjs` and `stale-lease-guard.mjs` modules unchanged; make the full source dependency closure visible to deployment sync/module tooling.
- Add a regression assertion covering every entrypoint sibling dependency.

## Root cause
At merged `cab1f6d`, both imported modules are present in Git and are canonical: `reconcile.mjs` originated in #15384 and `stale-lease-guard.mjs` in #15048. The runtime failure was a partial sync of the entrypoint without its dynamically imported siblings, not stale imports.

## Verification
- `pnpm backlog:test` — 34 passing
- Biome CI on changed files — passed
- `node --check scripts/backlog-orchestrator/backlog-orchestrator.mjs` — passed
- `git diff --check` — passed

No Linear mutations, credentials, concurrency changes, canary, or deployment bypass.