### PR TITLE
fix(ci): preserve staged profile access in performance gate

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -995,6 +995,8 @@ jobs:
           if [[ ! "$deployment_url" =~ ^https://jovie-[a-z0-9-]+-jovie\.vercel\.app$ ]]; then
             fail_performance_gate "Exact staged deployment URL is missing or invalid."
           fi
+          export EXPECTED_VERCEL_DEPLOYMENT_ORIGIN="$deployment_url"
+          export EXPECTED_VERCEL_ENVIRONMENT=production
 
           auth_state="$RUNNER_TEMP/uas-performance-auth-${GITHUB_RUN_ID}.json"
           dynamic_secrets_file="$RUNNER_TEMP/uas-performance-dynamic-secrets-${GITHUB_RUN_ID}"

--- a/apps/web/scripts/performance-budgets-guard.test.ts
+++ b/apps/web/scripts/performance-budgets-guard.test.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Browser, BrowserContext, Page } from '@playwright/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const playwrightMocks = vi.hoisted(() => ({
@@ -22,8 +22,10 @@ import {
   applyProfileWarmTransitionTimings,
   buildConfirmedPageResult,
   confirmTimingViolations,
+  createContextOptions,
   evaluateTimingConfirmation,
   loadGuardManifestRoutes,
+  loadPerformanceProtectedOriginCookies,
   measureSameRouteInteraction,
   measureWarmNavigationRoute,
   parseGuardCliArgs,
@@ -37,6 +39,29 @@ import type {
   PerfRouteDefinition,
   PerfTimingMetricName,
 } from './performance-route-manifest';
+
+const PROTECTED_DEPLOYMENT_URL = 'https://jovie-build123-jovie.vercel.app';
+
+function createProtectedOriginBrowserFixture(
+  cookies: readonly {
+    readonly domain: string;
+    readonly httpOnly: boolean;
+    readonly name: string;
+    readonly path: string;
+    readonly sameSite: 'Lax';
+    readonly secure: boolean;
+    readonly value: string;
+  }[]
+) {
+  const context = {
+    addCookies: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    cookies: vi.fn().mockResolvedValue(cookies),
+  } as unknown as BrowserContext;
+  const newContext = vi.fn().mockResolvedValue(context);
+  const browser = { newContext } as unknown as Browser;
+  return { browser, context, newContext };
+}
 
 function createConfirmationSample(
   metric: PerfTimingMetricName,
@@ -512,6 +537,184 @@ describe('performance budgets guard', () => {
 
     expect(playwrightMocks.chromiumLaunch).toHaveBeenCalledOnce();
     expect(playwrightMocks.browserClose).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'https://jov.ie',
+    'http://127.0.0.1:3000',
+    'https://foreign-project-foreign-team.vercel.app',
+  ])('keeps non-protected measurement target %s free of origin state', async baseUrl => {
+    const fixture = createProtectedOriginBrowserFixture([]);
+    const bootstrapOrigin = vi.fn();
+
+    await expect(
+      loadPerformanceProtectedOriginCookies(fixture.browser, baseUrl, {
+        bootstrapOrigin,
+      })
+    ).resolves.toEqual([]);
+
+    expect(fixture.newContext).not.toHaveBeenCalled();
+    expect(bootstrapOrigin).not.toHaveBeenCalled();
+  });
+
+  it('verifies staged access once and returns only exact-host infrastructure cookies', async () => {
+    const cookie = {
+      domain: 'jovie-build123-jovie.vercel.app',
+      httpOnly: true,
+      name: '__vercel_live_token',
+      path: '/',
+      sameSite: 'Lax' as const,
+      secure: true,
+      value: 'opaque-origin-cookie',
+    };
+    const fixture = createProtectedOriginBrowserFixture([cookie]);
+    const originBoundCookie = {
+      httpOnly: true,
+      name: cookie.name,
+      secure: true,
+      url: PROTECTED_DEPLOYMENT_URL,
+      value: cookie.value,
+    };
+    const bootstrapOrigin = vi.fn().mockResolvedValue([originBoundCookie]);
+
+    await expect(
+      loadPerformanceProtectedOriginCookies(
+        fixture.browser,
+        PROTECTED_DEPLOYMENT_URL,
+        { bootstrapOrigin }
+      )
+    ).resolves.toEqual([cookie]);
+
+    expect(fixture.newContext).toHaveBeenCalledWith({
+      storageState: { cookies: [], origins: [] },
+    });
+    expect(bootstrapOrigin).toHaveBeenCalledWith(PROTECTED_DEPLOYMENT_URL);
+    expect(fixture.context.addCookies).toHaveBeenCalledWith([
+      originBoundCookie,
+    ]);
+    expect(fixture.context.cookies).toHaveBeenCalledWith(
+      PROTECTED_DEPLOYMENT_URL
+    );
+    expect(fixture.context.close).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed and disposes the bootstrap context on unsafe cookie scope', async () => {
+    const fixture = createProtectedOriginBrowserFixture([
+      {
+        domain: '.jovie-build123-jovie.vercel.app',
+        httpOnly: true,
+        name: '__vercel_live_token',
+        path: '/',
+        sameSite: 'Lax',
+        secure: true,
+        value: 'unsafe-domain-cookie',
+      },
+    ]);
+
+    await expect(
+      loadPerformanceProtectedOriginCookies(
+        fixture.browser,
+        PROTECTED_DEPLOYMENT_URL,
+        {
+          bootstrapOrigin: vi.fn().mockResolvedValue([
+            {
+              httpOnly: true,
+              name: '__vercel_live_token',
+              secure: true,
+              url: PROTECTED_DEPLOYMENT_URL,
+              value: 'unsafe-domain-cookie',
+            },
+          ]),
+        }
+      )
+    ).rejects.toThrow('escaped the exact deployment host');
+
+    expect(fixture.context.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not create a browser context when immutable-build verification fails', async () => {
+    const fixture = createProtectedOriginBrowserFixture([]);
+
+    await expect(
+      loadPerformanceProtectedOriginCookies(
+        fixture.browser,
+        PROTECTED_DEPLOYMENT_URL,
+        {
+          bootstrapOrigin: vi
+            .fn()
+            .mockRejectedValue(new Error('wrong commit identity')),
+        }
+      )
+    ).rejects.toThrow('wrong commit identity');
+
+    expect(fixture.newContext).not.toHaveBeenCalled();
+  });
+
+  it('keeps public staged routes app-unauthenticated while attaching exact-host access', () => {
+    const route = {
+      requiresAuth: false,
+      viewport: { height: 844, width: 390 },
+    } as PerfRouteDefinition;
+    const authCookie = {
+      domain: 'jovie-build123-jovie.vercel.app',
+      name: 'better-auth.session_token',
+      path: '/',
+      secure: true,
+      value: 'app-session',
+    };
+    const protectedOriginCookie = {
+      domain: 'jovie-build123-jovie.vercel.app',
+      name: '__vercel_live_token',
+      path: '/',
+      secure: true,
+      value: 'origin-access',
+    };
+
+    expect(
+      createContextOptions(route, [authCookie], [protectedOriginCookie])
+    ).toEqual({
+      storageState: {
+        cookies: [protectedOriginCookie],
+        origins: [],
+      },
+      viewport: route.viewport,
+    });
+  });
+
+  it('merges verified origin access into authenticated contexts without stale duplicates', () => {
+    const route = {
+      requiresAuth: true,
+      viewport: { height: 844, width: 390 },
+    } as PerfRouteDefinition;
+    const authCookie = {
+      domain: 'jovie-build123-jovie.vercel.app',
+      name: 'better-auth.session_token',
+      path: '/',
+      secure: true,
+      value: 'app-session',
+    };
+    const staleProtectedOriginCookie = {
+      domain: 'jovie-20iadpkq2-jovie.vercel.app',
+      name: '__vercel_live_token',
+      path: '/',
+      secure: true,
+      value: 'stale-origin-access',
+    };
+    const protectedOriginCookie = {
+      ...staleProtectedOriginCookie,
+      value: 'verified-origin-access',
+    };
+
+    const options = createContextOptions(
+      route,
+      [authCookie, staleProtectedOriginCookie],
+      [protectedOriginCookie]
+    );
+
+    expect(options.storageState?.cookies).toEqual([
+      authCookie,
+      protectedOriginCookie,
+    ]);
   });
 
   it('does not pass a stalled warm destination from a persistent source shell', async () => {

--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -19,10 +19,11 @@ import {
   type PerfRouteDefinition,
   type PerfTimingMetricName,
 } from './performance-route-manifest';
+import protectedOriginModule from './vercel-protected-origin.cjs';
 
 type SameSiteValue = 'Lax' | 'None' | 'Strict';
 
-interface AuthCookie {
+export interface PerformanceContextCookie {
   readonly name: string;
   readonly value: string;
   readonly domain?: string;
@@ -33,6 +34,53 @@ interface AuthCookie {
   readonly secure?: boolean;
   readonly sameSite?: SameSiteValue;
 }
+
+interface AuthCookie extends PerformanceContextCookie {
+  readonly sameSite?: SameSiteValue;
+}
+
+interface OriginBoundCookie {
+  readonly httpOnly: boolean;
+  readonly name: string;
+  readonly secure: boolean;
+  readonly url: string;
+  readonly value: string;
+}
+
+interface ProtectedOriginDependencies {
+  readonly isProtectedDeployment: (baseUrl: string) => boolean;
+  readonly bootstrapOrigin: (
+    baseUrl: string
+  ) => Promise<readonly OriginBoundCookie[]>;
+}
+
+const { bootstrapOriginBoundAccess, isExactVercelDeploymentUrl } =
+  protectedOriginModule as {
+    readonly bootstrapOriginBoundAccess: (
+      baseUrl: string,
+      options: {
+        readonly bypassSecret?: string;
+        readonly expectedCommitSha?: string;
+        readonly expectedDeploymentOrigin?: string;
+        readonly expectedEnvironment?: string;
+      }
+    ) => Promise<{ readonly cookies: readonly OriginBoundCookie[] }>;
+    readonly isExactVercelDeploymentUrl: (baseUrl: string) => boolean;
+  };
+
+const DEFAULT_PROTECTED_ORIGIN_DEPENDENCIES: ProtectedOriginDependencies = {
+  bootstrapOrigin: async baseUrl => {
+    const access = await bootstrapOriginBoundAccess(baseUrl, {
+      bypassSecret: process.env.PLAYWRIGHT_VERCEL_BYPASS_SECRET,
+      expectedCommitSha:
+        process.env.EXPECTED_COMMIT_SHA ?? process.env.GITHUB_SHA,
+      expectedDeploymentOrigin: process.env.EXPECTED_VERCEL_DEPLOYMENT_ORIGIN,
+      expectedEnvironment: process.env.EXPECTED_VERCEL_ENVIRONMENT,
+    });
+    return access.cookies;
+  },
+  isProtectedDeployment: isExactVercelDeploymentUrl,
+};
 
 interface StorageStateFile {
   readonly cookies?: readonly AuthCookie[];
@@ -970,18 +1018,115 @@ function medianResourceValue(
   return medianNumber(samples.map(sample => sample.resourceValues[metric]));
 }
 
-function createContextOptions(
-  route: PerfRouteDefinition,
-  cookies: readonly AuthCookie[]
+function assertExactHostCookieScope(
+  cookie: PerformanceContextCookie,
+  expectedHostname: string
 ) {
-  const hasCookies = route.requiresAuth && cookies.length > 0;
+  const domain = cookie.domain?.toLowerCase();
+  if (
+    !domain ||
+    domain.startsWith('.') ||
+    domain !== expectedHostname ||
+    cookie.path !== '/' ||
+    cookie.secure !== true
+  ) {
+    throw new Error(
+      'Protected-origin performance state escaped the exact deployment host.'
+    );
+  }
+}
+
+/**
+ * Establish Vercel protection access once, verify the immutable build identity,
+ * and return only the resulting host-bound infrastructure cookies. The
+ * bootstrap context starts empty so app authentication can never leak into a
+ * public performance route.
+ */
+export async function loadPerformanceProtectedOriginCookies(
+  browser: Browser,
+  baseUrl: string,
+  dependencies: Partial<ProtectedOriginDependencies> = {}
+): Promise<readonly PerformanceContextCookie[]> {
+  const isProtectedDeployment =
+    dependencies.isProtectedDeployment ??
+    DEFAULT_PROTECTED_ORIGIN_DEPENDENCIES.isProtectedDeployment;
+  if (!isProtectedDeployment(baseUrl)) {
+    return [];
+  }
+
+  const bootstrapOrigin =
+    dependencies.bootstrapOrigin ??
+    DEFAULT_PROTECTED_ORIGIN_DEPENDENCIES.bootstrapOrigin;
+  const target = new URL(baseUrl);
+  const originBoundCookies = await bootstrapOrigin(baseUrl);
+  if (originBoundCookies.length === 0) {
+    throw new Error(
+      'Protected-origin performance bootstrap produced no browser cookie state.'
+    );
+  }
+  const context = await browser.newContext({
+    storageState: { cookies: [], origins: [] },
+  });
+  try {
+    await context.addCookies([...originBoundCookies]);
+    const cookies = await context.cookies(target.origin);
+    if (cookies.length === 0) {
+      throw new Error(
+        'Protected-origin performance bootstrap produced no browser cookie state.'
+      );
+    }
+    for (const cookie of cookies) {
+      assertExactHostCookieScope(cookie, target.hostname.toLowerCase());
+    }
+    return cookies;
+  } finally {
+    await context.close();
+  }
+}
+
+function cookieScopeKey(cookie: PerformanceContextCookie) {
+  let hostname = cookie.domain?.replace(/^\./, '').toLowerCase() ?? '';
+  if (!hostname && cookie.url) {
+    try {
+      hostname = new URL(cookie.url).hostname.toLowerCase();
+    } catch {
+      hostname = cookie.url.toLowerCase();
+    }
+  }
+  return `${cookie.name}\u0000${hostname}\u0000${cookie.path}`;
+}
+
+function mergeContextCookies(
+  authCookies: readonly AuthCookie[],
+  protectedOriginCookies: readonly PerformanceContextCookie[]
+) {
+  const cookies = new Map<string, PerformanceContextCookie>();
+  for (const cookie of authCookies) {
+    cookies.set(cookieScopeKey(cookie), cookie);
+  }
+  for (const cookie of protectedOriginCookies) {
+    cookies.set(cookieScopeKey(cookie), cookie);
+  }
+  return [...cookies.values()];
+}
+
+export function createContextOptions(
+  route: PerfRouteDefinition,
+  authCookies: readonly AuthCookie[],
+  protectedOriginCookies: readonly PerformanceContextCookie[] = []
+) {
+  const cookies = mergeContextCookies(
+    route.requiresAuth ? authCookies : [],
+    protectedOriginCookies
+  );
   return {
-    storageState: hasCookies
-      ? {
-          cookies: [...cookies],
-          origins: [],
-        }
-      : undefined,
+    storageState:
+      cookies.length > 0
+        ? {
+            cookies,
+            origins: [],
+          }
+        : undefined,
     viewport: route.viewport,
   };
 }
@@ -989,9 +1134,14 @@ function createContextOptions(
 async function createContext(
   browser: Browser,
   route: PerfRouteDefinition,
-  cookies: readonly AuthCookie[]
+  authCookies: readonly AuthCookie[],
+  protectedOriginCookies: readonly PerformanceContextCookie[]
 ) {
-  const options = createContextOptions(route, cookies);
+  const options = createContextOptions(
+    route,
+    authCookies,
+    protectedOriginCookies
+  );
   const context = await browser.newContext(options);
   return context;
 }
@@ -1012,13 +1162,19 @@ async function warmRoute(
   route: PerfRouteDefinition,
   baseUrl: string,
   url: string,
-  cookies: readonly AuthCookie[]
+  authCookies: readonly AuthCookie[],
+  protectedOriginCookies: readonly PerformanceContextCookie[]
 ) {
   if (route.warmupStrategy === 'none') {
     return;
   }
 
-  const context = await createContext(browser, route, cookies);
+  const context = await createContext(
+    browser,
+    route,
+    authCookies,
+    protectedOriginCookies
+  );
   try {
     const page = await context.newPage();
     if (route.warmupStrategy === 'authenticated-shell') {
@@ -1056,10 +1212,16 @@ async function measureRouteSample(
   baseUrl: string,
   url: string,
   resolvedPath: string,
-  cookies: readonly AuthCookie[],
+  authCookies: readonly AuthCookie[],
+  protectedOriginCookies: readonly PerformanceContextCookie[],
   devMode = false
 ): Promise<GuardSample> {
-  const context = await createContext(browser, route, cookies);
+  const context = await createContext(
+    browser,
+    route,
+    authCookies,
+    protectedOriginCookies
+  );
   try {
     const page = await context.newPage();
     await page.addInitScript(PERF_INIT_SCRIPT);
@@ -1523,6 +1685,10 @@ async function measureRoutesAgainstBudgets(
   const browser = await chromium.launch();
   try {
     const authCookies = loadAuthCookies(options.baseUrl, options.authPath);
+    const protectedOriginCookies = await loadPerformanceProtectedOriginCookies(
+      browser,
+      options.baseUrl
+    );
     const results: PageResult[] = [];
 
     for (const route of routes) {
@@ -1542,7 +1708,14 @@ async function measureRoutesAgainstBudgets(
       const url = resolveRouteUrl(options.baseUrl, resolvedPath);
       logInfo(`Checking ${route.id} -> ${resolvedPath}`, options);
 
-      await warmRoute(browser, route, options.baseUrl, url, authCookies);
+      await warmRoute(
+        browser,
+        route,
+        options.baseUrl,
+        url,
+        authCookies,
+        protectedOriginCookies
+      );
 
       const samples: GuardSample[] = [];
       for (let index = 0; index < options.runs; index += 1) {
@@ -1553,6 +1726,7 @@ async function measureRoutesAgainstBudgets(
           url,
           resolvedPath,
           authCookies,
+          protectedOriginCookies,
           devMode
         );
         samples.push(sample);
@@ -1597,6 +1771,7 @@ async function measureRoutesAgainstBudgets(
           url,
           resolvedPath,
           authCookies,
+          protectedOriginCookies,
           devMode
         );
         confirmationSamples.push(sample);

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1051,6 +1051,12 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(performanceStep).toContain(
       'PERFORMANCE_AUTH_STATE_PATH="$auth_state"'
     );
+    expect(performanceStep).toContain(
+      'export EXPECTED_VERCEL_DEPLOYMENT_ORIGIN="$deployment_url"'
+    );
+    expect(performanceStep).toContain(
+      'export EXPECTED_VERCEL_ENVIRONMENT=production'
+    );
     expect(performanceStep).toContain('--auth-path "$auth_state"');
     expect(performanceStep).toContain('--runs 3');
     expect(performanceStep).toContain(


### PR DESCRIPTION
## Outcome

Repairs the exact-staged production performance gate that blocked the already-merged public-profile release. The guard now bootstraps a host-bound Vercel protection cookie for the attested deployment and reuses it across every fresh measurement context without forwarding the bypass header.

Linear: JOV-4788

## Production failure reproduced

- Candidate build and staged canaries passed for main.
- Exact staged public-profile navigation budgets failed because fresh Playwright contexts were redirected to Vercel Authentication.
- Production promotion correctly remained skipped; this PR fixes that infrastructure boundary without weakening budgets, runs, or route coverage.

## Safety contract

- Only trusted Jovie Vercel deployment origins are eligible.
- Exact commit SHA, deployment origin, and environment are verified before cookies are accepted.
- Public routes receive only the protected-origin infrastructure cookie; application auth cookies remain isolated.
- Non-Vercel, local, production jov.ie, and foreign Vercel hosts do not bootstrap.
- Secrets and cookie values are never logged.

## Verification

- Independent strict review: PASS, no P0-P2 findings.
- Focused Vitest: 136/136 passing.
- Full required pre-push test partitions: passing.
- Typecheck, Biome, ESLint, repository hygiene, governance, CI harness: passing.
- Clean production build: 469/469 routes.
- Repository tracked-file hard limit: exactly 10,000.

## Bug-to-test

The regression is locked by unit coverage for eligible/ineligible origins, fail-closed attestation, exact-host secure cookies, context reuse, auth-cookie isolation, secret redaction, and workflow environment wiring.