### PR TITLE
perf(profile): cache collision-safe mode aliases

### DIFF
--- a/apps/web/app/[username]/[...slug]/page.tsx
+++ b/apps/web/app/[username]/[...slug]/page.tsx
@@ -20,27 +20,50 @@ import { REDIRECT_SINK_METADATA } from '@/lib/profile/metadata';
 
 const PROFILE_MODE_ALIAS_MARKER = '__profile-mode-alias';
 const PROFILE_MODE_ALIAS_RESOLVER = 'resolve';
+const PROFILE_MODE_ALIAS_CACHEABLE_SOURCES = new Set(['link', 'qr']);
+
+// This resolver contains no request-bound Dynamic API. Keeping the supported
+// attribution value in the private rewrite path lets Next cache the collision
+// decision and redirect at the edge while refreshing it on the same five-minute
+// cadence as the underlying collision data.
+export const revalidate = 300;
+
+// Opt unknown catch-all params into on-demand ISR. Returning an empty set is
+// intentional: real handles/slugs are discovered at request time, then the
+// resulting redirect, smart-link, or 404 is refreshed by `revalidate` above.
+export function generateStaticParams() {
+  return [];
+}
 
 interface CatchAllPageProps {
   readonly params: Promise<{
     readonly username: string;
     readonly slug: string[];
   }>;
-  readonly searchParams?: Promise<{
-    readonly source?: string | string[];
-  }>;
 }
 
-function getAliasSlug(slug: readonly string[]): string | null {
+interface ProfileModeAliasRequest {
+  readonly aliasSlug: string;
+  readonly source?: string;
+}
+
+function getAliasRequest(
+  slug: readonly string[]
+): ProfileModeAliasRequest | null {
   if (
-    slug.length !== 3 ||
+    (slug.length !== 3 && slug.length !== 4) ||
     slug[1] !== PROFILE_MODE_ALIAS_MARKER ||
     slug[2] !== PROFILE_MODE_ALIAS_RESOLVER
   ) {
     return null;
   }
   const aliasSlug = slug[0];
-  return aliasSlug && isLegacyProfileModeAlias(aliasSlug) ? aliasSlug : null;
+  if (!aliasSlug || !isLegacyProfileModeAlias(aliasSlug)) return null;
+
+  const source = slug[3]?.trim();
+  return source && PROFILE_MODE_ALIAS_CACHEABLE_SOURCES.has(source)
+    ? { aliasSlug, source }
+    : { aliasSlug };
 }
 
 async function getAliasCollisionState(
@@ -85,10 +108,10 @@ export async function generateMetadata({
   params,
 }: CatchAllPageProps): Promise<Metadata> {
   const { username, slug } = await params;
-  const aliasSlug = getAliasSlug(slug);
-  if (aliasSlug) {
+  const aliasRequest = getAliasRequest(slug);
+  if (aliasRequest) {
     return generateContentSmartLinkMetadata({
-      params: Promise.resolve({ username, slug: aliasSlug }),
+      params: Promise.resolve({ username, slug: aliasRequest.aliasSlug }),
     });
   }
   return REDIRECT_SINK_METADATA;
@@ -96,24 +119,30 @@ export async function generateMetadata({
 
 export default async function CatchAllPage({
   params,
-  searchParams,
 }: Readonly<CatchAllPageProps>) {
   const { username, slug } = await params;
-  const aliasSlug = getAliasSlug(slug);
-  if (!aliasSlug) notFound();
+  const aliasRequest = getAliasRequest(slug);
+  if (!aliasRequest) notFound();
 
   const creator = await getCreatorByUsername(username.toLowerCase());
   if (!creator) notFound();
 
-  const content = await getContentBySlug(creator.id, aliasSlug);
+  // Start the collision checks with the content lookup. The common mode-alias
+  // path no longer pays a second serial cache/database stage after proving the
+  // slug is not renderable content. Published content keeps precedence: a
+  // collision-check failure is ignored when the canonical renderer already won.
+  const collisionStatePromise = getAliasCollisionState(
+    creator.id,
+    aliasRequest.aliasSlug
+  ).then(
+    value => ({ ok: true as const, value }),
+    error => ({ error, ok: false as const })
+  );
+  const content = await getContentBySlug(creator.id, aliasRequest.aliasSlug);
   if (!content) {
-    // Both collision checks are read-only and independent. Starting them
-    // together preserves the precedence below while removing one full remote
-    // database round trip from every warmed legacy deep link (JOV-4788).
-    const [oldSlugRedirect, unpublished] = await getAliasCollisionState(
-      creator.id,
-      aliasSlug
-    );
+    const collisionState = await collisionStatePromise;
+    if (!collisionState.ok) throw collisionState.error;
+    const [oldSlugRedirect, unpublished] = collisionState.value;
     if (oldSlugRedirect) {
       permanentRedirect(
         `/${creator.usernameNormalized}/${oldSlugRedirect.currentSlug}`
@@ -123,8 +152,8 @@ export default async function CatchAllPage({
     if (!unpublished) {
       const legacyModeHref = getLegacyProfileModeRedirectHref(
         creator.usernameNormalized,
-        aliasSlug,
-        await searchParams
+        aliasRequest.aliasSlug,
+        aliasRequest.source ? { source: aliasRequest.source } : undefined
       );
       if (legacyModeHref) redirect(legacyModeHref);
       notFound();
@@ -138,7 +167,7 @@ export default async function CatchAllPage({
     <ContentSmartLinkPage
       params={Promise.resolve({
         username: creator.usernameNormalized,
-        slug: aliasSlug,
+        slug: aliasRequest.aliasSlug,
       })}
     />
   );

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -440,6 +440,11 @@ const nextConfig = {
     ];
   },
   async rewrites() {
+    // Only sources issued by Jovie's legacy QR/link helpers become ISR path
+    // variants. Arbitrary query values still resolve through the source-less
+    // fallback below, so reserved characters cannot alter the private path or
+    // create an unbounded cache-key surface.
+    const profileModeAliasSourcePattern = '^(?<profileSource>link|qr)$';
     const profileModeAliasRewrites = [
       'listen',
       'music',
@@ -447,10 +452,23 @@ const nextConfig = {
       'subscribe',
       'tip',
       'tour',
-    ].map(alias => ({
-      source: `/:username/${alias}`,
-      destination: `/:username/${alias}/__profile-mode-alias/resolve`,
-    }));
+    ].flatMap(alias => [
+      {
+        source: `/:username/${alias}`,
+        has: [
+          {
+            type: 'query',
+            key: 'source',
+            value: profileModeAliasSourcePattern,
+          },
+        ],
+        destination: `/:username/${alias}/__profile-mode-alias/resolve/:profileSource`,
+      },
+      {
+        source: `/:username/${alias}`,
+        destination: `/:username/${alias}/__profile-mode-alias/resolve`,
+      },
+    ]);
 
     return {
       beforeFiles: [],

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -73,7 +73,50 @@ function redirectSignedOutElectronAppShell(req: NextRequest): NextResponse {
 }
 
 function isReservedProfileAliasMarkerPath(pathname: string): boolean {
-  return pathname.split('/').includes('__profile-mode-alias');
+  return pathname.split('/').some(segment => {
+    try {
+      return decodeURIComponent(segment) === '__profile-mode-alias';
+    } catch {
+      // Next decodes route params after proxy execution. Reject malformed
+      // escapes here so no ambiguous segment can reach the private resolver.
+      return true;
+    }
+  });
+}
+
+const LEGACY_PROFILE_MODE_ALIASES = new Set([
+  'listen',
+  'music',
+  'releases',
+  'subscribe',
+  'tip',
+  'tour',
+]);
+
+function getDuplicateAliasSourceRedirect(
+  req: NextRequest
+): NextResponse | null {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return null;
+
+  const segments = req.nextUrl.pathname.split('/').filter(Boolean);
+  if (
+    segments.length !== 2 ||
+    !LEGACY_PROFILE_MODE_ALIASES.has(segments[1] ?? '')
+  ) {
+    return null;
+  }
+
+  const sources = req.nextUrl.searchParams.getAll('source');
+  if (sources.length <= 1) return null;
+
+  // The established redirect helper keeps the first non-empty source. Next's
+  // rewrite matcher otherwise selects the last repeated value, so collapse the
+  // request once at the public boundary before it can become an ISR cache key.
+  const source = sources.find(value => value.length > 0);
+  const canonicalUrl = req.nextUrl.clone();
+  canonicalUrl.searchParams.delete('source');
+  if (source) canonicalUrl.searchParams.set('source', source);
+  return NextResponse.redirect(canonicalUrl, 307);
 }
 
 export default async function middleware(
@@ -98,6 +141,9 @@ export default async function middleware(
   if (isReservedProfileAliasMarkerPath(req.nextUrl.pathname)) {
     return createFastNotFoundResponse();
   }
+
+  const duplicateAliasSourceRedirect = getDuplicateAliasSourceRedirect(req);
+  if (duplicateAliasSourceRedirect) return duplicateAliasSourceRedirect;
 
   const hostInfo = analyzeHost(req.nextUrl.hostname);
   if (hostInfo.isSupportHost) {

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -292,6 +292,10 @@ describe('proxy.ts middleware', () => {
       '/dualipa/music/__profile-mode-alias/resolve',
       '/dualipa/listen/__profile-mode-alias/resolve',
       '/tim/subscribe/__profile-mode-alias/resolve',
+      '/tim/subscribe/__profile-mode-alias/resolve/qr',
+      `/tim/subscribe/__profile-mode-alias/resolve/${'q'.repeat(256)}`,
+      '/tim/subscribe/__profile%2Dmode%2Dalias/resolve/qr',
+      '/tim/subscribe/%5F%5Fprofile-mode-alias/resolve/qr',
     ])('returns 404 for direct marker path %s before auth', async path => {
       const req = createUnauthenticatedRequest({ pathname: path });
       const res = await callMiddleware(req);
@@ -307,6 +311,40 @@ describe('proxy.ts middleware', () => {
       const res = await callMiddleware(req);
 
       expect(res.status).not.toBe(404);
+    });
+
+    it('canonicalizes repeated alias sources to the first non-empty value', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname:
+          '/dualipa/music?campaign=summer&source=&source=link&source=qr',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBe(307);
+      const location = new URL(
+        res.headers.get('location') ?? '',
+        'https://localhost'
+      );
+      expect(location.pathname).toBe('/dualipa/music');
+      expect(location.searchParams.getAll('source')).toEqual(['link']);
+      expect(location.searchParams.get('campaign')).toBe('summer');
+      expect(mocks.getSessionCookie).not.toHaveBeenCalled();
+      expect(mocks.checkProfileVisitorBlocked).not.toHaveBeenCalled();
+    });
+
+    it('removes repeated empty alias sources without redirecting elsewhere', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/dualipa/tour?source=&source=',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBe(307);
+      const location = new URL(
+        res.headers.get('location') ?? '',
+        'https://localhost'
+      );
+      expect(location.pathname).toBe('/dualipa/tour');
+      expect(location.searchParams.has('source')).toBe(false);
     });
   });
 

--- a/apps/web/tests/unit/profile/public-profile-page.test.ts
+++ b/apps/web/tests/unit/profile/public-profile-page.test.ts
@@ -863,14 +863,42 @@ describe('profile mode route redirects', () => {
     const nextConfig = nextConfigModule.default ?? nextConfigModule;
     const afterFiles = getAfterFilesRewrites(await nextConfig.rewrites());
 
-    expect(afterFiles.slice(0, 6)).toEqual(
-      ['listen', 'music', 'releases', 'subscribe', 'tip', 'tour'].map(
-        alias => ({
-          source: `/:username/${alias}`,
-          destination: `/:username/${alias}/__profile-mode-alias/resolve`,
-        })
+    expect(afterFiles.slice(0, 12)).toEqual(
+      ['listen', 'music', 'releases', 'subscribe', 'tip', 'tour'].flatMap(
+        alias => [
+          {
+            source: `/:username/${alias}`,
+            has: [
+              {
+                type: 'query',
+                key: 'source',
+                value: '^(?<profileSource>link|qr)$',
+              },
+            ],
+            destination: `/:username/${alias}/__profile-mode-alias/resolve/:profileSource`,
+          },
+          {
+            source: `/:username/${alias}`,
+            destination: `/:username/${alias}/__profile-mode-alias/resolve`,
+          },
+        ]
       )
     );
+  });
+
+  it('bounds cacheable attribution variants to Jovie-issued source values', async () => {
+    const nextConfigModule = await import('../../../next.config.js');
+    const nextConfig = nextConfigModule.default ?? nextConfigModule;
+    const afterFiles = getAfterFilesRewrites(await nextConfig.rewrites());
+    const sourcePattern = new RegExp(afterFiles[0]?.has?.[0]?.value ?? '');
+
+    expect(sourcePattern.test('qr')).toBe(true);
+    expect(sourcePattern.test('link')).toBe(true);
+    expect(sourcePattern.test('qr-code')).toBe(false);
+    expect(sourcePattern.test('email blast')).toBe(false);
+    expect(sourcePattern.test('a/b')).toBe(false);
+    expect(sourcePattern.test('x#y')).toBe(false);
+    expect(sourcePattern.test('q'.repeat(65))).toBe(false);
   });
 
   it.each([

--- a/apps/web/tests/unit/release/smart-link-metadata.test.ts
+++ b/apps/web/tests/unit/release/smart-link-metadata.test.ts
@@ -184,14 +184,22 @@ describe('smart-link metadata', () => {
     const result = await ProfileAliasResolverPage({
       params: Promise.resolve({
         username: 'dualipa',
-        slug: ['music', '__profile-mode-alias', 'resolve'],
+        slug: ['music', '__profile-mode-alias', 'resolve', 'qr'],
       }),
-      searchParams: Promise.resolve({ source: 'qr' }),
     });
 
     expect(result).toBeTruthy();
     expect(redirectMock).not.toHaveBeenCalled();
-    expect(getUnpublishedReleasePresenceMock).not.toHaveBeenCalled();
+    expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledOnce();
+  });
+
+  it('keeps collision-safe alias decisions eligible for on-demand ISR', async () => {
+    const { generateStaticParams, revalidate } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+
+    expect(generateStaticParams()).toEqual([]);
+    expect(revalidate).toBe(300);
   });
 
   it('uses a matching mode alias only after content lookups miss', async () => {
@@ -205,9 +213,8 @@ describe('smart-link metadata', () => {
       ProfileAliasResolverPage({
         params: Promise.resolve({
           username: 'dualipa',
-          slug: ['music', '__profile-mode-alias', 'resolve'],
+          slug: ['music', '__profile-mode-alias', 'resolve', 'qr'],
         }),
-        searchParams: Promise.resolve({ source: 'qr' }),
       })
     ).rejects.toThrow('NEXT_REDIRECT');
     expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledWith(
@@ -221,6 +228,29 @@ describe('smart-link metadata', () => {
       { onError: 'throw' }
     );
     expect(redirectMock).toHaveBeenCalledWith('/dualipa?mode=listen&source=qr');
+  });
+
+  it.each([
+    'email blast',
+    'a/b',
+    'x#y',
+    'q'.repeat(65),
+  ])('drops unsupported cache-key source %s without breaking the alias', async source => {
+    getContentBySlugMock.mockResolvedValue(null);
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+
+    await expect(
+      ProfileAliasResolverPage({
+        params: Promise.resolve({
+          username: 'dualipa',
+          slug: ['music', '__profile-mode-alias', 'resolve', source],
+        }),
+      })
+    ).rejects.toThrow('NEXT_REDIRECT');
+    expect(redirectMock).toHaveBeenCalledWith('/dualipa?mode=listen');
   });
 
   it('does not convert failed collision checks into a cached mode redirect', async () => {
@@ -293,10 +323,16 @@ describe('smart-link metadata', () => {
     expect(redirectMock).not.toHaveBeenCalled();
   });
 
-  it('starts independent alias collision checks in parallel', async () => {
-    getContentBySlugMock.mockResolvedValue(null);
+  it('starts content and independent alias collision checks in parallel', async () => {
+    let resolveContentLookup: ((value: null) => void) | undefined;
     let resolveRedirectLookup: ((value: null) => void) | undefined;
     let resolveUnpublishedLookup: ((value: null) => void) | undefined;
+    getContentBySlugMock.mockImplementation(
+      () =>
+        new Promise<null>(resolve => {
+          resolveContentLookup = resolve;
+        })
+    );
     findRedirectByOldSlugMock.mockImplementation(
       () =>
         new Promise<null>(resolve => {
@@ -321,12 +357,48 @@ describe('smart-link metadata', () => {
     });
 
     await vi.waitFor(() => {
+      expect(getContentBySlugMock).toHaveBeenCalledOnce();
       expect(findRedirectByOldSlugMock).toHaveBeenCalledOnce();
       expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledOnce();
     });
+    resolveContentLookup?.(null);
     resolveRedirectLookup?.(null);
     resolveUnpublishedLookup?.(null);
     await expect(result).rejects.toThrow('NEXT_REDIRECT');
+  });
+
+  it('settles collision failures while published-content lookup is pending', async () => {
+    let resolveContentLookup:
+      | ((value: { id: string; type: string; slug: string }) => void)
+      | undefined;
+    getContentBySlugMock.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveContentLookup = resolve;
+        })
+    );
+    findRedirectByOldSlugMock.mockRejectedValue(
+      new Error('collision lookup unavailable')
+    );
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+    const result = ProfileAliasResolverPage({
+      params: Promise.resolve({
+        username: 'dualipa',
+        slug: ['music', '__profile-mode-alias', 'resolve'],
+      }),
+    });
+
+    await vi.waitFor(() => {
+      expect(findRedirectByOldSlugMock).toHaveBeenCalledOnce();
+    });
+    await Promise.resolve();
+    resolveContentLookup?.({ id: 'track-music', type: 'track', slug: 'music' });
+
+    await expect(result).resolves.toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 
   it('keeps direct marker paths for arbitrary slugs on the catch-all 404', async () => {


### PR DESCRIPTION
## Outcome

Makes collision-safe public-profile mode aliases edge-cacheable for five minutes without weakening published, renamed, or unpublished smart-link precedence. This closes the post-promotion latency outlier that failed the production public-profile gate after PR #15481.

## What changed

- Classifies the collision resolver as on-demand SSG/ISR instead of dynamic SSR.
- Starts published-content and independent collision reads together, while settling collision failures immediately.
- Preserves Jovie-issued `qr` and `link` attribution as finite cache-key variants; unsupported values resolve source-less instead of entering an internal pathname.
- Canonicalizes repeated attribution to the established first-nonempty value.
- Blocks raw, percent-encoded, malformed, and forged private resolver paths before auth/routing.

## Verification

- Strict independent P0-P2 review: PASS.
- Production build: 469/469 routes; `/[username]/[...slug]` is `SSG` with on-demand fallback and 300-second revalidation.
- Runtime probe: first `?source=qr` request `MISS`, second request `HIT`; redirect remains `/dualipa?mode=subscribe&source=qr`.
- Runtime adversarial probes: reserved/unknown source values still return the canonical 307; raw and percent-encoded private markers return fail-closed 404.
- Focused release suite: 302 passed, 31 skipped.
- Full protected pre-push affected suite: all partitions passed (about 18k assertions), with typecheck, lint, proxy, Tailwind, secret, repo-hygiene, component, and CI-harness gates green.

## Risk

The resolver still fails closed if collision checks are unavailable and keeps the precedence order: published content, renamed slug, unpublished collision, then mode alias. No budget was raised. No external-data embedding was added.

Linear: JOV-4788
