### PR TITLE
fix(profile): close consent and alias review gaps [JOV-4783] [JOV-4788]

### DIFF
--- a/apps/web/app/[username]/[...slug]/page.tsx
+++ b/apps/web/app/[username]/[...slug]/page.tsx
@@ -49,8 +49,12 @@ async function getAliasCollisionState(
 ) {
   const load = () =>
     Promise.all([
-      findRedirectByOldSlug(creatorProfileId, aliasSlug),
-      getUnpublishedReleasePresence(creatorProfileId, aliasSlug),
+      findRedirectByOldSlug(creatorProfileId, aliasSlug, {
+        onError: 'throw',
+      }),
+      getUnpublishedReleasePresence(creatorProfileId, aliasSlug, {
+        onError: 'throw',
+      }),
     ]);
 
   if (

--- a/apps/web/app/[username]/[slug]/_lib/data.ts
+++ b/apps/web/app/[username]/[slug]/_lib/data.ts
@@ -662,7 +662,8 @@ function rehydrateContent(
  */
 export async function getUnpublishedReleasePresence(
   creatorProfileId: string,
-  slug: string
+  slug: string,
+  options: { readonly onError?: 'return-null' | 'throw' } = {}
 ): Promise<{ readonly title: string } | null> {
   try {
     const [row] = await db
@@ -694,6 +695,7 @@ export async function getUnpublishedReleasePresence(
       },
       'public-smart-link'
     );
+    if (options.onError === 'throw') throw error;
     return null;
   }
 }

--- a/apps/web/components/organisms/CookieBannerSection.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.tsx
@@ -81,7 +81,7 @@ export function CookieBannerSection() {
 
     const root = document.documentElement;
 
-    if (!visible || isSuppressedPath) {
+    if (!visible || isSuppressedPath || customize) {
       root.style.removeProperty('--cookie-banner-h');
       return;
     }
@@ -122,7 +122,7 @@ export function CookieBannerSection() {
       globalThis.removeEventListener('resize', update);
       root.style.removeProperty('--cookie-banner-h');
     };
-  }, [visible, isSuppressedPath, shouldClearProfileDock]);
+  }, [visible, isSuppressedPath, shouldClearProfileDock, customize]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -203,10 +203,10 @@ export function CookieBannerSection() {
         <aside
           aria-label='Cookie Consent'
           data-testid='cookie-banner'
-          className={`cookie-banner-card fixed bottom-4 right-4 z-[60] w-[calc(100vw-2rem)] max-w-85 sm:max-w-95 ${
+          className={`cookie-banner-card fixed bottom-4 right-4 z-[60] w-[calc(100vw-2rem)] max-w-85 ${
             shouldClearProfileDock
               ? 'cookie-banner-card--above-public-profile-dock'
-              : ''
+              : 'sm:max-w-95'
           }`}
         >
           <div className='rounded-2xl border border-(--linear-app-frame-seam) bg-surface-1 shadow-card px-4 py-4'>

--- a/apps/web/lib/discography/slug.ts
+++ b/apps/web/lib/discography/slug.ts
@@ -293,7 +293,8 @@ export async function findContentBySlug(
  */
 export async function findRedirectByOldSlug(
   creatorProfileId: string,
-  oldSlug: string
+  oldSlug: string,
+  options: { readonly onError?: 'return-null' | 'throw' } = {}
 ): Promise<{ type: ContentType; currentSlug: string } | null> {
   try {
     const [redirect] = await withRetry(
@@ -330,6 +331,7 @@ export async function findRedirectByOldSlug(
       },
       'public-smart-link'
     );
+    if (options.onError === 'throw') throw error;
     return null;
   }
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -635,6 +635,20 @@
   }
 }
 
+@media (min-width: 768px) and (max-width: 1179px) {
+  /* The compact card is vertically centered at tablet and narrow-desktop
+     widths. Include that centered shell's bottom inset before clearing its
+     dock; the phone-only offset would otherwise leave the two surfaces
+     overlapping. */
+  .cookie-banner-card--above-public-profile-dock {
+    bottom: calc(
+      max(var(--page-pad), calc((100dvh - 740px) / 2)) +
+      var(--profile-bottom-nav-height) +
+      8px
+    );
+  }
+}
+
 /* Compact mobile home hero: one definite token-driven height on every
    viewport (--cover-height, clamp(220px, 34svh, 400px)). The hero never
    shrink-wraps; media crops via object-cover and the carousel below owns the

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -1011,6 +1011,8 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
       { label: 'compact edge', width: 767, height: 1024 },
       { label: 'tablet', width: 768, height: 1024 },
       { label: 'desktop', width: 1024, height: 1024 },
+      { label: 'compact desktop edge', width: 1179, height: 1024 },
+      { label: 'desktop layout edge', width: 1180, height: 1024 },
       { label: 'wide desktop', width: 1440, height: 1024 },
     ] as const;
 
@@ -1036,7 +1038,9 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
             if (!element) return null;
             const bounds = element.getBoundingClientRect();
             return {
+              left: bounds.left,
               top: bounds.top,
+              right: bounds.right,
               bottom: bounds.bottom,
               width: bounds.width,
               height: bounds.height,
@@ -1072,7 +1076,7 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
         Object.assign(banner.style, {
           position: 'fixed',
           right: '16px',
-          width: 'min(340px, calc(100vw - 32px))',
+          width: 'min(380px, calc(100vw - 32px))',
           height: '118px',
           zIndex: '60',
         });
@@ -1108,6 +1112,19 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
           after.banner?.bottom ?? Number.POSITIVE_INFINITY,
           'phone consent card should clear the glass dock'
         ).toBeLessThanOrEqual((after.dock?.top ?? 0) - 8);
+      }
+
+      if (after.banner && after.dock) {
+        const overlapsHorizontally =
+          after.banner.left < after.dock.right &&
+          after.banner.right > after.dock.left;
+        const overlapsVertically =
+          after.banner.top < after.dock.bottom &&
+          after.banner.bottom > after.dock.top;
+        expect(
+          overlapsHorizontally && overlapsVertically,
+          `${viewport.label} consent card must not cover the glass dock`
+        ).toBe(false);
       }
 
       await page.evaluate(() => {

--- a/apps/web/tests/unit/cookie-banner.test.tsx
+++ b/apps/web/tests/unit/cookie-banner.test.tsx
@@ -142,9 +142,15 @@ describe('CookieBannerSection', () => {
     );
   });
 
-  it('gives the preferences modal sole ownership of the consent surface', () => {
+  it('gives the preferences modal sole ownership of the consent surface', async () => {
     setCookie('jv_cc_required=1');
     render(<CookieBannerSection />);
+
+    await vi.waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--cookie-banner-h')
+      ).toBe('28px');
+    });
 
     fireEvent.click(screen.getByRole('button', { name: /customize/i }));
 
@@ -152,6 +158,11 @@ describe('CookieBannerSection', () => {
     expect(
       screen.getByRole('dialog', { name: /cookie preferences/i })
     ).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--cookie-banner-h')
+      ).toBe('');
+    });
 
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
 
@@ -159,6 +170,11 @@ describe('CookieBannerSection', () => {
       screen.queryByRole('dialog', { name: /cookie preferences/i })
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('cookie-banner')).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(
+        document.documentElement.style.getPropertyValue('--cookie-banner-h')
+      ).toBe('28px');
+    });
   });
 
   it('publishes --cookie-banner-h CSS var for coordinated floating surfaces', async () => {

--- a/apps/web/tests/unit/release/smart-link-metadata.test.ts
+++ b/apps/web/tests/unit/release/smart-link-metadata.test.ts
@@ -212,9 +212,37 @@ describe('smart-link metadata', () => {
     ).rejects.toThrow('NEXT_REDIRECT');
     expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledWith(
       'creator-1',
-      'music'
+      'music',
+      { onError: 'throw' }
+    );
+    expect(findRedirectByOldSlugMock).toHaveBeenCalledWith(
+      'creator-1',
+      'music',
+      { onError: 'throw' }
     );
     expect(redirectMock).toHaveBeenCalledWith('/dualipa?mode=listen&source=qr');
+  });
+
+  it('does not convert failed collision checks into a cached mode redirect', async () => {
+    getContentBySlugMock.mockResolvedValue(null);
+    findRedirectByOldSlugMock.mockRejectedValue(
+      new Error('collision lookup unavailable')
+    );
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+
+    await expect(
+      ProfileAliasResolverPage({
+        params: Promise.resolve({
+          username: 'dualipa',
+          slug: ['music', '__profile-mode-alias', 'resolve'],
+        }),
+      })
+    ).rejects.toThrow('collision lookup unavailable');
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(permanentRedirectMock).not.toHaveBeenCalled();
   });
 
   it('keeps renamed-release redirects ahead of matching mode aliases', async () => {


### PR DESCRIPTION
Follow-up to #15465 after the closed-loop reviewers identified three release gaps.

What changed
- clear the measured cookie-banner property while the preferences modal owns the consent surface, and restore it after Cancel
- keep the consent card clear of the centered profile dock through the 768-1179 compact layout band
- fail closed when legacy-alias collision lookups error, so a transient database failure cannot cache a false mode redirect
- extend regression coverage across the 1179/1180 boundary and the rejected collision lookup path

Exact-source verification
- optimized production build: 752/752 static routes
- typecheck, Biome, Tailwind guard, component ship gate: pass
- focused units: 35/35
- exact standalone Chromium and WebKit: cookie actions 6/6; nine-breakpoint dock/CLS contract 2/2; desktop public-profile CLS 8/8; redirects and forged markers 14/14
- protected pre-push affected/full mandatory partitions and CI harness: pass

Known unrelated budget
- global CSS remains above its separate 100 KB budget under JOV-2269; this patch does not weaken or bypass that guard.