### PR TITLE
test(profile): require alias hop receipts

### DIFF
--- a/apps/web/scripts/performance-budgets-guard.test.ts
+++ b/apps/web/scripts/performance-budgets-guard.test.ts
@@ -1,4 +1,9 @@
-import type { Browser, BrowserContext, Page } from '@playwright/test';
+import type {
+  Browser,
+  BrowserContext,
+  Page,
+  Response as PlaywrightResponse,
+} from '@playwright/test';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const playwrightMocks = vi.hoisted(() => ({
@@ -21,8 +26,10 @@ import type {
 import {
   applyAliasPhaseTimings,
   applyProfileWarmTransitionTimings,
+  assertAliasNavigationHopReceipts,
   assertAliasPhaseTiming,
   buildConfirmedPageResult,
+  collectAliasNavigationHopReceipts,
   confirmTimingViolations,
   createAliasPhaseProbeScript,
   createContextOptions,
@@ -128,6 +135,184 @@ function markElementVisible(element: Element) {
     { height: 1, width: 1 },
   ] as unknown as DOMRectList);
 }
+
+interface MockNavigationRequest {
+  redirectedFrom: () => MockNavigationRequest | null;
+  response: () => Promise<MockNavigationResponse | null>;
+  url: () => string;
+}
+
+interface MockNavigationResponse {
+  headers: () => Record<string, string>;
+  request: () => MockNavigationRequest;
+  status: () => number;
+  url: () => string;
+}
+
+function createNavigationResponseChain(
+  hops: readonly {
+    readonly headers?: Record<string, string>;
+    readonly status: number;
+    readonly url: string;
+  }[]
+) {
+  let previousRequest: MockNavigationRequest | null = null;
+  let finalResponse: MockNavigationResponse | null = null;
+
+  for (const hop of hops) {
+    const redirectedFrom = previousRequest;
+    let response: MockNavigationResponse;
+    const request: MockNavigationRequest = {
+      redirectedFrom: () => redirectedFrom,
+      response: async () => response,
+      url: () => hop.url,
+    };
+    response = {
+      headers: () => hop.headers ?? {},
+      request: () => request,
+      status: () => hop.status,
+      url: () => hop.url,
+    };
+    previousRequest = request;
+    finalResponse = response;
+  }
+
+  return finalResponse as unknown as PlaywrightResponse;
+}
+
+function createAliasReceiptRoute() {
+  return {
+    aliasUsableResult: {
+      canonicalPath: '/[username]?mode=listen',
+      destinationAffordances: ['[data-testid="profile-primary-tab-listen"]'],
+    },
+    id: 'public-profile-listen',
+    path: '/[username]/listen',
+    readySelectors: {
+      content: ['[data-testid="profile-compact-shell"]'],
+      redirectDestinations: ['/[username]?mode=listen'],
+      shell: ['[data-testid="profile-compact-shell"]'],
+    },
+  } as PerfRouteDefinition;
+}
+
+describe('alias HTTP hop receipts', () => {
+  it('records the ordered redirect and canonical cache receipts', async () => {
+    const response = createNavigationResponseChain([
+      {
+        headers: {
+          age: '3',
+          'server-timing': 'resolver;dur=12',
+          'x-vercel-cache': 'HIT',
+          'x-vercel-id': 'sfo1::iad1::alias',
+        },
+        status: 307,
+        url: 'https://jov.ie/dualipa/listen',
+      },
+      {
+        headers: {
+          age: '901',
+          'x-nextjs-cache': 'HIT',
+          'x-vercel-cache': 'HIT',
+          'x-vercel-id': 'sfo1::canonical',
+        },
+        status: 200,
+        url: 'https://jov.ie/dualipa?mode=listen',
+      },
+    ]);
+
+    const receipts = await collectAliasNavigationHopReceipts(response);
+
+    expect(receipts).toEqual([
+      {
+        age: '3',
+        edgeCache: 'HIT',
+        nextCache: null,
+        origin: 'https://jov.ie',
+        path: '/dualipa/listen',
+        serverTiming: 'resolver;dur=12',
+        status: 307,
+        vercelId: 'sfo1::iad1::alias',
+      },
+      {
+        age: '901',
+        edgeCache: 'HIT',
+        nextCache: 'HIT',
+        origin: 'https://jov.ie',
+        path: '/dualipa?mode=listen',
+        serverTiming: null,
+        status: 200,
+        vercelId: 'sfo1::canonical',
+      },
+    ]);
+    expect(() =>
+      assertAliasNavigationHopReceipts(
+        'https://jov.ie',
+        createAliasReceiptRoute(),
+        '/dualipa/listen',
+        receipts
+      )
+    ).not.toThrow();
+  });
+
+  it.each([
+    {
+      label: 'client-side alias transition',
+      hops: [
+        {
+          age: null,
+          edgeCache: 'HIT',
+          nextCache: null,
+          origin: 'https://jov.ie',
+          path: '/dualipa?mode=listen',
+          serverTiming: null,
+          status: 200,
+          vercelId: 'sfo1::canonical',
+        },
+      ],
+    },
+    {
+      label: 'wrong redirect status',
+      hops: [
+        {
+          age: null,
+          edgeCache: 'HIT',
+          nextCache: null,
+          origin: 'https://jov.ie',
+          path: '/dualipa/listen',
+          serverTiming: null,
+          status: 308,
+          vercelId: 'sfo1::alias',
+        },
+        {
+          age: null,
+          edgeCache: 'HIT',
+          nextCache: null,
+          origin: 'https://jov.ie',
+          path: '/dualipa?mode=listen',
+          serverTiming: null,
+          status: 200,
+          vercelId: 'sfo1::canonical',
+        },
+      ],
+    },
+  ])('fails closed on a $label receipt', ({ hops }) => {
+    expect(() =>
+      assertAliasNavigationHopReceipts(
+        'https://jov.ie',
+        createAliasReceiptRoute(),
+        '/dualipa/listen',
+        hops
+      )
+    ).toThrow(/expected|HTTP hops/);
+  });
+
+  it('fails closed when navigation returns no HTTP response', async () => {
+    await expect(collectAliasNavigationHopReceipts(null)).rejects.toThrow(
+      /no HTTP response receipt/
+    );
+  });
+});
 
 describe('browser-observed alias readiness', () => {
   afterEach(() => {

--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -7,6 +7,8 @@ import {
   chromium,
   type Locator,
   type Page,
+  type Request as PlaywrightRequest,
+  type Response as PlaywrightResponse,
 } from '@playwright/test';
 import { PAC_TAB_BAR_RETURN_VISIT_KEY } from '../lib/profile/pac-tab-bar-experiment';
 import {
@@ -100,6 +102,17 @@ export interface AliasPhaseTiming {
   readonly destinationAffordanceMs: number;
 }
 
+export interface AliasNavigationHopReceipt {
+  readonly age: string | null;
+  readonly edgeCache: string | null;
+  readonly nextCache: string | null;
+  readonly origin: string;
+  readonly path: string;
+  readonly serverTiming: string | null;
+  readonly status: number;
+  readonly vercelId: string | null;
+}
+
 export interface AliasPhaseProbeConfig {
   readonly contentSelectors: readonly string[];
   readonly destinationSelectors: readonly string[];
@@ -134,6 +147,7 @@ export interface GuardCliOptions {
 
 export interface GuardSample {
   readonly aliasPhases?: AliasPhaseTiming;
+  readonly aliasNavigationHops?: readonly AliasNavigationHopReceipt[];
   readonly controllerObservedAliasResultMs?: number;
   readonly finalUrl: string;
   readonly resolvedPath: string;
@@ -691,6 +705,93 @@ function matchesExpectedPath(actualUrl: URL, expectedPath: string) {
   }
 
   return actualUrl.pathname === normalizedExpected;
+}
+
+export async function collectAliasNavigationHopReceipts(
+  finalResponse: PlaywrightResponse | null
+): Promise<readonly AliasNavigationHopReceipt[]> {
+  if (!finalResponse) {
+    throw new Error('Alias navigation produced no HTTP response receipt.');
+  }
+
+  const requests: PlaywrightRequest[] = [];
+  let request: PlaywrightRequest | null = finalResponse.request();
+  while (request) {
+    requests.unshift(request);
+    request = request.redirectedFrom();
+  }
+
+  const receipts: AliasNavigationHopReceipt[] = [];
+  for (const hopRequest of requests) {
+    const response = await hopRequest.response();
+    if (!response) {
+      throw new Error(
+        `Alias navigation hop ${hopRequest.url()} produced no HTTP response receipt.`
+      );
+    }
+    const headers = response.headers();
+    const responseUrl = new URL(response.url());
+    receipts.push({
+      age: headers.age ?? null,
+      edgeCache: headers['x-vercel-cache'] ?? null,
+      nextCache: headers['x-nextjs-cache'] ?? null,
+      origin: responseUrl.origin,
+      path: `${responseUrl.pathname}${responseUrl.search}`,
+      serverTiming: headers['server-timing'] ?? null,
+      status: response.status(),
+      vercelId: headers['x-vercel-id'] ?? null,
+    });
+  }
+
+  return receipts;
+}
+
+export function assertAliasNavigationHopReceipts(
+  baseUrl: string,
+  route: PerfRouteDefinition,
+  resolvedPath: string,
+  receipts: readonly AliasNavigationHopReceipt[]
+) {
+  const contract = route.aliasUsableResult;
+  if (!contract) return;
+
+  if (receipts.length !== 2) {
+    throw new Error(
+      `Alias route ${route.id} produced ${receipts.length} HTTP hops; expected one 307 redirect and one canonical 200 response.`
+    );
+  }
+
+  const [aliasHop, canonicalHop] = receipts;
+  if (!aliasHop || !canonicalHop) {
+    throw new Error(`Alias route ${route.id} is missing an HTTP hop receipt.`);
+  }
+
+  const expectedOrigin = new URL(baseUrl).origin;
+  if (
+    aliasHop.origin !== expectedOrigin ||
+    canonicalHop.origin !== expectedOrigin
+  ) {
+    throw new Error(`Alias route ${route.id} left the configured origin.`);
+  }
+
+  const expectedAliasPath = normalizePathWithQuery(resolvedPath);
+  if (aliasHop.path !== expectedAliasPath || aliasHop.status !== 307) {
+    throw new Error(
+      `Alias route ${route.id} began with ${aliasHop.status} ${aliasHop.path}; expected 307 ${expectedAliasPath}.`
+    );
+  }
+
+  const expectedCanonicalPath = normalizePathWithQuery(
+    resolveExpectedDynamicPath(contract.canonicalPath, resolvedPath)
+  );
+  if (
+    canonicalHop.path !== expectedCanonicalPath ||
+    canonicalHop.status !== 200
+  ) {
+    throw new Error(
+      `Alias route ${route.id} completed with ${canonicalHop.status} ${canonicalHop.path}; expected 200 ${expectedCanonicalPath}.`
+    );
+  }
 }
 
 export function assertAliasUsableResultUrl(
@@ -1480,6 +1581,7 @@ async function measureRouteSample(
       | Awaited<ReturnType<typeof collectBrowserMetrics>>
       | undefined;
     let aliasPhases: AliasPhaseTiming | undefined;
+    let aliasNavigationHops: readonly AliasNavigationHopReceipt[] | undefined;
     let controllerObservedAliasResultMs: number | undefined;
 
     const timingValues: Record<PerfTimingMetricName, number> = {
@@ -1534,7 +1636,7 @@ async function measureRouteSample(
       // includes same-origin redirects, and excludes Node-to-CDP scheduling.
       // Keep this wall-clock timer as a controller diagnostic only.
       const startedAt = Date.now();
-      await page.goto(url, {
+      const navigationResponse = await page.goto(url, {
         timeout: NAVIGATION_TIMEOUT_MS,
         waitUntil: 'domcontentloaded',
       });
@@ -1553,6 +1655,14 @@ async function measureRouteSample(
             'Alias route is missing its browser readiness probe.'
           );
         }
+        aliasNavigationHops =
+          await collectAliasNavigationHopReceipts(navigationResponse);
+        assertAliasNavigationHopReceipts(
+          baseUrl,
+          route,
+          resolvedPath,
+          aliasNavigationHops
+        );
         assertAliasUsableResultUrl(baseUrl, route, resolvedPath, page.url());
         await waitForAnyVisible(page, route.readySelectors.shell);
         await waitForAnyVisible(page, route.readySelectors.content);
@@ -1644,6 +1754,7 @@ async function measureRouteSample(
       browserMetrics.timingValues['time-to-first-byte'];
 
     return {
+      aliasNavigationHops,
       aliasPhases,
       controllerObservedAliasResultMs,
       finalUrl: browserMetrics.finalUrl,
@@ -2034,8 +2145,15 @@ async function measureRoutesAgainstBudgets(
         const aliasPhaseSummary = sample.aliasPhases
           ? ` phases redirect=${formatMetric(sample.aliasPhases.redirectCompleteMs, 'ms')} shell=${formatMetric(sample.aliasPhases.shellVisibleMs, 'ms')} interactive=${formatMetric(sample.aliasPhases.interactiveReadyMs, 'ms')} affordance=${formatMetric(sample.aliasPhases.destinationAffordanceMs, 'ms')} controller=${formatMetric(sample.controllerObservedAliasResultMs ?? 0, 'ms')}`
           : '';
+        const aliasHopSummary =
+          sample.aliasNavigationHops
+            ?.map((hop, hopIndex) => {
+              const cache = hop.edgeCache ?? hop.nextCache ?? '-';
+              return ` hop${hopIndex + 1}=${hop.status}:${hop.path}:cache=${cache}:age=${hop.age ?? '-'}:vercel=${hop.vercelId ?? '-'}`;
+            })
+            .join('') ?? '';
         logInfo(
-          `  sample ${index + 1}/${options.runs}: ${formatMetric(sample.timingValues[getPrimaryTimingMetricName(route)], 'ms')}${aliasPhaseSummary}`,
+          `  sample ${index + 1}/${options.runs}: ${formatMetric(sample.timingValues[getPrimaryTimingMetricName(route)], 'ms')}${aliasPhaseSummary}${aliasHopSummary}`,
           options
         );
       }

--- a/apps/web/tests/e2e/profile/responsive-shell.spec.ts
+++ b/apps/web/tests/e2e/profile/responsive-shell.spec.ts
@@ -285,6 +285,73 @@ test.describe('Public profile redirect parity @regression', () => {
     });
   }
 
+  test('alias deep links preserve mode and source through browser back and forward', async ({
+    browser,
+  }, testInfo) => {
+    const context = await browser.newContext({
+      ...testInfo.project.use,
+      storageState: { cookies: [], origins: [] },
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    const page = await context.newPage();
+
+    try {
+      await installPublicRouteMocks(page);
+      const handle =
+        process.env.PUBLIC_SURFACE_MUSIC_HANDLE?.trim() || 'dualipa';
+      const sourcePath = `/${handle}/listen?source=qr`;
+      const expectedFinalPath = `/${handle}?mode=listen&source=qr`;
+      const previousPath = '/artist-profiles';
+
+      const previousResponse = await page.goto(previousPath, {
+        waitUntil: 'domcontentloaded',
+        timeout: 120_000,
+      });
+      expect(previousResponse?.status() ?? 0).toBeLessThan(500);
+
+      const aliasResponse = await page.goto(sourcePath, {
+        waitUntil: 'domcontentloaded',
+        timeout: 120_000,
+      });
+      expect(aliasResponse?.status() ?? 0).toBe(200);
+      await waitForHydration(page);
+      await waitForAnyVisible(page, ['[data-testid="profile-header"]']);
+      expect(new URL(page.url()).pathname + new URL(page.url()).search).toBe(
+        expectedFinalPath
+      );
+
+      const backResponse = await page.goBack({
+        waitUntil: 'domcontentloaded',
+        timeout: 120_000,
+      });
+      expect(backResponse?.status() ?? 0).toBeLessThan(500);
+      expect(new URL(page.url()).pathname).toBe(previousPath);
+
+      const forwardResponse = await page.goForward({
+        waitUntil: 'domcontentloaded',
+        timeout: 120_000,
+      });
+      // A back-forward cache restoration legitimately has no network response.
+      // If the browser does revalidate, it must still resolve to a healthy 200.
+      if (forwardResponse) {
+        expect(forwardResponse.status()).toBe(200);
+      }
+      await waitForHydration(page);
+      await waitForAnyVisible(page, [
+        '[data-testid="profile-primary-tab-releases"]',
+        '[data-testid="profile-primary-tab-listen"]',
+      ]);
+      expect(new URL(page.url()).pathname + new URL(page.url()).search).toBe(
+        expectedFinalPath
+      );
+    } finally {
+      await page.close().catch(() => undefined);
+      await context.close().catch(() => undefined);
+    }
+  });
+
   test('direct resolver markers for non-alias slugs remain not found', async ({
     request,
   }) => {


### PR DESCRIPTION
## Summary

- make the public-profile performance gate prove the real same-origin HTTP 307 alias to 200 canonical chain
- emit edge cache, region, age, and server-timing receipts for every measured sample
- fail closed on missing responses, client-only transitions, or the wrong redirect status
- pin browser Back and Forward behavior while preserving mode and source query state
- keep every existing timing and resource threshold unchanged

## Validation

- focused Vitest: 69 passed
- full pre-push Vitest: 2,328 files passed, 8 intentionally skipped; 18,302 tests passed, 75 skipped, 6 todo
- production Back and Forward: Chromium 3 of 3 clean runs; WebKit 1 of 1
- production performance replay: 30 of 30 samples passed
  - listen median 879.5 ms, max 1,110.3 ms
  - music median 734.4 ms, max 858.9 ms
  - subscribe median 879.3 ms, max 958.1 ms
  - tip median 736.1 ms, max 938.2 ms
  - releases median 718.4 ms, max 1,074.1 ms
  - tour median 678.5 ms, max 782.8 ms
  - JS 854.4 KB of 1,050 KB budget; CSS 97.6 KB of 100 KB budget
- turbo typecheck: 11 of 11 tasks passed
- clean production build: 469 of 469 static pages
- Biome and CI harness validation passed

## Risk

Eval and browser-test only; no runtime product bytes or user-facing composition changed. Local Firefox coverage was unavailable because the Playwright Firefox executable is not installed; Chromium and WebKit cover the added history assertion.