### PR TITLE
fix(ops): harden Gem Linear transport

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/linear-client.transport.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/linear-client.transport.test.mjs
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import * as linear from '../linear-client.mjs';
+import { reconcileIssues } from '../reconcile.mjs';
+
+const jsonResponse = (
+  body,
+  { status = 200, contentType = 'application/json' } = {}
+) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: new Headers({ 'content-type': contentType }),
+  text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+});
+
+function withKey(key, fn) {
+  const previous = process.env.LINEAR_API_KEY;
+  process.env.LINEAR_API_KEY = key;
+  return Promise.resolve(fn()).finally(() => {
+    if (previous === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = previous;
+  });
+}
+
+describe('Gem Linear transport', () => {
+  it('accepts valid JSON, preserves the raw Authorization header, and returns data', async () => {
+    await withKey('linear-test-secret', async () => {
+      let request;
+      const data = await linear.graphql(
+        'query Viewer { viewer { id } }',
+        {},
+        {
+          fetchImpl: async (_url, options) => {
+            request = options;
+            return jsonResponse({ data: { viewer: { id: 'viewer-1' } } });
+          },
+        }
+      );
+      assert.deepEqual(data, { viewer: { id: 'viewer-1' } });
+      assert.ok(request);
+      const sent = /** @type {any} */ (request);
+      assert.equal(sent.headers.Authorization, 'linear-test-secret');
+      assert.equal(sent.headers['Content-Type'], 'application/json');
+    });
+  });
+
+  it('classifies non-JSON and malformed responses without exposing their body', async () => {
+    await withKey('body-secret', async () => {
+      await assert.rejects(
+        linear.graphql(
+          'query Html { viewer { id } }',
+          {},
+          {
+            maxAttempts: 1,
+            fetchImpl: async () =>
+              jsonResponse('<html>authorization: body-secret</html>', {
+                contentType: 'text/html',
+              }),
+          }
+        ),
+        error => {
+          const err = /** @type {any} */ (error);
+          return (
+            err.code === 'CONTENT_TYPE' &&
+            err.metadata.status === 200 &&
+            !JSON.stringify(err).includes('body-secret')
+          );
+        }
+      );
+
+      await assert.rejects(
+        linear.graphql(
+          'query Broken { viewer { id } }',
+          {},
+          {
+            maxAttempts: 1,
+            fetchImpl: async () =>
+              jsonResponse('{"data":', {
+                contentType: 'application/json; charset=utf-8',
+              }),
+          }
+        ),
+        error => {
+          const err = /** @type {any} */ (error);
+          return err.code === 'INVALID_JSON' && err.attempts === 1;
+        }
+      );
+    });
+  });
+
+  it('retries malformed JSON, 429, 5xx, and network failures with bounded backoff', async () => {
+    await withKey('retry-secret', async () => {
+      for (const sequence of [
+        [jsonResponse('{broken'), jsonResponse({ data: { ok: true } })],
+        [
+          jsonResponse({ error: 'busy' }, { status: 429 }),
+          jsonResponse({ data: { ok: true } }),
+        ],
+        [
+          jsonResponse({ error: 'down' }, { status: 503 }),
+          jsonResponse({ data: { ok: true } }),
+        ],
+        [
+          Object.assign(new Error('fetch failed'), { code: 'ECONNRESET' }),
+          jsonResponse({ data: { ok: true } }),
+        ],
+      ]) {
+        let attempts = 0;
+        const sleeps = [];
+        const data = await linear.graphql(
+          'query Retry { viewer { id } }',
+          {},
+          {
+            retryBaseMs: 3,
+            fetchImpl: async () => {
+              const result =
+                sequence[Math.min(attempts++, sequence.length - 1)];
+              if (result instanceof Error) throw result;
+              return result;
+            },
+            sleepImpl: async ms => sleeps.push(ms),
+          }
+        );
+        assert.deepEqual(data, { ok: true });
+        assert.equal(attempts, 2);
+        assert.deepEqual(sleeps, [3]);
+      }
+
+      await assert.rejects(
+        linear.graphql(
+          'query RetryExhausted { viewer { id } }',
+          {},
+          {
+            maxAttempts: 3,
+            retryBaseMs: 1,
+            fetchImpl: async () =>
+              jsonResponse({ error: 'still down' }, { status: 500 }),
+            sleepImpl: async () => {},
+          }
+        ),
+        error => {
+          const err = /** @type {any} */ (error);
+          return (
+            err.code === 'SERVER' &&
+            err.attempts === 3 &&
+            err.metadata.retryable === false
+          );
+        }
+      );
+    });
+  });
+
+  it('classifies auth, schema, deprecated, and ordinary GraphQL errors', () => {
+    assert.equal(
+      linear.classifyGraphQLErrors([{ message: 'Unauthorized' }]),
+      'AUTH'
+    );
+    assert.equal(
+      linear.classifyGraphQLErrors([
+        { message: 'Cannot query field "oldField"' },
+      ]),
+      'SCHEMA'
+    );
+    assert.equal(
+      linear.classifyGraphQLErrors([
+        { message: 'This endpoint is deprecated' },
+      ]),
+      'DEPRECATED'
+    );
+    assert.equal(
+      linear.classifyGraphQLErrors([{ message: 'something failed' }]),
+      'API'
+    );
+  });
+
+  it('keeps transport metadata allowlisted and bounds/redacts the response body', async () => {
+    await withKey('metadata-secret', async () => {
+      const body = `${'x'.repeat(400)} token=metadata-secret`;
+      await assert.rejects(
+        linear.graphql(
+          'query Metadata { viewer { id } }',
+          {},
+          {
+            maxAttempts: 1,
+            fetchImpl: async () =>
+              jsonResponse(body, { contentType: 'text/plain' }),
+          }
+        ),
+        error => {
+          const err = /** @type {any} */ (error);
+          assert.equal(err.code, 'CONTENT_TYPE');
+          assert.deepEqual(Object.keys(err.metadata).sort(), [
+            'attempt',
+            'contentType',
+            'retryable',
+            'status',
+          ]);
+          assert.ok(err.body.length <= linear.LINEAR_MAX_ERROR_BODY_LENGTH + 1);
+          assert.doesNotMatch(err.body, /metadata-secret/);
+          return true;
+        }
+      );
+    });
+  });
+
+  it('preserves supported identifier query and mutation payloads', async () => {
+    await withKey('query-secret', async () => {
+      const requests = [];
+      const fetchImpl = async (_url, options) => {
+        requests.push(JSON.parse(options.body));
+        return jsonResponse({
+          data: requests.at(-1).query.startsWith('mutation')
+            ? { issueUpdate: { success: true } }
+            : { issues: { nodes: [{ id: 'issue-1' }] } },
+        });
+      };
+      const issue = await linear.fetchIssue('JOV-123', { fetchImpl });
+      await linear.transitionIssue('issue-1', 'state-1', { fetchImpl });
+      assert.deepEqual(issue, { id: 'issue-1' });
+      assert.match(requests[0].query, /issues\s*\(/);
+      assert.doesNotMatch(requests[0].query, /issueSearch/);
+      assert.deepEqual(requests[0].variables, { teamKey: 'JOV', number: 123 });
+      assert.deepEqual(requests[1].variables, {
+        id: 'issue-1',
+        stateId: 'state-1',
+      });
+    });
+  });
+});
+
+describe('Gem reconciliation idempotency', () => {
+  it('does not duplicate a classification comment after reread', async () => {
+    const issue = {
+      id: 'issue-1',
+      identifier: 'JOV-1',
+      title: 'Transport repair',
+      description: 'test',
+      labels: { nodes: [] },
+      relations: { nodes: [] },
+      children: { nodes: [] },
+      state: { name: 'Triage', type: 'triage' },
+      comments: { nodes: [] },
+    };
+    let calls = 0;
+    const client = {
+      addComment: async (_id, body) => {
+        calls += 1;
+        issue.comments.nodes.push({ body });
+      },
+    };
+    await reconcileIssues({ issues: [issue], client });
+    issue.comments.nodes.push({ body: 'persisted' });
+    await reconcileIssues({ issues: [issue], client });
+    assert.equal(calls, 1);
+  });
+});

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -18,14 +18,41 @@ const API_URL = 'https://api.linear.app/graphql';
 export const LINEAR_REQUEST_TIMEOUT_MS = 10_000;
 export const LINEAR_MAX_ATTEMPTS = 3;
 export const LINEAR_RETRY_BASE_MS = 100;
+export const LINEAR_MAX_ERROR_BODY_LENGTH = 256;
+
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+const JSON_CONTENT_TYPE = /(^|;)\s*application\/json\s*(;|$)/i;
+
+function redactBody(value) {
+  const text = String(value ?? '')
+    .replace(/bearer\s+[^\s,;]+/gi, 'Bearer [REDACTED]')
+    .replace(
+      /(authorization|token|api[-_ ]?key|secret|password)\s*[:=]\s*[^,;\s]+/gi,
+      '$1=[REDACTED]'
+    );
+  return text.length > LINEAR_MAX_ERROR_BODY_LENGTH
+    ? `${text.slice(0, LINEAR_MAX_ERROR_BODY_LENGTH)}…`
+    : text;
+}
+
+function responseMetadata(response, attempt, extra = {}) {
+  return {
+    status: Number.isFinite(response?.status) ? response.status : undefined,
+    contentType: response?.headers?.get?.('content-type') || undefined,
+    attempt,
+    ...extra,
+  };
+}
 
 export class LinearTransportError extends Error {
   /** @param {string} message @param {any} [options] */
-  constructor(message, { code, cause, attempts } = {}) {
+  constructor(message, { code, cause, attempts, metadata, body } = {}) {
     super(message, { cause });
     this.name = 'LinearTransportError';
     this.code = code;
     this.attempts = attempts;
+    this.metadata = metadata;
+    if (body !== undefined) this.body = redactBody(body);
   }
 }
 
@@ -53,25 +80,38 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 /** @param {any[]} errors */
 export function classifyGraphQLErrors(errors) {
-  return errors.some(error =>
-    [error?.message, error?.extensions?.userPresentableMessage]
-      .filter(Boolean)
-      .some(message => /deprecated/i.test(message))
+  const messages = errors.flatMap(error =>
+    [error?.message, error?.extensions?.userPresentableMessage].filter(Boolean)
+  );
+  if (messages.some(message => /deprecated/i.test(message)))
+    return 'DEPRECATED';
+  if (
+    messages.some(message =>
+      /unauthori[sz]ed|invalid token|authentication/i.test(message)
+    )
   )
-    ? 'DEPRECATED'
-    : 'API';
+    return 'AUTH';
+  if (
+    messages.some(message =>
+      /cannot query field|unknown argument|validation|schema|syntax/i.test(
+        message
+      )
+    )
+  )
+    return 'SCHEMA';
+  return 'API';
 }
 
 /**
  * Bounded, retrying GraphQL transport. Only the API key is sent as the
- * normal Linear `Authorization: <key>` header; it is never logged or exposed
- * in an error. Retry is limited to transient network/timeout failures.
+ * normal Linear `Authorization` header; it is never logged or exposed in an
+ * error. Retry is bounded to network, malformed responses, 429, and 5xx.
  */
 export async function graphql(
   query,
   variables = {},
   {
-    fetchImpl = globalThis.fetch,
+    fetchImpl = /** @type {any} */ (globalThis.fetch),
     timeoutMs = LINEAR_REQUEST_TIMEOUT_MS,
     maxAttempts = LINEAR_MAX_ATTEMPTS,
     retryBaseMs = LINEAR_RETRY_BASE_MS,
@@ -93,7 +133,47 @@ export async function graphql(
         body: JSON.stringify({ query, variables }),
         signal: controller.signal,
       });
-      const data = /** @type {any} */ (await resp.json());
+      const contentType = resp?.headers?.get?.('content-type') || '';
+      const rawBody =
+        typeof resp?.text === 'function'
+          ? await resp.text()
+          : JSON.stringify(await resp.json());
+      const metadata = responseMetadata(resp, attempt);
+      if (contentType && !JSON_CONTENT_TYPE.test(contentType)) {
+        const error = /** @type {any} */ (
+          new Error('Linear response was not JSON')
+        );
+        error.code = 'CONTENT_TYPE';
+        error.retryable =
+          RETRYABLE_STATUS.has(resp?.status) || resp?.status >= 500;
+        throw Object.assign(error, { metadata, body: rawBody });
+      }
+      let data;
+      try {
+        data = JSON.parse(rawBody);
+      } catch (parseError) {
+        const error = /** @type {any} */ (
+          new Error('Linear response contained malformed JSON', {
+            cause: parseError,
+          })
+        );
+        error.code = 'INVALID_JSON';
+        error.retryable = true;
+        throw Object.assign(error, { metadata, body: rawBody });
+      }
+      if (resp?.ok === false || resp?.status >= 400) {
+        const error = /** @type {any} */ (
+          new Error(`Linear HTTP error (${resp.status})`)
+        );
+        error.code =
+          resp.status === 429
+            ? 'RATE_LIMITED'
+            : resp.status >= 500
+              ? 'SERVER'
+              : 'HTTP';
+        error.retryable = RETRYABLE_STATUS.has(resp.status);
+        throw Object.assign(error, { metadata, body: rawBody });
+      }
       if (data.errors) {
         const error = /** @type {any} */ (
           new Error(
@@ -101,23 +181,38 @@ export async function graphql(
           )
         );
         error.code = classifyGraphQLErrors(data.errors);
+        error.metadata = metadata;
+        throw error;
+      }
+      if (!data || typeof data !== 'object' || !Object.hasOwn(data, 'data')) {
+        const error = /** @type {any} */ (
+          new Error('Linear response had an invalid GraphQL shape')
+        );
+        error.code = 'SCHEMA';
+        error.metadata = metadata;
         throw error;
       }
       return data.data;
     } catch (error) {
-      lastError = error;
-      if (!isTransientNetworkError(error) || attempt === maxAttempts) {
+      const err = /** @type {any} */ (error);
+      lastError = err;
+      const retryable = Boolean(err?.retryable) || isTransientNetworkError(err);
+      if (!retryable || attempt === maxAttempts) {
         const code =
-          error?.name === 'AbortError' || error?.name === 'TimeoutError'
+          err?.name === 'AbortError' || err?.name === 'TimeoutError'
             ? 'TIMEOUT'
-            : isTransientNetworkError(error)
+            : isTransientNetworkError(err)
               ? 'NETWORK'
-              : error?.code === 'DEPRECATED'
-                ? 'DEPRECATED'
-                : 'API';
+              : err?.code || 'API';
         throw new LinearTransportError(
           `Linear GraphQL request failed (${code.toLowerCase()}, attempts=${attempt})`,
-          { code, cause: error, attempts: attempt }
+          {
+            code,
+            cause: isTransientNetworkError(err) ? err : undefined,
+            attempts: attempt,
+            metadata: { ...(err?.metadata || {}), retryable: false },
+            body: err?.body,
+          }
         );
       }
       await sleepImpl(retryBaseMs * 2 ** (attempt - 1));
@@ -370,7 +465,7 @@ export async function addComment(issueId, body) {
 /**
  * Transition an issue to a new state.
  */
-export async function transitionIssue(issueId, stateId) {
+export async function transitionIssue(issueId, stateId, options = {}) {
   return graphql(
     `
     mutation($id: String!, $stateId: String!) {
@@ -379,7 +474,8 @@ export async function transitionIssue(issueId, stateId) {
       }
     }
   `,
-    { id: issueId, stateId }
+    { id: issueId, stateId },
+    options
   );
 }
 


### PR DESCRIPTION
## Summary
- Harden Gem's Linear GraphQL transport with HTTP/content-type validation and bounded retries for malformed responses, network failures, 429, and 5xx.
- Add structured auth/schema/deprecated/API classification and bounded allowlisted metadata with redacted response bodies.
- Preserve supported identifier lookup and mutation payloads; add focused transport and reconciliation idempotency coverage.

## Verification
- `node --test scripts/backlog-orchestrator/__tests__/linear-client.transport.test.mjs scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` — 41 passed
- `node scripts/typecheck-scripts.mjs` — pass; 196 pre-existing baseline errors only
- `pnpm biome check --write ...` — pass
- repository pre-commit / pre-push gates — pass
- secret scan — pass

No Linear mutation, canary, concurrency increase, credential change, or audio action was performed.
