### PR TITLE
[JOV-4788] Reject nested private profile alias markers

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -72,15 +72,46 @@ function redirectSignedOutElectronAppShell(req: NextRequest): NextResponse {
   return response;
 }
 
+const PRIVATE_PROFILE_ALIAS_MARKER = '__profile-mode-alias';
+const MAX_PROFILE_ALIAS_SEGMENT_LENGTH = 2048;
+const MAX_PROFILE_ALIAS_DECODE_PASSES = 4;
+
 function isReservedProfileAliasMarkerPath(pathname: string): boolean {
   return pathname.split('/').some(segment => {
-    try {
-      return decodeURIComponent(segment) === '__profile-mode-alias';
-    } catch {
-      // Next decodes route params after proxy execution. Reject malformed
-      // escapes here so no ambiguous segment can reach the private resolver.
-      return true;
+    let decodedSegment = segment;
+
+    for (let pass = 0; pass < MAX_PROFILE_ALIAS_DECODE_PASSES; pass += 1) {
+      if (decodedSegment.length > MAX_PROFILE_ALIAS_SEGMENT_LENGTH) {
+        return true;
+      }
+
+      let nextDecodedSegment: string;
+      try {
+        nextDecodedSegment = decodeURIComponent(decodedSegment);
+      } catch {
+        // Next decodes route params after proxy execution. Reject malformed
+        // escapes at the public boundary. A literal percent produced by an
+        // earlier successful decode cannot reveal another encoded marker and
+        // remains a valid public path segment.
+        return pass === 0;
+      }
+
+      if (
+        nextDecodedSegment.split('/').includes(PRIVATE_PROFILE_ALIAS_MARKER)
+      ) {
+        return true;
+      }
+
+      if (nextDecodedSegment === decodedSegment) {
+        return false;
+      }
+
+      decodedSegment = nextDecodedSegment;
     }
+
+    // Excessively nested escaping is never emitted by Jovie. Fail closed so
+    // it cannot bypass this boundary or create attacker-controlled ISR keys.
+    return true;
   });
 }
 

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -296,11 +296,18 @@ describe('proxy.ts middleware', () => {
       `/tim/subscribe/__profile-mode-alias/resolve/${'q'.repeat(256)}`,
       '/tim/subscribe/__profile%2Dmode%2Dalias/resolve/qr',
       '/tim/subscribe/%5F%5Fprofile-mode-alias/resolve/qr',
+      '/tim/subscribe/%255F%255Fprofile-mode-alias/resolve/qr',
+      '/tim/subscribe/%25255F%25255Fprofile%25252Dmode%25252Dalias/resolve/qr',
+      '/tim/subscribe/%252525255F%252525255Fprofile-mode-alias/resolve/qr',
+      '/tim/subscribe/%252F__profile-mode-alias%252Fresolve/qr',
+      `/tim/subscribe/${'q'.repeat(2049)}/resolve/qr`,
     ])('returns 404 for direct marker path %s before auth', async path => {
       const req = createUnauthenticatedRequest({ pathname: path });
       const res = await callMiddleware(req);
 
       expect(res.status).toBe(404);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(await res.text()).toBe('');
       expect(mocks.getSessionCookie).not.toHaveBeenCalled();
       expect(mocks.resolveTestBypassUserId).not.toHaveBeenCalled();
       expect(mocks.checkProfileVisitorBlocked).not.toHaveBeenCalled();
@@ -308,6 +315,17 @@ describe('proxy.ts middleware', () => {
 
     it('does not block the public alias before its afterFiles rewrite', async () => {
       const req = createUnauthenticatedRequest({ pathname: '/dualipa/music' });
+      const res = await callMiddleware(req);
+
+      expect(res.status).not.toBe(404);
+    });
+
+    it.each([
+      '/tim/caf%C3%A9',
+      '/tim/100%25-real',
+      '/tim/%25zz',
+    ])('does not reject a valid encoded public path %s', async path => {
+      const req = createUnauthenticatedRequest({ pathname: path });
       const res = await callMiddleware(req);
 
       expect(res.status).not.toBe(404);


### PR DESCRIPTION
## Description

Production on `ec0887a` allowed a double-encoded private profile-alias marker to pass the proxy and create an on-demand ISR 404 cache key:

- `GET /dualipa/music/%255F%255Fprofile-mode-alias/resolve/adversarial-ec0887a-0741`
- First response: `404`, `X-Nextjs-Prerender: 1`, `X-Vercel-Cache: MISS`
- Repeated response: `404`, `X-Vercel-Cache: HIT`

This PR makes private-marker rejection bounded and fail-closed:

- Decode each path segment up to four passes.
- Reject segments over 2,048 characters or still nested after the decode budget.
- Reject raw malformed escapes.
- Detect the marker directly or inside decoded slash wrappers.
- Preserve valid encoded public paths, including Unicode and literal `%25`.
- Return the existing empty, `Cache-Control: no-store` fast 404 before auth, audience, database, or page routing.

`bug-to-test: satisfied`

`design-canonical: not applicable - proxy and regression-test change only`

## Validation

Completed on commit `7717083ef585dba0d2d033dac559ba6d66f0390c`:

- [x] Focused middleware suite: 76 applicable passed, 31 skipped
- [x] Typecheck passed
- [x] Biome passed
- [x] Clean production build passed (`469/469`)
- [x] Protected pre-push suite passed (18,264 assertions)
- [x] Built standalone replay: the exact production repro and encoded-slash wrapper both returned an immediate empty `404` with `Cache-Control: no-store`, no `X-Nextjs-Prerender`, and no cache `HIT`
- [x] Independent security review: PASS, no P0-P2 findings
- [x] Regression coverage added for nested markers, encoded slash, excessive nesting/length, empty no-store responses, Unicode, and `%25`
- [ ] Source PR CI passes on the exact head SHA
- [ ] Reviewer and bot comments are triaged without weakening any gate

## Risk and rollback

The changed guard runs at the global proxy boundary. The principal risk is false-positive rejection of unusually long or excessively nested encoded path segments. Positive regressions cover ordinary Unicode and percent-encoded public paths.

There are no UI, database, migration, environment-variable, or external-data changes.

Rollback is a revert of `7717083ef58`. Reverting restores the prior routing behavior but also reopens the forged ISR-key issue, so rollback should occur only through the centralized release controller during a confirmed routing incident.

## Release gates

- [ ] Required PR checks are green without skips or budget changes
- [ ] Native merge-queue combined-head unit, build, and applicable integration gates are green
- [ ] Merge receipt identifies the exact resulting `main` SHA
- [ ] Production controller authorizes that exact successful main CI attempt
- [ ] Immutable staging deployment reports the expected SHA and passes health/profile probes
- [ ] Production promotion completes through the normal release workflow
- [ ] Deployed production SHA matches current `main`
- [ ] Production replay passes before declaring `Production Verified`

### Required production replay

After promotion, request each adversarial path twice:

1. The original cached key: `/dualipa/music/%255F%255Fprofile-mode-alias/resolve/adversarial-ec0887a-0741`
2. The same double-encoded pattern with a fresh unique suffix.
3. An encoded-slash wrapper with a fresh unique suffix.

Every response must satisfy all of:

- Status is `404`
- Body is empty
- `Cache-Control` contains `no-store`
- `X-Nextjs-Prerender: 1` is absent
- `X-Vercel-Cache` is never `HIT`, including the repeat request

Control probes must also pass:

- `/api/health` returns `200`
- `/dualipa/music?source=qr` returns the expected `307`
- Its canonical destination `/dualipa?mode=listen&source=qr` returns `200`
- No normal public-profile routing regression is observed

Any failed criterion keeps the release unverified and routes remediation through the existing controller; do not weaken checks or manually mutate production aliases.

## Related

JOV-4788
