### PR TITLE
feat(marketing): add copy audit and review digest

### DIFF
--- a/apps/web/data/marketing/copy.ts
+++ b/apps/web/data/marketing/copy.ts
@@ -1,3 +1,6 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+
 /**
  * Meaning-first marketing copy contracts.
  *
@@ -21,6 +24,8 @@ export const MARKETING_COPY_TASTE_TAGS = [
 ] as const;
 
 export type MarketingCopyTasteTag = (typeof MARKETING_COPY_TASTE_TAGS)[number];
+
+const MARKETING_COPY_TASTE_TAG_SET = new Set<string>(MARKETING_COPY_TASTE_TAGS);
 
 export interface MarketingCopyClaim {
   readonly id: string;
@@ -605,4 +610,482 @@ export function auditMarketingCopySemantics(
     issueCounts,
     issues,
   };
+}
+
+interface CopyPatternRule {
+  readonly code: string;
+  readonly pattern: RegExp;
+  readonly message: string;
+  readonly headlineOnly?: boolean;
+}
+
+/**
+ * Small, explainable anti-slop layer. These are review signals, not a thesaurus
+ * or a global word ban: a truthful, outcome-bound line can still use any word.
+ */
+const COPY_PATTERN_RULES: readonly CopyPatternRule[] = [
+  {
+    code: 'artifact-language',
+    pattern:
+      /\b(?:mockups?|concept renders?|screenshots?|registry-backed|captured from|annotated|design artifact)\b/i,
+    message: 'Sell the product outcome, never the marketing artifact.',
+  },
+  {
+    code: 'ai-vocabulary',
+    pattern:
+      /\b(?:delve|crucial|robust|comprehensive|nuanced|multifaceted|furthermore|moreover|additionally|pivotal|landscape|tapestry|underscore|foster|showcase|intricate|vibrant|fundamental|significant|interplay)\b/i,
+    message:
+      'Replace stock model vocabulary with plain, product-specific words.',
+  },
+  {
+    code: 'marketing-slop',
+    pattern:
+      /\b(?:seamless(?:ly)?|unlock(?:s|ed|ing)?|elevat(?:e|es|ed|ing)|reimagin(?:e|es|ed|ing)|empower(?:s|ed|ing)?|leverage|cutting-edge|game-changing|world-class|supercharge(?:s|d|ing)?|all-in-one|ecosystem)\b/i,
+    message: 'Replace generic promotion with a concrete action or consequence.',
+  },
+  {
+    code: 'formulaic-contrast',
+    pattern: /\b(?:not|more than) (?:just|only)\b/i,
+    message:
+      'State the stronger idea directly instead of using a stock contrast.',
+  },
+  {
+    code: 'formulaic-range',
+    pattern: /\bfrom .{1,60} to\b/i,
+    message: 'Name the exact moments without a generic from-X-to-Y frame.',
+  },
+  {
+    code: 'filler-intro',
+    pattern: /\b(?:in today'?s|when it comes to|at the end of the day)\b/i,
+    message: 'Delete the introduction and lead with the point.',
+  },
+  {
+    code: 'vague-attribution',
+    pattern: /\b(?:experts say|studies show|many believe|industry leaders)\b/i,
+    message: 'Name the source or remove the attribution.',
+  },
+  {
+    code: 'chat-residue',
+    pattern:
+      /\b(?:as an ai|here is a revised|option [abc]:|i cannot assist)\b/i,
+    message: 'Remove model or drafting residue.',
+  },
+  {
+    code: 'dash-habit',
+    pattern: /[—–]/,
+    message: 'Use a period, comma, or colon. Do not use an em or en dash.',
+  },
+  {
+    code: 'generic-heading',
+    pattern: /^(?:built|designed) (?:for|to|around)\b/i,
+    message: 'Lead with the customer consequence, not a generic construction.',
+    headlineOnly: true,
+  },
+  {
+    code: 'rhetorical-heading',
+    pattern: /\?\s*$/,
+    message: 'Answer the question in the heading instead of asking it.',
+    headlineOnly: true,
+  },
+];
+
+function findDuplicates(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates];
+}
+
+export function normalizeMarketingCopyVisibleCopy(
+  copy: MarketingCopyVisibleCopy
+): string {
+  return [copy.headline, copy.body ?? '', ...(copy.supportingText ?? [])]
+    .map(normalizeText)
+    .join('|');
+}
+
+function auditCopyPatterns(
+  sectionId: string,
+  value: string,
+  headline: boolean
+): MarketingCopyAuditIssue[] {
+  return COPY_PATTERN_RULES.filter(
+    rule => (!rule.headlineOnly || headline) && rule.pattern.test(value)
+  ).map(rule => ({
+    code: rule.code,
+    sectionId,
+    message: `${rule.message} Found in: "${value}"`,
+  }));
+}
+
+/** Integrity fingerprint for the exact brief, evidence, candidate, and control reviewed. */
+export function createMarketingCopyReviewDigest(
+  brief: MarketingCopyPageBrief,
+  draft: MarketingCopyPageDraft
+): string {
+  const canonical = JSON.stringify({
+    schemaVersion: MARKETING_COPY_SPEC_VERSION,
+    brief,
+    draft: {
+      pageId: draft.pageId,
+      route: draft.route,
+      sections: draft.sections.map(section => ({
+        sectionId: section.sectionId,
+        candidateId: section.candidateId,
+        control: section.control,
+        headline: section.headline,
+        body: section.body,
+        supportingText: section.supportingText,
+        claimIds: section.claimIds,
+        lineBindings: section.lineBindings,
+        meaningTrace: section.meaningTrace,
+        tasteTags: section.tasteTags,
+      })),
+    },
+  });
+  return `marketing-copy/${MARKETING_COPY_SPEC_VERSION}/sha256/${bytesToHex(
+    sha256(new TextEncoder().encode(canonical))
+  )}`;
+}
+
+/** Structural, meaning, compression, and anti-slop audit for a whole page. */
+export function auditMarketingCopyPage(
+  brief: MarketingCopyPageBrief,
+  draft: MarketingCopyPageDraft
+): readonly MarketingCopyAuditIssue[] {
+  const issues: MarketingCopyAuditIssue[] = [];
+  const claimsById = new Map(brief.claims.map(claim => [claim.id, claim]));
+  const briefIds = brief.sections.map(section => section.sectionId);
+  const draftIds = draft.sections.map(section => section.sectionId);
+
+  if (
+    !brief.pageId.trim() ||
+    !brief.route.trim() ||
+    !brief.audience.trim() ||
+    !brief.objective.trim()
+  ) {
+    issues.push(
+      issue(
+        'invalid-page-brief',
+        undefined,
+        'The page brief needs a page ID, route, audience, and measurable objective.'
+      )
+    );
+  }
+  if (brief.pageId !== draft.pageId || brief.route !== draft.route) {
+    issues.push(
+      issue(
+        'page-mismatch',
+        undefined,
+        'The copy draft must target the same page and route as its brief.'
+      )
+    );
+  }
+
+  for (const duplicate of findDuplicates(brief.claims.map(claim => claim.id))) {
+    issues.push(
+      issue(
+        'duplicate-claim',
+        undefined,
+        `Claim ${duplicate} appears more than once in the registry.`
+      )
+    );
+  }
+  for (const claim of brief.claims) {
+    if (!claim.id.trim() || words(claim.statement).length < 3) {
+      issues.push(
+        issue(
+          'invalid-claim',
+          undefined,
+          'Every claim needs a stable ID and a meaningful statement.'
+        )
+      );
+    }
+    if (
+      claim.evidence.length === 0 ||
+      claim.evidence.some(evidence => !evidence.trim())
+    ) {
+      issues.push(
+        issue(
+          'missing-claim-evidence',
+          undefined,
+          `Claim ${claim.id || '(missing ID)'} needs direct evidence references.`
+        )
+      );
+    }
+  }
+  for (const duplicate of findDuplicates(briefIds)) {
+    issues.push(
+      issue(
+        'duplicate-brief-section',
+        duplicate,
+        `Section ${duplicate} appears more than once in the brief.`
+      )
+    );
+  }
+  for (const duplicate of findDuplicates(draftIds)) {
+    issues.push(
+      issue(
+        'duplicate-draft-section',
+        duplicate,
+        `Section ${duplicate} appears more than once in the draft.`
+      )
+    );
+  }
+  if (briefIds.join('|') !== draftIds.join('|')) {
+    issues.push(
+      issue(
+        'story-order',
+        undefined,
+        `Draft story order must be ${briefIds.join(' -> ')}.`
+      )
+    );
+  }
+  for (const duplicate of findDuplicates(
+    draft.sections.map(section => normalizeText(section.headline))
+  )) {
+    issues.push(
+      issue(
+        'duplicate-headline',
+        undefined,
+        `A page headline repeats the same idea: "${duplicate}".`
+      )
+    );
+  }
+
+  for (const sectionBrief of brief.sections) {
+    const section = draft.sections.find(
+      candidate => candidate.sectionId === sectionBrief.sectionId
+    );
+    if (!section) {
+      issues.push(
+        issue(
+          'missing-section',
+          sectionBrief.sectionId,
+          `Missing copy for section ${sectionBrief.sectionId}.`
+        )
+      );
+      continue;
+    }
+    if (
+      !sectionBrief.storyBeat.trim() ||
+      !sectionBrief.sectionJob.trim() ||
+      !sectionBrief.customerOutcome.trim() ||
+      !sectionBrief.messageSubject.trim() ||
+      !sectionBrief.visualEvidence.trim() ||
+      sectionBrief.headlineWordLimit < 1
+    ) {
+      issues.push(
+        issue(
+          'invalid-section-brief',
+          section.sectionId,
+          'Every section needs a story beat, job, customer outcome, message subject, visual evidence, and positive headline budget.'
+        )
+      );
+    }
+    if (
+      normalizeText(sectionBrief.messageSubject) ===
+      normalizeText(sectionBrief.visualEvidence)
+    ) {
+      issues.push(
+        issue(
+          'visual-is-message',
+          section.sectionId,
+          'Separate what the visual shows from what the section means.'
+        )
+      );
+    }
+    if (!section.candidateId.trim()) {
+      issues.push(
+        issue(
+          'missing-candidate-id',
+          section.sectionId,
+          'Every candidate needs a stable ID.'
+        )
+      );
+    }
+    if (
+      section.tasteTags.length === 0 ||
+      section.tasteTags.some(
+        tag => !tag.trim() || !MARKETING_COPY_TASTE_TAG_SET.has(tag)
+      )
+    ) {
+      issues.push(
+        issue(
+          'invalid-taste-tags',
+          section.sectionId,
+          'Taste tags must be non-empty values from the marketing copy schema.'
+        )
+      );
+    }
+    for (const duplicate of findDuplicates(section.tasteTags)) {
+      issues.push(
+        issue(
+          'duplicate-taste-tag',
+          section.sectionId,
+          `Taste tag ${duplicate} appears more than once.`
+        )
+      );
+    }
+    if (!section.control?.headline?.trim()) {
+      issues.push(
+        issue(
+          'missing-control',
+          section.sectionId,
+          'Every candidate needs complete visible control copy.'
+        )
+      );
+    } else if (
+      normalizeMarketingCopyVisibleCopy(section.control) ===
+      normalizeMarketingCopyVisibleCopy(section)
+    ) {
+      issues.push(
+        issue(
+          'no-op-candidate',
+          section.sectionId,
+          'The candidate must differ from its control copy.'
+        )
+      );
+    }
+
+    const headlineWords = words(section.headline).length;
+    if (headlineWords > sectionBrief.headlineWordLimit) {
+      issues.push(
+        issue(
+          'headline-budget',
+          section.sectionId,
+          `Headline has ${headlineWords} words; the limit is ${sectionBrief.headlineWordLimit}.`
+        )
+      );
+    }
+    for (const signalGroup of sectionBrief.headlineSignals) {
+      if (
+        !signalGroup.some(signal =>
+          normalizeText(section.headline).includes(normalizeText(signal))
+        )
+      ) {
+        issues.push(
+          issue(
+            'headline-intent',
+            section.sectionId,
+            `Headline does not carry the required meaning signal: ${signalGroup.join(' | ')}.`
+          )
+        );
+      }
+    }
+    if (sectionBrief.bodyWordLimit !== undefined) {
+      if (!section.body) {
+        issues.push(
+          issue(
+            'missing-body',
+            section.sectionId,
+            'This section brief requires one supporting line.'
+          )
+        );
+      } else {
+        const bodyWords = words(section.body).length;
+        if (bodyWords > sectionBrief.bodyWordLimit) {
+          issues.push(
+            issue(
+              'body-budget',
+              section.sectionId,
+              `Body has ${bodyWords} words; the limit is ${sectionBrief.bodyWordLimit}.`
+            )
+          );
+        }
+        for (const signalGroup of sectionBrief.bodySignals ?? []) {
+          if (
+            !signalGroup.some(signal =>
+              normalizeText(section.body ?? '').includes(normalizeText(signal))
+            )
+          ) {
+            issues.push(
+              issue(
+                'body-intent',
+                section.sectionId,
+                `Body does not carry the required meaning signal: ${signalGroup.join(' | ')}.`
+              )
+            );
+          }
+        }
+        const headlineMeaning = new Set(meaningfulWords(section.headline));
+        const bodyMeaning = new Set(meaningfulWords(section.body));
+        if (
+          headlineMeaning.size > 0 &&
+          [...headlineMeaning].filter(word => bodyMeaning.has(word)).length /
+            headlineMeaning.size >=
+            0.8
+        ) {
+          issues.push(
+            issue(
+              'redundant-support',
+              section.sectionId,
+              'The body repeats the headline instead of adding proof or consequence.'
+            )
+          );
+        }
+      }
+    }
+    const allowedClaims = new Set(sectionBrief.allowedClaimIds);
+    if (section.claimIds.length === 0) {
+      issues.push(
+        issue(
+          'missing-claim',
+          section.sectionId,
+          'Every section must cite at least one verified product claim.'
+        )
+      );
+    }
+    for (const claimId of section.claimIds) {
+      if (!claimsById.has(claimId)) {
+        issues.push(
+          issue(
+            'unknown-claim',
+            section.sectionId,
+            `Claim ${claimId} is not in the page claim registry.`
+          )
+        );
+      } else if (!allowedClaims.has(claimId)) {
+        issues.push(
+          issue(
+            'claim-out-of-scope',
+            section.sectionId,
+            `Claim ${claimId} is not allowed for this section job.`
+          )
+        );
+      }
+    }
+    if (words(section.meaningTrace).length < 5) {
+      issues.push(
+        issue(
+          'thin-meaning-trace',
+          section.sectionId,
+          'Explain how the candidate creates the intended customer belief.'
+        )
+      );
+    }
+    const visibleText = [
+      section.headline,
+      section.body ?? '',
+      ...(section.supportingText ?? []),
+    ].filter(Boolean);
+    for (const [index, value] of visibleText.entries()) {
+      issues.push(...auditCopyPatterns(section.sectionId, value, index === 0));
+      for (const phrase of sectionBrief.forbiddenPhrases ?? []) {
+        if (normalizeText(value).includes(normalizeText(phrase))) {
+          issues.push(
+            issue(
+              'section-forbidden-phrase',
+              section.sectionId,
+              `Remove section-specific phrase "${phrase}" from "${value}".`
+            )
+          );
+        }
+      }
+    }
+  }
+  return issues;
 }

--- a/apps/web/data/marketing/index.ts
+++ b/apps/web/data/marketing/index.ts
@@ -53,7 +53,9 @@ export type {
   MarketingCopyVisibleCopy,
 } from './copy';
 export {
+  auditMarketingCopyPage,
   auditMarketingCopySemantics,
+  createMarketingCopyReviewDigest,
   MARKETING_COPY_LINE_ROLES,
   MARKETING_COPY_SEMANTIC_ENFORCEMENTS,
   MARKETING_COPY_SPEC_VERSION,

--- a/apps/web/tests/unit/marketing/copy-semantic-guard.test.ts
+++ b/apps/web/tests/unit/marketing/copy-semantic-guard.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  auditMarketingCopyPage,
   auditMarketingCopySemantics,
+  createMarketingCopyReviewDigest,
   type MarketingCopyPageBrief,
   type MarketingCopyPageDraft,
 } from '@/data/marketing';
@@ -113,5 +115,62 @@ describe('meaning-first marketing copy guard', () => {
     );
     expect(result.status).toBe('advisory');
     expect(result.blocking).toBe(false);
+  });
+
+  it('passes a complete outcome-bound page through the structural audit', () => {
+    expect(
+      auditMarketingCopyPage(brief, draft('One profile for every fan'))
+    ).toEqual([]);
+  });
+
+  it('fingerprints the reviewed brief and candidate, so changed copy cannot reuse a receipt', () => {
+    const first = createMarketingCopyReviewDigest(
+      brief,
+      draft('One profile for every fan')
+    );
+    const second = createMarketingCopyReviewDigest(
+      brief,
+      draft('One profile for every release')
+    );
+    expect(first).toMatch(/^marketing-copy\/1\.1\.0\/sha256\/[a-f0-9]{64}$/);
+    expect(second).not.toBe(first);
+  });
+
+  it.each([
+    ['marketing-slop', 'Seamlessly unlock a world-class profile ecosystem.'],
+    ['formulaic-contrast', 'More than just a profile.'],
+    ['chat-residue', 'Here is a revised option A: your profile.'],
+    ['dash-habit', 'One profile — every fan.'],
+  ] as const)('flags %s in the anti-slop audit', (code, headline) => {
+    const issues = auditMarketingCopyPage(brief, draft(headline));
+    expect(issues.some(issue => issue.code === code)).toBe(true);
+  });
+
+  it('flags compression failures without banning truthful premium language', () => {
+    const briefWithBody: MarketingCopyPageBrief = {
+      ...brief,
+      sections: [{ ...brief.sections[0], bodyWordLimit: 30 }],
+    };
+    const issues = auditMarketingCopyPage(brief, {
+      ...draft('One profile for every fan'),
+      sections: [
+        {
+          ...draft('One profile for every fan').sections[0],
+          body: 'One profile for every fan, one profile for every fan, one profile for every fan.',
+        },
+      ],
+    });
+    expect(
+      auditMarketingCopyPage(briefWithBody, {
+        ...draft('One profile for every fan'),
+        sections: [
+          {
+            ...draft('One profile for every fan').sections[0],
+            body: 'One profile for every fan, one profile for every fan, one profile for every fan.',
+          },
+        ],
+      }).some(issue => issue.code === 'redundant-support')
+    ).toBe(true);
+    expect(issues.some(issue => issue.code === 'marketing-slop')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add a structural, meaning, compression, and anti-slop audit for marketing page drafts
- add content fingerprints, duplicate/claim checks, evidence and line-budget checks, and review-digest freshness
- add focused fixtures for marketing slop, formulaic contrast, chat residue, dash habits, compression, and truthful premium language

## Stack
- Core meaning-first guard: #15523 (merged through the normal GitHub workflow)
- This PR is the dependent audit layer, rebased onto current `main` after #15523.
- Native GitHub dependent PR; no Graphite, no gate bypass, no external-data embeddings.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/copy-semantic-guard.test.ts` (17 passed)
- normal pre-push gate passed: Biome, typecheck, component-ship gate, 290 Vitest files / 2,507 tests passed (9 skipped, 2 todo), CI harness validation
- incremental diff: 544 additions across 3 files (under the 800-line policy)

No deploy or merge is requested from this PR.
