### PR TITLE
fix(desktop): keep profile links in app shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Mac/Electron profile links stay in the app shell (#15488):** canonical public artist/profile paths now remain in-app with existing history/back and URL allowlist behavior, while non-profile external destinations remain browser-bound.
 - **Presence becomes the artist's recurring visibility workspace (JOV-4799/JOV-4800):** Contacts remains global; single-artist accounts keep Library, Calendar, and Presence flat while multi-artist accounts group only those artist-owned destinations under the selected artist; Presence summarizes search visibility, answer readiness, audience quality, and monitored pages; Gmail and Calendar authorization live only in Settings → Connections; and the Artist Profiles page links to Fan Notifications and Instant Merch where those outcomes materially extend profile discovery.
 - [internal] **Desktop @types/node aligned to 26.x with monorepo:** Dependabot package bumps only; no DMG publish in this PR.
 - **New Chat stays quiet until a useful skill earns discovery (JOV-4790):** the empty composer omits generic filler such as Share Feedback; only explicitly featured installed skills may appear unprompted, while the existing command surfaces keep every registered utility available on demand.

--- a/apps/desktop/scripts/desktop-url-disposition.test.ts
+++ b/apps/desktop/scripts/desktop-url-disposition.test.ts
@@ -50,7 +50,15 @@ test('desktop disposition opens auth routes externally instead of in-app', () =>
   ]);
 });
 
-test('desktop disposition opens allowlisted public routes externally', () => {
+test('desktop disposition keeps exact public profile links in-app', () => {
+  assertDisposition(productionPolicy, 'in-app', [
+    'https://jov.ie/tim',
+    'https://jov.ie/tim/pay?source=qr',
+    'https://jov.ie/tim/summer-tour/sounds',
+  ]);
+});
+
+test('desktop disposition opens allowlisted non-profile routes externally', () => {
   assertDisposition(productionPolicy, 'external', [
     'https://jov.ie/',
     'https://jov.ie/legal/privacy',
@@ -60,9 +68,6 @@ test('desktop disposition opens allowlisted public routes externally', () => {
     'https://jov.ie/blog/the-contact-problem',
     'https://jov.ie/about',
     'https://jov.ie/download',
-    'https://jov.ie/tim',
-    'https://jov.ie/tim/pay?source=qr',
-    'https://jov.ie/tim/summer-tour/sounds',
     'https://jov.ie/docs/getting-started',
     'https://docs.jov.ie/getting-started',
     'mailto:support@jov.ie',
@@ -109,11 +114,11 @@ test('desktop disposition allows local app origin only when running locally', ()
   assertDisposition(localPolicy, 'in-app', [
     'http://127.0.0.1:3112/app',
     'http://127.0.0.1:3112/signin/sso-callback?desktop_return=%2Fapp',
+    'http://127.0.0.1:3112/tim',
   ]);
   assertDisposition(localPolicy, 'external', [
     'http://127.0.0.1:3112/',
     'http://127.0.0.1:3112/pricing',
-    'http://127.0.0.1:3112/tim',
   ]);
   assertDisposition(localPolicy, 'blocked', [
     'http://localhost:3112/app',

--- a/apps/desktop/src/navigation.ts
+++ b/apps/desktop/src/navigation.ts
@@ -10,6 +10,11 @@ export interface UrlDispositionOptions {
 
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
 
+// Public artist profiles are first-class in-app destinations in Electron. Keep
+// this route contract beside the URL disposition rules so profile links and
+// deep links cannot drift back to the browser classification.
+const PUBLIC_PROFILE_ROUTE_PREFIX = '/';
+
 /** External auth provider origins that may be opened in the system browser. */
 const AUTH_PROVIDER_ORIGINS = [
   'https://accounts.jov.ie',
@@ -220,7 +225,9 @@ export function isAllowedInAppUrl(
     ) ||
     AUTH_CALLBACK_ROUTE_PREFIXES.some(prefix =>
       matchesPathPrefix(parsed.pathname, prefix)
-    )
+    ) ||
+    (parsed.pathname.startsWith(PUBLIC_PROFILE_ROUTE_PREFIX) &&
+      isAllowedPublicProfilePath(parsed.pathname))
   );
 }
 


### PR DESCRIPTION
## Summary
- Fix Electron URL disposition so canonical public artist/profile routes stay inside the Mac app.
- Preserve existing allowlists: marketing/public non-profile routes remain external, unsafe/foreign URLs remain blocked.
- Covers production and local app origins and nested profile deep links.

Closes #15488

## Root cause
`apps/desktop/src/navigation.ts` classified public profile paths (`/<username>/...`) only as same-origin external routes. The main-window `will-navigate` and `setWindowOpenHandler` therefore called `shell.openExternal` instead of allowing the in-app navigation.

## Test plan
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Regression test: `apps/desktop/scripts/desktop-url-disposition.test.ts`
- [x] Red before fix: exact `https://jov.ie/tim` expected in-app but received `external` (1 failed, 7 passed)
- [x] Green after fix: desktop URL disposition 8/8 passed
- [x] Desktop shell contract 12/12 passed
- [x] Desktop typecheck passed
- [x] Web typecheck passed
- [x] `test:bug-to-test` satisfied
- [x] Biome, diff check, gitleaks, and TruffleHog passed

## Compatibility
- Auth handoff routes unchanged.
- Electron history/back remains native because profile navigations are now permitted in the existing window rather than redirected to a new external browser.
- Modifier-key behavior and genuinely external URLs are unchanged; no renderer link handlers were modified.

## Risk
Medium: desktop navigation classification only. No auth, credentials, production data, or audio changes.
