### PR TITLE
perf(profile): fast-path negative mode aliases

### DIFF
--- a/apps/web/app/[username]/[...slug]/_lib/content-candidate.ts
+++ b/apps/web/app/[username]/[...slug]/_lib/content-candidate.ts
@@ -1,0 +1,124 @@
+import 'server-only';
+
+import { and, eq } from 'drizzle-orm';
+import { unstable_cache } from 'next/cache';
+import { cache } from 'react';
+import { shouldBypassPublicProfileQaCache } from '@/app/[username]/_lib/public-profile-qa';
+import { createSmartLinkContentTag, sanitizeCacheTags } from '@/lib/cache/tags';
+import { db, withRetry } from '@/lib/db';
+import {
+  discogRecordings,
+  discogReleases,
+  discogTracks,
+} from '@/lib/db/schema/content';
+import { env } from '@/lib/env';
+import { logger } from '@/lib/utils/logger';
+
+const PROFILE_MODE_ALIAS_REVALIDATE_SECONDS = 300;
+
+async function fetchProfileModeAliasContentCandidate(
+  creatorProfileId: string,
+  slug: string
+): Promise<boolean> {
+  return await withRetry(async () => {
+    // This is deliberately a conservative presence check, not a public-content
+    // eligibility decision. Any matching row delegates to the canonical smart-
+    // link resolver; only three definite misses may take the fast alias path.
+    const results = await Promise.allSettled([
+      db
+        .select({ id: discogReleases.id })
+        .from(discogReleases)
+        .where(
+          and(
+            eq(discogReleases.creatorProfileId, creatorProfileId),
+            eq(discogReleases.slug, slug)
+          )
+        )
+        .limit(1),
+      db
+        .select({ id: discogRecordings.id })
+        .from(discogRecordings)
+        .where(
+          and(
+            eq(discogRecordings.creatorProfileId, creatorProfileId),
+            eq(discogRecordings.slug, slug)
+          )
+        )
+        .limit(1),
+      db
+        .select({ id: discogTracks.id })
+        .from(discogTracks)
+        .where(
+          and(
+            eq(discogTracks.creatorProfileId, creatorProfileId),
+            eq(discogTracks.slug, slug)
+          )
+        )
+        .limit(1),
+    ]);
+
+    if (
+      results.some(
+        result => result.status === 'fulfilled' && result.value.length > 0
+      )
+    ) {
+      return true;
+    }
+
+    const failedResult = results.find(result => result.status === 'rejected');
+    if (failedResult?.status === 'rejected') {
+      throw failedResult.reason;
+    }
+
+    return false;
+  }, `profileModeAliasContentCandidate(${creatorProfileId}:${slug})`);
+}
+
+/**
+ * Proves only that a legacy profile-mode alias cannot resolve as smart-link
+ * content. A positive result still delegates every eligibility, precedence,
+ * and rendering decision to getContentBySlug.
+ */
+export const hasProfileModeAliasContentCandidate = cache(
+  async (creatorProfileId: string, slug: string): Promise<boolean> => {
+    const load = () =>
+      fetchProfileModeAliasContentCandidate(creatorProfileId, slug);
+
+    try {
+      if (
+        env.NODE_ENV === 'test' ||
+        env.NODE_ENV === 'development' ||
+        shouldBypassPublicProfileQaCache()
+      ) {
+        return await load();
+      }
+
+      return await unstable_cache(
+        load,
+        [`profile-mode-alias-content-candidate-${creatorProfileId}-${slug}`],
+        {
+          tags: sanitizeCacheTags([
+            'smartlink-content',
+            createSmartLinkContentTag(creatorProfileId),
+            `${createSmartLinkContentTag(creatorProfileId)}:${slug}`,
+          ]),
+          revalidate: PROFILE_MODE_ALIAS_REVALIDATE_SECONDS,
+        }
+      )();
+    } catch (error) {
+      logger.error(
+        'Failed profile mode alias content candidate check',
+        {
+          creatorProfileId,
+          error,
+          helper: 'hasProfileModeAliasContentCandidate',
+          route: '/[username]/[...slug]',
+          slug,
+        },
+        'public-profile'
+      );
+      // Never turn uncertainty into a cached profile-mode redirect.
+      throw error;
+    }
+  }
+);

--- a/apps/web/app/[username]/[...slug]/page.tsx
+++ b/apps/web/app/[username]/[...slug]/page.tsx
@@ -11,12 +11,10 @@ import {
   getCreatorByUsername,
   getUnpublishedReleasePresence,
 } from '@/app/[username]/[slug]/_lib/data';
-import ContentSmartLinkPage, {
-  generateMetadata as generateContentSmartLinkMetadata,
-} from '@/app/[username]/[slug]/page';
 import { sanitizeCacheTags } from '@/lib/cache/tags';
 import { findRedirectByOldSlug } from '@/lib/discography/slug';
 import { REDIRECT_SINK_METADATA } from '@/lib/profile/metadata';
+import { hasProfileModeAliasContentCandidate } from './_lib/content-candidate';
 
 const PROFILE_MODE_ALIAS_MARKER = '__profile-mode-alias';
 const PROFILE_MODE_ALIAS_RESOLVER = 'resolve';
@@ -110,6 +108,18 @@ export async function generateMetadata({
   const { username, slug } = await params;
   const aliasRequest = getAliasRequest(slug);
   if (aliasRequest) {
+    const creator = await getCreatorByUsername(username.toLowerCase());
+    if (!creator) return REDIRECT_SINK_METADATA;
+
+    const hasContentCandidate = await hasProfileModeAliasContentCandidate(
+      creator.id,
+      aliasRequest.aliasSlug
+    );
+    if (!hasContentCandidate) return REDIRECT_SINK_METADATA;
+
+    const { generateMetadata: generateContentSmartLinkMetadata } = await import(
+      '@/app/[username]/[slug]/page'
+    );
     return generateContentSmartLinkMetadata({
       params: Promise.resolve({ username, slug: aliasRequest.aliasSlug }),
     });
@@ -127,10 +137,9 @@ export default async function CatchAllPage({
   const creator = await getCreatorByUsername(username.toLowerCase());
   if (!creator) notFound();
 
-  // Start the collision checks with the content lookup. The common mode-alias
-  // path no longer pays a second serial cache/database stage after proving the
-  // slug is not renderable content. Published content keeps precedence: a
-  // collision-check failure is ignored when the canonical renderer already won.
+  // Start independent collision and candidate checks together. The common
+  // profile-mode alias path performs bounded ID-only checks in parallel;
+  // any possible content still delegates to the canonical smart-link loader.
   const collisionStatePromise = getAliasCollisionState(
     creator.id,
     aliasRequest.aliasSlug
@@ -138,7 +147,13 @@ export default async function CatchAllPage({
     value => ({ ok: true as const, value }),
     error => ({ error, ok: false as const })
   );
-  const content = await getContentBySlug(creator.id, aliasRequest.aliasSlug);
+  const hasContentCandidate = await hasProfileModeAliasContentCandidate(
+    creator.id,
+    aliasRequest.aliasSlug
+  );
+  const content = hasContentCandidate
+    ? await getContentBySlug(creator.id, aliasRequest.aliasSlug)
+    : null;
   if (!content) {
     const collisionState = await collisionStatePromise;
     if (!collisionState.ok) throw collisionState.error;
@@ -163,6 +178,9 @@ export default async function CatchAllPage({
   // Published and unpublished collisions keep the original public URL and use
   // the canonical smart-link renderer. Data helpers are request-memoized, so
   // this delegation does not turn the collision check into duplicate DB work.
+  const { default: ContentSmartLinkPage } = await import(
+    '@/app/[username]/[slug]/page'
+  );
   return (
     <ContentSmartLinkPage
       params={Promise.resolve({

--- a/apps/web/tests/unit/profile/profile-mode-alias-content-candidate.test.ts
+++ b/apps/web/tests/unit/profile/profile-mode-alias-content-candidate.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const tables = {
+    discogRecordings: {
+      id: 'recording-id',
+      creatorProfileId: 'recording-profile-id',
+      slug: 'recording-slug',
+    },
+    discogReleases: {
+      id: 'release-id',
+      creatorProfileId: 'release-profile-id',
+      slug: 'release-slug',
+    },
+    discogTracks: {
+      id: 'track-id',
+      creatorProfileId: 'track-profile-id',
+      slug: 'track-slug',
+    },
+  };
+
+  return {
+    dbSelect: vi.fn(),
+    loggerError: vi.fn(),
+    shouldBypassPublicProfileQaCache: vi.fn().mockReturnValue(false),
+    tables,
+    unstableCache: vi.fn((load: () => Promise<unknown>) => load),
+    withRetry: vi.fn(async (operation: () => Promise<unknown>) => operation()),
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    cache: <T extends (...args: never[]) => unknown>(fn: T): T => fn,
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  and: (...conditions: unknown[]) => conditions,
+  eq: (...values: unknown[]) => values,
+}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache: mocks.unstableCache,
+}));
+
+vi.mock('@/app/[username]/_lib/public-profile-qa', () => ({
+  shouldBypassPublicProfileQaCache: mocks.shouldBypassPublicProfileQaCache,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { select: mocks.dbSelect },
+  withRetry: mocks.withRetry,
+}));
+
+vi.mock('@/lib/db/schema/content', () => mocks.tables);
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { error: mocks.loggerError },
+}));
+
+type QueryResult = Promise<readonly { readonly id: string }[]>;
+
+function mockCandidateQueries(
+  results: readonly QueryResult[],
+  expectedSlug: string
+) {
+  const resultByTable = new Map<unknown, QueryResult>([
+    [mocks.tables.discogReleases, results[0]],
+    [mocks.tables.discogRecordings, results[1]],
+    [mocks.tables.discogTracks, results[2]],
+  ]);
+
+  mocks.dbSelect.mockImplementation(() => ({
+    from: vi.fn((table: (typeof mocks.tables)[keyof typeof mocks.tables]) => {
+      const result = resultByTable.get(table);
+      if (!result) throw new Error('Unexpected candidate query table');
+
+      return {
+        where: vi.fn((conditions: unknown) => {
+          expect(conditions).toEqual([
+            [table.creatorProfileId, 'profile-1'],
+            [table.slug, expectedSlug],
+          ]);
+          return {
+            limit: vi.fn((limit: number) => {
+              expect(limit).toBe(1);
+              return result;
+            }),
+          };
+        }),
+      };
+    }),
+  }));
+}
+
+describe('profile mode alias content candidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.shouldBypassPublicProfileQaCache.mockReturnValue(false);
+    mocks.unstableCache.mockImplementation(
+      (load: () => Promise<unknown>) => load
+    );
+    mocks.withRetry.mockImplementation(
+      async (operation: () => Promise<unknown>) => operation()
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('proves a miss only after all three indexed lookups miss in parallel', async () => {
+    let resolveRelease:
+      | ((rows: readonly { readonly id: string }[]) => void)
+      | undefined;
+    let resolveRecording:
+      | ((rows: readonly { readonly id: string }[]) => void)
+      | undefined;
+    let resolveLegacyTrack:
+      | ((rows: readonly { readonly id: string }[]) => void)
+      | undefined;
+    mockCandidateQueries(
+      [
+        new Promise(resolve => {
+          resolveRelease = resolve;
+        }),
+        new Promise(resolve => {
+          resolveRecording = resolve;
+        }),
+        new Promise(resolve => {
+          resolveLegacyTrack = resolve;
+        }),
+      ],
+      'listen'
+    );
+
+    const { hasProfileModeAliasContentCandidate } = await import(
+      '@/app/[username]/[...slug]/_lib/content-candidate'
+    );
+    const result = hasProfileModeAliasContentCandidate('profile-1', 'listen');
+
+    await vi.waitFor(() => expect(mocks.dbSelect).toHaveBeenCalledTimes(3));
+    resolveRelease?.([]);
+    resolveRecording?.([]);
+    resolveLegacyTrack?.([]);
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  it.each([
+    0, 1, 2,
+  ])('delegates to the canonical resolver when candidate lookup %i finds a row', async candidateIndex => {
+    mockCandidateQueries(
+      [0, 1, 2].map(index =>
+        Promise.resolve(index === candidateIndex ? [{ id: 'candidate' }] : [])
+      ),
+      'music'
+    );
+
+    const { hasProfileModeAliasContentCandidate } = await import(
+      '@/app/[username]/[...slug]/_lib/content-candidate'
+    );
+
+    await expect(
+      hasProfileModeAliasContentCandidate('profile-1', 'music')
+    ).resolves.toBe(true);
+  });
+
+  it('delegates when a candidate hit has a parallel lookup failure', async () => {
+    mockCandidateQueries(
+      [
+        Promise.resolve([{ id: 'candidate' }]),
+        Promise.reject(new Error('recording lookup unavailable')),
+        Promise.resolve([]),
+      ],
+      'music'
+    );
+
+    const { hasProfileModeAliasContentCandidate } = await import(
+      '@/app/[username]/[...slug]/_lib/content-candidate'
+    );
+
+    await expect(
+      hasProfileModeAliasContentCandidate('profile-1', 'music')
+    ).resolves.toBe(true);
+  });
+
+  it('fails closed when any candidate lookup is uncertain', async () => {
+    const failure = new Error('database unavailable');
+    mockCandidateQueries(
+      [Promise.reject(failure), Promise.resolve([]), Promise.resolve([])],
+      'tour'
+    );
+
+    const { hasProfileModeAliasContentCandidate } = await import(
+      '@/app/[username]/[...slug]/_lib/content-candidate'
+    );
+
+    await expect(
+      hasProfileModeAliasContentCandidate('profile-1', 'tour')
+    ).rejects.toThrow('database unavailable');
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      'Failed profile mode alias content candidate check',
+      expect.objectContaining({
+        creatorProfileId: 'profile-1',
+        helper: 'hasProfileModeAliasContentCandidate',
+        slug: 'tour',
+      }),
+      'public-profile'
+    );
+  });
+
+  it('shares the canonical smart-link tags and five-minute TTL in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mockCandidateQueries(
+      [Promise.resolve([]), Promise.resolve([]), Promise.resolve([])],
+      'alerts'
+    );
+
+    const { hasProfileModeAliasContentCandidate } = await import(
+      '@/app/[username]/[...slug]/_lib/content-candidate'
+    );
+    await hasProfileModeAliasContentCandidate('profile-1', 'alerts');
+
+    expect(mocks.unstableCache).toHaveBeenCalledWith(
+      expect.any(Function),
+      ['profile-mode-alias-content-candidate-profile-1-alerts'],
+      {
+        tags: [
+          'smartlink-content',
+          'smartlink-content:profile-1',
+          'smartlink-content:profile-1:alerts',
+        ],
+        revalidate: 300,
+      }
+    );
+  });
+
+  it('bypasses cross-request caching for deterministic profile QA', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mocks.shouldBypassPublicProfileQaCache.mockReturnValue(true);
+    mockCandidateQueries(
+      [Promise.resolve([]), Promise.resolve([]), Promise.resolve([])],
+      'shop'
+    );
+
+    const { hasProfileModeAliasContentCandidate } = await import(
+      '@/app/[username]/[...slug]/_lib/content-candidate'
+    );
+    await hasProfileModeAliasContentCandidate('profile-1', 'shop');
+
+    expect(mocks.unstableCache).not.toHaveBeenCalled();
+    expect(mocks.dbSelect).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/tests/unit/release/smart-link-metadata.test.ts
+++ b/apps/web/tests/unit/release/smart-link-metadata.test.ts
@@ -4,6 +4,7 @@ const {
   getContentBySlugMock,
   getCreatorByUsernameMock,
   getFeaturedSmartLinkStaticParamsMock,
+  hasProfileModeAliasContentCandidateMock,
   getUnpublishedReleasePresenceMock,
   findRedirectByOldSlugMock,
   notFoundMock,
@@ -13,6 +14,7 @@ const {
   getContentBySlugMock: vi.fn(),
   getCreatorByUsernameMock: vi.fn(),
   getFeaturedSmartLinkStaticParamsMock: vi.fn().mockResolvedValue([]),
+  hasProfileModeAliasContentCandidateMock: vi.fn(),
   getUnpublishedReleasePresenceMock: vi.fn(),
   findRedirectByOldSlugMock: vi.fn(),
   notFoundMock: vi.fn(),
@@ -56,6 +58,10 @@ vi.mock('@/lib/discography/slug', () => ({
   findRedirectByOldSlug: findRedirectByOldSlugMock,
 }));
 
+vi.mock('@/app/[username]/[...slug]/_lib/content-candidate', () => ({
+  hasProfileModeAliasContentCandidate: hasProfileModeAliasContentCandidateMock,
+}));
+
 vi.mock('@/lib/entity/queries', () => ({
   getArtistEntitySameAs: vi.fn().mockResolvedValue([]),
 }));
@@ -65,6 +71,8 @@ describe('smart-link metadata', () => {
     vi.resetModules();
     getCreatorByUsernameMock.mockReset();
     getContentBySlugMock.mockReset();
+    hasProfileModeAliasContentCandidateMock.mockReset();
+    hasProfileModeAliasContentCandidateMock.mockResolvedValue(false);
     getUnpublishedReleasePresenceMock.mockReset();
     getUnpublishedReleasePresenceMock.mockResolvedValue(null);
     findRedirectByOldSlugMock.mockReset();
@@ -155,6 +163,10 @@ describe('smart-link metadata', () => {
   });
 
   it('renders published content before considering a matching mode alias', async () => {
+    hasProfileModeAliasContentCandidateMock.mockResolvedValue(true);
+    findRedirectByOldSlugMock.mockResolvedValue({
+      currentSlug: 'renamed-music',
+    });
     getContentBySlugMock.mockResolvedValue({
       id: 'track-music',
       type: 'track',
@@ -190,6 +202,7 @@ describe('smart-link metadata', () => {
 
     expect(result).toBeTruthy();
     expect(redirectMock).not.toHaveBeenCalled();
+    expect(permanentRedirectMock).not.toHaveBeenCalled();
     expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledOnce();
   });
 
@@ -202,9 +215,56 @@ describe('smart-link metadata', () => {
     expect(revalidate).toBe(300);
   });
 
-  it('uses a matching mode alias only after content lookups miss', async () => {
-    getContentBySlugMock.mockResolvedValue(null);
+  it('returns redirect-sink metadata without loading the smart-link resolver after definite content misses', async () => {
+    const { generateMetadata } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
 
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        username: 'dualipa',
+        slug: ['listen', '__profile-mode-alias', 'resolve'],
+      }),
+    });
+
+    expect(metadata).toEqual({ robots: { index: false, follow: false } });
+    expect(hasProfileModeAliasContentCandidateMock).toHaveBeenCalledWith(
+      'creator-1',
+      'listen'
+    );
+    expect(getContentBySlugMock).not.toHaveBeenCalled();
+  });
+
+  it('delegates candidate metadata to the canonical smart-link resolver', async () => {
+    hasProfileModeAliasContentCandidateMock.mockResolvedValue(true);
+    getContentBySlugMock.mockResolvedValue({
+      id: 'track-music',
+      type: 'track',
+      slug: 'music',
+      releaseSlug: null,
+      title: 'Music',
+      artworkUrl: 'https://example.com/music.jpg',
+      artworkSizes: null,
+      releaseDate: new Date('2024-01-01T00:00:00Z'),
+      providerLinks: [],
+      previewUrl: null,
+    });
+
+    const { generateMetadata } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        username: 'dualipa',
+        slug: ['music', '__profile-mode-alias', 'resolve'],
+      }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe('https://jov.ie/dualipa/music');
+    expect(getContentBySlugMock).toHaveBeenCalledWith('creator-1', 'music');
+  });
+
+  it('uses a matching mode alias after definite content misses', async () => {
     const { default: ProfileAliasResolverPage } = await import(
       '@/app/[username]/[...slug]/page'
     );
@@ -227,6 +287,7 @@ describe('smart-link metadata', () => {
       'music',
       { onError: 'throw' }
     );
+    expect(getContentBySlugMock).not.toHaveBeenCalled();
     expect(redirectMock).toHaveBeenCalledWith('/dualipa?mode=listen&source=qr');
   });
 
@@ -275,6 +336,28 @@ describe('smart-link metadata', () => {
     expect(permanentRedirectMock).not.toHaveBeenCalled();
   });
 
+  it('fails closed when the content-candidate check is uncertain', async () => {
+    hasProfileModeAliasContentCandidateMock.mockRejectedValue(
+      new Error('candidate lookup unavailable')
+    );
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+
+    await expect(
+      ProfileAliasResolverPage({
+        params: Promise.resolve({
+          username: 'dualipa',
+          slug: ['listen', '__profile-mode-alias', 'resolve'],
+        }),
+      })
+    ).rejects.toThrow('candidate lookup unavailable');
+    expect(getContentBySlugMock).not.toHaveBeenCalled();
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(permanentRedirectMock).not.toHaveBeenCalled();
+  });
+
   it('keeps renamed-release redirects ahead of matching mode aliases', async () => {
     getContentBySlugMock.mockResolvedValue(null);
     findRedirectByOldSlugMock.mockResolvedValue({
@@ -302,7 +385,34 @@ describe('smart-link metadata', () => {
     expect(redirectMock).not.toHaveBeenCalled();
   });
 
+  it('keeps renamed-release redirects after a conservative candidate falls through', async () => {
+    hasProfileModeAliasContentCandidateMock.mockResolvedValue(true);
+    getContentBySlugMock.mockResolvedValue(null);
+    findRedirectByOldSlugMock.mockResolvedValue({
+      currentSlug: 'renamed-music',
+    });
+
+    const { default: ProfileAliasResolverPage } = await import(
+      '@/app/[username]/[...slug]/page'
+    );
+
+    await expect(
+      ProfileAliasResolverPage({
+        params: Promise.resolve({
+          username: 'dualipa',
+          slug: ['music', '__profile-mode-alias', 'resolve'],
+        }),
+      })
+    ).rejects.toThrow('NEXT_PERMANENT_REDIRECT');
+    expect(getContentBySlugMock).toHaveBeenCalledWith('creator-1', 'music');
+    expect(permanentRedirectMock).toHaveBeenCalledWith(
+      '/dualipa/renamed-music'
+    );
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
   it('keeps unpublished collisions on the canonical smart-link renderer', async () => {
+    hasProfileModeAliasContentCandidateMock.mockResolvedValue(true);
     getContentBySlugMock.mockResolvedValue(null);
     getUnpublishedReleasePresenceMock.mockResolvedValue({
       id: 'unpublished-music',
@@ -323,14 +433,14 @@ describe('smart-link metadata', () => {
     expect(redirectMock).not.toHaveBeenCalled();
   });
 
-  it('starts content and independent alias collision checks in parallel', async () => {
-    let resolveContentLookup: ((value: null) => void) | undefined;
+  it('starts candidate and independent alias collision checks in parallel', async () => {
+    let resolveCandidateLookup: ((value: false) => void) | undefined;
     let resolveRedirectLookup: ((value: null) => void) | undefined;
     let resolveUnpublishedLookup: ((value: null) => void) | undefined;
-    getContentBySlugMock.mockImplementation(
+    hasProfileModeAliasContentCandidateMock.mockImplementation(
       () =>
-        new Promise<null>(resolve => {
-          resolveContentLookup = resolve;
+        new Promise<false>(resolve => {
+          resolveCandidateLookup = resolve;
         })
     );
     findRedirectByOldSlugMock.mockImplementation(
@@ -357,17 +467,19 @@ describe('smart-link metadata', () => {
     });
 
     await vi.waitFor(() => {
-      expect(getContentBySlugMock).toHaveBeenCalledOnce();
+      expect(hasProfileModeAliasContentCandidateMock).toHaveBeenCalledOnce();
       expect(findRedirectByOldSlugMock).toHaveBeenCalledOnce();
       expect(getUnpublishedReleasePresenceMock).toHaveBeenCalledOnce();
     });
-    resolveContentLookup?.(null);
+    resolveCandidateLookup?.(false);
     resolveRedirectLookup?.(null);
     resolveUnpublishedLookup?.(null);
     await expect(result).rejects.toThrow('NEXT_REDIRECT');
+    expect(getContentBySlugMock).not.toHaveBeenCalled();
   });
 
   it('settles collision failures while published-content lookup is pending', async () => {
+    hasProfileModeAliasContentCandidateMock.mockResolvedValue(true);
     let resolveContentLookup:
       | ((value: { id: string; type: string; slug: string }) => void)
       | undefined;


### PR DESCRIPTION
## Description

Fixes forward the production-only cold tail observed on legacy public-profile mode aliases. The required post-deploy profile gate on exact main `7845e48d3f72cd98d49e4dbf6340d6ceaf3e628f` passed 28/30 samples but recorded redirect-dominated `/dualipa/listen` outliers at 1606.7 ms and 1520.9 ms against the existing 1500 ms hard maximum.

This PR:

- runs release, recording, and legacy-track ID-presence checks concurrently for the six reserved profile-mode aliases;
- skips the canonical smart-link content resolver and its large page module only after all three content models definitely miss;
- delegates every possible candidate to the unchanged canonical resolver;
- preserves published content > renamed slug > unpublished content > profile-mode redirect precedence;
- shares the exact `smartlink-content` tags, 300-second TTL, and deterministic QA bypass used by the canonical path;
- throws on uncertain all-miss results, so lookup failure cannot become a cached redirect.

No performance threshold, retry policy, rewrite, middleware, route revalidation, consent/auth flow, UI composition, migration, or external-data embedding changed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Chore

## Testing

- [x] Unit tests pass
- [ ] E2E tests pass — exact staged/production browser gates are owned by the post-merge production controller
- [x] Manual testing completed
- [x] New regression tests added

### Bug-to-Test Rule

- [x] Regression tests added or updated
- [x] `bug-to-test: satisfied`

Regression coverage proves all three content models, exact query targets/predicates, parallel start, positive-hit plus parallel failure, all-miss fail-closed behavior, canonical cache tags/TTL, QA cache bypass, metadata short-circuit, published/renamed/unpublished precedence, unsupported attribution, and direct-marker rejection.

### Local receipts (Node 22.23.1, pnpm 9.15.4)

- Full Vitest: **18,298 passed, 0 failed**; 75 intentional pending, 6 todo; all 6,806 suites passed.
- Focused final: **168 passed**, 31 intentional skips.
- Push-selected gate: **44/44 passed**, including profile layout-shift/card/hero ratchets.
- `pnpm turbo typecheck`: **11/11 packages passed**.
- Production build: **469/469 static routes generated**.
- Biome, ESLint, server boundaries, Tailwind guard, component ship gate, CI harness, secret scans: passed.
- Three independent low-reasoning reviews: no remaining P0-P3 findings.
- Local CodeRabbit: source findings fixed; final retry after test-hardening was service-rate-limited for 43 minutes.

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Complex precedence and fail-closed behavior commented
- [x] No console logging added
- [x] TypeScript types defined
- [x] Performance considerations addressed

## Accessibility / Browser Testing

No rendered UI or interaction changed. Existing exhaustive public-profile accessibility, keyboard/touch, reduced-motion, responsive, hero-fill, glass-navigation, and one-card carousel evidence remains unchanged. Exact staged and canonical browser verification is required post-merge.

## Database Changes

None. Read-only indexed/bounded ID-presence queries only; no schema or migration change.

## Deployment Notes

- Fresh controller generation required; do not rerun the failed deployment generation.
- Existing 1500 ms hard maximum and 1000 ms median remain unchanged.
- Production verification must be reported separately from source CI and merge evidence.

## Design Skill Evidence

`design-canonical: not applicable` — this fix changes only server alias resolution and tests; no pixels, copy, motion, density, icons, or composition changed.

## Related Issues

- JOV-4788
- Related to #15494

## Checklist

- [x] Conventional PR title
- [x] Branch based on current `origin/main`
- [ ] All hosted CI checks pass
- [x] Documentation not required
- [x] Changelog not required for internal route-performance repair
