### PR TITLE
fix(profile): eliminate consent CLS and accelerate deep links [JOV-4783] [JOV-4788]

### DIFF
--- a/apps/web/app/[username]/[...slug]/page.tsx
+++ b/apps/web/app/[username]/[...slug]/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 import { notFound, permanentRedirect, redirect } from 'next/navigation';
 import {
   getLegacyProfileModeRedirectHref,
   isLegacyProfileModeAlias,
 } from '@/app/[username]/_lib/mode-route-redirect';
+import { shouldBypassPublicProfileQaCache } from '@/app/[username]/_lib/public-profile-qa';
 import {
   getContentBySlug,
   getCreatorByUsername,
@@ -12,6 +14,7 @@ import {
 import ContentSmartLinkPage, {
   generateMetadata as generateContentSmartLinkMetadata,
 } from '@/app/[username]/[slug]/page';
+import { sanitizeCacheTags } from '@/lib/cache/tags';
 import { findRedirectByOldSlug } from '@/lib/discography/slug';
 import { REDIRECT_SINK_METADATA } from '@/lib/profile/metadata';
 
@@ -38,6 +41,38 @@ function getAliasSlug(slug: readonly string[]): string | null {
   }
   const aliasSlug = slug[0];
   return aliasSlug && isLegacyProfileModeAlias(aliasSlug) ? aliasSlug : null;
+}
+
+async function getAliasCollisionState(
+  creatorProfileId: string,
+  aliasSlug: string
+) {
+  const load = () =>
+    Promise.all([
+      findRedirectByOldSlug(creatorProfileId, aliasSlug),
+      getUnpublishedReleasePresence(creatorProfileId, aliasSlug),
+    ]);
+
+  if (
+    process.env.NODE_ENV === 'test' ||
+    process.env.NODE_ENV === 'development' ||
+    shouldBypassPublicProfileQaCache()
+  ) {
+    return load();
+  }
+
+  return unstable_cache(
+    load,
+    [`profile-mode-alias-collision-${creatorProfileId}-${aliasSlug}`],
+    {
+      tags: sanitizeCacheTags([
+        'smartlink-content',
+        `smartlink-content:${creatorProfileId}`,
+        `smartlink-content:${creatorProfileId}:${aliasSlug}`,
+      ]),
+      revalidate: 300,
+    }
+  )();
 }
 
 // Catch-all for unknown sub-paths — returns a context-aware 404.
@@ -68,17 +103,19 @@ export default async function CatchAllPage({
 
   const content = await getContentBySlug(creator.id, aliasSlug);
   if (!content) {
-    const oldSlugRedirect = await findRedirectByOldSlug(creator.id, aliasSlug);
+    // Both collision checks are read-only and independent. Starting them
+    // together preserves the precedence below while removing one full remote
+    // database round trip from every warmed legacy deep link (JOV-4788).
+    const [oldSlugRedirect, unpublished] = await getAliasCollisionState(
+      creator.id,
+      aliasSlug
+    );
     if (oldSlugRedirect) {
       permanentRedirect(
         `/${creator.usernameNormalized}/${oldSlugRedirect.currentSlug}`
       );
     }
 
-    const unpublished = await getUnpublishedReleasePresence(
-      creator.id,
-      aliasSlug
-    );
     if (!unpublished) {
       const legacyModeHref = getLegacyProfileModeRedirectHref(
         creator.usernameNormalized,

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -38,7 +38,7 @@ export function PublicProfileLayoutShell({
   const hasAmbientBg = Boolean(heroImageUrl && !heroImageError);
   return (
     <div
-      className='profile-viewport relative h-[calc(100dvh-var(--cookie-banner-h,0px))] overflow-hidden bg-(--profile-stage-bg) text-primary-token md:h-auto md:min-h-[calc(100dvh-var(--cookie-banner-h,0px))] md:overflow-x-hidden md:overflow-y-auto'
+      className='profile-viewport relative h-dvh overflow-hidden bg-(--profile-stage-bg) text-primary-token md:h-auto md:min-h-dvh md:overflow-x-hidden md:overflow-y-auto'
       style={profileAccentStyle}
       data-testid='public-profile-layout-shell'
     >
@@ -62,8 +62,8 @@ export function PublicProfileLayoutShell({
           // Center the stable stage container (not per-content height) so
           // mode/tab switches do not reflow vertical position (JOV-1369).
           isDesktopLayout
-            ? 'public-profile-layout-frame--desktop min-h-[calc(100dvh-var(--cookie-banner-h,0px))] items-center'
-            : 'public-profile-layout-frame--compact min-h-[calc(100dvh-var(--cookie-banner-h,0px))] items-stretch md:items-center'
+            ? 'public-profile-layout-frame--desktop min-h-dvh items-center'
+            : 'public-profile-layout-frame--compact min-h-dvh items-stretch md:items-center'
         )}
         data-layout={isDesktopLayout ? 'desktop' : 'compact'}
       >

--- a/apps/web/components/molecules/CookieActions.stories.tsx
+++ b/apps/web/components/molecules/CookieActions.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { CookieActions } from './CookieActions';
+
+const meta: Meta<typeof CookieActions> = {
+  title: 'Molecules/CookieActions',
+  component: CookieActions,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onAcceptAll: fn(),
+    onReject: fn(),
+    onCustomize: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Compact: Story = {
+  args: {
+    compact: true,
+  },
+};
+
+export const Standard: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    compact: true,
+    disabled: true,
+  },
+};

--- a/apps/web/components/molecules/CookieActions.tsx
+++ b/apps/web/components/molecules/CookieActions.tsx
@@ -44,24 +44,24 @@ export function CookieActions({
   compact = false,
 }: CookieActionsProps) {
   const containerClass = compact
-    ? `flex shrink-0 flex-row items-center flex-wrap gap-1.5 ${className}`
+    ? `flex shrink-0 flex-row items-center flex-wrap gap-1 ${className}`
     : `flex shrink-0 flex-col sm:flex-row sm:flex-wrap ${className}`;
-  const containerGap = compact ? '6px' : 'var(--linear-space-2)';
+  const containerGap = compact ? '4px' : 'var(--linear-space-2)';
 
   const secStyle: CSSProperties = compact
     ? {
         ...secondaryButtonStyle,
         fontSize: '12px',
-        padding: '6px 10px',
-        height: '36px',
+        padding: '6px',
+        height: '44px',
       }
     : secondaryButtonStyle;
   const priStyle: CSSProperties = compact
     ? {
         ...primaryButtonStyle,
         fontSize: '12px',
-        padding: '6px 12px',
-        height: '36px',
+        padding: '6px 8px',
+        height: '44px',
       }
     : primaryButtonStyle;
 
@@ -77,7 +77,7 @@ export function CookieActions({
     <div className={containerClass} style={{ gap: containerGap }}>
       <div
         className='flex'
-        style={{ gap: compact ? '6px' : 'var(--linear-space-2)' }}
+        style={{ gap: compact ? '4px' : 'var(--linear-space-2)' }}
       >
         <button
           type='button'

--- a/apps/web/components/molecules/CookieActions.tsx
+++ b/apps/web/components/molecules/CookieActions.tsx
@@ -1,3 +1,4 @@
+// @coverage-via apps/web/tests/unit/cookie-banner.test.tsx
 'use client';
 
 import type { CSSProperties } from 'react';

--- a/apps/web/components/organisms/CookieBannerSection.stories.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useEffect, useState } from 'react';
+import { CookieBannerSection } from './CookieBannerSection';
+
+function RequiredConsentFixture() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    document.cookie = 'jv_cc_required=1; path=/';
+    localStorage.removeItem('jv_cc');
+    setReady(true);
+
+    return () => {
+      document.cookie = 'jv_cc_required=; Max-Age=0; path=/';
+      document.documentElement.style.removeProperty('--cookie-banner-h');
+    };
+  }, []);
+
+  return ready ? <CookieBannerSection /> : null;
+}
+
+const meta: Meta<typeof CookieBannerSection> = {
+  title: 'Organisms/CookieBannerSection',
+  component: CookieBannerSection,
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: {
+      viewports: [320, 390],
+    },
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/tim',
+        query: {},
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AboveProfileNavigation: Story = {
+  render: () => <RequiredConsentFixture />,
+};

--- a/apps/web/components/organisms/CookieBannerSection.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.tsx
@@ -199,7 +199,7 @@ export function CookieBannerSection() {
 
   return (
     <>
-      {visible && !isSuppressedPath ? (
+      {visible && !isSuppressedPath && !customize ? (
         <aside
           aria-label='Cookie Consent'
           data-testid='cookie-banner'

--- a/apps/web/components/organisms/CookieBannerSection.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.tsx
@@ -7,7 +7,10 @@ import { useEffect, useState } from 'react';
 import { CookieActions } from '@/components/molecules/CookieActions';
 import { CookieModal } from '@/components/organisms/CookieModal';
 import { APP_ROUTES } from '@/constants/routes';
-import { shouldSuppressCookieBannerForPathname } from '@/lib/cookies/banner-visibility';
+import {
+  shouldPlaceCookieBannerAbovePublicProfileDock,
+  shouldSuppressCookieBannerForPathname,
+} from '@/lib/cookies/banner-visibility';
 import { saveConsent } from '@/lib/cookies/consent';
 import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import { setConsentState } from '@/lib/tracking/consent';
@@ -32,6 +35,8 @@ function isBannerRequiredFromCookie(): boolean {
 export function CookieBannerSection() {
   const pathname = usePathname();
   const isSuppressedPath = shouldSuppressCookieBannerForPathname(pathname);
+  const shouldClearProfileDock =
+    shouldPlaceCookieBannerAbovePublicProfileDock(pathname);
 
   const [visible, setVisible] = useState(false);
   const [customize, setCustomize] = useState(false);
@@ -65,13 +70,12 @@ export function CookieBannerSection() {
     }
   }, [visible]);
 
-  // Publish banner height + bottom offset + a separation gap as a CSS custom
-  // property on :root so layout regions (profile shells, QR coordination)
-  // reserve the exact space occupied by the fixed bottom-right card
-  // (bottom-4 = 16px + measured h) PLUS a 12px gap so chrome stacked above the
-  // banner (e.g. the public-profile bottom tab nav) never abuts or overlaps it
-  // (JOV-3555 — regression of JOV-1982). Cleared on hide/consent for zero
-  // layout impact. Matches useCookieBannerHeight total offset for toasts.
+  // Publish banner height + its rendered bottom offset + a separation gap as a
+  // CSS custom property on :root so floating surfaces (toasts, QR coordination)
+  // can reserve the exact space occupied by the fixed card. Public-profile
+  // phone navigation clears the card with route-stable CSS instead of reading
+  // this late measurement into page geometry (JOV-4783). Cleared on
+  // hide/consent; matches useCookieBannerHeight total offset for toasts.
   useEffect(() => {
     if (typeof document === 'undefined') return;
 
@@ -87,16 +91,23 @@ export function CookieBannerSection() {
     );
     if (!banner) return;
 
-    // 16px = banner's `bottom-4` inset from the viewport bottom.
+    // 16px is the non-profile `bottom-4` fallback. On a phone profile the
+    // route modifier places the card above the 74px navigation footprint, so
+    // measure the rendered inset instead of publishing a stale constant.
     // 12px = separation gap between the banner top and any chrome stacked above
     // it (bottom tab nav) so both surfaces stay clear and fully tappable.
-    const BANNER_BOTTOM_INSET_PX = 16;
+    const DEFAULT_BANNER_BOTTOM_INSET_PX = 16;
     const BANNER_SEPARATION_GAP_PX = 12;
 
     const update = () => {
+      const bounds = banner.getBoundingClientRect();
+      const renderedBottomInset =
+        bounds.height > 0
+          ? Math.max(0, globalThis.innerHeight - bounds.bottom)
+          : DEFAULT_BANNER_BOTTOM_INSET_PX;
       root.style.setProperty(
         '--cookie-banner-h',
-        `${banner.getBoundingClientRect().height + BANNER_BOTTOM_INSET_PX + BANNER_SEPARATION_GAP_PX}px`
+        `${bounds.height + renderedBottomInset + BANNER_SEPARATION_GAP_PX}px`
       );
     };
 
@@ -104,12 +115,14 @@ export function CookieBannerSection() {
 
     const ro = new ResizeObserver(update);
     ro.observe(banner);
+    globalThis.addEventListener('resize', update);
 
     return () => {
       ro.disconnect();
+      globalThis.removeEventListener('resize', update);
       root.style.removeProperty('--cookie-banner-h');
     };
-  }, [visible, isSuppressedPath]);
+  }, [visible, isSuppressedPath, shouldClearProfileDock]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -190,7 +203,11 @@ export function CookieBannerSection() {
         <aside
           aria-label='Cookie Consent'
           data-testid='cookie-banner'
-          className='fixed bottom-4 right-4 z-[60] w-[calc(100vw-2rem)] max-w-85 sm:max-w-95'
+          className={`cookie-banner-card fixed bottom-4 right-4 z-[60] w-[calc(100vw-2rem)] max-w-85 sm:max-w-95 ${
+            shouldClearProfileDock
+              ? 'cookie-banner-card--above-public-profile-dock'
+              : ''
+          }`}
         >
           <div className='rounded-2xl border border-(--linear-app-frame-seam) bg-surface-1 shadow-card px-4 py-4'>
             <div className='flex items-start gap-3'>

--- a/apps/web/components/organisms/CookieModal.stories.tsx
+++ b/apps/web/components/organisms/CookieModal.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { CookieModal } from './CookieModal';
+
+const meta: Meta<typeof CookieModal> = {
+  title: 'Organisms/CookieModal',
+  component: CookieModal,
+  parameters: {
+    layout: 'fullscreen',
+    jovie: {
+      // Internal category metadata owns the disabled Essential switch; it is
+      // not a CookieModal prop that Storybook can control.
+      uncoveredProps: ['disabled'],
+    },
+    chromatic: {
+      viewports: [390, 1024],
+    },
+  },
+  args: {
+    open: true,
+    onClose: fn(),
+    onSave: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Preferences: Story = {};

--- a/apps/web/components/organisms/CookieModal.tsx
+++ b/apps/web/components/organisms/CookieModal.tsx
@@ -99,6 +99,7 @@ function CookieCategories({
                 disabled={category.disabled}
                 aria-labelledby={titleId}
                 aria-describedby={descId}
+                className='before:h-11 before:w-11'
               />
             </div>
           </div>
@@ -193,7 +194,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
               size='sm'
               onClick={onClose}
               disabled={isSaving}
-              className='flex-1'
+              className='min-h-11 flex-1'
             >
               Cancel
             </Button>
@@ -203,7 +204,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
               size='sm'
               onClick={save}
               disabled={isSaving}
-              className='flex-1'
+              className='min-h-11 flex-1'
             >
               Save Preferences
             </Button>
@@ -257,6 +258,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
           size='sm'
           onClick={onClose}
           disabled={isSaving}
+          className='min-h-11'
         >
           Cancel
         </Button>
@@ -266,6 +268,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
           size='sm'
           onClick={save}
           disabled={isSaving}
+          className='min-h-11'
         >
           Save Preferences
         </Button>

--- a/apps/web/components/organisms/CookieModal.tsx
+++ b/apps/web/components/organisms/CookieModal.tsx
@@ -1,3 +1,4 @@
+// @coverage-via apps/web/tests/unit/cookie-banner-fixes.test.tsx
 'use client';
 
 import {
@@ -99,7 +100,7 @@ function CookieCategories({
                 disabled={category.disabled}
                 aria-labelledby={titleId}
                 aria-describedby={descId}
-                className='before:h-11 before:w-11'
+                className='before:h-12 before:w-12'
               />
             </div>
           </div>
@@ -110,7 +111,7 @@ function CookieCategories({
         For more details, see our{' '}
         <Link
           href={APP_ROUTES.LEGAL_COOKIES}
-          className='text-secondary-token underline hover:opacity-80'
+          className='inline-flex min-h-12 items-center text-secondary-token underline hover:opacity-80'
         >
           Cookie Policy
         </Link>
@@ -173,7 +174,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
         >
           <SheetHeader className='pb-1'>
             <SheetTitlePrimitive className='text-app font-semibold text-primary-token'>
-              Cookie preferences
+              Cookie Preferences
             </SheetTitlePrimitive>
             <SheetDescription className='sr-only'>
               Manage your cookie preferences
@@ -194,7 +195,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
               size='sm'
               onClick={onClose}
               disabled={isSaving}
-              className='min-h-11 flex-1'
+              className='min-h-12 flex-1'
             >
               Cancel
             </Button>
@@ -204,7 +205,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
               size='sm'
               onClick={save}
               disabled={isSaving}
-              className='min-h-11 flex-1'
+              className='min-h-12 flex-1'
             >
               Save Preferences
             </Button>
@@ -258,7 +259,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
           size='sm'
           onClick={onClose}
           disabled={isSaving}
-          className='min-h-11'
+          className='min-h-12'
         >
           Cancel
         </Button>
@@ -268,7 +269,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
           size='sm'
           onClick={save}
           disabled={isSaving}
-          className='min-h-11'
+          className='min-h-12'
         >
           Save Preferences
         </Button>

--- a/apps/web/lib/cookies/banner-visibility.ts
+++ b/apps/web/lib/cookies/banner-visibility.ts
@@ -1,3 +1,5 @@
+import { getPublicProfileCandidate } from '@/lib/routing/proxy-routing';
+
 const COOKIE_BANNER_SUPPRESSED_PATH_PREFIXES = [
   '/app',
   '/demo',
@@ -19,4 +21,20 @@ export function shouldSuppressCookieBannerForPathname(
   return COOKIE_BANNER_SUPPRESSED_PATH_PREFIXES.some(
     prefix => pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
+}
+
+/**
+ * True when the cookie card must clear the fixed public-profile dock.
+ *
+ * Public profiles own nested interaction routes such as `/:handle/alerts`, so
+ * classification is based on the first segment while still delegating the
+ * reserved-handle rules to the canonical proxy-routing helper.
+ */
+export function shouldPlaceCookieBannerAbovePublicProfileDock(
+  pathname: string | null | undefined
+): boolean {
+  const firstSegment = pathname?.split('/').filter(Boolean)[0];
+  if (!firstSegment) return false;
+
+  return getPublicProfileCandidate(`/${firstSegment}`) !== null;
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -244,9 +244,11 @@
 
 .public-profile-layout-frame--compact {
   max-width: min(100%, calc(var(--content-max) + (var(--page-pad) * 2)));
-  /* Mobile: fill viewport so the phone-frame surface can stretch. */
+  /* Keep the stage geometry independent from lazy floating overlays. Cookie
+     consent clears the phone nav by moving its own fixed card, never by
+     resizing the profile after first paint. */
   height: 100%;
-  min-height: calc(100dvh - var(--cookie-banner-h, 0px));
+  min-height: 100dvh;
 }
 
 .public-profile-layout-compact-slot {
@@ -612,6 +614,13 @@
    static DOM, but out of mobile layout so it cannot add page scroll below the
    compact profile. Desktop keeps the readable AEO section. */
 @media (max-width: 767px) {
+  /* The consent card mounts lazily after geo/cookie checks. Its route-derived
+     modifier is present on first paint, keeping it above the canonical glass
+     dock without changing any profile box geometry or moving the card later. */
+  .cookie-banner-card--above-public-profile-dock {
+    bottom: calc(var(--profile-bottom-nav-height) + 8px);
+  }
+
   .profile-viewport ~ .profile-aeo-content {
     position: absolute;
     top: 0;

--- a/apps/web/tests/e2e/cookies.spec.ts
+++ b/apps/web/tests/e2e/cookies.spec.ts
@@ -39,6 +39,14 @@ async function openHomepageWithBanner(
     }
   });
 
+  // Middleware refreshes the region flag on every request. Send the same
+  // deterministic EU geo signal used by production edge requests so it cannot
+  // overwrite the fixture cookie with a non-consent region during navigation.
+  await page.setExtraHTTPHeaders({
+    'x-vercel-ip-country': 'DE',
+    'x-vercel-ip-country-region': 'BE',
+  });
+
   // Set the middleware-controlled cookie that enables the banner
   await page.context().addCookies([
     {
@@ -82,6 +90,21 @@ test.describe('Cookie banner @smoke', () => {
     expect(box, 'Cookie banner has no bounding box').not.toBeNull();
     expect(box!.width, 'Cookie banner has zero width').toBeGreaterThan(0);
     expect(box!.height, 'Cookie banner has zero height').toBeGreaterThan(0);
+
+    for (const actionName of ['Reject', 'Customize', 'Accept All']) {
+      const actionBox = await banner
+        .getByRole('button', { name: actionName, exact: true })
+        .boundingBox();
+      expect(actionBox, `${actionName} has no bounding box`).not.toBeNull();
+      expect(
+        actionBox!.width,
+        `${actionName} misses the 44px touch width`
+      ).toBeGreaterThanOrEqual(44);
+      expect(
+        actionBox!.height,
+        `${actionName} misses the 44px touch height`
+      ).toBeGreaterThanOrEqual(44);
+    }
   });
 
   test('Accept All button is clickable and has nonzero bounding box', async ({
@@ -94,8 +117,7 @@ test.describe('Cookie banner @smoke', () => {
     const banner = page.locator('[data-testid="cookie-banner"]');
     await expect(banner).toBeVisible({ timeout: SMOKE_TIMEOUTS.VISIBILITY });
 
-    // On mobile viewports the actions area is hidden until "Manage" is clicked.
-    // At desktop width (1280px default) the actions are always visible.
+    // Floating-card actions stay directly available at every breakpoint.
     const acceptBtn = banner.getByRole('button', { name: 'Accept All' });
 
     await expect(
@@ -105,10 +127,14 @@ test.describe('Cookie banner @smoke', () => {
 
     const box = await acceptBtn.boundingBox();
     expect(box, '"Accept All" button has no bounding box').not.toBeNull();
-    expect(box!.width, '"Accept All" button has zero width').toBeGreaterThan(0);
-    expect(box!.height, '"Accept All" button has zero height').toBeGreaterThan(
-      0
-    );
+    expect(
+      box!.width,
+      '"Accept All" button misses 44px touch width'
+    ).toBeGreaterThanOrEqual(44);
+    expect(
+      box!.height,
+      '"Accept All" button misses 44px touch height'
+    ).toBeGreaterThanOrEqual(44);
 
     // Clicking must not throw and must dismiss the banner
     await acceptBtn.click();
@@ -133,13 +159,14 @@ test.describe('Cookie banner @smoke', () => {
 
     const custBox = await customizeBtn.boundingBox();
     expect(custBox, '"Customize" button has no bounding box').not.toBeNull();
-    expect(custBox!.width, '"Customize" button has zero width').toBeGreaterThan(
-      0
-    );
+    expect(
+      custBox!.width,
+      '"Customize" button misses 44px touch width'
+    ).toBeGreaterThanOrEqual(44);
     expect(
       custBox!.height,
-      '"Customize" button has zero height'
-    ).toBeGreaterThan(0);
+      '"Customize" button misses 44px touch height'
+    ).toBeGreaterThanOrEqual(44);
 
     // Open the cookie modal
     await customizeBtn.click();
@@ -154,6 +181,12 @@ test.describe('Cookie banner @smoke', () => {
       '"Save Preferences" button did not appear after clicking Customize'
     ).toBeVisible({ timeout: SMOKE_TIMEOUTS.VISIBILITY });
 
+    // Dialog scale-in briefly transforms the visual box below its settled CSS
+    // size. Evaluate the stable interaction state, not an animation frame.
+    await expect
+      .poll(async () => (await saveBtn.boundingBox())?.height ?? 0)
+      .toBeGreaterThanOrEqual(44);
+
     const saveBox = await saveBtn.boundingBox();
     expect(
       saveBox,
@@ -161,11 +194,32 @@ test.describe('Cookie banner @smoke', () => {
     ).not.toBeNull();
     expect(
       saveBox!.width,
-      '"Save Preferences" button has zero width'
-    ).toBeGreaterThan(0);
+      '"Save Preferences" button misses 44px touch width'
+    ).toBeGreaterThanOrEqual(44);
     expect(
       saveBox!.height,
-      '"Save Preferences" button has zero height'
-    ).toBeGreaterThan(0);
+      '"Save Preferences" button misses 44px touch height'
+    ).toBeGreaterThanOrEqual(44);
+
+    const cancelBtn = page.getByRole('button', { name: 'Cancel', exact: true });
+    const cancelBox = await cancelBtn.boundingBox();
+    expect(cancelBox, '"Cancel" button has no bounding box').not.toBeNull();
+    expect(cancelBox!.width).toBeGreaterThanOrEqual(44);
+    expect(cancelBox!.height).toBeGreaterThanOrEqual(44);
+
+    const analyticsSwitch = page.getByRole('switch', { name: /analytics/i });
+    const switchHitArea = await analyticsSwitch.evaluate(control => {
+      const pseudo = getComputedStyle(control, '::before');
+      return {
+        width: Number.parseFloat(pseudo.width),
+        height: Number.parseFloat(pseudo.height),
+      };
+    });
+    expect(switchHitArea.width).toBeGreaterThanOrEqual(44);
+    expect(switchHitArea.height).toBeGreaterThanOrEqual(44);
+
+    await analyticsSwitch.focus();
+    await page.keyboard.press('Space');
+    await expect(analyticsSwitch).toBeChecked();
   });
 });

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -337,7 +337,9 @@ async function waitForAnyVisible(
 
 async function settleLayout(page: Page) {
   await page.evaluate(async () => {
-    if ('fonts' in document) {
+    // WebKit can leave FontFaceSet.ready pending across repeated viewport
+    // navigations even after the set has reached its terminal loaded state.
+    if ('fonts' in document && document.fonts.status === 'loading') {
       await document.fonts.ready;
     }
   });

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -999,6 +999,122 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
     }
   });
 
+  test('late cookie consent measurement never reflows the profile stage or covers the dock', async ({
+    page,
+  }) => {
+    const viewports = [
+      { label: 'phone small', width: 320, height: 568 },
+      { label: 'phone', width: 390, height: 844 },
+      { label: 'phone max', width: 430, height: 932 },
+      { label: 'compact edge', width: 767, height: 1024 },
+      { label: 'tablet', width: 768, height: 1024 },
+      { label: 'desktop', width: 1024, height: 1024 },
+      { label: 'wide desktop', width: 1440, height: 1024 },
+    ] as const;
+
+    for (const viewport of viewports) {
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      });
+      await smokeNavigate(page, '/demo/showcase/public-profile', {
+        timeout: 120_000,
+      });
+      await waitForHydration(page);
+      await waitForAnyVisible(
+        page,
+        ['[data-testid="profile-pac"]'],
+        SMOKE_TIMEOUTS.NAVIGATION
+      );
+      await settleLayout(page);
+
+      const readGeometry = () =>
+        page.evaluate(() => {
+          const rect = (element: Element | null) => {
+            if (!element) return null;
+            const bounds = element.getBoundingClientRect();
+            return {
+              top: bounds.top,
+              bottom: bounds.bottom,
+              width: bounds.width,
+              height: bounds.height,
+            };
+          };
+
+          return {
+            shell: rect(document.querySelector('.profile-viewport')),
+            frame: rect(document.querySelector('.public-profile-layout-frame')),
+            cover: rect(
+              document.querySelector('[data-testid="profile-cover"]')
+            ),
+            dock: rect(
+              document.querySelector('[data-testid="profile-tab-bar"]')
+            ),
+            banner: rect(
+              document.querySelector('[data-testid="cookie-banner"]')
+            ),
+          };
+        });
+
+      const before = await readGeometry();
+      await page.evaluate(() => {
+        document.documentElement.style.setProperty(
+          '--cookie-banner-h',
+          '146px'
+        );
+
+        const banner = document.createElement('aside');
+        banner.className =
+          'cookie-banner-card cookie-banner-card--above-public-profile-dock';
+        banner.dataset.testid = 'cookie-banner';
+        Object.assign(banner.style, {
+          position: 'fixed',
+          right: '16px',
+          width: 'min(340px, calc(100vw - 32px))',
+          height: '118px',
+          zIndex: '60',
+        });
+        document.body.append(banner);
+      });
+      await page.evaluate(
+        () =>
+          new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+      );
+
+      const after = await readGeometry();
+      expect(
+        after.shell,
+        `${viewport.label} shell must ignore delayed cookie height`
+      ).toEqual(before.shell);
+      expect(
+        after.frame,
+        `${viewport.label} frame must ignore delayed cookie height`
+      ).toEqual(before.frame);
+      expect(
+        after.cover,
+        `${viewport.label} hero must ignore delayed cookie height`
+      ).toEqual(before.cover);
+      expect(
+        after.dock,
+        `${viewport.label} dock must ignore delayed cookie height`
+      ).toEqual(before.dock);
+
+      if (viewport.width < 768) {
+        expect(after.banner, 'phone consent card should render').not.toBeNull();
+        expect(after.dock, 'phone dock should render').not.toBeNull();
+        expect(
+          after.banner?.bottom ?? Number.POSITIVE_INFINITY,
+          'phone consent card should clear the glass dock'
+        ).toBeLessThanOrEqual((after.dock?.top ?? 0) - 8);
+      }
+
+      await page.evaluate(() => {
+        document.documentElement.style.removeProperty('--cookie-banner-h');
+        document.querySelector('[data-testid="cookie-banner"]')?.remove();
+      });
+    }
+  });
+
   test('mock-home includes horizontally scrollable back-catalog cards', async ({
     page,
   }) => {

--- a/apps/web/tests/unit/cookie-banner-fixes.test.tsx
+++ b/apps/web/tests/unit/cookie-banner-fixes.test.tsx
@@ -189,15 +189,21 @@ describe('CookieModal loads saved preferences', () => {
     render(<CookieModal open onClose={vi.fn()} />);
 
     for (const control of screen.getAllByRole('switch')) {
-      expect(control.className).toContain('before:h-11');
-      expect(control.className).toContain('before:w-11');
+      expect(control.className).toContain('before:h-12');
+      expect(control.className).toContain('before:w-12');
     }
     expect(screen.getByRole('button', { name: /cancel/i }).className).toContain(
-      'min-h-11'
+      'min-h-12'
     );
     expect(
       screen.getByRole('button', { name: /save preferences/i }).className
-    ).toContain('min-h-11');
+    ).toContain('min-h-12');
+    expect(
+      screen.getByRole('link', { name: /cookie policy/i }).className
+    ).toContain('min-h-12');
+    const close = screen.getByRole('button', { name: 'Close' });
+    expect(close.className).toContain('h-12');
+    expect(close.className).toContain('w-12');
   });
 
   it('calls onSave and onClose when Save Preferences succeeds', async () => {

--- a/apps/web/tests/unit/cookie-banner-fixes.test.tsx
+++ b/apps/web/tests/unit/cookie-banner-fixes.test.tsx
@@ -184,6 +184,22 @@ describe('CookieModal loads saved preferences', () => {
     );
   });
 
+  it('keeps consent controls on a 44px touch-target floor', async () => {
+    const { CookieModal } = await import('@/components/organisms/CookieModal');
+    render(<CookieModal open onClose={vi.fn()} />);
+
+    for (const control of screen.getAllByRole('switch')) {
+      expect(control.className).toContain('before:h-11');
+      expect(control.className).toContain('before:w-11');
+    }
+    expect(screen.getByRole('button', { name: /cancel/i }).className).toContain(
+      'min-h-11'
+    );
+    expect(
+      screen.getByRole('button', { name: /save preferences/i }).className
+    ).toContain('min-h-11');
+  });
+
   it('calls onSave and onClose when Save Preferences succeeds', async () => {
     const onSave = vi.fn();
     const onClose = vi.fn();

--- a/apps/web/tests/unit/cookie-banner.test.tsx
+++ b/apps/web/tests/unit/cookie-banner.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CookieBannerSection } from '@/components/organisms/CookieBannerSection';
-import { shouldSuppressCookieBannerForPathname } from '@/lib/cookies/banner-visibility';
+import {
+  shouldPlaceCookieBannerAbovePublicProfileDock,
+  shouldSuppressCookieBannerForPathname,
+} from '@/lib/cookies/banner-visibility';
 
 vi.mock('@/lib/cookies/consent', () => ({
   saveConsent: vi.fn(),
@@ -56,6 +59,20 @@ describe('CookieBannerSection', () => {
     expect(shouldSuppressCookieBannerForPathname(pathname)).toBe(true);
   });
 
+  it.each([
+    ['/tim', true],
+    ['/tim/alerts', true],
+    ['/dualipa/merch/card-1', true],
+    ['/pricing', false],
+    ['/artist-profiles', false],
+    ['/app/profile', false],
+    ['/', false],
+  ])('classifies profile dock placement for %s', (pathname, expected) => {
+    expect(shouldPlaceCookieBannerAbovePublicProfileDock(pathname)).toBe(
+      expected
+    );
+  });
+
   it('renders as floating bottom-right card (not full-width bar) with correct classes and compact actions when required', () => {
     setCookie('jv_cc_required=1');
     render(<CookieBannerSection />);
@@ -83,6 +100,9 @@ describe('CookieBannerSection', () => {
       screen.getByRole('button', { name: /customize/i })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument();
+    for (const button of screen.getAllByRole('button')) {
+      expect(button).toHaveStyle({ height: '44px' });
+    }
     // Privacy link present (condensed legal text)
     expect(banner.textContent).toContain('essential functionality');
     expect(screen.getByRole('link', { name: /privacy/i })).toHaveAttribute(
@@ -91,7 +111,7 @@ describe('CookieBannerSection', () => {
     );
   });
 
-  it('publishes --cookie-banner-h CSS var from measured floating card height (for toasts + profile shells)', async () => {
+  it('publishes --cookie-banner-h CSS var for coordinated floating surfaces', async () => {
     setCookie('jv_cc_required=1');
     render(<CookieBannerSection />);
     // The ResizeObserver effect in Section sets the var from data-testid rect
@@ -103,10 +123,9 @@ describe('CookieBannerSection', () => {
     });
   });
 
-  // JOV-3555: the published reservation must include the banner's 16px bottom
-  // inset PLUS a 12px separation gap so the public-profile bottom tab nav stacked
-  // above it never abuts/overlaps the banner. jsdom reports 0 measured height, so
-  // the value reduces to 16 + 12 = 28px.
+  // The published reservation includes the rendered bottom inset plus a 12px
+  // separation gap. jsdom reports 0 measured height, so the implementation
+  // uses its 16px non-profile fallback and the value reduces to 28px.
   it('reserves bottom inset + separation gap above the measured banner height', async () => {
     setCookie('jv_cc_required=1');
     render(<CookieBannerSection />);

--- a/apps/web/tests/unit/cookie-banner.test.tsx
+++ b/apps/web/tests/unit/cookie-banner.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CookieActions } from '@/components/molecules/CookieActions';
 import { CookieBannerSection } from '@/components/organisms/CookieBannerSection';
 import {
   shouldPlaceCookieBannerAbovePublicProfileDock,
@@ -17,6 +18,36 @@ function setCookie(value: string) {
     value,
   });
 }
+
+describe('CookieActions', () => {
+  it('keeps every compact action touch-sized and dispatches its callback', () => {
+    const onAcceptAll = vi.fn();
+    const onReject = vi.fn();
+    const onCustomize = vi.fn();
+
+    render(
+      <CookieActions
+        compact
+        onAcceptAll={onAcceptAll}
+        onReject={onReject}
+        onCustomize={onCustomize}
+      />
+    );
+
+    const actions = [
+      screen.getByRole('button', { name: /reject/i }),
+      screen.getByRole('button', { name: /customize/i }),
+      screen.getByRole('button', { name: /accept all/i }),
+    ];
+    for (const action of actions) {
+      expect(action).toHaveStyle({ height: '44px' });
+      fireEvent.click(action);
+    }
+    expect(onReject).toHaveBeenCalledOnce();
+    expect(onCustomize).toHaveBeenCalledOnce();
+    expect(onAcceptAll).toHaveBeenCalledOnce();
+  });
+});
 
 describe('CookieBannerSection', () => {
   afterEach(() => {
@@ -109,6 +140,25 @@ describe('CookieBannerSection', () => {
       'href',
       '/legal/privacy'
     );
+  });
+
+  it('gives the preferences modal sole ownership of the consent surface', () => {
+    setCookie('jv_cc_required=1');
+    render(<CookieBannerSection />);
+
+    fireEvent.click(screen.getByRole('button', { name: /customize/i }));
+
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('dialog', { name: /cookie preferences/i })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole('dialog', { name: /cookie preferences/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('cookie-banner')).toBeInTheDocument();
   });
 
   it('publishes --cookie-banner-h CSS var for coordinated floating surfaces', async () => {

--- a/apps/web/tests/unit/release/smart-link-metadata.test.ts
+++ b/apps/web/tests/unit/release/smart-link-metadata.test.ts
@@ -5,20 +5,24 @@ const {
   getCreatorByUsernameMock,
   getFeaturedSmartLinkStaticParamsMock,
   getUnpublishedReleasePresenceMock,
+  findRedirectByOldSlugMock,
   notFoundMock,
+  permanentRedirectMock,
   redirectMock,
 } = vi.hoisted(() => ({
   getContentBySlugMock: vi.fn(),
   getCreatorByUsernameMock: vi.fn(),
   getFeaturedSmartLinkStaticParamsMock: vi.fn().mockResolvedValue([]),
   getUnpublishedReleasePresenceMock: vi.fn(),
+  findRedirectByOldSlugMock: vi.fn(),
   notFoundMock: vi.fn(),
+  permanentRedirectMock: vi.fn(),
   redirectMock: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
   notFound: notFoundMock,
-  permanentRedirect: vi.fn(),
+  permanentRedirect: permanentRedirectMock,
   redirect: redirectMock,
 }));
 
@@ -49,7 +53,7 @@ vi.mock('@/app/[username]/[slug]/_lib/data', () => ({
 }));
 
 vi.mock('@/lib/discography/slug', () => ({
-  findRedirectByOldSlug: vi.fn().mockResolvedValue(null),
+  findRedirectByOldSlug: findRedirectByOldSlugMock,
 }));
 
 vi.mock('@/lib/entity/queries', () => ({
@@ -63,9 +67,15 @@ describe('smart-link metadata', () => {
     getContentBySlugMock.mockReset();
     getUnpublishedReleasePresenceMock.mockReset();
     getUnpublishedReleasePresenceMock.mockResolvedValue(null);
+    findRedirectByOldSlugMock.mockReset();
+    findRedirectByOldSlugMock.mockResolvedValue(null);
     notFoundMock.mockReset();
     notFoundMock.mockImplementation(() => {
       throw new Error('NEXT_NOT_FOUND');
+    });
+    permanentRedirectMock.mockReset();
+    permanentRedirectMock.mockImplementation(() => {
+      throw new Error('NEXT_PERMANENT_REDIRECT');
     });
     redirectMock.mockReset();
     redirectMock.mockImplementation(() => {
@@ -205,6 +215,90 @@ describe('smart-link metadata', () => {
       'music'
     );
     expect(redirectMock).toHaveBeenCalledWith('/dualipa?mode=listen&source=qr');
+  });
+
+  it('keeps renamed-release redirects ahead of matching mode aliases', async () => {
+    getContentBySlugMock.mockResolvedValue(null);
+    findRedirectByOldSlugMock.mockResolvedValue({
+      currentSlug: 'renamed-music',
+    });
+    getUnpublishedReleasePresenceMock.mockResolvedValue({
+      id: 'unpublished-music',
+    });
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+
+    await expect(
+      ProfileAliasResolverPage({
+        params: Promise.resolve({
+          username: 'dualipa',
+          slug: ['music', '__profile-mode-alias', 'resolve'],
+        }),
+      })
+    ).rejects.toThrow('NEXT_PERMANENT_REDIRECT');
+    expect(permanentRedirectMock).toHaveBeenCalledWith(
+      '/dualipa/renamed-music'
+    );
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps unpublished collisions on the canonical smart-link renderer', async () => {
+    getContentBySlugMock.mockResolvedValue(null);
+    getUnpublishedReleasePresenceMock.mockResolvedValue({
+      id: 'unpublished-music',
+    });
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+    const result = await ProfileAliasResolverPage({
+      params: Promise.resolve({
+        username: 'dualipa',
+        slug: ['music', '__profile-mode-alias', 'resolve'],
+      }),
+    });
+
+    expect(result).toBeTruthy();
+    expect(permanentRedirectMock).not.toHaveBeenCalled();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('starts independent alias collision checks in parallel', async () => {
+    getContentBySlugMock.mockResolvedValue(null);
+    let resolveRedirectLookup: ((value: null) => void) | undefined;
+    let resolveUnpublishedLookup: ((value: null) => void) | undefined;
+    findRedirectByOldSlugMock.mockImplementation(
+      () =>
+        new Promise<null>(resolve => {
+          resolveRedirectLookup = resolve;
+        })
+    );
+    getUnpublishedReleasePresenceMock.mockImplementation(
+      () =>
+        new Promise<null>(resolve => {
+          resolveUnpublishedLookup = resolve;
+        })
+    );
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+    const result = ProfileAliasResolverPage({
+      params: Promise.resolve({
+        username: 'dualipa',
+        slug: ['music', '__profile-mode-alias', 'resolve'],
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(findRedirectByOldSlugMock).toHaveBeenCalledOnce();
+      expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledOnce();
+    });
+    resolveRedirectLookup?.(null);
+    resolveUnpublishedLookup?.(null);
+    await expect(result).rejects.toThrow('NEXT_REDIRECT');
   });
 
   it('keeps direct marker paths for arbitrary slugs on the catch-all 404', async () => {

--- a/packages/ui/atoms/close-button.test.tsx
+++ b/packages/ui/atoms/close-button.test.tsx
@@ -103,6 +103,8 @@ describe('closeButtonClassName', () => {
 
   it('uses the shared pill close button shape', () => {
     expect(closeButtonClassName).toContain('rounded-full');
+    expect(closeButtonClassName).toContain('h-12');
+    expect(closeButtonClassName).toContain('w-12');
     expect(closeButtonClassName).not.toContain(
       'rounded-(--linear-app-radius-item)'
     );

--- a/packages/ui/atoms/close-button.tsx
+++ b/packages/ui/atoms/close-button.tsx
@@ -9,7 +9,7 @@ import { cn } from '../lib/utils';
  * Provides consistent close button styling across Dialog, AlertDialog, and Sheet.
  */
 export const closeButtonStyles = {
-  base: 'absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full text-secondary-token opacity-70 transition-colors duration-normal ease-interactive',
+  base: 'absolute right-4 top-4 inline-flex h-12 w-12 items-center justify-center rounded-full text-secondary-token opacity-70 transition-colors duration-normal ease-interactive',
   hover:
     'hover:bg-interactive-hover hover:text-primary-token hover:opacity-100',
   focus:


### PR DESCRIPTION
## Summary

- keep the public-profile shell at a stable `100dvh` so late consent measurement cannot resize the hero, carousel, or glass navigation
- position consent above the mobile dock from route-stable profile classification, publish the true floating inset, and make the preferences modal the sole consent surface while open
- enforce 44–48px consent targets, compact the 320px layout, add component stories, and make the cross-browser layout evaluator robust to WebKit's already-loaded `FontFaceSet.ready` edge case
- cache and parallelize legacy alias collision checks while preserving renamed, unpublished, missing, and forged-marker semantics
- no external data embedding is introduced

## User-visible proof

- exact optimized production build: 469/469 routes generated
- Chromium exact-build E2E: consent 4/4, CLS regression 2/2, responsive modes/deep links/forged marker 56/56
- WebKit exact-build E2E: consent 4/4, CLS regression 2/2, deep links/forged marker 8/8
- strict rendered matrix: 320, 390, 430, 767, 768, 1024, and 1440px; CLS 0 through 1024 and 0.00049 at 1440; no overflow; hero fill; one-card snap rail; dock clearance; 48px modal targets; zero Axe findings on the product surface
- component ship gate: PASS, 137 stories, all changed-component ratchets improved or held
- protected pre-push: full typecheck/lint, affected tests, mandatory partitions, and CI harness all green

## Performance

- optimized standalone alias medians: listen 84ms, music 81ms, subscribe 79ms, tip 78ms, releases 78ms, tour 88ms; all under the existing 100ms contract
- route scripts 915.1KB / 1050KB and total transfer 1105.6–1107.9KB / 1200KB pass
- the existing global stylesheet remains 139.1KB / 100KB; JOV-2269 owns that debt and this change does not widen or bypass the budget

## Scoped infrastructure note

- Storybook compiles all 137 stories and the component ship gate is green. The aggregate Storybook a11y runner remains blocked by the pre-existing addon/core version mismatch tracked in JOV-4419; direct product-surface Axe checks are green.

## Issues

- JOV-4783
- JOV-4788
