### PR TITLE
docs(release): close native stacked PR handoff gaps

### DIFF
--- a/.claude/rules/pr-stacking.md
+++ b/.claude/rules/pr-stacking.md
@@ -76,16 +76,18 @@ the parent merges, keep both the old parent tip and the recorded child remote
 tip for the rebase boundary and force-with-lease, then:
 
 ```bash
-old_parent_tip=<recorded-parent-tip>
-old_child_tip=<recorded-child-head>
-remote_child_tip=$(git ls-remote origin "refs/heads/<child-branch>" | awk '{print $1}')
+child_branch=feat/x-02
+pr_number=123
+old_parent_tip=RECORDED_PARENT_SHA
+old_child_tip=RECORDED_CHILD_SHA
+remote_child_tip=$(git ls-remote origin "refs/heads/$child_branch" | awk '{print $1}')
 test "$remote_child_tip" = "$old_child_tip"
 git fetch origin main
-gh pr edit <child> --base main
-git rebase --onto origin/main "$old_parent_tip" <child-branch>
-git push --force-with-lease="refs/heads/<child-branch>:$old_child_tip" origin <child-branch>
-git merge-base --is-ancestor origin/main <child-branch>
-test "$(git ls-remote origin "refs/heads/<child-branch>" | awk '{print $1}')" = "$(git rev-parse <child-branch>)"
+gh pr edit "$pr_number" --base main
+git rebase --onto origin/main "$old_parent_tip" "$child_branch"
+git push --force-with-lease="refs/heads/$child_branch:$old_child_tip" origin "$child_branch"
+git merge-base --is-ancestor origin/main "$child_branch"
+test "$(git ls-remote origin "refs/heads/$child_branch" | awk '{print $1}')" = "$(git rev-parse "$child_branch")"
 ```
 
 The first equality is the pre-rebase remote-head proof; the explicit lease makes

--- a/.claude/rules/pr-stacking.md
+++ b/.claude/rules/pr-stacking.md
@@ -67,18 +67,30 @@ git push -u origin feat/x-02
 gh pr create --draft --base feat/x-01 --head feat/x-02
 ```
 
+Keep every dependent child draft and unenrolled while its immediate-parent base
+is still open. Only mark the child ready and add `merge-queue` after its parent
+has landed, the child targets `main`, and the rebase and fresh checks below pass.
+
 Record every branch, PR number, immediate-parent base, and exact head SHA. When
-the parent merges, keep its old tip for the rebase boundary, then:
+the parent merges, keep both the old parent tip and the recorded child remote
+tip for the rebase boundary and force-with-lease, then:
 
 ```bash
+old_parent_tip=<recorded-parent-tip>
+old_child_tip=<recorded-child-head>
+remote_child_tip=$(git ls-remote origin "refs/heads/<child-branch>" | awk '{print $1}')
+test "$remote_child_tip" = "$old_child_tip"
 git fetch origin main
 gh pr edit <child> --base main
-git rebase --onto origin/main <old-parent-tip> <child-branch>
-git push --force-with-lease origin <child-branch>
+git rebase --onto origin/main "$old_parent_tip" <child-branch>
+git push --force-with-lease="refs/heads/<child-branch>:$old_child_tip" origin <child-branch>
+git merge-base --is-ancestor origin/main <child-branch>
+test "$(git ls-remote origin "refs/heads/<child-branch>" | awk '{print $1}')" = "$(git rev-parse <child-branch>)"
 ```
 
-Prove the child remote head was unchanged before rebasing, inspect ancestry and
-the semantic diff, and wait for the fresh source checks before queue enrollment.
-Keep the parent branch until the child has converged. Land one layer at a time
-through GitHub's native merge queue; never bypass it or create a second landing
-transport. See also [`ci-branching.md`](ci-branching.md).
+The first equality is the pre-rebase remote-head proof; the explicit lease makes
+the push fail closed if another writer moved the branch. Inspect the semantic
+diff, wait for fresh source checks, then enroll. Keep the parent branch until the
+child has converged. Land one layer at a time through GitHub's native merge
+queue; never bypass it or create a second landing transport. See also
+[`ci-branching.md`](ci-branching.md).

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -49,21 +49,32 @@ pnpm --filter @jovie/web run test:bug-to-test
 
 ### Branch Hygiene
 
-- Always rebase on main before pushing (not merge).
+- Root PRs and children being retargeted after a parent lands must rebase on
+  `main` before becoming ready or entering the queue (never merge `main` into a
+  branch). A dependent child may initially push its immediate-parent base while
+  draft; follow the native stacked-PR handoff in `pr-stacking.md` before readying.
 - **History Sanity Check:** Before starting work or rebasing, verify the branch shares a recent ancestor with `main`. Use `git merge-base main <branch>`. If the result is empty or the branch is >5,000 commits behind, it is a zombie; re-plant it onto a fresh `main` base instead of rebasing.
 
-- **Agent routine work:** `tim/jov-*` → `integration/loop-{domain}` → train PR → `main` (see [`.claude/rules/ci-branching.md`](ci-branching.md)). Do not open routine agent PRs directly to `main`.
+- **Agent routine waves:** `tim/jov-*` → `integration/loop-{domain}` → train PR →
+  `main` (see [`.claude/rules/ci-branching.md`](ci-branching.md)). An explicitly
+  authorized dependent stack is the exception: use the native root-to-`main`,
+  child-to-parent-draft, then retarget/rebase sequence in `pr-stacking.md`.
 - **Human / hotfix:** `hotfix/*` or `needs-human` labeled PRs may target `main` with full CI.
 - If a PR has been open >24h without progress, close it and re-create from fresh integration base or `main`.
 
 ### Incremental Shipping (Ship Fast, Fail Fast)
 
 - When a command produces multiple independent fixes, ship each as its own PR.
-- **Open a draft PR on first push** — CI runs immediately, giving early feedback.
+- **Open a draft PR on first push** — root PRs target `main`; dependent children
+  target their immediate parent and stay draft/unenrolled until retargeted.
+  Source CI begins when the PR targets `main` (or a supported integration base),
+  giving early feedback without violating stack order.
 - Push frequently — concurrency groups cancel stale CI runs automatically.
 - Run `/ship` when ready — it detects the draft PR and promotes it to ready-for-review.
-- CI runs in parallel on all PRs while the agent continues working.
-- This maximizes throughput: N PRs × parallel CI > 1 large PR × serial CI.
+- CI runs in parallel on eligible root/integration PRs while the agent continues
+  working; dependent children receive source CI after the parent lands and the
+  child is retargeted/rebased to `main`.
+- This preserves throughput without enrolling a child against an unlanded base.
 - If a PR fails CI, fix and push again; don't create a new PR.
 - Enable auto-merge only after the PR is marked ready (not while draft).
 
@@ -71,11 +82,14 @@ pnpm --filter @jovie/web run test:bug-to-test
 
 AI agents MUST follow the "draft PR first, commit often" pattern for all non-trivial work:
 
-1. **First commit on branch:** Push immediately and open a draft PR:
+1. **First commit on branch:** Push immediately and open a draft PR. For a root
+   layer, target `main`; for a dependent layer, target the immediate parent:
    ```bash
    git push -u origin <branch-name>
-   gh pr create --draft --base main --title "WIP: <description>" --body "Draft — CI feedback loop in progress"
+   gh pr create --draft --base <main-or-immediate-parent> --title "WIP: <description>" --body "Draft — CI feedback loop in progress"
    ```
+   Keep the dependent child draft and unenrolled until its parent lands; then
+   follow [`pr-stacking.md`](pr-stacking.md) to retarget, rebase, and verify.
 
 2. **Iterate on CI feedback:** Push frequently. Each push triggers CI with cancel-in-progress (stale runs are automatically cancelled). Check CI status:
    ```bash

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -9,8 +9,10 @@ PR discipline, ship validation, branch strategy, deploy flow, bot-review blockin
 - Max 40 files changed per PR (excluding lockfiles, generated files, snapshots, svg)
 - Max 800 lines of diff (additions + deletions) — enforced by `pr-size-guard.yml`
   (repo vars `PR_MAX_LINES`/`PR_MAX_FILES`); approved mechanical codemods use `big-pr`
-- If a task requires more, split into a `gt` stack with clear dependencies
-  (see [`.claude/rules/pr-stacking.md`](pr-stacking.md))
+- If a task requires more, split into a native GitHub stacked-PR sequence with
+  clear dependencies; push each layer normally, open children against their
+  immediate parent while draft, then retarget/rebase each child onto `main`
+  after its parent lands (see [`.claude/rules/pr-stacking.md`](pr-stacking.md))
 
 ### Pre-Push Gate
 

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -16,10 +16,12 @@ parent lands. Graphite is not required and there is no second landing transport.
    recorded parent tip, prove its exact remote head lease and semantic ancestry,
    then mark it ready and apply `merge-queue`. Automation normally does this;
    humans can use `gh pr edit <pr> --add-label merge-queue` only after that proof.
-3. `merge-queue-autoenroll.yml` revalidates the PR's current state, `main` base,
-   hard-gate labels, terminal checks, and exact head SHA. It enrolls through
-   `scripts/merge-queue-backend.mjs` and proves authoritative queue state after
-   mutation. The label remains intent/audit evidence, never queue truth.
+3. Before labeling, the operator must verify the child targets `main` and that
+   its exact head is the rebased SHA. `merge-queue-autoenroll.yml` then
+   revalidates the PR's current state, hard-gate labels, terminal checks, and
+   exact head SHA. It enrolls through `scripts/merge-queue-backend.mjs` and
+   proves authoritative queue state after mutation. The label remains intent/
+   audit evidence, never queue truth.
 4. GitHub creates a synthetic `merge_group` head against current `main` and
    waits for the same required contexts on that exact combined SHA.
 5. GitHub squash-merges the green queue entry. `linear-sync-on-merge.yml`

--- a/.github/MERGE_QUEUE.md
+++ b/.github/MERGE_QUEUE.md
@@ -9,11 +9,15 @@ parent lands. Graphite is not required and there is no second landing transport.
 
 ## How a PR lands
 
-1. Open a PR against `main`. Source CI emits the required aggregate contexts.
-2. Apply `merge-queue` when the PR is ready. Automation normally does this;
-   humans can use `gh pr edit <pr> --add-label merge-queue`.
-3. `merge-queue-autoenroll.yml` revalidates the PR's current state, hard-gate
-   labels, terminal checks, and exact head SHA. It enrolls through
+1. Open a root PR against `main`. A dependent child may instead target its
+   immediate parent while both are open, but it must remain draft and must not
+   receive `merge-queue` while that parent base is live.
+2. After the parent lands, retarget the child to `main`, rebase it from the
+   recorded parent tip, prove its exact remote head lease and semantic ancestry,
+   then mark it ready and apply `merge-queue`. Automation normally does this;
+   humans can use `gh pr edit <pr> --add-label merge-queue` only after that proof.
+3. `merge-queue-autoenroll.yml` revalidates the PR's current state, `main` base,
+   hard-gate labels, terminal checks, and exact head SHA. It enrolls through
    `scripts/merge-queue-backend.mjs` and proves authoritative queue state after
    mutation. The label remains intent/audit evidence, never queue truth.
 4. GitHub creates a synthetic `merge_group` head against current `main` and


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4820 -->
## Summary
- close the native GitHub stacked-PR handoff fail-closed gaps left after #15525
- require dependent children to remain draft/unenrolled while their parent is open
- require exact parent/head/base verification before queue labeling
- keep controller claims scoped to the checks it actually performs

## Dependency/order
This is the ordered follow-up to [#15525](https://github.com/JovieInc/Jovie/pull/15525), which landed the baseline Graphite removal and native GitHub policy on `main` at `2c65a8513bf290f6ff001bb5b756b60c2ec2a50`.

This PR is docs/canon only and must land before opening the JOV-4820 ten-layer profile stack. It targets `main` directly and has no profile implementation changes.

## Proof
- base: `main`
- head: `168f37e274e`
- local normal pre-push gate: passed
- focused validators: `ci:branching-guard:validate`, `ci:harness:validate`, `ci:merge-queue:check`, `ci:merge-queue:verify`, `git diff --check`
