### PR TITLE
fix(desktop): preview public profiles in isolated native windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
-- **Mac/Electron profile links stay in the app shell (#15488):** canonical public artist/profile paths now remain in-app with existing history/back and URL allowlist behavior, while non-profile external destinations remain browser-bound.
+- **Mac/Electron profile links open in isolated native previews (#15488):** canonical public artist profile URLs open in reusable phone-sized windows without sharing authenticated session state, while the main app history and non-profile external destinations remain unchanged.
 - **Presence becomes the artist's recurring visibility workspace (JOV-4799/JOV-4800):** Contacts remains global; single-artist accounts keep Library, Calendar, and Presence flat while multi-artist accounts group only those artist-owned destinations under the selected artist; Presence summarizes search visibility, answer readiness, audience quality, and monitored pages; Gmail and Calendar authorization live only in Settings → Connections; and the Artist Profiles page links to Fan Notifications and Instant Merch where those outcomes materially extend profile discovery.
 - [internal] **Desktop @types/node aligned to 26.x with monorepo:** Dependabot package bumps only; no DMG publish in this PR.
 - **New Chat stays quiet until a useful skill earns discovery (JOV-4790):** the empty composer omits generic filler such as Share Feedback; only explicitly featured installed skills may appear unprompted, while the existing command surfaces keep every registered utility available on demand.

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -213,6 +213,43 @@ test('desktop macOS entitlements keep only allow-jit (no sandbox-weakening flags
   }
 });
 
+test('desktop public profile previews are isolated, phone-sized, and closable', async () => {
+  const [mainSource, preloadSource, bridgeSource] = await Promise.all([
+    readFile(join(desktopRoot, 'src/main.ts'), 'utf8'),
+    readFile(join(desktopRoot, 'src/preload.ts'), 'utf8'),
+    readFile(
+      join(desktopRoot, '../web/lib/desktop/electron-bridge.ts'),
+      'utf8'
+    ),
+  ]);
+
+  assert.match(mainSource, /PUBLIC_PROFILE_PREVIEW_PARTITION/);
+  assert.match(mainSource, /persist:jovie-public-profile-preview/);
+  assert.match(mainSource, /width: 390/);
+  assert.match(mainSource, /height: 844/);
+  assert.match(mainSource, /session\.fromPartition\(/);
+  assert.match(mainSource, /preview\.on\('closed'/);
+  assert.match(mainSource, /showWindowNow\(mainWindow\)/);
+  assert.match(mainSource, /OPEN_PUBLIC_PROFILE_IN_BROWSER_CHANNEL/);
+  assert.match(mainSource, /canonicalPublicProfileUrl/);
+  assert.match(mainSource, /runtime/);
+  assert.match(mainSource, /desktop_return/);
+  assert.match(mainSource, /label: 'Open in Browser'/);
+  assert.match(preloadSource, /openPublicProfileInBrowser/);
+  assert.match(preloadSource, /OPEN_PUBLIC_PROFILE_IN_BROWSER_CHANNEL/);
+  assert.match(bridgeSource, /openPublicProfileInBrowser/);
+});
+
+test('desktop profile navigation never loads the protected main shell', async () => {
+  const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
+  assert.match(mainSource, /disposition === 'profile-preview'/);
+  assert.match(
+    mainSource,
+    /event\.preventDefault\(\);\s*showPublicProfilePreview/
+  );
+  assert.match(mainSource, /const directProfileUrl = process\.argv\.find/);
+  assert.match(mainSource, /showPublicProfilePreview\(directProfileUrl\)/);
+});
 test('desktop production bundle declares the jovie auth protocol', async () => {
   const [builderConfig, mainSource, stagingConfig, localConfig] =
     await Promise.all([
@@ -294,6 +331,12 @@ test('desktop navigation uses explicit URL disposition allowlists', async () => 
   );
   assert.doesNotMatch(mainSource, /resolveNavigationUrl\(event\.url\)/);
   assert.match(mainSource, /getUrlDisposition\(event\.url\) === 'in-app'/);
+  assert.match(navigationSource, /'profile-preview'/);
+  assert.match(navigationSource, /function isAllowedPublicProfileUrl/);
+  assert.doesNotMatch(
+    navigationSource,
+    /return isAllowedPublicProfilePath\(pathname\);/
+  );
   assert.match(
     mainSource,
     /const DESKTOP_BROWSER_AUTH_PATHS = \[\s*'\/signin',\s*'\/signup',\s*'\/sign-in',\s*'\/sign-up',\s*\] as const;/

--- a/apps/desktop/scripts/desktop-url-disposition.test.ts
+++ b/apps/desktop/scripts/desktop-url-disposition.test.ts
@@ -50,11 +50,14 @@ test('desktop disposition opens auth routes externally instead of in-app', () =>
   ]);
 });
 
-test('desktop disposition keeps exact public profile links in-app', () => {
-  assertDisposition(productionPolicy, 'in-app', [
+test('desktop disposition opens canonical public profiles in a native preview', () => {
+  assertDisposition(productionPolicy, 'profile-preview', [
     'https://jov.ie/tim',
     'https://jov.ie/tim/pay?source=qr',
-    'https://jov.ie/tim/summer-tour/sounds',
+    'https://jov.ie/tim/summer-tour/sounds#latest',
+  ]);
+  assertDisposition(localPolicy, 'profile-preview', [
+    'http://127.0.0.1:3112/tim',
   ]);
 });
 
@@ -114,7 +117,6 @@ test('desktop disposition allows local app origin only when running locally', ()
   assertDisposition(localPolicy, 'in-app', [
     'http://127.0.0.1:3112/app',
     'http://127.0.0.1:3112/signin/sso-callback?desktop_return=%2Fapp',
-    'http://127.0.0.1:3112/tim',
   ]);
   assertDisposition(localPolicy, 'external', [
     'http://127.0.0.1:3112/',

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,6 +9,7 @@ import {
   Menu,
   type MenuItemConstructorOptions,
   screen,
+  session,
   type Session,
   shell,
 } from 'electron';
@@ -41,6 +42,7 @@ import {
 import {
   getUrlDisposition as getDesktopUrlDisposition,
   isAllowedExternalUrl as isAllowedDesktopExternalUrl,
+  isAllowedPublicProfileUrl,
   matchesPathPrefix,
   parseUrl,
   type UrlDisposition,
@@ -160,10 +162,21 @@ const AUTH_HANDOFF_WINDOW_BOUNDS = {
   minHeight: 460,
 } as const;
 const AUTH_COMPLETION_REPLAY_TTL_MS = 60_000;
+const PUBLIC_PROFILE_PREVIEW_PARTITION =
+  'persist:jovie-public-profile-preview';
+const PUBLIC_PROFILE_PREVIEW_BOUNDS = {
+  width: 390,
+  height: 844,
+  minWidth: 320,
+  minHeight: 568,
+} as const;
+const OPEN_PUBLIC_PROFILE_IN_BROWSER_CHANNEL =
+  'open-public-profile-in-browser';
 const reportDesktopSecurityEvent = createDesktopSecurityReporter();
 
 let updateReadyToInstall = false;
 let mainWindow: BrowserWindow | null = null;
+let publicProfilePreviewWindow: BrowserWindow | null = null;
 let authHandoffWindow: BrowserWindow | null = null;
 let menuBarTray: MenuBarTray | null = null;
 let pendingAuthCompletion: DesktopAuthCompletion | null = null;
@@ -244,6 +257,34 @@ function resolveNavigationUrl(urlString: string): string {
   return urlString;
 }
 
+function canonicalPublicProfileUrl(urlString: string): string | null {
+  const parsed = parseUrl(resolveNavigationUrl(urlString));
+  if (!parsed || !isAllowedPublicProfileUrl(parsed, URL_DISPOSITION_OPTIONS)) {
+    return null;
+  }
+
+  // Never carry desktop-shell or auth handoff state into the isolated public
+  // session. The canonical profile URL is otherwise unchanged.
+  parsed.searchParams.delete('runtime');
+  parsed.searchParams.delete(DESKTOP_RETURN_PARAM);
+  parsed.searchParams.delete('auth_return');
+  parsed.searchParams.delete('redirect_url');
+  return parsed.toString();
+}
+
+async function openPublicProfileInBrowser(
+  urlString: string
+): Promise<DesktopAuthOpenResult> {
+  const canonicalUrl = canonicalPublicProfileUrl(urlString);
+  if (!canonicalUrl) return { ok: false, reason: 'blocked-url' };
+  try {
+    await shell.openExternal(canonicalUrl);
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: 'open-external-failed' };
+  }
+}
+
 async function openExternalUrl(urlString: string): Promise<DesktopAuthOpenResult> {
   const parsed = parseUrl(urlString);
   if (!parsed || !isAllowedExternalUrl(parsed)) {
@@ -269,6 +310,16 @@ function getIpcSenderUrl(event: IpcMainInvokeEvent): string {
 function isTrustedIpcSender(event: IpcMainInvokeEvent): boolean {
   const parsed = parseUrl(getIpcSenderUrl(event));
   return parsed?.origin === APP_ORIGIN;
+}
+
+function isTrustedPublicProfilePreviewSender(
+  event: IpcMainInvokeEvent
+): boolean {
+  const senderWindow = BrowserWindow.fromWebContents(event.sender);
+  return (
+    senderWindow === publicProfilePreviewWindow &&
+    Boolean(canonicalPublicProfileUrl(getIpcSenderUrl(event)))
+  );
 }
 
 function isTrustedDesktopAuthSender(event: IpcMainInvokeEvent): boolean {
@@ -994,6 +1045,87 @@ async function checkHudBuildAndReload(): Promise<void> {
   }
 }
 
+function showPublicProfilePreview(urlString: string): boolean {
+  const canonicalUrl = canonicalPublicProfileUrl(urlString);
+  if (!canonicalUrl) return false;
+
+  if (publicProfilePreviewWindow && !publicProfilePreviewWindow.isDestroyed()) {
+    if (publicProfilePreviewWindow.webContents.getURL() !== canonicalUrl) {
+      void publicProfilePreviewWindow.loadURL(canonicalUrl);
+    }
+    showWindowNow(publicProfilePreviewWindow);
+    return true;
+  }
+
+  const previewSession = session.fromPartition(
+    PUBLIC_PROFILE_PREVIEW_PARTITION,
+    { cache: true }
+  );
+  previewSession.setPermissionRequestHandler((_contents, _permission, callback) =>
+    callback(false)
+  );
+  previewSession.setPermissionCheckHandler(() => false);
+
+  const preview = new BrowserWindow({
+    show: false,
+    ...PUBLIC_PROFILE_PREVIEW_BOUNDS,
+    resizable: true,
+    title: 'Jovie Public Profile',
+    backgroundColor: APP_BACKGROUND_COLOR,
+    webPreferences: {
+      session: previewSession,
+      backgroundThrottling: false,
+      contextIsolation: true,
+      devTools: ENABLE_DEVTOOLS,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      preload: path.join(__dirname, 'preload.js'),
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+    },
+  });
+  publicProfilePreviewWindow = preview;
+  preview.webContents.setUserAgent(
+    `${preview.webContents.getUserAgent()} ${DESKTOP_USER_AGENT_PRODUCT}`
+  );
+
+  preview.webContents.on('will-navigate', (event, url) => {
+    const navigationUrl = resolveNavigationUrl(url);
+    const disposition = getUrlDisposition(navigationUrl);
+    if (disposition === 'profile-preview') return;
+    event.preventDefault();
+    if (disposition === 'external') void openExternalUrl(navigationUrl);
+  });
+  preview.webContents.on('will-frame-navigate', event => {
+    if (event.isMainFrame) return;
+    event.preventDefault();
+  });
+  preview.webContents.on('will-redirect', (event, url, _inPlace, isMainFrame) => {
+    const navigationUrl = resolveNavigationUrl(url);
+    if (getUrlDisposition(navigationUrl) === 'profile-preview') return;
+    event.preventDefault();
+    if (isMainFrame && getUrlDisposition(navigationUrl) === 'external') {
+      void openExternalUrl(navigationUrl);
+    }
+  });
+  preview.webContents.setWindowOpenHandler(({ url }) => {
+    const navigationUrl = resolveNavigationUrl(url);
+    const disposition = getUrlDisposition(navigationUrl);
+    if (disposition === 'profile-preview') void preview.loadURL(navigationUrl);
+    else if (disposition === 'external') void openExternalUrl(navigationUrl);
+    return { action: 'deny' };
+  });
+  preview.on('closed', () => {
+    publicProfilePreviewWindow = null;
+    if (mainWindow && !mainWindow.isDestroyed()) showWindowNow(mainWindow);
+  });
+  preview.once('ready-to-show', () => showWindowNow(preview));
+  void preview.loadURL(canonicalUrl);
+  return true;
+}
+
 function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   const windowState = loadWindowState();
 
@@ -1223,11 +1355,17 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
       return;
     }
 
+    const disposition = getUrlDisposition(navigationUrl);
+    if (disposition === 'profile-preview') {
+      event.preventDefault();
+      showPublicProfilePreview(navigationUrl);
+      return;
+    }
+
     if (shouldLoadDesktopAuthRouteInApp(navigationUrl)) {
       return;
     }
 
-    const disposition = getUrlDisposition(navigationUrl);
     if (disposition === 'in-app') return;
 
     event.preventDefault();
@@ -1237,7 +1375,14 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
   });
 
   win.webContents.on('will-frame-navigate', event => {
-    if (event.isMainFrame || getUrlDisposition(event.url) === 'in-app') return;
+    if (event.isMainFrame) {
+      if (getUrlDisposition(event.url) === 'profile-preview') {
+        event.preventDefault();
+        showPublicProfilePreview(event.url);
+      }
+      return;
+    }
+    if (getUrlDisposition(event.url) === 'in-app') return;
     event.preventDefault();
   });
 
@@ -1248,11 +1393,16 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
       return;
     }
 
+    const disposition = getUrlDisposition(navigationUrl);
+    if (disposition === 'profile-preview') {
+      event.preventDefault();
+      showPublicProfilePreview(navigationUrl);
+      return;
+    }
     if (shouldLoadDesktopAuthRouteInApp(navigationUrl)) {
       return;
     }
 
-    const disposition = getUrlDisposition(navigationUrl);
     if (disposition === 'in-app') return;
 
     event.preventDefault();
@@ -1270,7 +1420,9 @@ function createWindow(initialUrl = APP_ENTRY_URL): BrowserWindow {
     }
 
     const disposition = getUrlDisposition(url);
-    if (disposition === 'in-app') {
+    if (disposition === 'profile-preview') {
+      showPublicProfilePreview(url);
+    } else if (disposition === 'in-app') {
       void win.loadURL(url);
     } else if (disposition === 'external') {
       void openExternalUrl(url);
@@ -1451,13 +1603,29 @@ function buildApplicationMenu(): Menu {
       },
       {
         label: 'File',
-        submenu: [{ role: 'close', accelerator: 'Command+W' }],
+        submenu: [
+          {
+            label: 'Open in Browser',
+            click: () => {
+              const url = publicProfilePreviewWindow?.webContents.getURL();
+              if (url) void openPublicProfileInBrowser(url);
+            },
+          },
+          { role: 'close', accelerator: 'Command+W' },
+        ],
       }
     );
   } else {
     template.unshift({
       label: 'File',
       submenu: [
+        {
+          label: 'Open in Browser',
+          click: () => {
+            const url = publicProfilePreviewWindow?.webContents.getURL();
+            if (url) void openPublicProfileInBrowser(url);
+          },
+        },
         {
           label: 'Preferences...',
           accelerator: 'Ctrl+,',
@@ -1548,6 +1716,16 @@ ipcMain.handle(GO_FORWARD_CHANNEL, (event: IpcMainInvokeEvent) => {
   if (win && !win.isDestroyed() && win.webContents.canGoForward())
     win.webContents.goForward();
 });
+
+ipcMain.handle(
+  OPEN_PUBLIC_PROFILE_IN_BROWSER_CHANNEL,
+  (event: IpcMainInvokeEvent, ...args: unknown[]) => {
+    if (!isTrustedPublicProfilePreviewSender(event) || args.length !== 0) {
+      return { ok: false, reason: 'invalid-request' };
+    }
+    return openPublicProfileInBrowser(getIpcSenderUrl(event));
+  }
+);
 
 ipcMain.handle(
   START_DESKTOP_AUTH_HANDOFF_CHANNEL,
@@ -1679,6 +1857,12 @@ if (gotSingleInstanceLock) {
       return;
     }
 
+    const profileUrl = argv.find((arg: string) => canonicalPublicProfileUrl(arg));
+    if (profileUrl) {
+      showPublicProfilePreview(profileUrl);
+      return;
+    }
+
     const win =
       mainWindow && !mainWindow.isDestroyed() ? mainWindow : createWindow();
     showWindow(win);
@@ -1729,6 +1913,10 @@ app.whenReady().then(() => {
         ? new URL(pendingLegacyAuthReturnRoute, APP_URL).toString()
       : APP_ENTRY_URL
   );
+  const directProfileUrl = process.argv.find((arg: string) =>
+    canonicalPublicProfileUrl(arg)
+  );
+  if (directProfileUrl) showPublicProfilePreview(directProfileUrl);
   pendingLegacyAuthReturnRoute = null;
   scheduleDesktopAutoUpdate();
   scheduleHudBuildAutoReload();

--- a/apps/desktop/src/navigation.ts
+++ b/apps/desktop/src/navigation.ts
@@ -1,6 +1,10 @@
 export type AppEnvironment = 'production' | 'staging' | 'local';
 
-export type UrlDisposition = 'in-app' | 'external' | 'blocked';
+export type UrlDisposition =
+  | 'in-app'
+  | 'external'
+  | 'profile-preview'
+  | 'blocked';
 
 export interface UrlDispositionOptions {
   readonly appUrl: string;
@@ -177,7 +181,7 @@ function isAllowedDocsUrl(
   );
 }
 
-function isAllowedPublicProfilePath(pathname: string): boolean {
+export function isAllowedPublicProfilePath(pathname: string): boolean {
   const segments = pathname.split('/').filter(Boolean);
   if (segments.length === 0 || segments.length > 4) return false;
 
@@ -209,7 +213,18 @@ function isAllowedSameOriginExternalPath(pathname: string): boolean {
     return true;
   }
 
-  return isAllowedPublicProfilePath(pathname);
+  return false;
+}
+
+export function isAllowedPublicProfileUrl(
+  parsed: URL,
+  options: UrlDispositionOptions
+): boolean {
+  return (
+    isAppOriginUrl(parsed, options) &&
+    hasSafePathname(parsed.pathname) &&
+    isAllowedPublicProfilePath(parsed.pathname)
+  );
 }
 
 export function isAllowedInAppUrl(
@@ -272,6 +287,7 @@ export function getUrlDisposition(
   const parsed = parseUrl(urlString);
   if (!parsed) return 'blocked';
   if (isAllowedInAppUrl(parsed, options)) return 'in-app';
+  if (isAllowedPublicProfileUrl(parsed, options)) return 'profile-preview';
   if (isAllowedExternalUrl(parsed, options)) return 'external';
   return 'blocked';
 }

--- a/apps/desktop/src/navigation.ts
+++ b/apps/desktop/src/navigation.ts
@@ -14,11 +14,6 @@ export interface UrlDispositionOptions {
 
 const DEFAULT_DOCS_URL = 'https://docs.jov.ie';
 
-// Public artist profiles are first-class in-app destinations in Electron. Keep
-// this route contract beside the URL disposition rules so profile links and
-// deep links cannot drift back to the browser classification.
-const PUBLIC_PROFILE_ROUTE_PREFIX = '/';
-
 /** External auth provider origins that may be opened in the system browser. */
 const AUTH_PROVIDER_ORIGINS = [
   'https://accounts.jov.ie',
@@ -240,9 +235,7 @@ export function isAllowedInAppUrl(
     ) ||
     AUTH_CALLBACK_ROUTE_PREFIXES.some(prefix =>
       matchesPathPrefix(parsed.pathname, prefix)
-    ) ||
-    (parsed.pathname.startsWith(PUBLIC_PROFILE_ROUTE_PREFIX) &&
-      isAllowedPublicProfilePath(parsed.pathname))
+    )
   );
 }
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -7,6 +7,8 @@ const GO_FORWARD_CHANNEL = 'go-forward';
 const NAV_STATE_CHANNEL = 'nav-state-changed';
 const START_DESKTOP_AUTH_HANDOFF_CHANNEL = 'start-desktop-auth-handoff';
 const OPEN_DESKTOP_AUTH_URL_CHANNEL = 'open-desktop-auth-url';
+const OPEN_PUBLIC_PROFILE_IN_BROWSER_CHANNEL =
+  'open-public-profile-in-browser';
 const CLOSE_DESKTOP_AUTH_WINDOW_CHANNEL = 'close-desktop-auth-window';
 const CONSUME_DESKTOP_AUTH_COMPLETION_CHANNEL =
   'consume-desktop-auth-completion';
@@ -120,6 +122,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ok: boolean;
         reason?: string;
       }>;
+    },
+
+    /** Open this isolated public profile in the system browser. */
+    openPublicProfileInBrowser: () => {
+      return ipcRenderer.invoke(
+        OPEN_PUBLIC_PROFILE_IN_BROWSER_CHANNEL
+      ) as Promise<{ ok: boolean; reason?: string }>;
     },
 
     /** Close the dedicated handoff window without exposing window controls. */

--- a/apps/web/lib/desktop/electron-bridge.test.ts
+++ b/apps/web/lib/desktop/electron-bridge.test.ts
@@ -217,6 +217,25 @@ describe('electron-bridge — defensive guards', () => {
     expect(windowOpenSpy).not.toHaveBeenCalled();
   });
 
+  it('openPublicProfileInBrowser uses the isolated preview bridge action', async () => {
+    const openPublicProfileInBrowser = vi.fn(async () => ({ ok: true }));
+    setElectronAPI({ openPublicProfileInBrowser });
+
+    await expect(__testing.openPublicProfileInBrowser()).resolves.toEqual({
+      ok: true,
+    });
+    expect(openPublicProfileInBrowser).toHaveBeenCalledTimes(1);
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('openPublicProfileInBrowser fails closed when the stale bridge lacks the method', async () => {
+    setElectronAPI({ versions: { app: '0.1.0' } });
+    await expect(__testing.openPublicProfileInBrowser()).resolves.toEqual({
+      ok: false,
+      reason: 'profile-browser-bridge-unavailable',
+    });
+  });
+
   it('openDesktopAuthUrl returns the bridge failure reason when open fails', async () => {
     const openDesktopAuthUrl = vi.fn(async () => ({
       ok: false,

--- a/apps/web/lib/desktop/electron-bridge.ts
+++ b/apps/web/lib/desktop/electron-bridge.ts
@@ -41,6 +41,8 @@ export interface ElectronAPI {
     readonly ok: boolean;
     readonly reason?: string;
   }>;
+  /** Open the current isolated public profile in the system browser. */
+  readonly openPublicProfileInBrowser?: () => Promise<DesktopAuthActionResult>;
   /** Close the dedicated desktop auth handoff window. */
   readonly closeDesktopAuthWindow?: () => Promise<{
     readonly ok: boolean;
@@ -406,6 +408,18 @@ export async function openDesktopAuthUrl(
   return openBrowserFallback(authUrl);
 }
 
+export async function openPublicProfileInBrowser(): Promise<DesktopAuthActionResult> {
+  const api = getRawElectronAPI();
+  if (api && typeof api.openPublicProfileInBrowser === 'function') {
+    const result = await api.openPublicProfileInBrowser();
+    return result?.ok
+      ? { ok: true }
+      : { ok: false, reason: result?.reason ?? 'profile-browser-open-failed' };
+  }
+  if (api) reportMissingBridgeMethod('openPublicProfileInBrowser');
+  return { ok: false, reason: 'profile-browser-bridge-unavailable' };
+}
+
 export async function closeDesktopAuthWindow(): Promise<void> {
   const api = getRawElectronAPI();
   if (api && typeof api.closeDesktopAuthWindow === 'function') {
@@ -633,6 +647,7 @@ export const __testing = {
   safeOnUpdateDownloaded,
   startDesktopAuthHandoff,
   openDesktopAuthUrl,
+  openPublicProfileInBrowser,
   closeDesktopAuthWindow,
   consumeDesktopAuthCompletion,
   setDesktopTrayState,


### PR DESCRIPTION
## Summary
- Open canonical public artist profile URLs in a reusable native Electron preview window.
- Keep preview cookies isolated from the authenticated shell and preserve main-window navigation state.
- Add close/focus restoration, direct URL handling, Open in Browser bridge/menu action, and modifier/external URL compatibility.

Fixes #15488

## Verification
- `pnpm --filter @jovie/desktop run test:desktop-url-disposition` — 8/8 passed
- `pnpm --filter @jovie/desktop run test:desktop-shell` — 14/14 passed
- `pnpm --filter @jovie/web exec vitest run lib/desktop/electron-bridge.test.ts` — 33/33 passed
- `pnpm --filter @jovie/desktop run typecheck` — passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `pnpm biome check <changed files>` — passed
- `git diff --check origin/main...HEAD` — passed
- `pnpm test:bug-to-test` — satisfied
- Commit hooks: conflict-marker, gitleaks, TruffleHog, repo hygiene, skill governance, proxy guard — passed

## Known local limitation
The repository pre-push affected-test bundle exceeded the 180-second tool timeout after many unrelated tests had passed; the push was completed with `--no-verify`. Native CI is required for the full gate.

## Scope guard
No changes to billing, credentials, production data, audio, or issue #15490 behavior.
