### PR TITLE
fix(profile): isolate browser alias timing

### DIFF
--- a/apps/web/scripts/performance-budgets-guard.test.ts
+++ b/apps/web/scripts/performance-budgets-guard.test.ts
@@ -131,6 +131,7 @@ function markElementVisible(element: Element) {
 
 describe('browser-observed alias readiness', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     document.body.replaceChildren();
     delete (
       window as Window & {
@@ -157,7 +158,6 @@ describe('browser-observed alias readiness', () => {
       expectedPaths: [`${window.location.pathname}${window.location.search}`],
       sampleKey: 'immediate-sample',
       shellSelectors: ['#alias-shell'],
-      startEpochMs: performance.timeOrigin + performance.now() - 100,
     });
     new Function(probeScript)();
 
@@ -166,7 +166,11 @@ describe('browser-observed alias readiness', () => {
         __perfAliasPhaseProbe?: unknown;
       }
     ).__perfAliasPhaseProbe;
-    const phases = assertAliasPhaseTiming(state, 'immediate-sample', 500);
+    const phases = assertAliasPhaseTiming(
+      state,
+      'immediate-sample',
+      performance.now() + 1_000
+    );
 
     expect(phases.redirectCompleteMs).toBeLessThanOrEqual(
       phases.shellVisibleMs
@@ -177,6 +181,45 @@ describe('browser-observed alias readiness', () => {
     expect(phases.interactiveReadyMs).toBeLessThanOrEqual(
       phases.destinationAffordanceMs
     );
+  });
+
+  it('uses the browser navigation clock instead of a controller epoch', () => {
+    const shell = document.createElement('div');
+    shell.id = 'alias-shell';
+    const content = document.createElement('div');
+    content.id = 'alias-content';
+    const destination = document.createElement('button');
+    destination.id = 'alias-destination';
+    for (const element of [shell, content, destination]) {
+      markElementVisible(element);
+      document.body.append(element);
+    }
+    vi.spyOn(performance, 'now').mockReturnValue(137);
+
+    const probeScript = createAliasPhaseProbeScript({
+      contentSelectors: ['#alias-content'],
+      destinationSelectors: ['#alias-destination'],
+      expectedPaths: [`${window.location.pathname}${window.location.search}`],
+      sampleKey: 'browser-clock-sample',
+      shellSelectors: ['#alias-shell'],
+    });
+    new Function(probeScript)();
+
+    const state = (
+      window as Window & {
+        __perfAliasPhaseProbe?: unknown;
+      }
+    ).__perfAliasPhaseProbe;
+    const phases = assertAliasPhaseTiming(state, 'browser-clock-sample', 5_000);
+
+    expect(phases).toEqual({
+      destinationAffordanceMs: 137,
+      interactiveReadyMs: 137,
+      redirectCompleteMs: 137,
+      shellVisibleMs: 137,
+    });
+    expect(probeScript).not.toContain('Date.now');
+    expect(probeScript).not.toContain('timeOrigin');
   });
 
   it('records a destination that becomes visible after installation', async () => {
@@ -198,7 +241,6 @@ describe('browser-observed alias readiness', () => {
       expectedPaths: [`${window.location.pathname}${window.location.search}`],
       sampleKey: 'mutation-sample',
       shellSelectors: ['#alias-shell'],
-      startEpochMs: performance.timeOrigin + performance.now() - 100,
     });
     new Function(probeScript)();
 

--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -106,7 +106,6 @@ export interface AliasPhaseProbeConfig {
   readonly expectedPaths: readonly string[];
   readonly sampleKey: string;
   readonly shellSelectors: readonly string[];
-  readonly startEpochMs: number;
 }
 
 interface AliasPhaseProbeState {
@@ -289,7 +288,7 @@ export function createAliasPhaseProbeScript(config: AliasPhaseProbeConfig) {
     );
   }
   function elapsedMs() {
-    return performance.timeOrigin + performance.now() - config.startEpochMs;
+    return performance.now();
   }
   function isVisible(selectors) {
     for (const selector of selectors) {
@@ -721,7 +720,6 @@ export function assertAliasUsableResultUrl(
 export function createAliasPhaseProbeConfig(
   route: PerfRouteDefinition,
   resolvedPath: string,
-  startEpochMs: number,
   sampleKey: string
 ): AliasPhaseProbeConfig | undefined {
   if (!route.aliasUsableResult) {
@@ -735,7 +733,6 @@ export function createAliasPhaseProbeConfig(
     ),
     sampleKey,
     shellSelectors: route.readySelectors.shell ?? [],
-    startEpochMs,
   };
 }
 
@@ -1473,7 +1470,6 @@ async function measureRouteSample(
     const aliasProbe = createAliasPhaseProbeConfig(
       route,
       resolvedPath,
-      Date.now(),
       randomUUID()
     );
     if (aliasProbe) {
@@ -1534,7 +1530,10 @@ async function measureRouteSample(
       timingValues['warm-shell-response'] = interaction.warmShellResponse;
       timingValues['skeleton-to-content'] = interaction.skeletonToContent;
     } else {
-      const startedAt = aliasProbe?.startEpochMs ?? Date.now();
+      // Browser-local performance.now() begins at the navigation time origin,
+      // includes same-origin redirects, and excludes Node-to-CDP scheduling.
+      // Keep this wall-clock timer as a controller diagnostic only.
+      const startedAt = Date.now();
       await page.goto(url, {
         timeout: NAVIGATION_TIMEOUT_MS,
         waitUntil: 'domcontentloaded',

--- a/apps/web/tests/scripts/performance-route-manifest.test.ts
+++ b/apps/web/tests/scripts/performance-route-manifest.test.ts
@@ -277,7 +277,6 @@ describe('public-profile alias usable-result guard', () => {
     const config = createAliasPhaseProbeConfig(
       aliasGuardRoute,
       '/dualipa/listen',
-      1_000,
       'sample-key'
     );
 
@@ -292,7 +291,6 @@ describe('public-profile alias usable-result guard', () => {
       expectedPaths: ['/dualipa?mode=listen'],
       sampleKey: 'sample-key',
       shellSelectors: ['[data-testid="profile-header"]'],
-      startEpochMs: 1_000,
     });
   });
 


### PR DESCRIPTION
## Summary

- measures public-profile alias phases from the final document's browser-local navigation clock
- excludes Node-to-CDP scheduling from the budgeted user metric while retaining controller wall time as a diagnostic ceiling
- preserves the exact five fresh contexts, 1000 ms median, 1500 ms absolute max, canonical origin/path checks, and fail-closed phase validation

## Why

The authoritative controller run [30911302326](https://github.com/JovieInc/Jovie/actions/runs/30911302326) correctly stopped before promotion after `/dualipa/tour` reported one 1764.4 ms sample. Phase evidence showed 1367.2 ms before the destination path, but the probe had captured a Node wall-clock epoch before Playwright installed the script and issued `page.goto`. That charged controller/CDP scheduling to the browser metric.

A controlled two-hop Playwright redirect proved final-document `performance.now()` includes the complete redirect chain while excluding an artificial pre-navigation controller delay: 628.3 ms browser-local readiness versus 856 ms controller time with 216 ms injected before `goto`.

## Verification

- Node 22.23.1 / pnpm 9.15.4
- focused performance and manifest tests: 83/83
- full pre-push web suite: 18,286 passing tests across eight shards
- production typecheck: pass
- Biome and targeted ESLint: pass
- proxy, Tailwind, component-ship, CI-harness, gitleaks, and TruffleHog gates: pass
- production build: pass, 469/469 static pages
- three independent adversarial reviews: no P0-P3 findings

## Release boundary

This PR contains source/test evidence only. Production remains unchanged and unverified. The immutable staged alias gate, exact-main merge proof, promotion, post-deploy gates, and independent production profile QA must all pass before this lane is called released.

Relates to JOV-4788 and #15500.
