### PR TITLE
perf(profile): remove server validators from client bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Public artist profiles load with a leaner browser bundle:** server-only validation no longer ships with profile music, merch, event, and alerts interactions, removing the Zod client chunk while preserving the existing experience.
+- **Profile activity respects the visitor's privacy choices:** anonymous audience joining now follows canonical analytics consent, regional consent requirements, Global Privacy Control, Do Not Track, and legacy opt-outs.
 - **Mac/Electron profile links open in isolated native previews (#15488):** canonical public artist profile URLs open in reusable phone-sized windows without sharing authenticated session state, while the main app history and non-profile external destinations remain unchanged.
 - **Presence becomes the artist's recurring visibility workspace (JOV-4799/JOV-4800):** Contacts remains global; single-artist accounts keep Library, Calendar, and Presence flat while multi-artist accounts group only those artist-owned destinations under the selected artist; Presence summarizes search visibility, answer readiness, audience quality, and monitored pages; Gmail and Calendar authorization live only in Settings → Connections; and the Artist Profiles page links to Fan Notifications and Instant Merch where those outcomes materially extend profile discovery.
 - [internal] **Desktop @types/node aligned to 26.x with monorepo:** Dependabot package bumps only; no DMG publish in this PR.

--- a/apps/web/app/api/profile/pac-event/route.ts
+++ b/apps/web/app/api/profile/pac-event/route.ts
@@ -3,18 +3,25 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createRateLimitedResponse } from '@/app/api/notifications/route-helpers';
 import { AUDIENCE_ANON_COOKIE } from '@/constants/app';
 import { trackEvent } from '@/lib/analytics/runtime-aware';
+import {
+  COOKIE_BANNER_REQUIRED_COOKIE,
+  isCookieBannerRequired,
+} from '@/lib/cookies/consent-regions';
+import {
+  CONSENT_COOKIE_NAME,
+  parseConsentCookieValue,
+} from '@/lib/cookies/consent-state';
 import { captureError } from '@/lib/error-tracking';
 import { logStatsigEvent } from '@/lib/flags/statsig';
 import { generalLimiter, getClientIP } from '@/lib/rate-limit';
-import {
-  PAC_IDENTITY_BLOCKED_CONSENTS,
-  pacEventBeaconSchema,
-} from '@/lib/tracking/pac-events-contract';
+import { pacEventBeaconSchema } from '@/lib/tracking/pac-events-contract';
+import { PAC_IDENTITY_BLOCKED_CONSENTS } from '@/lib/tracking/pac-events-shared';
 import { logger } from '@/lib/utils/logger';
 
 export const runtime = 'nodejs';
 
 const MAX_BODY_BYTES = 4096;
+const LEGACY_TRACKING_CONSENT_COOKIE = 'jv_tracking_consent';
 
 /**
  * First-party sink for PAC (Primary Action Card) instrumentation events —
@@ -70,10 +77,39 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     const event = parsed.data;
-    const identityAllowed = !PAC_IDENTITY_BLOCKED_CONSENTS.includes(
+    const cookieStore = await cookies();
+
+    // Never trust the beacon's positive consent claim for identity joining.
+    // The httpOnly granular cookie and server-resolved region policy are
+    // authoritative. Client-reported opt-outs remain an extra fail-closed
+    // signal, while GPC/DNT and the legacy rejection cookie are also honored.
+    const requiresCookieConsent =
+      cookieStore.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1' ||
+      isCookieBannerRequired(
+        request.headers.get('x-vercel-ip-country') ??
+          request.headers.get('cf-ipcountry'),
+        request.headers.get('x-vercel-ip-country-region')
+      );
+    const canonicalConsent = parseConsentCookieValue(
+      cookieStore.get(CONSENT_COOKIE_NAME)?.value
+    );
+    const serverAllowsAnalytics =
+      canonicalConsent?.analytics === true ||
+      (canonicalConsent === null && !requiresCookieConsent);
+    const browserOptedOut =
+      request.headers.get('sec-gpc') === '1' ||
+      request.headers.get('dnt') === '1' ||
+      request.headers.get('dnt') === 'yes';
+    const legacyOptedOut =
+      cookieStore.get(LEGACY_TRACKING_CONSENT_COOKIE)?.value === 'rejected';
+    const clientOptedOut = PAC_IDENTITY_BLOCKED_CONSENTS.includes(
       event.consent
     );
-    const cookieStore = await cookies();
+    const identityAllowed =
+      serverAllowsAnalytics &&
+      !browserOptedOut &&
+      !legacyOptedOut &&
+      !clientOptedOut;
     const jvAid = identityAllowed
       ? (cookieStore.get(AUDIENCE_ANON_COOKIE)?.value ?? null)
       : null;

--- a/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
+++ b/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
@@ -10,6 +10,7 @@ import { track } from '@/lib/analytics';
 import { captureError } from '@/lib/error-tracking';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import { useNotifications } from '@/lib/hooks/useNotifications';
+import { getNotificationCaptureError } from '@/lib/notifications/capture-validation';
 import {
   getNotificationSubscribeSuccessMessage,
   NOTIFICATION_COPY,
@@ -22,7 +23,6 @@ import {
   useSubscribeNotificationsMutation,
   useVerifyEmailOtpMutation,
 } from '@/lib/queries/useNotificationStatusQuery';
-import { getNotificationCaptureError } from '@/lib/validation/schemas/notifications';
 import type { Artist } from '@/types/db';
 import type { NotificationChannel } from '@/types/notifications';
 import {

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -38,7 +38,7 @@ import {
   invalidateCaptureDismissalStatus,
 } from '@/lib/profile/capture-dismissal-client';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
-import type { PacState as PacEventState } from '@/lib/tracking/pac-events-contract';
+import type { PacState as PacEventState } from '@/lib/tracking/pac-events-shared';
 import { cn } from '@/lib/utils';
 import { formatAmount } from '@/lib/utils/format-number';
 import { formatDuration } from '@/lib/utils/formatDuration';

--- a/apps/web/components/features/profile/usePacEvents.ts
+++ b/apps/web/components/features/profile/usePacEvents.ts
@@ -28,7 +28,7 @@ import {
   type PacClientEventName,
   type PacEventExtras,
   type PacState,
-} from '@/lib/tracking/pac-events-contract';
+} from '@/lib/tracking/pac-events-shared';
 
 const EXPOSURE_VISIBILITY_THRESHOLD = 0.5;
 const EXPOSURE_OBSERVER_THRESHOLDS = [0, 0.25, 0.5];

--- a/apps/web/lib/notifications/capture-validation.ts
+++ b/apps/web/lib/notifications/capture-validation.ts
@@ -1,0 +1,106 @@
+/**
+ * Dependency-light validation for notification capture fields rendered on
+ * public profiles. Server request schemas wrap this logic with Zod.
+ */
+
+const EMAIL_MAX_LENGTH = 254;
+const PHONE_MAX_LENGTH = 32;
+const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/; // NOSONAR (S5852) - bounded by EMAIL_MAX_LENGTH before regex use
+const CONTROL_OR_SPACE_REGEX = /[\s\p{Cc}]/u;
+const E164_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
+
+export const NOTIFICATION_CAPTURE_ERROR_MESSAGES = {
+  emailRequired: 'Email address is required.',
+  emailTooLong: 'Email address must be 254 characters or fewer.',
+  emailNoSpaces: 'Email address cannot contain spaces or control characters.',
+  emailFormat:
+    'Email address must include a local part, @, domain, and top-level domain.',
+  phoneRequired: 'Phone number is required.',
+  phoneTooLong: 'Phone number must be 32 characters or fewer.',
+  phoneFormat: 'Phone number must be a valid US or Canadian number.',
+  smsCountry: 'SMS notifications are available in the US and Canada only.',
+} as const;
+
+export interface NotificationCaptureInput {
+  readonly channel: 'email' | 'sms';
+  readonly value: string;
+  readonly country_code?: string;
+}
+
+export interface NotificationCaptureIssue {
+  readonly message: string;
+  readonly path: 'value' | 'country_code';
+}
+
+export function getNotificationCaptureIssue(
+  input: NotificationCaptureInput
+): NotificationCaptureIssue | null {
+  if (input.channel === 'email') {
+    const trimmed = input.value.trim();
+
+    if (!trimmed) {
+      return {
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailRequired,
+        path: 'value',
+      };
+    }
+
+    if (trimmed.length > EMAIL_MAX_LENGTH) {
+      return {
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailTooLong,
+        path: 'value',
+      };
+    }
+
+    if (CONTROL_OR_SPACE_REGEX.test(trimmed)) {
+      return {
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailNoSpaces,
+        path: 'value',
+      };
+    }
+
+    return EMAIL_REGEX.test(trimmed)
+      ? null
+      : {
+          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailFormat,
+          path: 'value',
+        };
+  }
+
+  const countryCode = input.country_code?.toUpperCase();
+  if (countryCode !== 'US' && countryCode !== 'CA') {
+    return {
+      message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry,
+      path: 'country_code',
+    };
+  }
+
+  const trimmed = input.value.trim();
+  if (!trimmed) {
+    return {
+      message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneRequired,
+      path: 'value',
+    };
+  }
+
+  if (trimmed.length > PHONE_MAX_LENGTH) {
+    return {
+      message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneTooLong,
+      path: 'value',
+    };
+  }
+
+  return E164_PHONE_REGEX.test(trimmed)
+    ? null
+    : {
+        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneFormat,
+        path: 'value',
+      };
+}
+
+export function getNotificationCaptureError(
+  input: NotificationCaptureInput
+): string | null {
+  return getNotificationCaptureIssue(input)?.message ?? null;
+}

--- a/apps/web/lib/notifications/validation.ts
+++ b/apps/web/lib/notifications/validation.ts
@@ -1,4 +1,4 @@
-import { getNotificationCaptureError } from '@/lib/validation/schemas/notifications';
+import { getNotificationCaptureError } from '@/lib/notifications/capture-validation';
 
 const EMAIL_MAX_LENGTH = 254;
 const PHONE_MAX_LENGTH = 32;

--- a/apps/web/lib/tracking/pac-events-contract.ts
+++ b/apps/web/lib/tracking/pac-events-contract.ts
@@ -1,11 +1,9 @@
 /**
- * PAC (Primary Action Card) instrumentation contract — spec §8.
+ * PAC (Primary Action Card) server validation contract — spec §8.
  *
- * Shared, isomorphic definitions for the PAC event schema (issue #13063,
- * parent cluster #13060). This module is import-safe from both server code
- * (the `/api/profile/pac-event` sink, webhook back-join helpers) and client
- * code (the emitter in `pac-events.ts`). Keep it free of `server-only`,
- * `use client`, and Next.js runtime imports.
+ * Zod-backed validation for the `/api/profile/pac-event` sink. Browser-safe
+ * constants, types, and the variant builder live in `pac-events-shared` so
+ * the public profile does not ship the server validation dependency.
  *
  * Payload contract — every event carries:
  * - `jv_aid`   — anonymous audience id. `null` on the client (the cookie is
@@ -22,118 +20,12 @@
  */
 
 import { z } from 'zod';
-import type { ProfilePacAssignment } from '@/lib/flags/profile-pac';
+import {
+  PAC_CLIENT_EVENTS,
+  PAC_CONSENT_STATES,
+  PAC_STATES,
+} from '@/lib/tracking/pac-events-shared';
 import { uuidSchema } from '@/lib/validation/schemas/base';
-
-/** First-party sink endpoint for PAC beacon events. */
-export const PAC_EVENT_ENDPOINT = '/api/profile/pac-event';
-
-/** Client-emitted PAC events (fired from the profile surface). */
-export const PAC_CLIENT_EVENTS = [
-  /** PAC ≥50% visible — once per state per session. */
-  'pac_exposure',
-  /** Visitor initiated playback. */
-  'pac_play_start',
-  /** 30 seconds of cumulative playback. */
-  'pac_play_30s',
-  /** Track completed. */
-  'pac_play_complete',
-  /** Email/SMS capture prompt appeared. */
-  'capture_prompt_shown',
-  /** Capture form submitted. */
-  'capture_submit',
-  /** Capture succeeded. */
-  'capture_success',
-  /** Capture failed — carries the failing rule in `extras.rule`. */
-  'capture_error',
-  /** Visitor dismissed the capture prompt. */
-  'capture_dismiss',
-  /** Email ↔ SMS channel toggle — carries `extras.channel`. */
-  'capture_channel_toggle',
-  /** Secondary (S2 slot) action clicked — carries `extras.slot`. */
-  'pac_secondary_click',
-] as const;
-
-export type PacClientEventName = (typeof PAC_CLIENT_EVENTS)[number];
-
-/**
- * Server-emitted PAC events. `pac_s2_convert` is the webhook back-join for
- * merch/tip/ticket conversions — emitted by commerce webhook handlers via
- * `trackPacS2Convert`, never by the client.
- */
-export const PAC_SERVER_EVENTS = ['pac_s2_convert'] as const;
-
-export type PacServerEventName = (typeof PAC_SERVER_EVENTS)[number];
-
-export type PacEventName = PacClientEventName | PacServerEventName;
-
-/** PAC state machine states (spec §8 payload contract). */
-export const PAC_STATES = [
-  'idle',
-  'playing',
-  'prompt',
-  'submitting',
-  'error',
-  'success',
-  'dismissed',
-  'merch',
-  'tip',
-  'tickets',
-  'rsvp',
-  'following',
-] as const;
-
-export type PacState = (typeof PAC_STATES)[number];
-
-/** Consent states mirrored from `@/lib/tracking/consent` (kept in sync). */
-export const PAC_CONSENT_STATES = [
-  'undecided',
-  'accepted',
-  'rejected',
-  'gpc-opted-out',
-] as const;
-
-export type PacConsentState = (typeof PAC_CONSENT_STATES)[number];
-
-/**
- * Consent states under which the sink must NOT join the event to the
- * visitor's `jv_aid` identity. Events still count toward anonymous,
- * session-scoped aggregates (the experiment denominator).
- */
-export const PAC_IDENTITY_BLOCKED_CONSENTS: readonly PacConsentState[] = [
-  'rejected',
-  'gpc-opted-out',
-];
-
-/** Structured extras attached per-event (e.g. `rule`, `channel`, `slot`). */
-export type PacEventExtras = Readonly<
-  Record<string, string | number | boolean>
->;
-
-/** Canonical payload shape for every PAC event. */
-export interface PacEventPayload {
-  readonly event: PacEventName;
-  readonly jv_aid: string | null;
-  readonly profile_id: string;
-  readonly pac_state: PacState;
-  readonly variant_id: string;
-  readonly session_id: string;
-  readonly consent: PacConsentState;
-  readonly ts: number;
-  readonly extras?: PacEventExtras;
-}
-
-/**
- * Builds the combined variant key for the visitor's PAC assignment.
- * Keys every event to all experiment slots (S1 copy/trigger, S2, plus
- * component arms for tab-bar + dismiss) so any slot's arms can be compared
- * without re-deriving assignment server-side.
- */
-export function buildPacVariantId(assignment: ProfilePacAssignment): string {
-  const { copyArm, triggerThreshold, s2Slot, tabBar, dismissAffordance } =
-    assignment;
-  return `copy:${copyArm}|trigger:${triggerThreshold}|s2:${s2Slot}|tab:${tabBar}|dismiss:${dismissAffordance}`;
-}
 
 /**
  * Zod schema for client beacons arriving at the sink. `jv_aid` is accepted

--- a/apps/web/lib/tracking/pac-events-shared.ts
+++ b/apps/web/lib/tracking/pac-events-shared.ts
@@ -1,0 +1,103 @@
+/**
+ * PAC (Primary Action Card) event definitions shared by browser emitters and
+ * server sinks. Keep this module dependency-light: it is part of the public
+ * profile client graph. Runtime validation belongs in `pac-events-contract`.
+ */
+
+import type { ProfilePacAssignment } from '@/lib/flags/profile-pac';
+
+/** First-party sink endpoint for PAC beacon events. */
+export const PAC_EVENT_ENDPOINT = '/api/profile/pac-event';
+
+/** Client-emitted PAC events (fired from the profile surface). */
+export const PAC_CLIENT_EVENTS = [
+  /** PAC ≥50% visible — once per state per session. */
+  'pac_exposure',
+  /** Visitor initiated playback. */
+  'pac_play_start',
+  /** 30 seconds of cumulative playback. */
+  'pac_play_30s',
+  /** Track completed. */
+  'pac_play_complete',
+  /** Email/SMS capture prompt appeared. */
+  'capture_prompt_shown',
+  /** Capture form submitted. */
+  'capture_submit',
+  /** Capture succeeded. */
+  'capture_success',
+  /** Capture failed — carries the failing rule in `extras.rule`. */
+  'capture_error',
+  /** Visitor dismissed the capture prompt. */
+  'capture_dismiss',
+  /** Email ↔ SMS channel toggle — carries `extras.channel`. */
+  'capture_channel_toggle',
+  /** Secondary (S2 slot) action clicked — carries `extras.slot`. */
+  'pac_secondary_click',
+] as const;
+
+export type PacClientEventName = (typeof PAC_CLIENT_EVENTS)[number];
+
+/** Server-emitted PAC events, never accepted from the browser sink. */
+export const PAC_SERVER_EVENTS = ['pac_s2_convert'] as const;
+
+export type PacServerEventName = (typeof PAC_SERVER_EVENTS)[number];
+export type PacEventName = PacClientEventName | PacServerEventName;
+
+/** PAC state machine states (spec §8 payload contract). */
+export const PAC_STATES = [
+  'idle',
+  'playing',
+  'prompt',
+  'submitting',
+  'error',
+  'success',
+  'dismissed',
+  'merch',
+  'tip',
+  'tickets',
+  'rsvp',
+  'following',
+] as const;
+
+export type PacState = (typeof PAC_STATES)[number];
+
+/** Consent states mirrored from `@/lib/tracking/consent` (kept in sync). */
+export const PAC_CONSENT_STATES = [
+  'undecided',
+  'accepted',
+  'rejected',
+  'gpc-opted-out',
+] as const;
+
+export type PacConsentState = (typeof PAC_CONSENT_STATES)[number];
+
+/** Consent states where the sink must not join events to `jv_aid`. */
+export const PAC_IDENTITY_BLOCKED_CONSENTS: readonly PacConsentState[] = [
+  'rejected',
+  'gpc-opted-out',
+];
+
+/** Structured extras attached per-event (e.g. `rule`, `channel`, `slot`). */
+export type PacEventExtras = Readonly<
+  Record<string, string | number | boolean>
+>;
+
+/** Canonical payload shape for every PAC event. */
+export interface PacEventPayload {
+  readonly event: PacEventName;
+  readonly jv_aid: string | null;
+  readonly profile_id: string;
+  readonly pac_state: PacState;
+  readonly variant_id: string;
+  readonly session_id: string;
+  readonly consent: PacConsentState;
+  readonly ts: number;
+  readonly extras?: PacEventExtras;
+}
+
+/** Builds the combined variant key for the visitor's PAC assignment. */
+export function buildPacVariantId(assignment: ProfilePacAssignment): string {
+  const { copyArm, triggerThreshold, s2Slot, tabBar, dismissAffordance } =
+    assignment;
+  return `copy:${copyArm}|trigger:${triggerThreshold}|s2:${s2Slot}|tab:${tabBar}|dismiss:${dismissAffordance}`;
+}

--- a/apps/web/lib/tracking/pac-events.ts
+++ b/apps/web/lib/tracking/pac-events.ts
@@ -26,7 +26,7 @@ import {
   type PacEventExtras,
   type PacEventPayload,
   type PacState,
-} from '@/lib/tracking/pac-events-contract';
+} from '@/lib/tracking/pac-events-shared';
 
 const SESSION_ID_STORAGE_KEY = 'jv_pac_session';
 const EXPOSURE_STORAGE_PREFIX = 'jv_pac_exposed';

--- a/apps/web/lib/tracking/pac-s2-convert.ts
+++ b/apps/web/lib/tracking/pac-s2-convert.ts
@@ -16,7 +16,7 @@
 import { trackEvent } from '@/lib/analytics/runtime-aware';
 import type { ProfilePacS2Slot } from '@/lib/flags/profile-pac';
 import { logStatsigEvent } from '@/lib/flags/statsig';
-import type { PacEventPayload } from '@/lib/tracking/pac-events-contract';
+import type { PacEventPayload } from '@/lib/tracking/pac-events-shared';
 import { logger } from '@/lib/utils/logger';
 
 export interface PacS2ConvertInput {

--- a/apps/web/lib/validation/schemas/notifications.ts
+++ b/apps/web/lib/validation/schemas/notifications.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
+import {
+  getNotificationCaptureError,
+  getNotificationCaptureIssue,
+  NOTIFICATION_CAPTURE_ERROR_MESSAGES,
+} from '@/lib/notifications/capture-validation';
 
 import { uuidSchema } from './base';
+
+export { getNotificationCaptureError, NOTIFICATION_CAPTURE_ERROR_MESSAGES };
 
 /**
  * Notification validation schemas for subscriber management.
@@ -26,25 +33,6 @@ export const notificationChannelSchema = z.enum(['email', 'sms']);
  */
 export type NotificationChannel = z.infer<typeof notificationChannelSchema>;
 
-const EMAIL_MAX_LENGTH = 254;
-const PHONE_MAX_LENGTH = 32;
-const EMAIL_REGEX =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/; // NOSONAR (S5852) - bounded by EMAIL_MAX_LENGTH before regex use
-const CONTROL_OR_SPACE_REGEX = /[\s\p{Cc}]/gu;
-const E164_PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
-
-export const NOTIFICATION_CAPTURE_ERROR_MESSAGES = {
-  emailRequired: 'Email address is required.',
-  emailTooLong: 'Email address must be 254 characters or fewer.',
-  emailNoSpaces: 'Email address cannot contain spaces or control characters.',
-  emailFormat:
-    'Email address must include a local part, @, domain, and top-level domain.',
-  phoneRequired: 'Phone number is required.',
-  phoneTooLong: 'Phone number must be 32 characters or fewer.',
-  phoneFormat: 'Phone number must be a valid US or Canadian number.',
-  smsCountry: 'SMS notifications are available in the US and Canada only.',
-} as const;
-
 export const notificationCaptureSchema = z
   .object({
     channel: notificationChannelSchema.extract(['email', 'sms']),
@@ -56,96 +44,19 @@ export const notificationCaptureSchema = z
       .optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.channel === 'email') {
-      const trimmed = data.value.trim();
+    const issue = getNotificationCaptureIssue(data);
+    if (!issue) return;
 
-      if (!trimmed) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailRequired,
-          path: ['value'],
-        });
-        return;
-      }
-
-      if (trimmed.length > EMAIL_MAX_LENGTH) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailTooLong,
-          path: ['value'],
-        });
-        return;
-      }
-
-      if (CONTROL_OR_SPACE_REGEX.test(trimmed)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailNoSpaces,
-          path: ['value'],
-        });
-        return;
-      }
-
-      if (!EMAIL_REGEX.test(trimmed)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailFormat,
-          path: ['value'],
-        });
-      }
-      return;
-    }
-
-    const countryCode = data.country_code?.toUpperCase();
-    if (countryCode !== 'US' && countryCode !== 'CA') {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry,
-        path: ['country_code'],
-      });
-      return;
-    }
-
-    const trimmed = data.value.trim();
-    if (!trimmed) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneRequired,
-        path: ['value'],
-      });
-      return;
-    }
-
-    if (trimmed.length > PHONE_MAX_LENGTH) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneTooLong,
-        path: ['value'],
-      });
-      return;
-    }
-
-    if (!E164_PHONE_REGEX.test(trimmed)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneFormat,
-        path: ['value'],
-      });
-    }
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: issue.message,
+      path: [issue.path],
+    });
   });
 
 export type NotificationCaptureInput = z.infer<
   typeof notificationCaptureSchema
 >;
-
-export function getNotificationCaptureError(
-  input: NotificationCaptureInput
-): string | null {
-  const parsed = notificationCaptureSchema.safeParse(input);
-  return parsed.success
-    ? null
-    : (parsed.error.issues[0]?.message ?? 'Invalid notification contact.');
-}
 
 // =============================================================================
 // Notification Unsubscribe Method Type

--- a/apps/web/tests/lib/notifications/validation.test.ts
+++ b/apps/web/tests/lib/notifications/validation.test.ts
@@ -5,13 +5,15 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  getNotificationCaptureError,
+  NOTIFICATION_CAPTURE_ERROR_MESSAGES,
+  type NotificationCaptureInput,
+} from '@/lib/notifications/capture-validation';
+import {
   normalizeSubscriptionEmail,
   normalizeSubscriptionPhone,
 } from '@/lib/notifications/validation';
-import {
-  getNotificationCaptureError,
-  NOTIFICATION_CAPTURE_ERROR_MESSAGES,
-} from '@/lib/validation/schemas/notifications';
+import { notificationCaptureSchema } from '@/lib/validation/schemas/notifications';
 
 describe('Notification Validation', () => {
   describe('getNotificationCaptureError', () => {
@@ -37,6 +39,88 @@ describe('Notification Validation', () => {
           value: 'fan@example.com',
         })
       ).toBeNull();
+    });
+
+    it('stays deterministic and aligned with the server schema', () => {
+      const cases: ReadonlyArray<
+        readonly [NotificationCaptureInput, string | null]
+      > = [
+        [
+          { channel: 'email', value: '' },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailRequired,
+        ],
+        [
+          { channel: 'email', value: `${'a'.repeat(250)}@x.com` },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailTooLong,
+        ],
+        [
+          { channel: 'email', value: 'fan @domain.com' },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailNoSpaces,
+        ],
+        [
+          { channel: 'email', value: 'fan@domain' },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.emailFormat,
+        ],
+        [{ channel: 'email', value: 'fan@example.com' }, null],
+        [
+          { channel: 'sms', value: '+15551234567' },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry,
+        ],
+        [
+          {
+            channel: 'sms',
+            value: '+15551234567',
+            country_code: 'GB',
+          },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.smsCountry,
+        ],
+        [
+          { channel: 'sms', value: '', country_code: 'US' },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneRequired,
+        ],
+        [
+          {
+            channel: 'sms',
+            value: `+1${'2'.repeat(32)}`,
+            country_code: 'US',
+          },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneTooLong,
+        ],
+        [
+          { channel: 'sms', value: '555-1234', country_code: 'US' },
+          NOTIFICATION_CAPTURE_ERROR_MESSAGES.phoneFormat,
+        ],
+        [
+          {
+            channel: 'sms',
+            value: '+15551234567',
+            country_code: 'US',
+          },
+          null,
+        ],
+        [
+          {
+            channel: 'sms',
+            value: '+15551234567',
+            country_code: 'CA',
+          },
+          null,
+        ],
+      ];
+
+      for (const [input, expected] of cases) {
+        expect(getNotificationCaptureError(input)).toBe(expected);
+
+        // Repeat the same validation to guard against stateful regular
+        // expressions changing the user-facing message between submissions.
+        expect(getNotificationCaptureError(input)).toBe(expected);
+
+        const parsed = notificationCaptureSchema.safeParse(input);
+        const serverError = parsed.success
+          ? null
+          : (parsed.error.issues[0]?.message ?? null);
+        expect(serverError).toBe(expected);
+      }
     });
 
     it('limits SMS capture to US and Canada', () => {

--- a/apps/web/tests/unit/api/profile/pac-event.test.ts
+++ b/apps/web/tests/unit/api/profile/pac-event.test.ts
@@ -60,11 +60,23 @@ vi.mock('@/lib/utils/logger', () => ({
 }));
 
 import { POST } from '@/app/api/profile/pac-event/route';
-import { PAC_CLIENT_EVENTS } from '@/lib/tracking/pac-events-contract';
+import { AUDIENCE_ANON_COOKIE } from '@/constants/app';
+import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
+import { CONSENT_COOKIE_NAME } from '@/lib/cookies/consent-state';
+import { PAC_CLIENT_EVENTS } from '@/lib/tracking/pac-events-shared';
 
 const PROFILE_ID = '3f9c2f6a-8f1e-4b6a-9a44-1c2d3e4f5a6b';
 const SESSION_ID = '7a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d';
 const JV_AID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e';
+const CLIENT_SUPPLIED_JV_AID = 'c3d4e5f6-a7b8-4c9d-8e0f-1a2b3c4d5e6f';
+const LEGACY_TRACKING_CONSENT_COOKIE = 'jv_tracking_consent';
+
+function setCookieValues(values: Readonly<Record<string, string>>): void {
+  mockCookiesGet.mockImplementation((name: string) => {
+    const value = values[name];
+    return value === undefined ? undefined : { value };
+  });
+}
 
 function buildPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -80,11 +92,14 @@ function buildPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function buildRequest(body: unknown) {
+function buildRequest(
+  body: unknown,
+  headers: Readonly<Record<string, string>> = {}
+) {
   return new NextRequest('http://localhost/api/profile/pac-event', {
     method: 'POST',
     body: typeof body === 'string' ? body : JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
 
@@ -92,7 +107,10 @@ describe('POST /api/profile/pac-event', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGeneralLimiterLimit.mockResolvedValue({ success: true });
-    mockCookiesGet.mockReturnValue({ value: JV_AID });
+    setCookieValues({
+      [AUDIENCE_ANON_COOKIE]: JV_AID,
+      [COOKIE_BANNER_REQUIRED_COOKIE]: '0',
+    });
   });
 
   it('accepts every client event name with a full payload', async () => {
@@ -104,15 +122,20 @@ describe('POST /api/profile/pac-event', () => {
     expect(mockTrackEvent).toHaveBeenCalledTimes(PAC_CLIENT_EVENTS.length);
   });
 
-  it('enriches jv_aid server-side from the httpOnly cookie', async () => {
-    const response = await POST(buildRequest(buildPayload()));
+  it.each([
+    'undecided',
+    'accepted',
+  ] as const)('derives jv_aid from the httpOnly cookie when server policy allows and client consent is %s', async consent => {
+    const response = await POST(
+      buildRequest(buildPayload({ consent, jv_aid: CLIENT_SUPPLIED_JV_AID }))
+    );
 
     expect(response.status).toBe(204);
     expect(mockTrackEvent).toHaveBeenCalledWith(
       'pac_exposure',
       expect.objectContaining({ jv_aid: JV_AID })
     );
-    // Statsig user is the stable jv_aid when identity joining is allowed.
+    // Statsig user is the trusted cookie value, never the client-supplied id.
     expect(mockLogStatsigEvent).toHaveBeenCalledWith(
       JV_AID,
       'pac_exposure',
@@ -122,6 +145,109 @@ describe('POST /api/profile/pac-event', () => {
         pac_state: 'idle',
         session_id: SESSION_ID,
       })
+    );
+  });
+
+  it('joins identity in a consent-required region only with canonical analytics consent', async () => {
+    setCookieValues({
+      [AUDIENCE_ANON_COOKIE]: JV_AID,
+      [COOKIE_BANNER_REQUIRED_COOKIE]: '1',
+      [CONSENT_COOKIE_NAME]: JSON.stringify({
+        essential: true,
+        analytics: true,
+        marketing: false,
+      }),
+    });
+
+    const response = await POST(
+      buildRequest(buildPayload({ consent: 'accepted' }))
+    );
+
+    expect(response.status).toBe(204);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'pac_exposure',
+      expect.objectContaining({ jv_aid: JV_AID })
+    );
+  });
+
+  it.each([
+    {
+      name: 'canonical analytics rejection',
+      cookies: {
+        [AUDIENCE_ANON_COOKIE]: JV_AID,
+        [COOKIE_BANNER_REQUIRED_COOKIE]: '0',
+        [CONSENT_COOKIE_NAME]: JSON.stringify({
+          essential: true,
+          analytics: false,
+          marketing: true,
+        }),
+      },
+      headers: {},
+    },
+    {
+      name: 'missing consent in a required region',
+      cookies: {
+        [AUDIENCE_ANON_COOKIE]: JV_AID,
+        [COOKIE_BANNER_REQUIRED_COOKIE]: '1',
+      },
+      headers: {},
+    },
+    {
+      name: 'server-resolved required geography',
+      cookies: { [AUDIENCE_ANON_COOKIE]: JV_AID },
+      headers: { 'x-vercel-ip-country': 'DE' },
+    },
+    {
+      name: 'Global Privacy Control',
+      cookies: {
+        [AUDIENCE_ANON_COOKIE]: JV_AID,
+        [COOKIE_BANNER_REQUIRED_COOKIE]: '0',
+      },
+      headers: { 'sec-gpc': '1' },
+    },
+    {
+      name: 'Do Not Track',
+      cookies: {
+        [AUDIENCE_ANON_COOKIE]: JV_AID,
+        [COOKIE_BANNER_REQUIRED_COOKIE]: '0',
+      },
+      headers: { dnt: '1' },
+    },
+    {
+      name: 'legacy consent rejection',
+      cookies: {
+        [AUDIENCE_ANON_COOKIE]: JV_AID,
+        [COOKIE_BANNER_REQUIRED_COOKIE]: '0',
+        [LEGACY_TRACKING_CONSENT_COOKIE]: 'rejected',
+      },
+      headers: {},
+    },
+  ])('ignores positive client consent under $name', async ({
+    cookies,
+    headers,
+  }) => {
+    setCookieValues(cookies);
+
+    const response = await POST(
+      buildRequest(
+        buildPayload({
+          consent: 'accepted',
+          jv_aid: CLIENT_SUPPLIED_JV_AID,
+        }),
+        headers
+      )
+    );
+
+    expect(response.status).toBe(204);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'pac_exposure',
+      expect.objectContaining({ jv_aid: null })
+    );
+    expect(mockLogStatsigEvent).toHaveBeenCalledWith(
+      `pac-session:${SESSION_ID}`,
+      'pac_exposure',
+      expect.anything(),
+      expect.anything()
     );
   });
 
@@ -145,7 +271,7 @@ describe('POST /api/profile/pac-event', () => {
   });
 
   it('falls back to session scope when no jv_aid cookie exists', async () => {
-    mockCookiesGet.mockReturnValue(undefined);
+    setCookieValues({ [COOKIE_BANNER_REQUIRED_COOKIE]: '0' });
 
     const response = await POST(buildRequest(buildPayload()));
 

--- a/apps/web/tests/unit/tracking/pac-events-client-boundary.test.ts
+++ b/apps/web/tests/unit/tracking/pac-events-client-boundary.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CLIENT_SOURCES = [
+  'lib/tracking/pac-events.ts',
+  'lib/notifications/validation.ts',
+  'components/features/profile/usePacEvents.ts',
+  'components/features/profile/pac/ProfilePacCard.tsx',
+  'components/features/profile/artist-notifications-cta/useSubscriptionForm.ts',
+] as const;
+
+const SERVER_CONTRACTS = [
+  '@/lib/tracking/pac-events-contract',
+  '@/lib/validation/schemas/notifications',
+] as const;
+
+const FORBIDDEN_SHARED_IMPORTS = [
+  'server-only',
+  "from 'zod'",
+  'from "zod"',
+  '@/lib/validation/',
+  '@/lib/db',
+  '@/lib/env-server',
+  '@/lib/flags/statsig',
+  'next/headers',
+  'next/cache',
+] as const;
+
+function readWebSource(sourcePath: string): string {
+  return readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+}
+
+describe('PAC public-profile client boundary', () => {
+  it('keeps client entrypoints off Zod-backed server contracts', () => {
+    for (const sourcePath of CLIENT_SOURCES) {
+      const source = readWebSource(sourcePath);
+      for (const serverContract of SERVER_CONTRACTS) {
+        expect(source, sourcePath).not.toContain(serverContract);
+      }
+    }
+  });
+
+  it('keeps the shared event definitions free of server dependencies', () => {
+    const source = readWebSource('lib/tracking/pac-events-shared.ts');
+
+    for (const forbiddenImport of FORBIDDEN_SHARED_IMPORTS) {
+      expect(source, forbiddenImport).not.toContain(forbiddenImport);
+    }
+  });
+
+  it('keeps notification capture validation free of server dependencies', () => {
+    const source = readWebSource('lib/notifications/capture-validation.ts');
+
+    for (const forbiddenImport of FORBIDDEN_SHARED_IMPORTS) {
+      expect(source, forbiddenImport).not.toContain(forbiddenImport);
+    }
+  });
+});

--- a/apps/web/tests/unit/tracking/pac-events.test.ts
+++ b/apps/web/tests/unit/tracking/pac-events.test.ts
@@ -30,6 +30,7 @@ import {
   trackPacClientEvent,
   trackPacExposure,
 } from '@/lib/tracking/pac-events';
+import { pacEventBeaconSchema } from '@/lib/tracking/pac-events-contract';
 import {
   buildPacVariantId,
   PAC_CLIENT_EVENTS,
@@ -37,8 +38,7 @@ import {
   PAC_SERVER_EVENTS,
   PAC_STATES,
   type PacClientEventName,
-  pacEventBeaconSchema,
-} from '@/lib/tracking/pac-events-contract';
+} from '@/lib/tracking/pac-events-shared';
 
 const PROFILE_ID = '3f9c2f6a-8f1e-4b6a-9a44-1c2d3e4f5a6b';
 


### PR DESCRIPTION
## Description\n\nMakes the public-profile browser path materially lighter and hardens profile analytics identity handling at the server boundary.\n\n- Moves the dependency-light PAC browser contract out of the Zod-backed server module.\n- Moves notification capture field validation out of the Zod-backed server schema.\n- Removes Zod from the exact root public-profile client graph.\n- Derives PAC identity joining only from canonical server-side analytics consent and region policy. GPC, DNT, legacy rejection, invalid required-region choices, negative canonical consent, and negative client consent all fail closed.\n- Adds deterministic server/client parity, bundle-boundary, validation, and PAC privacy regression coverage.\n- Updates the changelog.\n\nExact current-main baseline to this branch:\n- Public-profile chunks: 39 to 38\n- Raw client bytes: 1,752,054 to 1,459,329\n- Delta: -292,725 bytes (-16.71%)\n- Zod chunks/bytes on the route: 1 / 288,044 to 0 / 0\n\n## Type of Change\n\n- [x] Bug fix (privacy/consent hardening)\n- [ ] New feature\n- [ ] Breaking change\n- [ ] Documentation update\n- [x] Refactoring\n- [x] Performance improvement\n- [ ] Chore\n\n## Testing\n\n- [x] Unit tests pass\n- [x] E2E tests pass\n- [x] Manual testing completed\n- [x] New tests added\n\nbug-to-test: satisfied\n\nVerification on commit 62be25331e033d1006bd4d407a4121b63512679c:\n- Full web Vitest: 2,327 files passed, 8 skipped; 18,276 tests passed, 75 skipped, 6 todo.\n- Focused profile/privacy suite: 121/121 passed.\n- Production build: 752/752 static pages; build ID WXoBRqzY4ea0UtNOTMib1.\n- Production-build profile E2E: 19/19 passed across mobile, tablet, and desktop.\n- Route performance: all six profile modes passed the 1,500 ms max gate; listen median/max 177/216 ms, music 170/279 ms, subscribe 212/829 ms, tip 175/256 ms, releases 168/393 ms, tour 157/252 ms.\n- Exact build manifest: 38 route chunks, 1,459,329 raw bytes, zero Zod chunks.\n- Biome, TypeScript, server-boundary lint, commit hooks, pre-push affected verification, CI harness: passed.\n\n## Functional and Design Evidence\n\nNo visual composition was changed by this commit. The release lane was nevertheless exercised end to end against the current public-profile surface:\n\n- Hero-fill, high-quality glass navigation, shared Jovie grid, one-card-at-a-time carousel, 44 px touch targets, reserved layout, reduced motion, keyboard/touch, aliases, alerts, and consent paths verified.\n- Geometry evaluation: 11/11.\n- Mobile stability evaluation: 89/89.\n- Functional, CLS, responsive, visual, and redirect evaluation: 69/69.\n- Route CSS evaluation: 19/19.\n- Prior exact-production browser inventory: 14/14 routes.\n- Fresh production verification remains a post-deployment gate and is not claimed by local or CI evidence.\n\nDesign-read: public artist profile for fans, with a clean native music-product language, leaning toward Apple Music restraint and the shared Jovie design system.\n\nDESIGN_VARIANCE: 2\nMOTION_INTENSITY: 1\nVISUAL_DENSITY: 2\n\ndesign-canonical:\n- Contrast: pass\n- States: pass\n- Layout and grid: pass\n- Motion and reduced motion: pass\n- Icons: pass\n- Anti-slop: pass\n- Evidence: pass\n\n## Accessibility and Browser Testing\n\n- [x] Keyboard navigation\n- [x] Screen reader semantics\n- [x] Contrast\n- [x] Focus indicators\n- [x] ARIA/state behavior\n- [x] Chrome/Chromium\n- [x] Mobile browser viewports\n- [x] Reduced motion\n\nSafari and Firefox source/runtime compatibility are covered by shared standards and tests; no engine-specific client API was introduced.\n\n## Database and Deployment\n\nNo database migration, environment variable, feature flag, third-party service, or external-data embedding change.\n\nNormal deployment only after required CI and review gates pass. Production acceptance requires exact deployed SHA proof plus a fresh unauthenticated profile route/security/performance/browser replay.\n\n## Review Findings\n\nIndependent adversarial review found one P1 before landing: positive client-declared consent could influence identity attachment. Fixed before commit and re-audited with no remaining P0-P3 findings. Focused PAC suite: 19/19 passed.\n\nA deterministic validation-regex parity concern was also fixed with repeat-call and server/client parity tests.\n\n## Related Issues\n\nRelated to #15494\nRelated to JOV-4788\n\n## Checklist\n\n- [x] PR title follows conventional commit format\n- [x] Branch is up to date with target branch\n- [ ] All CI checks pass\n- [x] Documentation/changelog updated\n- [x] No icon or custom SVG changes\n- [x] No database changes\n- [x] No prompt/eval file changes\n\n\n## Documentation\n\n- CHANGELOG.md: added two user-facing Unreleased entries for the leaner public-profile browser bundle and server-authoritative profile activity privacy behavior.\n- README.md, CONTRIBUTING.md, VERSION, architecture/COMPONENTS.md, and the public-profile, consent, and privacy references were audited against the diff; no factual updates are required.\n- VERSION remains 26.7.0 because this change belongs to the current Unreleased train.\n- No new TODO, FIXME, HACK, or XXX markers were introduced.