### PR TITLE
fix(calendar): restore seven-column month geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- **Calendar keeps a usable seven-column month grid (JOV-4819):** the authenticated desktop calendar and its loading state now own explicit responsive grid geometry, preventing production builds from collapsing the month into a single narrow day column.
 - **Public artist profiles load with a leaner browser bundle:** server-only validation no longer ships with profile music, merch, event, and alerts interactions, removing the Zod client chunk and making hydrated controls ready before background effects while preserving the existing experience.
 - **Profile activity respects the visitor's privacy choices:** anonymous audience joining now follows canonical analytics consent, regional consent requirements, Global Privacy Control, Do Not Track, and legacy opt-outs.
 - **Mac/Electron profile links open in isolated native previews (#15488):** canonical public artist profile URLs open in reusable phone-sized windows without sharing authenticated session state, while the main app history and non-profile external destinations remain unchanged.

--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -470,7 +470,7 @@ export function CalendarPageClient() {
         ready={!isLoading && !releasesError && !eventsError}
       />
       <PageContent className='px-3 py-2 sm:px-3 sm:py-2'>
-        <div className='grid h-full min-h-0 grid-cols-1 gap-3 lg:grid-cols-6'>
+        <div className='system-b-calendar-workspace-grid h-full min-h-0 gap-3'>
           <nav
             aria-label='Calendar Filters'
             data-testid='calendar-filter-rail'
@@ -501,9 +501,15 @@ export function CalendarPageClient() {
             />
           </nav>
 
-          <div className='flex min-w-0 flex-col gap-3 lg:col-span-5'>
+          <div
+            data-testid='calendar-main-plane'
+            className='system-b-calendar-main-plane flex min-w-0 flex-col gap-3'
+          >
             <div className='system-b-calendar-panel overflow-hidden'>
-              <div className='system-b-calendar-weekday-row grid grid-cols-7'>
+              <div
+                data-testid='calendar-weekday-grid'
+                className='system-b-calendar-month-grid system-b-calendar-weekday-row'
+              >
                 {DAY_NAMES.map(d => (
                   <div
                     key={d}
@@ -513,7 +519,10 @@ export function CalendarPageClient() {
                   </div>
                 ))}
               </div>
-              <div className='grid grid-cols-7'>
+              <div
+                data-testid='calendar-month-grid'
+                className='system-b-calendar-month-grid'
+              >
                 {grid.map(cell => {
                   const key = localDateKey(cell.date);
                   const visibleReleases = cellShowsRelease ? cell.releases : [];

--- a/apps/web/app/app/(shell)/calendar/CalendarRouteSkeleton.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarRouteSkeleton.tsx
@@ -71,7 +71,7 @@ export function CalendarRouteSkeleton() {
       }
     >
       <PageContent className='px-3 py-2 sm:px-3 sm:py-2'>
-        <div className='grid h-full min-h-0 grid-cols-1 gap-3 lg:grid-cols-6'>
+        <div className='system-b-calendar-workspace-grid h-full min-h-0 gap-3'>
           <div
             aria-hidden='true'
             data-testid='calendar-filter-rail-skeleton'
@@ -86,16 +86,16 @@ export function CalendarRouteSkeleton() {
           </div>
           <div
             data-testid='calendar-grid-skeleton'
-            className='overflow-hidden rounded-xl border border-subtle lg:col-span-5'
+            className='system-b-calendar-main-plane overflow-hidden rounded-xl border border-subtle'
           >
-            <div className='grid grid-cols-7 border-b border-subtle'>
+            <div className='system-b-calendar-month-grid border-b border-subtle'>
               {CALENDAR_WEEKDAY_KEYS.map(key => (
                 <div key={key} className='px-2 py-2'>
                   <div className='skeleton mx-auto h-3 w-8 rounded-sm' />
                 </div>
               ))}
             </div>
-            <div className='grid grid-cols-7'>
+            <div className='system-b-calendar-month-grid'>
               {CALENDAR_GRID_CELL_KEYS.map(key => (
                 <div
                   key={key}

--- a/apps/web/styles/system-b-app.css
+++ b/apps/web/styles/system-b-app.css
@@ -1447,6 +1447,26 @@
 }
 
 /* System B calendar route primitives */
+:where(.system-b-calendar-workspace-grid) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+:where(.system-b-calendar-month-grid) {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-calendar-workspace-grid) {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  :where(.system-b-calendar-main-plane) {
+    grid-column: span 5 / span 5;
+  }
+}
+
 :where(.system-b-calendar-month-label) {
   min-width: calc(var(--space-24) + var(--space-10) + var(--space-4));
   color: var(--color-text-primary-token);

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -188,7 +188,16 @@ describe('CalendarPageClient', () => {
     const filterRail = screen.getByTestId('calendar-filter-rail');
     expect(filterRail).toHaveAttribute('aria-label', 'Calendar Filters');
     expect(filterRail).toHaveClass('min-h-8', 'lg:flex-col');
-    expect(filterRail.parentElement).toHaveClass('lg:grid-cols-6');
+    expect(filterRail.parentElement).toHaveClass(
+      'system-b-calendar-workspace-grid'
+    );
+    expect(screen.getByTestId('calendar-main-plane')).toHaveClass(
+      'system-b-calendar-main-plane'
+    );
+    expect(screen.getByTestId('calendar-weekday-grid').children).toHaveLength(
+      7
+    );
+    expect(screen.getByTestId('calendar-month-grid').children).toHaveLength(42);
     expect(screen.getByRole('button', { name: 'All' })).toHaveClass(
       'system-b-calendar-filter-pill'
     );
@@ -359,12 +368,12 @@ describe('CalendarRouteSkeleton', () => {
     );
     expect(screen.getByTestId('calendar-grid-skeleton')).toBeInTheDocument();
     expect(screen.getByTestId('calendar-grid-skeleton')).toHaveClass(
-      'lg:col-span-5'
+      'system-b-calendar-main-plane'
     );
     expect(
       screen
         .getByTestId('calendar-grid-skeleton')
-        .querySelectorAll('.grid-cols-7 > div')
+        .querySelectorAll('.system-b-calendar-month-grid > div')
     ).toHaveLength(49);
   });
 });

--- a/apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts
+++ b/apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts
@@ -107,6 +107,25 @@ describe('calendar shell style guard', () => {
     ).toEqual([]);
   });
 
+  it('owns seven-column month geometry in named calendar primitives', () => {
+    const source = readFileSync(DESIGN_SYSTEM, 'utf8');
+    const match = source.match(CALENDAR_PRIMITIVES_PATTERN);
+    const primitiveBlock = match?.[1] ?? '';
+
+    expect(primitiveBlock).toMatch(
+      /\.system-b-calendar-workspace-grid[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)/
+    );
+    expect(primitiveBlock).toMatch(
+      /\.system-b-calendar-month-grid[\s\S]*?grid-template-columns:\s*repeat\(7,\s*minmax\(0,\s*1fr\)\)/
+    );
+    expect(primitiveBlock).toMatch(
+      /@media \(min-width:\s*1024px\)[\s\S]*?\.system-b-calendar-workspace-grid[\s\S]*?grid-template-columns:\s*repeat\(6,\s*minmax\(0,\s*1fr\)\)/
+    );
+    expect(primitiveBlock).toMatch(
+      /\.system-b-calendar-main-plane[\s\S]*?grid-column:\s*span 5 \/ span 5/
+    );
+  });
+
   it('keeps selected, bulk-action, rejected, and loading states on named hooks', () => {
     const source = readFileSync(CALENDAR_CLIENT, 'utf8');
 


### PR DESCRIPTION
## Summary
- restore explicit seven-column Calendar month geometry in built CSS
- keep hydrated and loading states on the same named System B grid primitives
- add regression coverage for six-column workspace allocation, five-column main plane, seven weekdays, and 42 day cells

## Root cause
The authenticated route source is excluded from Tailwind source discovery, so route-only `lg:grid-cols-6`, `lg:col-span-5`, and `grid-cols-7` utilities were not all present in production CSS. The outer workspace partially resolved while the main pane and month grid collapsed into one narrow column.

## Evidence
- production reproduction: month plane 133.5px at 1159px, seven cells shared one x-position
- exact-head 1159px: month plane 715.5px, seven distinct ~101.9px tracks, 42 cells, 0px horizontal overflow
- exact-head 1024px: month plane 603px, seven distinct ~85.9px tracks, 42 cells, 0px horizontal overflow
- console/network scan: no console errors and no settled 4xx/5xx/network errors
- loading skeleton reserves the same named workspace/main/month geometry

Local artifacts:
- `/private/tmp/jovie-jov4819-calendar-before-1159.png`
- `/private/tmp/jovie-jov4819-calendar-after-1159.png`
- `/private/tmp/jovie-jov4819-calendar-after-1024.png`

## Checks
- `pnpm --filter web exec vitest run tests/unit/calendar/CalendarPageClient.test.tsx tests/unit/calendar/calendar-shell-style-guard.test.ts --maxWorkers 1` — 17/17
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — pass
- Biome — clean
- `git diff --check` — clean
- independent Codex adversarial review — no actionable findings
- Grok 4.5 design-review fallback attempted; unavailable due current account rate limit

Closes JOV-4819
