### PR TITLE
Install deterministic backlog plan and admission gates

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,9 +234,10 @@
     "backlog:reconcile": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs reconcile",
     "backlog:audit": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs audit",
     "backlog:admit-next": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs admit-next",
+    "backlog:gate-next": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs gate-next",
     "backlog:approve-plan": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs approve-plan",
     "backlog:report": "node scripts/backlog-orchestrator/backlog-orchestrator.mjs report",
-    "backlog:test": "node --test scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs"
+    "backlog:test": "node --test scripts/backlog-orchestrator/__tests__/*.test.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.100.1",

--- a/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
@@ -63,7 +63,10 @@ describe('deterministic no-model gates', () => {
       'Repeated events group into one issue.',
       'Focused normalizer tests pass.',
     ]);
-    assert.equal(planGate.validatePlanCandidate(issue(), result.evidence), null);
+    assert.equal(
+      planGate.validatePlanCandidate(issue(), result.evidence),
+      null
+    );
   });
 
   it('fails closed on project, ownership, epic, sensitive, stale, and incomplete work', () => {

--- a/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
@@ -23,7 +23,7 @@ Normalize the unstable token before sending the event.
     priority: 2,
     estimate: 2,
     state: { name: 'Backlog' },
-    project: { name: 'Infra & CI/CD' },
+    project: { name: 'Infra & CI/CD', slugId: '82c6fbd42405' },
     assignee: null,
     labels: {
       nodes: [

--- a/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import * as admissionGate from '../admission-gate.mjs';
+import * as deterministicGates from '../deterministic-gates.mjs';
+import * as planGate from '../plan-gate.mjs';
+
+function issue(overrides = {}) {
+  return {
+    id: 'issue-id',
+    identifier: 'JOV-4305',
+    title: 'Normalize one Sentry fingerprint',
+    description: `## Problem
+One deterministic alert fingerprint fans out.
+
+## Proposed fix
+Normalize the unstable token before sending the event.
+
+## Acceptance criteria
+* Repeated events group into one issue.
+* Focused normalizer tests pass.`,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    priority: 2,
+    estimate: 2,
+    state: { name: 'Backlog' },
+    project: { name: 'Infra & CI/CD' },
+    assignee: null,
+    labels: {
+      nodes: [
+        { id: 'ready-id', name: 'ready-for-intake' },
+        { id: 'testing-id', name: 'testing' },
+      ],
+    },
+    children: { nodes: [] },
+    comments: { nodes: [] },
+    ...overrides,
+  };
+}
+
+function plannedIssue(overrides = {}) {
+  const base = issue();
+  const { evidence } = deterministicGates.buildDeterministicPlanEvidence(base);
+  const receipt = planGate.buildPlanGateReceipt(base, evidence);
+  return issue({
+    labels: {
+      nodes: [
+        ...base.labels.nodes,
+        { id: 'plan-id', name: planGate.PLAN_APPROVED_LABEL },
+      ],
+    },
+    comments: { nodes: [{ body: receipt }] },
+    ...overrides,
+  });
+}
+
+describe('deterministic no-model gates', () => {
+  it('builds complete bounded plan evidence only from an allowlisted issue', () => {
+    const result = deterministicGates.buildDeterministicPlanEvidence(issue());
+    assert.equal(result.reason, null);
+    assert.equal(result.evidence.repo, 'JovieInc/Jovie');
+    assert.equal(result.evidence.project, 'Infra & CI/CD');
+    assert.deepEqual(result.evidence.acceptance, [
+      'Repeated events group into one issue.',
+      'Focused normalizer tests pass.',
+    ]);
+    assert.equal(planGate.validatePlanCandidate(issue(), result.evidence), null);
+  });
+
+  it('fails closed on project, ownership, epic, sensitive, stale, and incomplete work', () => {
+    const cases = [
+      issue({ project: { name: 'LogYourBody' } }),
+      issue({ assignee: { id: 'tim', name: 'Tim White' } }),
+      issue({ labels: { nodes: [{ name: 'type:epic' }] } }),
+      issue({ title: 'Rotate a production credential' }),
+      issue({ createdAt: '2025-01-01T00:00:00.000Z' }),
+      issue({ description: 'No structured acceptance section' }),
+    ];
+    for (const candidate of cases) {
+      assert.notEqual(
+        deterministicGates.validateDeterministicPlanCandidate(candidate, {
+          now: '2026-08-05T00:00:00.000Z',
+        }),
+        null
+      );
+    }
+  });
+
+  it('selects exactly one eligible issue deterministically', () => {
+    const result = deterministicGates.selectDeterministicPlanCandidate(
+      [
+        issue({ identifier: 'JOV-4304', priority: 3 }),
+        issue({ identifier: 'JOV-4305', priority: 2 }),
+      ],
+      { now: '2026-08-05T00:00:00.000Z' }
+    );
+    assert.equal(result.selected.identifier, 'JOV-4305');
+  });
+
+  it('materializes admission receipt and label with authoritative rereads', async () => {
+    const original = plannedIssue();
+    const receipt = admissionGate.buildAdmissionGateReceipt(original);
+    const afterReceipt = plannedIssue({
+      comments: {
+        nodes: [...original.comments.nodes, { body: receipt }],
+      },
+    });
+    const afterLabel = plannedIssue({
+      labels: {
+        nodes: [
+          ...original.labels.nodes,
+          { id: 'admission-id', name: 'admission-approved' },
+        ],
+      },
+      comments: afterReceipt.comments,
+    });
+    const reads = [afterReceipt, afterLabel, afterLabel];
+    const calls = { comments: 0, labels: 0, reads: 0 };
+    const client = {
+      async addComment() {
+        calls.comments += 1;
+        return { commentCreate: { success: true } };
+      },
+      async fetchIssue() {
+        calls.reads += 1;
+        return reads.shift();
+      },
+      async fetchTeamLabel() {
+        return { id: 'admission-id', name: 'admission-approved' };
+      },
+      async setIssueLabels() {
+        calls.labels += 1;
+        return { issueUpdate: { success: true } };
+      },
+    };
+    const result = await admissionGate.approveAdmission({
+      issue: original,
+      client,
+      teamId: 'team-id',
+    });
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(calls, { comments: 1, labels: 1, reads: 3 });
+  });
+
+  it('counts an admitted intent before Symphony starts work', () => {
+    const base = plannedIssue();
+    const gateReceipt = admissionGate.buildAdmissionGateReceipt(base);
+    const admitted = plannedIssue({
+      state: { name: 'Todo' },
+      labels: {
+        nodes: [
+          ...base.labels.nodes,
+          { id: 'admission-id', name: 'admission-approved' },
+          { id: 'symphony-id', name: 'symphony' },
+        ],
+      },
+      comments: {
+        nodes: [...base.comments.nodes, { body: gateReceipt }],
+      },
+    });
+    assert.deepEqual(deterministicGates.admissionIntentLoad([admitted]), {
+      count: 1,
+      identifiers: ['JOV-4305'],
+    });
+  });
+});

--- a/scripts/backlog-orchestrator/__tests__/plan-gate.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/plan-gate.test.mjs
@@ -37,7 +37,7 @@ function evidence(overrides = {}) {
 
 function client({ rereads = [], addCommentError = null } = {}) {
   const queue = [...rereads];
-  const calls = { addComment: [], fetchIssue: 0 };
+  const calls = { addComment: [], fetchIssue: 0, setIssueLabels: [] };
   return {
     calls,
     async addComment(id, body) {
@@ -49,6 +49,13 @@ function client({ rereads = [], addCommentError = null } = {}) {
       calls.fetchIssue += 1;
       return queue.shift();
     },
+    async fetchTeamLabel() {
+      return { id: 'plan-approved-id', name: 'plan-approved' };
+    },
+    async setIssueLabels(id, labelIds) {
+      calls.setIssueLabels.push({ id, labelIds });
+      return { issueUpdate: { success: true } };
+    },
   };
 }
 
@@ -56,8 +63,14 @@ describe('plan-gate/v1', () => {
   it('approves a verified concrete bounded issue and verifies the receipt by reread', async () => {
     const original = issue();
     const receipt = planGate.buildPlanGateReceipt(original, evidence());
-    const after = issue({ comments: { nodes: [{ body: receipt }] } });
-    const fake = client({ rereads: [after] });
+    const afterReceipt = issue({ comments: { nodes: [{ body: receipt }] } });
+    const afterLabel = issue({
+      comments: { nodes: [{ body: receipt }] },
+      labels: { nodes: [{ id: 'plan-approved-id', name: 'plan-approved' }] },
+    });
+    const fake = client({
+      rereads: [afterReceipt, afterLabel, afterLabel],
+    });
 
     const result = await planGate.approvePlan({
       issue: original,
@@ -69,7 +82,8 @@ describe('plan-gate/v1', () => {
     assert.equal(result.receipt, receipt);
     assert.match(receipt, /<!-- plan-gate\/v1 -->/);
     assert.equal(fake.calls.addComment.length, 1);
-    assert.equal(fake.calls.fetchIssue, 1);
+    assert.equal(fake.calls.setIssueLabels.length, 1);
+    assert.equal(fake.calls.fetchIssue, 3);
   });
 
   it('is an idempotent no-op for the same stable receipt', async () => {
@@ -77,7 +91,12 @@ describe('plan-gate/v1', () => {
     const receipt = planGate.buildPlanGateReceipt(original, evidence());
     const fake = client();
     const result = await planGate.approvePlan({
-      issue: issue({ comments: { nodes: [{ body: receipt }] } }),
+      issue: issue({
+        comments: { nodes: [{ body: receipt }] },
+        labels: {
+          nodes: [{ id: 'plan-approved-id', name: 'plan-approved' }],
+        },
+      }),
       evidence: evidence(),
       client: fake,
     });
@@ -85,6 +104,7 @@ describe('plan-gate/v1', () => {
     assert.equal(result.status, 'already-approved');
     assert.equal(result.receipt, receipt);
     assert.deepEqual(fake.calls.addComment, []);
+    assert.deepEqual(fake.calls.setIssueLabels, []);
     assert.equal(fake.calls.fetchIssue, 0);
   });
 
@@ -127,6 +147,19 @@ describe('plan-gate/v1', () => {
     assert.equal(result.status, 'rejected');
     assert.match(result.reason, /rollback/);
     assert.equal(fake.calls.addComment.length, 0);
+  });
+
+  it('rejects a forged or stale plan receipt', () => {
+    const original = issue();
+    const receipt = planGate
+      .buildPlanGateReceipt(original, evidence())
+      .replace(/"fingerprint":"[a-f0-9]+"/, '"fingerprint":"forged"');
+    assert.equal(
+      planGate.planGateReceipt(
+        issue({ comments: { nodes: [{ body: receipt }] } })
+      ),
+      null
+    );
   });
 
   it('propagates transport failure as a blocked operation', async () => {

--- a/scripts/backlog-orchestrator/admission-gate.mjs
+++ b/scripts/backlog-orchestrator/admission-gate.mjs
@@ -1,0 +1,171 @@
+/** Deterministic approval boundary between a verified plan and Symphony. */
+
+import { createHash } from 'node:crypto';
+import {
+  PLAN_APPROVED_LABEL,
+  planGateReceipt,
+} from './plan-gate.mjs';
+
+export const ADMISSION_GATE_SCHEMA = 'admission-gate/v1';
+export const ADMISSION_GATE_PREFIX = '<!-- admission-gate/v1 -->';
+export const ADMISSION_GATE_SUFFIX = '<!--/admission-gate-->';
+export const ADMISSION_APPROVED_LABEL = 'admission-approved';
+
+const ALLOWED_STATES = new Set(['Triage', 'Backlog', 'Todo']);
+const PROTECTED_LABELS = new Set([
+  'blocked',
+  'codex-blocked',
+  'codex-in-progress',
+  'human-review-required',
+  'incident',
+  'needs-human',
+  'no-auto',
+  'protected',
+  'risk:high',
+  'tim-approved',
+  'tim-owned',
+]);
+
+function labelsOf(issue) {
+  return (issue?.labels?.nodes || issue?.labels || [])
+    .map(label => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean)
+    .map(label => label.toLowerCase());
+}
+
+function commentsOf(issue) {
+  return issue?.comments?.nodes || issue?.comments || [];
+}
+
+function commentBody(comment) {
+  return typeof comment === 'string' ? comment : comment?.body || '';
+}
+
+function hasLabel(issue, label) {
+  return labelsOf(issue).includes(label.toLowerCase());
+}
+
+function isTimOwned(issue) {
+  const assignee = issue?.assignee;
+  return Boolean(
+    assignee &&
+      /tim(?:\s|-|_)*white|itstimwhite|^tim$/i.test(
+        `${assignee.id || ''} ${assignee.name || ''} ${assignee.email || ''}`
+      )
+  );
+}
+
+export function validateAdmissionCandidate(issue) {
+  if (!issue?.id || !/^JOV-\d+$/.test(issue.identifier || ''))
+    return 'not-concrete-jovie-issue';
+  if (!ALLOWED_STATES.has(issue.state?.name || issue.state))
+    return 'ambiguous-or-active-state';
+  if (isTimOwned(issue)) return 'tim-owned';
+  if (labelsOf(issue).some(label => PROTECTED_LABELS.has(label)))
+    return 'protected-or-human-review';
+  if (!hasLabel(issue, PLAN_APPROVED_LABEL)) return 'plan-label-missing';
+  if (!planGateReceipt(issue)) return 'plan-receipt-missing-or-invalid';
+  return null;
+}
+
+export function admissionGateFingerprint(issue) {
+  const plan = planGateReceipt(issue);
+  return createHash('sha256')
+    .update(`${issue.identifier}|${plan?.payload?.fingerprint || ''}`)
+    .digest('hex')
+    .slice(0, 24);
+}
+
+export function buildAdmissionGateReceipt(issue) {
+  const plan = planGateReceipt(issue);
+  const payload = {
+    schema: ADMISSION_GATE_SCHEMA,
+    issue: issue.identifier,
+    fingerprint: admissionGateFingerprint(issue),
+    planFingerprint: plan?.payload?.fingerprint || '',
+    decision: 'approved',
+  };
+  return `${ADMISSION_GATE_PREFIX}\n${JSON.stringify(payload)}\n${ADMISSION_GATE_SUFFIX}`;
+}
+
+function hasReceipt(issue, receipt) {
+  return commentsOf(issue).some(comment => commentBody(comment) === receipt);
+}
+
+function mutationSucceeded(result) {
+  return (
+    result?.success === true ||
+    result?.commentCreate?.success === true ||
+    result?.issueUpdate?.success === true
+  );
+}
+
+function labelIds(issue, labelId) {
+  return [
+    ...new Set([
+      ...(issue?.labels?.nodes || []).map(label => label.id).filter(Boolean),
+      labelId,
+    ]),
+  ];
+}
+
+export async function approveAdmission({ issue, client, teamId = null }) {
+  const reason = validateAdmissionCandidate(issue);
+  if (reason) return { status: 'rejected', reason };
+
+  const receipt = buildAdmissionGateReceipt(issue);
+  if (
+    hasReceipt(issue, receipt) &&
+    hasLabel(issue, ADMISSION_APPROVED_LABEL)
+  ) {
+    return {
+      status: 'already-approved',
+      identifier: issue.identifier,
+      fingerprint: admissionGateFingerprint(issue),
+      receipt,
+    };
+  }
+
+  let current = issue;
+  if (!hasReceipt(current, receipt)) {
+    const result = await client.addComment(current.id, receipt);
+    if (!mutationSucceeded(result))
+      throw new Error('admission-gate-receipt-mutation-failed');
+    current = await client.fetchIssue(current.identifier);
+    if (!current || !hasReceipt(current, receipt))
+      throw new Error('admission-gate-receipt-verification-failed');
+  }
+
+  if (!hasLabel(current, ADMISSION_APPROVED_LABEL)) {
+    const label = await client.fetchTeamLabel?.(
+      teamId,
+      ADMISSION_APPROVED_LABEL
+    );
+    if (!label?.id) throw new Error('admission-approved-label-not-found');
+    const result = await client.setIssueLabels(
+      current.id,
+      labelIds(current, label.id)
+    );
+    if (!mutationSucceeded(result))
+      throw new Error('admission-gate-label-mutation-failed');
+    current = await client.fetchIssue(current.identifier);
+    if (!current || !hasLabel(current, ADMISSION_APPROVED_LABEL))
+      throw new Error('admission-gate-label-verification-failed');
+  }
+
+  const reread = await client.fetchIssue(current.identifier);
+  if (
+    !reread ||
+    !hasReceipt(reread, receipt) ||
+    !hasLabel(reread, ADMISSION_APPROVED_LABEL) ||
+    validateAdmissionCandidate(reread)
+  )
+    throw new Error('admission-gate-final-verification-failed');
+
+  return {
+    status: 'approved',
+    identifier: reread.identifier,
+    fingerprint: admissionGateFingerprint(reread),
+    receipt,
+  };
+}

--- a/scripts/backlog-orchestrator/admission-gate.mjs
+++ b/scripts/backlog-orchestrator/admission-gate.mjs
@@ -1,10 +1,7 @@
 /** Deterministic approval boundary between a verified plan and Symphony. */
 
 import { createHash } from 'node:crypto';
-import {
-  PLAN_APPROVED_LABEL,
-  planGateReceipt,
-} from './plan-gate.mjs';
+import { PLAN_APPROVED_LABEL, planGateReceipt } from './plan-gate.mjs';
 
 export const ADMISSION_GATE_SCHEMA = 'admission-gate/v1';
 export const ADMISSION_GATE_PREFIX = '<!-- admission-gate/v1 -->';
@@ -114,10 +111,7 @@ export async function approveAdmission({ issue, client, teamId = null }) {
   if (reason) return { status: 'rejected', reason };
 
   const receipt = buildAdmissionGateReceipt(issue);
-  if (
-    hasReceipt(issue, receipt) &&
-    hasLabel(issue, ADMISSION_APPROVED_LABEL)
-  ) {
+  if (hasReceipt(issue, receipt) && hasLabel(issue, ADMISSION_APPROVED_LABEL)) {
     return {
       status: 'already-approved',
       identifier: issue.identifier,

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -14,6 +14,7 @@
  *   node scripts/backlog-orchestrator/backlog-orchestrator.mjs reconcile --dry-run
  *   node scripts/backlog-orchestrator/backlog-orchestrator.mjs audit
  *   node scripts/backlog-orchestrator/backlog-orchestrator.mjs admit-next
+ *   node scripts/backlog-orchestrator/backlog-orchestrator.mjs gate-next
  *   node scripts/backlog-orchestrator/backlog-orchestrator.mjs approve-plan --issue=JOV-123 --evidence-file=/path/evidence.json
  *   node scripts/backlog-orchestrator/backlog-orchestrator.mjs report
  */
@@ -27,7 +28,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Keep the complete control-plane dependency closure visible to source sync and
 // module tooling. These are canonical sibling modules, not host-only copies.
 import * as admitter from './admitter.mjs';
+import * as admissionGate from './admission-gate.mjs';
 import * as classifier from './classifier.mjs';
+import * as deterministicGates from './deterministic-gates.mjs';
 import * as linear from './linear-client.mjs';
 import * as planGate from './plan-gate.mjs';
 import * as reconciler from './reconcile.mjs';
@@ -81,6 +84,8 @@ Usage:
   node backlog-orchestrator.mjs reconcile --issue=JOV-123  Single issue
   node backlog-orchestrator.mjs audit                Full backlog audit (shadow)
   node backlog-orchestrator.mjs admit-next            Admit next work item
+  node backlog-orchestrator.mjs gate-next             Plan, approve, and admit one safe issue
+  node backlog-orchestrator.mjs gate-next --dry-run   Show the next issue without mutations
   node backlog-orchestrator.mjs approve-plan --issue=JOV-123 --evidence-file=/path/evidence.json
   node backlog-orchestrator.mjs report                Generate shadow report
 `);
@@ -95,6 +100,8 @@ Usage:
     await runReconcile(cache, isDryRun, issueArg);
   } else if (command === 'admit-next') {
     await runAdmitNext(cache, isDryRun);
+  } else if (command === 'gate-next') {
+    await runGateNext(isDryRun, issueArg);
   } else if (command === 'approve-plan') {
     await runApprovePlan(issueArg, evidenceFile, evidenceJson, isDryRun);
   } else {
@@ -132,8 +139,179 @@ async function runApprovePlan(issueArg, evidenceFile, evidenceJson, isDryRun) {
     issue,
     evidence,
     client: linear,
+    teamId: TEAM_ID,
   });
   console.log(JSON.stringify(receipt, null, 2));
+}
+
+async function admissionPreflight() {
+  const productionRed = await scorer.isProductionRed();
+  if (productionRed) {
+    return {
+      open: false,
+      reason: 'production health is red or unavailable',
+      load: { count: 0, identifiers: [] },
+    };
+  }
+  const symphonyIssues = await linear.fetchTeamSymphonyIssues(TEAM_ID);
+  const load = deterministicGates.admissionIntentLoad(symphonyIssues);
+  return {
+    open: load.count < admitter.MAX_CONCURRENT_SHIPPING,
+    reason:
+      load.count < admitter.MAX_CONCURRENT_SHIPPING
+        ? 'open'
+        : `at capacity (${load.count}/${admitter.MAX_CONCURRENT_SHIPPING})`,
+    load,
+  };
+}
+
+async function runGateNext(isDryRun, issueArg) {
+  const preflight = await admissionPreflight();
+  if (!preflight.open) {
+    console.log(
+      JSON.stringify(
+        {
+          schema: 'deterministic-gates/run/v1',
+          status: 'blocked',
+          stage: 'preflight',
+          reason: preflight.reason,
+          active: preflight.load.identifiers,
+          mutations: 0,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  const issues = issueArg
+    ? [await linear.fetchIssue(issueArg)].filter(Boolean)
+    : await linear.fetchTeamGateCandidates(TEAM_ID);
+  const selection = deterministicGates.selectDeterministicPlanCandidate(
+    issues,
+    { issueIdentifier: issueArg }
+  );
+  if (!selection.selected) {
+    console.log(
+      JSON.stringify(
+        {
+          schema: 'deterministic-gates/run/v1',
+          status: 'blocked',
+          stage: 'selection',
+          reason: issueArg ? 'requested issue is not eligible' : 'no eligible issue',
+          decisions: selection.decisions,
+          mutations: 0,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  const selected = selection.selected;
+  const plan = deterministicGates.buildDeterministicPlanEvidence(selected);
+  const planReason =
+    plan.reason || planGate.validatePlanCandidate(selected, plan.evidence);
+  if (planReason) {
+    console.log(
+      JSON.stringify(
+        {
+          schema: 'deterministic-gates/run/v1',
+          status: 'blocked',
+          stage: 'plan',
+          issue: selected.identifier,
+          reason: planReason,
+          mutations: 0,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  if (isDryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          schema: 'deterministic-gates/run/v1',
+          status: 'would-admit',
+          issue: selected.identifier,
+          plan: plan.evidence,
+          mutations: 0,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  const planResult = await planGate.approvePlan({
+    issue: selected,
+    evidence: plan.evidence,
+    client: linear,
+    teamId: TEAM_ID,
+  });
+  if (planResult.status === 'rejected')
+    throw new Error(`plan gate rejected: ${planResult.reason}`);
+
+  let current = await linear.fetchIssue(selected.identifier);
+  const finalPreflight = await admissionPreflight();
+  if (!finalPreflight.open)
+    throw new Error(`admission preflight blocked: ${finalPreflight.reason}`);
+
+  const admissionResult = await admissionGate.approveAdmission({
+    issue: current,
+    client: linear,
+    teamId: TEAM_ID,
+  });
+  if (admissionResult.status === 'rejected')
+    throw new Error(`admission gate rejected: ${admissionResult.reason}`);
+
+  current = await linear.fetchIssue(selected.identifier);
+  const classification = classifier.classifyDeterministic(current, [current]);
+  classification.issue = current;
+  classification.labels = current.labels.nodes.map(label => label.name);
+  const lease = await admitter.admitIssue({
+    issue: current,
+    classification,
+    client: linear,
+    teamId: TEAM_ID,
+    todoStateId: TODO_STATE_ID,
+  });
+  if (!['admitted', 'already-admitted'].includes(lease.status))
+    throw new Error(`lease rejected: ${lease.reason}`);
+
+  const verified = await linear.fetchIssue(selected.identifier);
+  const evidence = admitter.hasAdmissionEvidence(verified);
+  const load = deterministicGates.admissionIntentLoad([verified]);
+  if (
+    verified.state?.name !== 'Todo' ||
+    !evidence.eligible ||
+    !verified.labels.nodes.some(label => label.name === admitter.SYMPHONY_LABEL) ||
+    load.count !== 1
+  )
+    throw new Error('final gate-and-lease verification failed');
+
+  console.log(
+    JSON.stringify(
+      {
+        schema: 'deterministic-gates/run/v1',
+        status: 'admitted',
+        issue: selected.identifier,
+        planGate: planResult.status,
+        admissionGate: admissionResult.status,
+        lease: lease.status,
+        active: load.identifiers,
+        mutations: 'verified',
+      },
+      null,
+      2
+    )
+  );
 }
 
 async function runAudit(cache, isDryRun) {

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -25,10 +25,10 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+import * as admissionGate from './admission-gate.mjs';
 // Keep the complete control-plane dependency closure visible to source sync and
 // module tooling. These are canonical sibling modules, not host-only copies.
 import * as admitter from './admitter.mjs';
-import * as admissionGate from './admission-gate.mjs';
 import * as classifier from './classifier.mjs';
 import * as deterministicGates from './deterministic-gates.mjs';
 import * as linear from './linear-client.mjs';
@@ -199,7 +199,9 @@ async function runGateNext(isDryRun, issueArg) {
           schema: 'deterministic-gates/run/v1',
           status: 'blocked',
           stage: 'selection',
-          reason: issueArg ? 'requested issue is not eligible' : 'no eligible issue',
+          reason: issueArg
+            ? 'requested issue is not eligible'
+            : 'no eligible issue',
           decisions: selection.decisions,
           mutations: 0,
         },
@@ -272,9 +274,11 @@ async function runGateNext(isDryRun, issueArg) {
     throw new Error(`admission gate rejected: ${admissionResult.reason}`);
 
   current = await linear.fetchIssue(selected.identifier);
-  const classification = classifier.classifyDeterministic(current, [current]);
-  classification.issue = current;
-  classification.labels = current.labels.nodes.map(label => label.name);
+  const classification = {
+    ...classifier.classifyDeterministic(current, [current]),
+    issue: current,
+    labels: current.labels.nodes.map(label => label.name),
+  };
   const lease = await admitter.admitIssue({
     issue: current,
     classification,
@@ -291,7 +295,9 @@ async function runGateNext(isDryRun, issueArg) {
   if (
     verified.state?.name !== 'Todo' ||
     !evidence.eligible ||
-    !verified.labels.nodes.some(label => label.name === admitter.SYMPHONY_LABEL) ||
+    !verified.labels.nodes.some(
+      label => label.name === admitter.SYMPHONY_LABEL
+    ) ||
     load.count !== 1
   )
     throw new Error('final gate-and-lease verification failed');

--- a/scripts/backlog-orchestrator/deterministic-gates.mjs
+++ b/scripts/backlog-orchestrator/deterministic-gates.mjs
@@ -24,7 +24,10 @@ const PROTECTED_LABELS = new Set([
   'tim-owned',
   'type:epic',
 ]);
-const SAFE_PROJECTS = new Set(['Infra & CI/CD']);
+export const SYMPHONY_PROJECT = {
+  name: 'Infra & CI/CD',
+  slugId: '82c6fbd42405',
+};
 const PROHIBITED_TEXT =
   /credential|secret|password|api[ -]?key|access token|private key|billing|payment|checkout|database migration|schema migration|production deploy|publish externally|delete (?:customer|production|user) data|destructive|synthetic|bundle|workstream|batch|epic-only/i;
 const ACTIVE_PR = /github\.com\/JovieInc\/Jovie\/pull\/\d+/i;
@@ -87,7 +90,11 @@ export function validateDeterministicPlanCandidate(
     return 'inactive-or-active-state';
   if (isTimOwned(issue)) return 'tim-owned';
   if (issue.assignee) return 'already-assigned';
-  if (!SAFE_PROJECTS.has(issue.project?.name)) return 'project-not-allowlisted';
+  if (
+    issue.project?.name !== SYMPHONY_PROJECT.name ||
+    issue.project?.slugId !== SYMPHONY_PROJECT.slugId
+  )
+    return 'project-not-allowlisted';
 
   const labels = labelsOf(issue);
   if (!labels.some(label => READY_LABELS.has(label)))

--- a/scripts/backlog-orchestrator/deterministic-gates.mjs
+++ b/scripts/backlog-orchestrator/deterministic-gates.mjs
@@ -1,0 +1,210 @@
+/** No-model plan and admission gate orchestration. */
+
+import { ADMISSION_APPROVED_LABEL } from './admission-gate.mjs';
+import { ADMISSION_RECEIPT_PREFIX, SYMPHONY_LABEL } from './admitter.mjs';
+import { PLAN_APPROVED_LABEL } from './plan-gate.mjs';
+
+const READY_LABELS = new Set(['ready-for-intake', 'agent-ready']);
+const REQUIRED_EXECUTION_LABELS = new Set(['automated', 'testing']);
+const PROTECTED_LABELS = new Set([
+  'blocked',
+  'codex-blocked',
+  'codex-in-progress',
+  'founder-fast-track',
+  'human-review-required',
+  'incident',
+  'launch-blocker',
+  'missed-work',
+  'needs-human',
+  'no-auto',
+  'protected',
+  'risk:high',
+  'symphony',
+  'tim-approved',
+  'tim-owned',
+  'type:epic',
+]);
+const SAFE_PROJECTS = new Set(['Infra & CI/CD']);
+const PROHIBITED_TEXT =
+  /credential|secret|password|api[ -]?key|access token|private key|billing|payment|checkout|database migration|schema migration|production deploy|publish externally|delete (?:customer|production|user) data|destructive|synthetic|bundle|workstream|batch|epic-only/i;
+const ACTIVE_PR = /github\.com\/JovieInc\/Jovie\/pull\/\d+/i;
+const MAX_CANDIDATE_AGE_DAYS = 60;
+
+function labelsOf(issue) {
+  return (issue?.labels?.nodes || issue?.labels || [])
+    .map(label => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean)
+    .map(label => label.toLowerCase());
+}
+
+function commentsOf(issue) {
+  return issue?.comments?.nodes || issue?.comments || [];
+}
+
+function commentBody(comment) {
+  return typeof comment === 'string' ? comment : comment?.body || '';
+}
+
+function isTimOwned(issue) {
+  const assignee = issue?.assignee;
+  return Boolean(
+    assignee &&
+      /tim(?:\s|-|_)*white|itstimwhite|^tim$/i.test(
+        `${assignee.id || ''} ${assignee.name || ''} ${assignee.email || ''}`
+      )
+  );
+}
+
+function section(description, names) {
+  const wanted = new Set(names.map(name => name.toLowerCase()));
+  const lines = String(description || '').split('\n');
+  const start = lines.findIndex(line => {
+    const match = /^#{2,3}\s+(.+?)\s*$/.exec(line);
+    return match && wanted.has(match[1].toLowerCase());
+  });
+  if (start < 0) return '';
+  const end = lines.findIndex(
+    (line, index) => index > start && /^#{2,3}\s+/.test(line)
+  );
+  return lines.slice(start + 1, end < 0 ? undefined : end).join('\n').trim();
+}
+
+function cleanList(value) {
+  return value
+    .split('\n')
+    .map(line => line.replace(/^\s*(?:[-*]|\d+[.)])\s+/, '').trim())
+    .filter(Boolean)
+    .slice(0, 12);
+}
+
+export function validateDeterministicPlanCandidate(
+  issue,
+  { now = new Date().toISOString() } = {}
+) {
+  if (!issue?.id || !/^JOV-\d+$/.test(issue.identifier || ''))
+    return 'not-concrete-jovie-issue';
+  if (!['Triage', 'Backlog', 'Todo'].includes(issue.state?.name || issue.state))
+    return 'inactive-or-active-state';
+  if (isTimOwned(issue)) return 'tim-owned';
+  if (issue.assignee) return 'already-assigned';
+  if (!SAFE_PROJECTS.has(issue.project?.name)) return 'project-not-allowlisted';
+
+  const labels = labelsOf(issue);
+  if (!labels.some(label => READY_LABELS.has(label)))
+    return 'readiness-label-missing';
+  if (!labels.some(label => REQUIRED_EXECUTION_LABELS.has(label)))
+    return 'execution-evidence-label-missing';
+  if (labels.some(label => PROTECTED_LABELS.has(label)))
+    return 'protected-or-human-review';
+  if ((issue.children?.nodes || []).length > 0) return 'parent-or-bundle';
+
+  const text = `${issue.title || ''}\n${issue.description || ''}`;
+  if (PROHIBITED_TEXT.test(text)) return 'sensitive-or-external-work';
+  if (commentsOf(issue).some(comment => ACTIVE_PR.test(commentBody(comment))))
+    return 'active-pull-request';
+
+  const createdAt = new Date(issue.createdAt || 0).getTime();
+  const current = new Date(now).getTime();
+  if (
+    !Number.isFinite(createdAt) ||
+    !Number.isFinite(current) ||
+    current < createdAt ||
+    (current - createdAt) / 86_400_000 > MAX_CANDIDATE_AGE_DAYS
+  )
+    return 'stale-or-invalid-created-at';
+
+  if (!section(issue.description, ['Proposed fix', 'Implementation plan']))
+    return 'scope-section-missing';
+  if (!section(issue.description, ['Acceptance criteria']))
+    return 'acceptance-section-missing';
+  return null;
+}
+
+export function buildDeterministicPlanEvidence(issue) {
+  const reason = validateDeterministicPlanCandidate(issue);
+  if (reason) return { evidence: null, reason };
+  const scope = section(issue.description, [
+    'Implementation plan',
+    'Proposed fix',
+  ]);
+  const acceptance = cleanList(
+    section(issue.description, ['Acceptance criteria'])
+  );
+  return {
+    reason: null,
+    evidence: {
+      verified: true,
+      concrete: true,
+      bounded: true,
+      repo: 'JovieInc/Jovie',
+      project: issue.project.name,
+      owner: 'Gem',
+      scope: scope.slice(0, 1800),
+      acceptance,
+      test: [
+        'Run focused tests for the touched paths and the repository-prescribed validation; do not weaken CI gates.',
+      ],
+      rollback:
+        'Revert the single issue-scoped commit or pull request. This gate does not merge or deploy.',
+    },
+  };
+}
+
+function priorityValue(priority) {
+  return ({ 1: 100, 2: 80, 3: 50, 4: 20, 0: 10 })[priority] || 0;
+}
+
+export function selectDeterministicPlanCandidate(
+  issues,
+  { issueIdentifier = null, now = new Date().toISOString() } = {}
+) {
+  const decisions = issues.map(issue => ({
+    issue,
+    reason: validateDeterministicPlanCandidate(issue, { now }),
+  }));
+  const eligible = decisions
+    .filter(decision => !decision.reason)
+    .map(decision => decision.issue)
+    .filter(issue => !issueIdentifier || issue.identifier === issueIdentifier)
+    .sort(
+      (a, b) =>
+        priorityValue(b.priority) - priorityValue(a.priority) ||
+        (a.estimate ?? 99) - (b.estimate ?? 99) ||
+        b.identifier.localeCompare(a.identifier)
+    );
+  return {
+    selected: eligible[0] || null,
+    decisions: decisions.map(({ issue, reason }) => ({
+      identifier: issue.identifier,
+      reason: reason || 'eligible',
+    })),
+  };
+}
+
+function hasLabels(issue, names) {
+  const labels = new Set(labelsOf(issue));
+  return names.every(name => labels.has(name));
+}
+
+export function admissionIntentLoad(issues) {
+  const active = issues.filter(issue => {
+    if (!['Todo', 'In Progress', 'In Review'].includes(issue.state?.name))
+      return false;
+    if (
+      !hasLabels(issue, [
+        PLAN_APPROVED_LABEL,
+        ADMISSION_APPROVED_LABEL,
+        SYMPHONY_LABEL,
+      ])
+    )
+      return false;
+    return commentsOf(issue).some(comment => {
+      const body = commentBody(comment);
+      return (
+        body.startsWith('<!-- admission-gate/v1 -->') ||
+        body.startsWith(ADMISSION_RECEIPT_PREFIX)
+      );
+    });
+  });
+  return { count: active.length, identifiers: active.map(x => x.identifier) };
+}

--- a/scripts/backlog-orchestrator/deterministic-gates.mjs
+++ b/scripts/backlog-orchestrator/deterministic-gates.mjs
@@ -69,7 +69,10 @@ function section(description, names) {
   const end = lines.findIndex(
     (line, index) => index > start && /^#{2,3}\s+/.test(line)
   );
-  return lines.slice(start + 1, end < 0 ? undefined : end).join('\n').trim();
+  return lines
+    .slice(start + 1, end < 0 ? undefined : end)
+    .join('\n')
+    .trim();
 }
 
 function cleanList(value) {
@@ -158,7 +161,7 @@ export function buildDeterministicPlanEvidence(issue) {
 }
 
 function priorityValue(priority) {
-  return ({ 1: 100, 2: 80, 3: 50, 4: 20, 0: 10 })[priority] || 0;
+  return { 1: 100, 2: 80, 3: 50, 4: 20, 0: 10 }[priority] || 0;
 }
 
 export function selectDeterministicPlanCandidate(

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -257,6 +257,7 @@ export async function fetchTeamTriageIssues(teamId, maxResults = 1000) {
               assignee { id name }
               creator { id name }
               labels { nodes { id name } }
+              project { id name slugId }
               parent { id identifier title }
               children { nodes { id identifier title } }
               relations {
@@ -314,6 +315,7 @@ export async function fetchTeamActiveIssues(teamId, maxResults = 1000) {
               assignee { id name }
               creator { id name }
               labels { nodes { id name } }
+              project { id name slugId }
               parent { id identifier title }
               children { nodes { id identifier title } }
               relations { nodes { type relatedIssue { id identifier title } } }
@@ -378,6 +380,92 @@ export async function fetchTeamInProgressIssues(teamId, maxResults = 1000) {
     cursor = edge.pageInfo.endCursor;
   }
   return issues;
+}
+
+/**
+ * Fetch the narrow deterministic gate pool. Filtering on readiness labels keeps
+ * the five-minute control-plane poll bounded instead of scanning the backlog.
+ */
+export async function fetchTeamGateCandidates(teamId, maxResults = 500) {
+  const issues = [];
+  let cursor = null;
+  while (issues.length < maxResults) {
+    const data = await graphql(
+      `
+      query($teamId: String!, $cursor: String) {
+        team(id: $teamId) {
+          issues(
+            first: 50,
+            after: $cursor,
+            filter: {
+              state: { name: { in: ["Triage", "Backlog", "Todo"] } },
+              labels: { some: { name: { in: ["ready-for-intake", "agent-ready"] } } }
+            }
+          ) {
+            nodes {
+              id identifier title description url createdAt updatedAt priority estimate
+              assignee { id name }
+              creator { id name }
+              labels { nodes { id name } }
+              project { id name slugId }
+              parent { id identifier title }
+              children { nodes { id identifier title } }
+              relations { nodes { type relatedIssue { id identifier title } } }
+              state { id name type }
+              comments { nodes { id body createdAt } }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    `,
+      { teamId, cursor }
+    );
+    const edge = data.team.issues;
+    issues.push(...edge.nodes);
+    if (!edge.pageInfo.hasNextPage) break;
+    cursor = edge.pageInfo.endCursor;
+  }
+  return issues.slice(0, maxResults);
+}
+
+/** Fetch possible machine-admission intents for authoritative capacity checks. */
+export async function fetchTeamSymphonyIssues(teamId, maxResults = 100) {
+  const issues = [];
+  let cursor = null;
+  while (issues.length < maxResults) {
+    const data = await graphql(
+      `
+      query($teamId: String!, $cursor: String) {
+        team(id: $teamId) {
+          issues(
+            first: 50,
+            after: $cursor,
+            filter: {
+              state: { name: { in: ["Todo", "In Progress", "In Review"] } },
+              labels: { some: { name: { eq: "symphony" } } }
+            }
+          ) {
+            nodes {
+              id identifier title updatedAt
+              assignee { id name }
+              labels { nodes { id name } }
+              state { id name type }
+              comments { nodes { id body createdAt } }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    `,
+      { teamId, cursor }
+    );
+    const edge = data.team.issues;
+    issues.push(...edge.nodes);
+    if (!edge.pageInfo.hasNextPage) break;
+    cursor = edge.pageInfo.endCursor;
+  }
+  return issues.slice(0, maxResults);
 }
 
 /**

--- a/scripts/backlog-orchestrator/plan-gate.mjs
+++ b/scripts/backlog-orchestrator/plan-gate.mjs
@@ -11,6 +11,7 @@ import { createHash } from 'node:crypto';
 export const PLAN_GATE_SCHEMA = 'plan-gate/v1';
 export const PLAN_GATE_PREFIX = '<!-- plan-gate/v1 -->';
 export const PLAN_GATE_SUFFIX = '<!--/plan-gate-->';
+export const PLAN_APPROVED_LABEL = 'plan-approved';
 
 const ALLOWED_STATES = new Set(['Triage', 'Backlog', 'Todo']);
 const PROTECTED_LABELS = new Set([
@@ -171,20 +172,68 @@ function hasReceipt(issue, receipt) {
   return commentsOf(issue).some(comment => commentBody(comment) === receipt);
 }
 
+export function planGateReceipt(issue) {
+  const body = commentsOf(issue)
+    .map(commentBody)
+    .find(
+      value =>
+        value.startsWith(`${PLAN_GATE_PREFIX}\n`) &&
+        value.endsWith(`\n${PLAN_GATE_SUFFIX}`)
+    );
+  if (!body) return null;
+  try {
+    const payload = JSON.parse(
+      body.slice(
+        `${PLAN_GATE_PREFIX}\n`.length,
+        -`\n${PLAN_GATE_SUFFIX}`.length
+      )
+    );
+    if (
+      payload?.schema !== PLAN_GATE_SCHEMA ||
+      payload?.issue !== issue?.identifier ||
+      !payload?.fingerprint ||
+      !payload?.evidence ||
+      validatePlanCandidate(issue, payload.evidence) ||
+      planGateFingerprint(issue, payload.evidence) !== payload.fingerprint
+    )
+      return null;
+    return { body, payload };
+  } catch {
+    return null;
+  }
+}
+
 function mutationSucceeded(result) {
-  return result?.success === true || result?.commentCreate?.success === true;
+  return (
+    result?.success === true ||
+    result?.commentCreate?.success === true ||
+    result?.issueUpdate?.success === true
+  );
+}
+
+function hasLabel(issue, name) {
+  return labelsOf(issue).includes(name.toLowerCase());
+}
+
+function labelIds(issue, labelId) {
+  return [
+    ...new Set([
+      ...(issue?.labels?.nodes || []).map(label => label.id).filter(Boolean),
+      labelId,
+    ]),
+  ];
 }
 
 /**
  * Write exactly one plan receipt, or return an idempotent no-op. The client is
  * injected so this boundary remains unit-testable without touching Linear.
  */
-export async function approvePlan({ issue, evidence, client }) {
+export async function approvePlan({ issue, evidence, client, teamId = null }) {
   const reason = validatePlanCandidate(issue, evidence);
   if (reason) return { status: 'rejected', reason };
 
   const receipt = buildPlanGateReceipt(issue, evidence);
-  if (hasReceipt(issue, receipt)) {
+  if (hasReceipt(issue, receipt) && hasLabel(issue, PLAN_APPROVED_LABEL)) {
     return {
       status: 'already-approved',
       identifier: issue.identifier,
@@ -193,16 +242,43 @@ export async function approvePlan({ issue, evidence, client }) {
     };
   }
 
-  const result = await client.addComment(issue.id, receipt);
-  if (!mutationSucceeded(result))
-    throw new Error('plan-gate-receipt-mutation-failed');
+  let current = issue;
+  let mutated = false;
+  if (!hasReceipt(current, receipt)) {
+    const result = await client.addComment(current.id, receipt);
+    if (!mutationSucceeded(result))
+      throw new Error('plan-gate-receipt-mutation-failed');
+    mutated = true;
+    current = await client.fetchIssue(current.identifier);
+    if (!current || !hasReceipt(current, receipt))
+      throw new Error('plan-gate-receipt-verification-failed');
+  }
 
-  const reread = await client.fetchIssue(issue.identifier);
-  if (!reread || !hasReceipt(reread, receipt))
-    throw new Error('plan-gate-receipt-verification-failed');
+  if (!hasLabel(current, PLAN_APPROVED_LABEL)) {
+    const label = await client.fetchTeamLabel?.(teamId, PLAN_APPROVED_LABEL);
+    if (!label?.id) throw new Error('plan-approved-label-not-found');
+    const result = await client.setIssueLabels(
+      current.id,
+      labelIds(current, label.id)
+    );
+    if (!mutationSucceeded(result))
+      throw new Error('plan-gate-label-mutation-failed');
+    mutated = true;
+    current = await client.fetchIssue(current.identifier);
+    if (!current || !hasLabel(current, PLAN_APPROVED_LABEL))
+      throw new Error('plan-gate-label-verification-failed');
+  }
+
+  const reread = await client.fetchIssue(current.identifier);
+  if (
+    !reread ||
+    !hasReceipt(reread, receipt) ||
+    !hasLabel(reread, PLAN_APPROVED_LABEL)
+  )
+    throw new Error('plan-gate-final-verification-failed');
 
   return {
-    status: 'approved',
+    status: mutated ? 'approved' : 'already-approved',
     identifier: reread.identifier,
     fingerprint: planGateFingerprint(issue, evidence),
     receipt,

--- a/scripts/backlog-orchestrator/scorer.mjs
+++ b/scripts/backlog-orchestrator/scorer.mjs
@@ -91,8 +91,8 @@ export async function isProductionRed() {
     const data = /** @type {any} */ (await resp.json());
     return data.status !== 'ok';
   } catch {
-    // If we can't check, assume safe (fail open for local)
-    return false;
+    // Admission is a mutation boundary: unavailable production evidence blocks.
+    return true;
   }
 }
 


### PR DESCRIPTION
No Linear issue — ad-hoc control-plane repair.

## What changed
- materialize exact plan and admission receipts plus `plan-approved` / `admission-approved` labels
- add a conservative no-LLM `gate-next` command with production-health and single-intent capacity checks
- query only readiness-labeled candidates and fail closed on protected, stale, sensitive, assigned, epic, or non-infra work
- include all backlog orchestrator tests in `backlog:test`

## Verification
- `node --test scripts/backlog-orchestrator/__tests__/*.test.mjs` (52/52)
- live Gem dry-run on JOV-4305 returned `would-admit` with `mutations: 0`

This PR does not merge, deploy, or claim customer impact.