### PR TITLE
perf(profile): measure alias readiness in browser

### DIFF
--- a/apps/web/scripts/performance-budgets-guard.test.ts
+++ b/apps/web/scripts/performance-budgets-guard.test.ts
@@ -1,5 +1,5 @@
 import type { Browser, BrowserContext, Page } from '@playwright/test';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const playwrightMocks = vi.hoisted(() => ({
   browserClose: vi.fn(),
@@ -19,9 +19,12 @@ import type {
   ViolationResult,
 } from './performance-budgets-guard';
 import {
+  applyAliasPhaseTimings,
   applyProfileWarmTransitionTimings,
+  assertAliasPhaseTiming,
   buildConfirmedPageResult,
   confirmTimingViolations,
+  createAliasPhaseProbeScript,
   createContextOptions,
   evaluateTimingConfirmation,
   loadGuardManifestRoutes,
@@ -119,6 +122,176 @@ function createTimingViolation(
     routeId,
   };
 }
+
+function markElementVisible(element: Element) {
+  vi.spyOn(element, 'getClientRects').mockReturnValue([
+    { height: 1, width: 1 },
+  ] as unknown as DOMRectList);
+}
+
+describe('browser-observed alias readiness', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    delete (
+      window as Window & {
+        __perfAliasPhaseProbe?: unknown;
+      }
+    ).__perfAliasPhaseProbe;
+  });
+
+  it('records immediately visible phases in destination order', () => {
+    const shell = document.createElement('div');
+    shell.id = 'alias-shell';
+    const content = document.createElement('div');
+    content.id = 'alias-content';
+    const destination = document.createElement('button');
+    destination.id = 'alias-destination';
+    for (const element of [shell, content, destination]) {
+      markElementVisible(element);
+      document.body.append(element);
+    }
+
+    const probeScript = createAliasPhaseProbeScript({
+      contentSelectors: ['#alias-content'],
+      destinationSelectors: ['#alias-destination'],
+      expectedPaths: [`${window.location.pathname}${window.location.search}`],
+      sampleKey: 'immediate-sample',
+      shellSelectors: ['#alias-shell'],
+      startEpochMs: performance.timeOrigin + performance.now() - 100,
+    });
+    new Function(probeScript)();
+
+    const state = (
+      window as Window & {
+        __perfAliasPhaseProbe?: unknown;
+      }
+    ).__perfAliasPhaseProbe;
+    const phases = assertAliasPhaseTiming(state, 'immediate-sample', 500);
+
+    expect(phases.redirectCompleteMs).toBeLessThanOrEqual(
+      phases.shellVisibleMs
+    );
+    expect(phases.shellVisibleMs).toBeLessThanOrEqual(
+      phases.interactiveReadyMs
+    );
+    expect(phases.interactiveReadyMs).toBeLessThanOrEqual(
+      phases.destinationAffordanceMs
+    );
+  });
+
+  it('records a destination that becomes visible after installation', async () => {
+    const shell = document.createElement('div');
+    shell.id = 'alias-shell';
+    const content = document.createElement('div');
+    content.id = 'alias-content';
+    const destination = document.createElement('button');
+    destination.id = 'alias-destination';
+    destination.style.display = 'none';
+    for (const element of [shell, content, destination]) {
+      markElementVisible(element);
+      document.body.append(element);
+    }
+
+    const probeScript = createAliasPhaseProbeScript({
+      contentSelectors: ['#alias-content'],
+      destinationSelectors: ['#alias-destination'],
+      expectedPaths: [`${window.location.pathname}${window.location.search}`],
+      sampleKey: 'mutation-sample',
+      shellSelectors: ['#alias-shell'],
+      startEpochMs: performance.timeOrigin + performance.now() - 100,
+    });
+    new Function(probeScript)();
+
+    destination.style.display = 'block';
+    destination.dataset.ready = 'true';
+
+    await vi.waitFor(() => {
+      const state = (
+        window as Window & {
+          __perfAliasPhaseProbe?: {
+            destinationAffordanceMs?: number;
+          };
+        }
+      ).__perfAliasPhaseProbe;
+      expect(state?.destinationAffordanceMs).toEqual(expect.any(Number));
+    });
+  });
+
+  it.each([
+    {
+      label: 'missing',
+      state: {
+        redirectCompleteMs: 10,
+        sampleKey: 'phase-sample',
+        shellVisibleMs: 20,
+      },
+    },
+    {
+      label: 'stale',
+      state: {
+        destinationAffordanceMs: 40,
+        interactiveReadyMs: 30,
+        redirectCompleteMs: 10,
+        sampleKey: 'old-sample',
+        shellVisibleMs: 20,
+      },
+    },
+    {
+      label: 'non-monotonic',
+      state: {
+        destinationAffordanceMs: 40,
+        interactiveReadyMs: 15,
+        redirectCompleteMs: 10,
+        sampleKey: 'phase-sample',
+        shellVisibleMs: 20,
+      },
+    },
+  ])('fails closed on $label phase evidence', ({ state }) => {
+    expect(() => assertAliasPhaseTiming(state, 'phase-sample', 500)).toThrow(
+      /probe|phase/i
+    );
+  });
+
+  it('keeps controller delay diagnostic without charging it to the user metric', () => {
+    const phases = assertAliasPhaseTiming(
+      {
+        destinationAffordanceMs: 580,
+        interactiveReadyMs: 540,
+        redirectCompleteMs: 120,
+        sampleKey: 'phase-sample',
+        shellVisibleMs: 300,
+      },
+      'phase-sample',
+      1600
+    );
+
+    const timings = createConfirmationSample(
+      'usable-alias-result',
+      0
+    ).timingValues;
+    applyAliasPhaseTimings(timings, phases);
+
+    expect(timings['redirect-complete']).toBe(120);
+    expect(timings['interactive-shell-ready']).toBe(540);
+    expect(timings['usable-alias-result']).toBe(580);
+  });
+
+  it('rejects browser phases that exceed controller observation', () => {
+    expect(() =>
+      assertAliasPhaseTiming(
+        {
+          destinationAffordanceMs: 701,
+          interactiveReadyMs: 600,
+          redirectCompleteMs: 100,
+          sampleKey: 'phase-sample',
+          shellVisibleMs: 300,
+        },
+        'phase-sample',
+        500
+      )
+    ).toThrow(/diverged/);
+  });
+});
 
 function createConfirmationPage(options: {
   readonly id: string;

--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -87,8 +88,38 @@ interface StorageStateFile {
 }
 
 interface PerfPageWindow extends Window {
+  __perfAliasPhaseProbe?: AliasPhaseProbeState;
   __perfWarmNavFallbackStart?: number;
   __perfWarmNavStart?: number;
+}
+
+export interface AliasPhaseTiming {
+  readonly redirectCompleteMs: number;
+  readonly shellVisibleMs: number;
+  readonly interactiveReadyMs: number;
+  readonly destinationAffordanceMs: number;
+}
+
+export interface AliasPhaseProbeConfig {
+  readonly contentSelectors: readonly string[];
+  readonly destinationSelectors: readonly string[];
+  readonly expectedPaths: readonly string[];
+  readonly sampleKey: string;
+  readonly shellSelectors: readonly string[];
+  readonly startEpochMs: number;
+}
+
+interface AliasPhaseProbeState {
+  destinationAffordanceMs?: number;
+  error?: string;
+  installedPath: string;
+  interactiveReadyMs?: number;
+  lastPath?: string;
+  redirectCompleteMs?: number;
+  requestAnimationFrameType: string;
+  scanCount: number;
+  sampleKey: string;
+  shellVisibleMs?: number;
 }
 
 export interface GuardCliOptions {
@@ -103,6 +134,8 @@ export interface GuardCliOptions {
 }
 
 export interface GuardSample {
+  readonly aliasPhases?: AliasPhaseTiming;
+  readonly controllerObservedAliasResultMs?: number;
   readonly finalUrl: string;
   readonly resolvedPath: string;
   readonly timingValues: Record<PerfTimingMetricName, number>;
@@ -226,6 +259,135 @@ const PERF_INIT_SCRIPT = `
   }).observe({ type: 'first-input', buffered: true });
 })();
 `;
+
+/**
+ * Build a raw browser script so TS runtime helpers cannot leak into the code
+ * Playwright serializes. The probe observes the user-visible destination inside
+ * the page, separating renderer readiness from runner/CDP scheduling latency.
+ */
+export function createAliasPhaseProbeScript(config: AliasPhaseProbeConfig) {
+  const serializedConfig = JSON.stringify(config).replaceAll('<', '\\u003c');
+  return `
+(() => {
+  const config = ${serializedConfig};
+  const state = {
+    installedPath: window.location.pathname + window.location.search,
+    requestAnimationFrameType: typeof window.requestAnimationFrame,
+    sampleKey: config.sampleKey,
+    scanCount: 0,
+  };
+  window.__perfAliasPhaseProbe = state;
+
+  function currentPath() {
+    return window.location.pathname + window.location.search;
+  }
+  function isExpectedDestination() {
+    return config.expectedPaths.some(expectedPath =>
+      expectedPath.includes('?')
+        ? currentPath() === expectedPath
+        : window.location.pathname === expectedPath
+    );
+  }
+  function elapsedMs() {
+    return performance.timeOrigin + performance.now() - config.startEpochMs;
+  }
+  function isVisible(selectors) {
+    for (const selector of selectors) {
+      let candidates;
+      try {
+        candidates = document.querySelectorAll(selector);
+      } catch {
+        continue;
+      }
+      for (const candidate of candidates) {
+        const style = window.getComputedStyle(candidate);
+        if (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          style.visibility !== 'collapse' &&
+          Number.parseFloat(style.opacity || '1') > 0 &&
+          candidate.getClientRects().length > 0
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  let animationFrame;
+  let observer;
+  function finish() {
+    observer?.disconnect();
+    if (animationFrame !== undefined) {
+      window.cancelAnimationFrame(animationFrame);
+      animationFrame = undefined;
+    }
+  }
+  function scheduleScan() {
+    if (animationFrame === undefined) {
+      try {
+        animationFrame = window.requestAnimationFrame(scan);
+      } catch (error) {
+        state.error = error instanceof Error ? error.message : String(error);
+        finish();
+      }
+    }
+  }
+  function scan() {
+    animationFrame = undefined;
+    state.scanCount += 1;
+    state.lastPath = currentPath();
+    if (window.__perfAliasPhaseProbe?.sampleKey !== config.sampleKey) {
+      finish();
+      return;
+    }
+    if (!isExpectedDestination()) {
+      scheduleScan();
+      return;
+    }
+
+    state.redirectCompleteMs ??= elapsedMs();
+    if (state.shellVisibleMs === undefined && isVisible(config.shellSelectors)) {
+      state.shellVisibleMs = elapsedMs();
+    }
+    if (
+      state.shellVisibleMs !== undefined &&
+      state.interactiveReadyMs === undefined &&
+      isVisible(config.contentSelectors)
+    ) {
+      state.interactiveReadyMs = elapsedMs();
+    }
+    if (
+      state.interactiveReadyMs !== undefined &&
+      state.destinationAffordanceMs === undefined &&
+      isVisible(config.destinationSelectors)
+    ) {
+      state.destinationAffordanceMs = elapsedMs();
+    }
+
+    if (state.destinationAffordanceMs !== undefined) {
+      finish();
+      return;
+    }
+    scheduleScan();
+  }
+
+  try {
+    observer = new MutationObserver(scheduleScan);
+    observer.observe(document, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+    document.addEventListener('DOMContentLoaded', scheduleScan, { once: true });
+    scan();
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : String(error);
+  }
+})();
+`;
+}
 
 function writeStderr(message: string) {
   process.stderr.write(`${message}\n`);
@@ -556,6 +718,27 @@ export function assertAliasUsableResultUrl(
   }
 }
 
+export function createAliasPhaseProbeConfig(
+  route: PerfRouteDefinition,
+  resolvedPath: string,
+  startEpochMs: number,
+  sampleKey: string
+): AliasPhaseProbeConfig | undefined {
+  if (!route.aliasUsableResult) {
+    return undefined;
+  }
+  return {
+    contentSelectors: route.readySelectors.content ?? [],
+    destinationSelectors: route.aliasUsableResult.destinationAffordances,
+    expectedPaths: expectedRoutePaths(route, resolvedPath).map(
+      normalizePathWithQuery
+    ),
+    sampleKey,
+    shellSelectors: route.readySelectors.shell ?? [],
+    startEpochMs,
+  };
+}
+
 export function assertHostedAliasRunCount(
   route: PerfRouteDefinition,
   runs: number,
@@ -584,6 +767,60 @@ export async function waitForExpectedUrl(
       ),
     { timeout: timeoutMs, waitUntil: 'domcontentloaded' }
   );
+}
+
+const ALIAS_PHASE_KEYS = [
+  'redirectCompleteMs',
+  'shellVisibleMs',
+  'interactiveReadyMs',
+  'destinationAffordanceMs',
+] as const satisfies readonly (keyof AliasPhaseTiming)[];
+
+export function assertAliasPhaseTiming(
+  input: unknown,
+  expectedSampleKey: string,
+  controllerObservedMs: number
+): AliasPhaseTiming {
+  if (!input || typeof input !== 'object') {
+    throw new Error(
+      'Alias readiness probe produced no browser phase evidence.'
+    );
+  }
+  const candidate = input as Record<string, unknown>;
+  if (candidate.sampleKey !== expectedSampleKey) {
+    throw new Error('Alias readiness probe returned stale sample evidence.');
+  }
+
+  const values = ALIAS_PHASE_KEYS.map(key => {
+    const value = candidate[key];
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `Alias readiness probe is missing valid ${key} evidence.`
+      );
+    }
+    return value;
+  });
+  for (let index = 1; index < values.length; index += 1) {
+    if ((values[index] ?? 0) < (values[index - 1] ?? 0)) {
+      throw new Error('Alias readiness probe phases are not monotonic.');
+    }
+  }
+  if (
+    !Number.isFinite(controllerObservedMs) ||
+    controllerObservedMs < 0 ||
+    (values.at(-1) ?? 0) > controllerObservedMs + 100
+  ) {
+    throw new Error(
+      'Alias readiness probe diverged from controller-observed timing.'
+    );
+  }
+
+  return {
+    redirectCompleteMs: values[0] as number,
+    shellVisibleMs: values[1] as number,
+    interactiveReadyMs: values[2] as number,
+    destinationAffordanceMs: values[3] as number,
+  };
 }
 
 async function waitForAnyVisible(
@@ -1157,6 +1394,15 @@ export function applyProfileWarmTransitionTimings(
   timingValues['interactive-shell-ready'] = interaction.skeletonToContent;
 }
 
+export function applyAliasPhaseTimings(
+  timingValues: Record<PerfTimingMetricName, number>,
+  phases: AliasPhaseTiming
+) {
+  timingValues['redirect-complete'] = phases.redirectCompleteMs;
+  timingValues['interactive-shell-ready'] = phases.interactiveReadyMs;
+  timingValues['usable-alias-result'] = phases.destinationAffordanceMs;
+}
+
 async function warmRoute(
   browser: Browser,
   route: PerfRouteDefinition,
@@ -1224,10 +1470,21 @@ async function measureRouteSample(
   );
   try {
     const page = await context.newPage();
+    const aliasProbe = createAliasPhaseProbeConfig(
+      route,
+      resolvedPath,
+      Date.now(),
+      randomUUID()
+    );
+    if (aliasProbe) {
+      await page.addInitScript(createAliasPhaseProbeScript(aliasProbe));
+    }
     await page.addInitScript(PERF_INIT_SCRIPT);
     let browserMetrics:
       | Awaited<ReturnType<typeof collectBrowserMetrics>>
       | undefined;
+    let aliasPhases: AliasPhaseTiming | undefined;
+    let controllerObservedAliasResultMs: number | undefined;
 
     const timingValues: Record<PerfTimingMetricName, number> = {
       'cumulative-layout-shift': 0,
@@ -1277,7 +1534,7 @@ async function measureRouteSample(
       timingValues['warm-shell-response'] = interaction.warmShellResponse;
       timingValues['skeleton-to-content'] = interaction.skeletonToContent;
     } else {
-      const startedAt = Date.now();
+      const startedAt = aliasProbe?.startEpochMs ?? Date.now();
       await page.goto(url, {
         timeout: NAVIGATION_TIMEOUT_MS,
         waitUntil: 'domcontentloaded',
@@ -1292,6 +1549,11 @@ async function measureRouteSample(
       }
 
       if (route.aliasUsableResult) {
+        if (!aliasProbe) {
+          throw new Error(
+            'Alias route is missing its browser readiness probe.'
+          );
+        }
         assertAliasUsableResultUrl(baseUrl, route, resolvedPath, page.url());
         await waitForAnyVisible(page, route.readySelectors.shell);
         await waitForAnyVisible(page, route.readySelectors.content);
@@ -1299,7 +1561,45 @@ async function measureRouteSample(
           page,
           route.aliasUsableResult.destinationAffordances
         );
-        timingValues['usable-alias-result'] = Date.now() - startedAt;
+        try {
+          await page.waitForFunction(
+            sampleKey => {
+              const perfWindow = window as PerfPageWindow;
+              const state = perfWindow.__perfAliasPhaseProbe;
+              return (
+                state?.sampleKey === sampleKey &&
+                typeof state.destinationAffordanceMs === 'number'
+              );
+            },
+            aliasProbe.sampleKey,
+            { timeout: READY_TIMEOUT_MS }
+          );
+        } catch (error) {
+          const probeEvidence = await page.evaluate(sampleKey => {
+            const perfWindow = window as PerfPageWindow;
+            const state = perfWindow.__perfAliasPhaseProbe;
+            return {
+              currentPath: `${window.location.pathname}${window.location.search}`,
+              phases: state?.sampleKey === sampleKey ? state : null,
+            };
+          }, aliasProbe.sampleKey);
+          const reason = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Alias readiness probe did not complete: ${JSON.stringify(probeEvidence)}. Underlying: ${reason}`
+          );
+        }
+        controllerObservedAliasResultMs = Date.now() - startedAt;
+        const probeState = await page.evaluate(sampleKey => {
+          const perfWindow = window as PerfPageWindow;
+          const state = perfWindow.__perfAliasPhaseProbe;
+          return state?.sampleKey === sampleKey ? state : null;
+        }, aliasProbe.sampleKey);
+        aliasPhases = assertAliasPhaseTiming(
+          probeState,
+          aliasProbe.sampleKey,
+          controllerObservedAliasResultMs
+        );
+        applyAliasPhaseTimings(timingValues, aliasPhases);
       }
 
       if (
@@ -1345,6 +1645,8 @@ async function measureRouteSample(
       browserMetrics.timingValues['time-to-first-byte'];
 
     return {
+      aliasPhases,
+      controllerObservedAliasResultMs,
       finalUrl: browserMetrics.finalUrl,
       resolvedPath,
       resourceValues: browserMetrics.resourceValues,
@@ -1730,8 +2032,11 @@ async function measureRoutesAgainstBudgets(
           devMode
         );
         samples.push(sample);
+        const aliasPhaseSummary = sample.aliasPhases
+          ? ` phases redirect=${formatMetric(sample.aliasPhases.redirectCompleteMs, 'ms')} shell=${formatMetric(sample.aliasPhases.shellVisibleMs, 'ms')} interactive=${formatMetric(sample.aliasPhases.interactiveReadyMs, 'ms')} affordance=${formatMetric(sample.aliasPhases.destinationAffordanceMs, 'ms')} controller=${formatMetric(sample.controllerObservedAliasResultMs ?? 0, 'ms')}`
+          : '';
         logInfo(
-          `  sample ${index + 1}/${options.runs}: ${formatMetric(sample.timingValues[getPrimaryTimingMetricName(route)], 'ms')}`,
+          `  sample ${index + 1}/${options.runs}: ${formatMetric(sample.timingValues[getPrimaryTimingMetricName(route)], 'ms')}${aliasPhaseSummary}`,
           options
         );
       }

--- a/apps/web/tests/scripts/performance-route-manifest.test.ts
+++ b/apps/web/tests/scripts/performance-route-manifest.test.ts
@@ -3,6 +3,7 @@ import { APP_ROUTES } from '../../constants/routes';
 import {
   assertAliasUsableResultUrl,
   assertHostedAliasRunCount,
+  createAliasPhaseProbeConfig,
   createPageResult,
 } from '../../scripts/performance-budgets-guard';
 import {
@@ -272,6 +273,29 @@ function aliasGuardSample(usableAliasResult: number) {
 }
 
 describe('public-profile alias usable-result guard', () => {
+  it('builds a destination-scoped browser probe before navigation', () => {
+    const config = createAliasPhaseProbeConfig(
+      aliasGuardRoute,
+      '/dualipa/listen',
+      1_000,
+      'sample-key'
+    );
+
+    expect(config).toEqual({
+      contentSelectors: [
+        '[data-testid="profile-compact-shell"][data-interactive-ready="true"]',
+      ],
+      destinationSelectors: [
+        '[data-testid="profile-primary-tab-releases"]',
+        '[data-testid="profile-primary-tab-listen"]',
+      ],
+      expectedPaths: ['/dualipa?mode=listen'],
+      sampleKey: 'sample-key',
+      shellSelectors: ['[data-testid="profile-header"]'],
+      startEpochMs: 1_000,
+    });
+  });
+
   it('rejects same-path results on a different origin', () => {
     expect(() =>
       assertAliasUsableResultUrl(


### PR DESCRIPTION
## Outcome

Makes the production public-profile alias gate measure when the destination is visibly usable inside Chromium, instead of charging controller/CDP observation latency to the user-facing metric.

The shared Chromium lifecycle, five fresh contexts per alias, 1000 ms median budget, and 1500 ms hard maximum are unchanged. Missing, stale, non-finite, negative, non-monotonic, or controller-divergent phase evidence fails closed.

Relates #15494.

## What changed

- installs a raw pre-navigation browser probe scoped to the exact canonical destination
- records redirect, visible shell, hydrated interactive shell, and destination-affordance phases
- keeps controller-observed elapsed time as diagnostic evidence only
- preserves all phase evidence in logs and JSON samples
- adds regression coverage for immediate/mutated readiness and fail-closed evidence handling

No product UI, profile behavior, privacy contract, consent flow, threshold, retry, or browser-lifecycle change.

## Exact-artifact evaluation

Replayed all six aliases against the same immutable production-target deployment withheld by the prior controller, using one shared Chromium and five fresh contexts per alias:

| Alias | Median | Hard max |
| --- | ---: | ---: |
| listen | 708.9 ms | 1365.7 ms |
| music | 721.2 ms | 829.6 ms |
| subscribe | 841.2 ms | 1173.8 ms |
| tip | 775.1 ms | 911.3 ms |
| releases | 715.0 ms | 867.2 ms |
| tour | 683.7 ms | 787.7 ms |

30/30 samples passed the unchanged 1500 ms hard maximum; all six medians passed the unchanged 1000 ms budget.

## Verification

- production build: PASS, 469/469 static pages
- production TypeScript check: PASS
- Biome + ESLint: PASS
- focused performance/profile tests: PASS, 119/119
- pre-push full web suite: PASS, 18,285 tests across eight shards
- component ship ratchet + CI harness validation: PASS
- three independent adversarial reviews: no P0-P3 findings

Repository-wide test-typechecking still has the existing unrelated fixture/schema baseline errors; production typecheck and every executed test above pass.