### PR TITLE
test(profile): pin geo consent backstop

### DIFF
--- a/apps/web/tests/unit/api/profile/pac-event.test.ts
+++ b/apps/web/tests/unit/api/profile/pac-event.test.ts
@@ -193,8 +193,11 @@ describe('POST /api/profile/pac-event', () => {
       headers: {},
     },
     {
-      name: 'server-resolved required geography',
-      cookies: { [AUDIENCE_ANON_COOKIE]: JV_AID },
+      name: 'server geo overriding a client-writable non-required cookie',
+      cookies: {
+        [AUDIENCE_ANON_COOKIE]: JV_AID,
+        [COOKIE_BANNER_REQUIRED_COOKIE]: '0',
+      },
       headers: { 'x-vercel-ip-country': 'DE' },
     },
     {


### PR DESCRIPTION
## Summary
- Pins fail-closed PAC identity behavior when the client-readable cookie is 0 but server geo resolves to a consent-required region.
- Preserves the canonical server-side privacy contract merged in #15495.
- Test-only follow-up: no runtime, bundle, or UI changes.

## Why
The cookie is intentionally client-readable for banner rendering, so a client value of 0 cannot override server-resolved geo policy at an identity boundary.

## Verification
- PAC route unit suite: 19/19
- Biome: clean
- Required pre-push typecheck, component gate, lint, affected test, and CI harness gates: pass
- Diff against current main: one test file, 5 additions and 2 replacements

## Documentation
No documentation change is required because this commit only pins an existing privacy contract in regression coverage.

Follow-up to #15495. Related: JOV-4788.