### PR TITLE
docs(release): support native GitHub stacked PRs

### DIFF
--- a/.claude/rules/pr-stacking.md
+++ b/.claude/rules/pr-stacking.md
@@ -1,8 +1,8 @@
 # PR Stacking & Size
 
 > Part of the canonical [`docs/PR_FLOW.md`](../../docs/PR_FLOW.md). Default: small
-> sibling PRs to `main`; dependent work uses a `gt` stack; a mechanical sweep ships
-> as one `big-pr` PR — **never** N base-on-base micro-PRs (that collapsed the queue
+> sibling PRs to `main`; dependent work uses a native GitHub stack; a mechanical sweep ships
+> as one `big-pr` PR — **never** an uncontrolled N-deep base-on-base pile (that collapsed the queue
 > on 2026-06-22, #11689).
 
 Small, reviewable PRs that move through GitHub's native merge queue quickly.
@@ -33,15 +33,16 @@ parent lands, then to run the **full** source and combined-head pipeline. A
 and any one slow/failing/conflicted member stalls the whole chain. (This
 happened — June 2026, collapsed in #11689.) One `big-pr` PR = one CI run.
 
-Agents generating drift/token sweeps: emit a single PR per sweep. Do not call
-`gt create` once per component.
+Agents generating drift/token sweeps: emit a single PR per sweep. Do not create
+one stacked PR per component.
 
 ## Stack, don't pile
 
-- **Dependent work** (B needs A) → a **PR stack managed with the Graphite CLI**:
-  `gt create` per logical step, then `gt restack`/`gt submit`. Graphite manages
-  branch relationships and PR submission only; GitHub's native queue lands
-  each PR after its parent is on `main` and the child is retargeted/rebased.
+- **Dependent work** (B needs A) → a **native GitHub stacked-PR sequence**:
+  push each layer normally and open it against its immediate parent. After the
+  parent lands, retarget the child to `main`, rebase it onto the new `origin/main`,
+  and push with `--force-with-lease` before running fresh checks. Graphite is not
+  required and is not a landing transport.
 - **Independent work** in the same area → **sibling PRs** off `main`. They land
   in parallel and don't trigger each other's rebases.
 - **One PR = one logical change.** No drive-by refactors — pull them into their
@@ -57,11 +58,27 @@ Agents generating drift/token sweeps: emit a single PR per sweep. Do not call
 ## How
 
 ```bash
-gt create -m "feat(x): step 1"     # base
-gt create -m "feat(x): step 2"     # stacked on step 1
-gt submit --stack                  # opens/updates the whole stack
+git switch -c feat/x-01 origin/main
+git push -u origin feat/x-01
+gh pr create --draft --base main --head feat/x-01
+
+git switch -c feat/x-02 feat/x-01
+git push -u origin feat/x-02
+gh pr create --draft --base feat/x-01 --head feat/x-02
 ```
 
-After a parent lands, retarget/rebase the next child onto `main`, push its exact
-head, then apply `merge-queue`. The native controller owns enrollment and
-combined-head validation. See also [`ci-branching.md`](ci-branching.md).
+Record every branch, PR number, immediate-parent base, and exact head SHA. When
+the parent merges, keep its old tip for the rebase boundary, then:
+
+```bash
+git fetch origin main
+gh pr edit <child> --base main
+git rebase --onto origin/main <old-parent-tip> <child-branch>
+git push --force-with-lease origin <child-branch>
+```
+
+Prove the child remote head was unchanged before rebasing, inspect ancestry and
+the semantic diff, and wait for the fresh source checks before queue enrollment.
+Keep the parent branch until the child has converged. Land one layer at a time
+through GitHub's native merge queue; never bypass it or create a second landing
+transport. See also [`ci-branching.md`](ci-branching.md).

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -2,9 +2,10 @@
 
 `main` merges through GitHub's native merge queue. The live repository variable
 is `MERGE_QUEUE_BACKEND=native`, and ruleset `Main Branch Protection`
-(`10512119`) owns queue admission and combined-head validation. Graphite is a
-stack-construction CLI only: use `gt` to create, restack, and submit dependent
-PRs, never to enroll, validate, or land them.
+(`10512119`) owns queue admission and combined-head validation. Native GitHub is
+also the supported stack-construction path: dependent PRs may temporarily target
+their immediate parent, then are retargeted and rebased onto `main` after that
+parent lands. Graphite is not required and there is no second landing transport.
 
 ## How a PR lands
 

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -1,8 +1,9 @@
 name: PR Size Guard
 
 # Forces small, reviewable PRs — which forces stacking. A change too big to
-# review as one PR must be split into dependent PRs managed with the `gt` CLI
-# (`gt create` per logical step) or independent sibling PRs. Opt out for
+# review as one PR must be split into dependent PRs using native GitHub
+# stacked-PR discipline (each child retargeted and rebased after its parent
+# lands) or independent sibling PRs. Opt out for
 # approved mechanical codemods (token sweeps, renames, generated output) with
 # the `big-pr` label. Thresholds tunable via repo vars PR_MAX_LINES / PR_MAX_FILES.
 # Circular shared-CI repair trains may use `integration-train`, but only with a

--- a/docs/PR_FLOW.md
+++ b/docs/PR_FLOW.md
@@ -24,14 +24,18 @@ If you are an agent about to open a PR, read [Agent checklist](#agent-checklist)
   (`pr-size-guard`, repo vars `PR_MAX_LINES`/`PR_MAX_FILES`; mechanical codemods
   use `big-pr`). Independent changes are **sibling PRs off `main`** — parallel,
   never based on each other.
-- **Dependent work → a real `gt` stack** (`gt create` per step; restacks once;
-  children auto-retarget to `main` as bases land). **Never** hand-create N
-  base-on-base PRs — that ran 63 full CI pipelines for one diff and collapsed the
-  queue (#11689). One mechanical sweep = **one `big-pr` PR**
+- **Dependent work → a native GitHub stacked-PR sequence.** Push each layer
+  normally and open it against its immediate parent. After the parent lands,
+  retarget the child to `main`, rebase onto the new `origin/main`, push with
+  `--force-with-lease`, and wait for fresh checks before queue enrollment.
+  Record the branch, PR, base, and head SHA for every layer. Do not create an
+  uncontrolled base-on-base pile; one mechanical sweep = **one `big-pr` PR**
   ([`pr-stacking.md`](../.claude/rules/pr-stacking.md)).
-- **Always target `main`** (or a live integration branch), **never an ephemeral
-  stack-base branch** — when that base is deleted the PR shows a phantom
-  `CONFLICTING` (this bit #11589). If a PR's base is gone, retarget to `main`.
+- **Root PRs target `main`** (or a live integration branch). A dependent child
+  may temporarily target its immediate parent while that parent is open; once
+  the parent lands, retarget the child to `main` and rebase before enrollment.
+  Never leave a child targeting a deleted or unrelated ephemeral branch; if its
+  base is gone, retarget to `main` and prove the semantic tree.
 - **Integration branches are an option, not the default** — use only for a
   coordinated multi-agent wave on one domain, then one train PR
   ([`ci-branching.md`](../.claude/rules/ci-branching.md)).
@@ -197,8 +201,9 @@ never false-positive.**
 
 Before you open a PR:
 
-1. **Small + focused**, targeting `main`. Dependent? `gt` stack. Mechanical sweep?
-   one `big-pr` PR. Never base-on-base micro-PRs.
+1. **Small + focused**, targeting `main`. Dependent? Use the native GitHub
+   retarget/rebase sequence in [`pr-stacking.md`](../.claude/rules/pr-stacking.md).
+   Mechanical sweep? one `big-pr` PR. Never create an uncontrolled stack.
 2. **Don't add heavy CI to the PR path.** New scan/security/perf job → post-merge
    or nightly, not `pull_request`.
 3. **Taste-touching?** Add a screenshot to the body. The classifier applies


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4820 -->

Founder-authorized canon correction for the JOV-4820 public-profile stack.

- Graphite is superseded and is no longer a required tool.
- Native GitHub is the supported stacked-PR construction and landing path.
- Each dependent layer is pushed normally and opened against its immediate parent.
- After a parent lands, the child is retargeted to main, rebased with an explicit old-parent boundary, force-pushed with --force-with-lease, and reverified before queue enrollment.
- Branch, PR, base, and exact head SHA must be recorded; no queue or merge bypass is allowed.

This docs-only PR must land before the ten-layer profile stack is rebased and opened.