### PR TITLE
feat: group artist destinations in left nav

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/lib/tracking/navigation-telemetry';
 import { CustomerNavMoreMenu } from './CustomerNavMoreMenu';
 import {
+  artistNavigation,
   artistSettingsNavigation,
   CUSTOMER_NAV_CAPACITY,
   partitionCustomerNavigation,
@@ -208,6 +209,10 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
   ]);
 
   const artistSettingsLabel = 'Artist';
+  const artistLabel =
+    selectedProfile?.displayName?.trim() ||
+    selectedProfile?.username?.trim() ||
+    'Artist';
 
   // Memoize nav sections for dashboard (non-settings) mode
   const navSections = useMemo<readonly DashboardNavSection[]>(
@@ -483,6 +488,15 @@ export function DashboardNav({ children: searchSurface }: DashboardNavProps) {
                   )}
                 </div>
               ))}
+              <div data-nav-section='artist'>
+                <SidebarCollapsibleGroup
+                  label={artistLabel}
+                  defaultOpen
+                  storageKey={`dashboard.artist.${profileId || 'selected'}`}
+                >
+                  {renderSection(artistNavigation)}
+                </SidebarCollapsibleGroup>
+              </div>
             </SidebarGroupContent>
           </SidebarGroup>
         )}

--- a/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
@@ -2,6 +2,7 @@ import { CalendarDays, CheckSquare, Music, SquarePen } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  artistNavigation,
   CUSTOMER_NAV_CAPACITY,
   customerNavVisibleCap,
   partitionCustomerNavigation,
@@ -51,15 +52,11 @@ describe('partitionCustomerNavigation', () => {
     expect(partition.visible.map(item => item.id)).toEqual([
       'chat',
       'inbox',
-      'library',
-    ]);
-    expect(partition.more.map(item => item.id)).toEqual([
-      'contacts',
       'profiles',
-      'calendar',
     ]);
+    expect(partition.more).toEqual([]);
     expect(partition.visible).toEqual(mobilePrimaryNavigation);
-    expect(partition.more).toEqual(mobileExpandedNavigation);
+    expect(mobileExpandedNavigation).toEqual(artistNavigation);
   });
 
   it('keeps the full approved core set on the desktop rail with an empty More', () => {
@@ -126,7 +123,7 @@ describe('partitionCustomerNavigation', () => {
     expect(partition.visible.map(item => item.id)).toEqual([
       'chat',
       'inbox',
-      'library',
+      'profiles',
     ]);
   });
 

--- a/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/capacity.test.ts
@@ -2,12 +2,12 @@ import { CalendarDays, CheckSquare, Music, SquarePen } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 import {
-  artistNavigation,
   CUSTOMER_NAV_CAPACITY,
   customerNavVisibleCap,
   partitionCustomerNavigation,
 } from './capacity';
 import {
+  artistNavigation,
   mobileExpandedNavigation,
   mobilePrimaryNavigation,
   primaryNavigation,

--- a/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  artistNavigation,
   CUSTOMER_NAV_CAPACITY,
   desktopMoreNavigation,
   desktopPrimaryNavigation,
@@ -13,13 +14,18 @@ import {
 const CANONICAL_NAVIGATION = [
   ['chat', 'New Chat', APP_ROUTES.CHAT],
   ['inbox', 'Inbox', APP_ROUTES.DASHBOARD],
+  ['profiles', 'Connections', APP_ROUTES.PROFILES],
+] as const;
+
+const ARTIST_NAVIGATION = [
   ['library', 'Library', APP_ROUTES.LIBRARY],
   ['contacts', 'Contacts', APP_ROUTES.CONTACTS],
-  ['profiles', 'Connections', APP_ROUTES.PROFILES],
   ['calendar', 'Calendar', APP_ROUTES.CALENDAR],
 ] as const;
 
-function toContract(items: readonly (typeof primaryNavigation)[number][]) {
+function toContract(
+  items: readonly { id: string; name: string; href: string }[]
+) {
   return items.map(item => [item.id, item.name, item.href]);
 }
 
@@ -39,23 +45,30 @@ describe('canonical customer shell navigation', () => {
     );
   });
 
+  it('keeps artist-scoped destinations together for the artist group shell', () => {
+    expect(toContract(artistNavigation)).toEqual(ARTIST_NAVIGATION);
+  });
+
   it('derives mobile primary + More destinations from the capacity partition', () => {
     const partition = partitionCustomerNavigation(primaryNavigation, {
       visibleCap: CUSTOMER_NAV_CAPACITY.mobilePrimaryVisible,
     });
 
     expect(mobilePrimaryNavigation).toEqual(partition.visible);
-    expect(mobileExpandedNavigation).toEqual(partition.more);
-    expect([...mobilePrimaryNavigation, ...mobileExpandedNavigation]).toEqual(
-      primaryNavigation
+    expect(mobileExpandedNavigation.slice(0, partition.more.length)).toEqual(
+      partition.more
     );
 
     for (const [index, item] of [
       ...mobilePrimaryNavigation,
-      ...mobileExpandedNavigation,
+      ...partition.more,
     ].entries()) {
       expect(item).toBe(primaryNavigation[index]);
     }
+
+    expect(mobileExpandedNavigation.slice(partition.more.length)).toEqual(
+      artistNavigation
+    );
   });
 
   it('keeps the full approved core set on desktop with no More overflow', () => {

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -98,9 +98,17 @@ export const calendarNavItem: NavItem = {
   description: 'See release dates, events, and calendar moments',
 };
 
+/** Destinations owned by the currently selected artist group. */
+export const artistNavigation = [
+  libraryNavItem,
+  contactsNavItem,
+  calendarNavItem,
+] as const satisfies readonly NavItem[];
+
 /**
- * Founder-approved customer shell IA. This ordered tuple is the only source
- * consumed by desktop and mobile navigation (JOV-3763).
+ * Founder-approved global customer shell IA. Artist-scoped destinations live
+ * in `artistNavigation` so the desktop rail can render them under the artist
+ * group while mobile keeps them in the expanded menu (JOV-4800).
  *
  * Capacity (JOV-4515): every entry here is `core` and must fit the desktop
  * primary rail. Mark new trial destinations `experimental` so they overflow
@@ -110,10 +118,7 @@ export const calendarNavItem: NavItem = {
 export const primaryNavigation = [
   chatNavItem,
   inboxNavItem,
-  libraryNavItem,
-  contactsNavItem,
   profilesNavItem,
-  calendarNavItem,
 ] as const satisfies readonly NavItem[];
 
 export const settingsNavItem: NavItem = {
@@ -236,6 +241,7 @@ export const mobilePrimaryNavigation: NavItem[] = [
 /** Items shown in the expanded "more" menu on mobile. */
 export const mobileExpandedNavigation: NavItem[] = [
   ...mobileDefaultPartition.more,
+  ...artistNavigation,
 ];
 
 export type {

--- a/apps/web/components/features/dashboard/dashboard-nav/index.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/index.ts
@@ -5,6 +5,7 @@ export type {
   PartitionCustomerNavigationOptions,
 } from './config';
 export {
+  artistNavigation,
   artistSettingsNavigation,
   CUSTOMER_NAV_CAPACITY,
   calendarNavItem,

--- a/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useMemo } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  artistNavigation,
   CUSTOMER_NAV_CAPACITY,
   isLibraryNavigationRoute,
   partitionCustomerNavigation,
@@ -79,7 +80,10 @@ export function DashboardMobileTabs({
     });
     return {
       primaryItems: partition.visible.map(toMenuItem),
-      expandedItems: partition.more.map(toMenuItem),
+      expandedItems: [
+        ...partition.more,
+        ...artistNavigation,
+      ].map(toMenuItem),
     };
   }, [activeItemId]);
 

--- a/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardMobileTabs.tsx
@@ -80,10 +80,7 @@ export function DashboardMobileTabs({
     });
     return {
       primaryItems: partition.visible.map(toMenuItem),
-      expandedItems: [
-        ...partition.more,
-        ...artistNavigation,
-      ].map(toMenuItem),
+      expandedItems: [...partition.more, ...artistNavigation].map(toMenuItem),
     };
   }, [activeItemId]);
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4800 -->

## Summary
- Add a persisted, keyboard-accessible selected-artist group to the authenticated desktop sidebar.
- Nest Library, Contacts, and Calendar under the artist group while keeping New Chat, Inbox, and Connections global.
- Keep the same artist destinations available in the mobile expanded menu.
- Releases remain represented by the existing Library route, preserving the current Library/Assets decision.

Fixes JOV-4800

## Validation
- `node --version` ✅ v22.23.1
- `pnpm --version` ✅ 9.15.4
- `pnpm install --offline --frozen-lockfile` ⚠️ blocked: missing cached `postcss-8.5.23.tgz`
- `pnpm install --frozen-lockfile` ⚠️ blocked by sandbox filesystem (`ERR_PNPM_EROFS`) while fetching uncached tarballs
- Biome and Vitest could not run because dependencies are not installed.
- Static review completed for the six touched navigation files.

## Screenshots
Not captured. Browser/runtime dependencies were unavailable in this workspace.

## Risk
This is the first IA slice using the currently selected artist as the representative group. Lease navigation is not fabricated because no lease route exists in the current application; the existing Library route remains the release/asset surface.