### PR TITLE
fix(ios): normalize Sentry auth error fingerprints (JOV-4305)

### DIFF
--- a/apps/ios/Jovie/App/LiveAuthBootstrapper.swift
+++ b/apps/ios/Jovie/App/LiveAuthBootstrapper.swift
@@ -38,9 +38,16 @@ enum MobileAuthReturnError: LocalizedError {
   }
 }
 
-private struct MobileAuthFinalizationStageError: LocalizedError {
+private struct MobileAuthFinalizationStageError: LocalizedError, CustomNSError {
   let stage: String
   let underlyingError: Error
+
+  static let errorDomain = "MobileAuthFinalizationStageError"
+  var errorCode: Int { 1 }
+
+  var errorUserInfo: [String: Any] {
+    [NSUnderlyingErrorKey: underlyingError as NSError]
+  }
 
   var errorDescription: String? {
     let message = underlyingError.localizedDescription.isEmpty

--- a/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
+++ b/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
@@ -178,7 +178,7 @@ final class SentryObservabilityProvider: ObservabilityProvider {
   }
 
   private static func normalizeFingerprint(event: Event) {
-    guard let exceptions = event.exceptions as? [SentryException] else { return }
+    guard let exceptions = event.exceptions else { return }
 
     let types = exceptions.map { exception in
       exception.type.map(SentryEventNormalizer.normalizeUnknownContext)

--- a/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
+++ b/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
@@ -245,7 +245,7 @@ enum SentryEventNormalizer {
   static func normalizeUnknownContext(_ value: String) -> String {
     let dottedContextRemoved = value.replacingOccurrences(
       of: unknownContextPattern,
-      with: ".",
+      with: "",
       options: .regularExpression
     )
     return dottedContextRemoved.replacingOccurrences(

--- a/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
+++ b/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
@@ -239,12 +239,18 @@ final class SentryObservabilityProvider: ObservabilityProvider {
 
 enum SentryEventNormalizer {
   private static let unknownContextPattern = #"\.\(unknown context at \$[0-9a-fA-F]+\)"#
+  private static let bareUnknownContextPattern = #"\(unknown context at \$[0-9a-fA-F]+\)"#
   private static let mobileAuthErrorName = "MobileAuthFinalizationStageError"
 
   static func normalizeUnknownContext(_ value: String) -> String {
-    value.replacingOccurrences(
+    let dottedContextRemoved = value.replacingOccurrences(
       of: unknownContextPattern,
       with: ".",
+      options: .regularExpression
+    )
+    return dottedContextRemoved.replacingOccurrences(
+      of: bareUnknownContextPattern,
+      with: "",
       options: .regularExpression
     )
   }

--- a/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
+++ b/apps/ios/Jovie/Core/Observability/SentryObservabilityProvider.swift
@@ -27,7 +27,8 @@ final class SentryObservabilityProvider: ObservabilityProvider {
       options.sendDefaultPii = false
       options.enableCaptureFailedRequests = false
       options.beforeSend = { event in
-        Self.redact(event: event)
+        Self.normalizeFingerprint(event: event)
+        return Self.redact(event: event)
       }
       options.beforeBreadcrumb = { breadcrumb in
         Self.redact(breadcrumb: breadcrumb)
@@ -176,6 +177,29 @@ final class SentryObservabilityProvider: ObservabilityProvider {
     return event
   }
 
+  private static func normalizeFingerprint(event: Event) {
+    guard let exceptions = event.exceptions as? [SentryException] else { return }
+
+    let types = exceptions.map { exception in
+      exception.type.map(SentryEventNormalizer.normalizeUnknownContext)
+    }
+    let values = exceptions.map { exception in
+      exception.value.map(SentryEventNormalizer.normalizeUnknownContext)
+    }
+
+    for (index, exception) in exceptions.enumerated() {
+      exception.type = types[index]
+      exception.value = values[index]
+    }
+
+    if let fingerprint = SentryEventNormalizer.mobileAuthFingerprint(
+      exceptionTypes: types,
+      exceptionValues: values
+    ) {
+      event.fingerprint = fingerprint
+    }
+  }
+
   private static func redact(breadcrumb: Breadcrumb) -> Breadcrumb? {
     if let data = breadcrumb.data {
       breadcrumb.data = ObservabilityRedactor.sanitizedContext(data)
@@ -210,6 +234,54 @@ final class SentryObservabilityProvider: ObservabilityProvider {
     }
 
     return span
+  }
+}
+
+enum SentryEventNormalizer {
+  private static let unknownContextPattern = #"\.\(unknown context at \$[0-9a-fA-F]+\)"#
+  private static let mobileAuthErrorName = "MobileAuthFinalizationStageError"
+
+  static func normalizeUnknownContext(_ value: String) -> String {
+    value.replacingOccurrences(
+      of: unknownContextPattern,
+      with: ".",
+      options: .regularExpression
+    )
+  }
+
+  static func mobileAuthFingerprint(
+    exceptionTypes: [String?],
+    exceptionValues: [String?]
+  ) -> [String]? {
+    let normalizedTypes = exceptionTypes.compactMap { $0 }.map(normalizeUnknownContext)
+    guard normalizedTypes.contains(where: { $0.contains(mobileAuthErrorName) }) else {
+      return nil
+    }
+
+    guard let stage = exceptionValues
+      .compactMap({ $0 })
+      .compactMap(Self.authStage(from:))
+      .first,
+      let underlyingErrorClass = normalizedTypes.reversed().first(where: {
+        !$0.contains(mobileAuthErrorName)
+      })
+    else {
+      return nil
+    }
+
+    return [mobileAuthErrorName, stage, underlyingErrorClass]
+  }
+
+  private static func authStage(from value: String) -> String? {
+    let prefix = "Native auth "
+    let suffix = " failed:"
+    guard value.hasPrefix(prefix), let suffixRange = value.range(of: suffix) else {
+      return nil
+    }
+
+    let stageStart = value.index(value.startIndex, offsetBy: prefix.count)
+    guard stageStart < suffixRange.lowerBound else { return nil }
+    return String(value[stageStart..<suffixRange.lowerBound])
   }
 }
 

--- a/apps/ios/JovieTests/ObservabilityTests.swift
+++ b/apps/ios/JovieTests/ObservabilityTests.swift
@@ -97,6 +97,37 @@ final class RecordingObservabilityProvider: ObservabilityProvider {
 @Suite(.serialized)
 @MainActor
 struct ObservabilityTests {
+  @Test(arguments: [
+    "Jovie.(unknown context at $104d1ab9c).MobileAuthFinalizationStageError",
+    "Jovie.(unknown context at $10ABCDEF).MobileAuthFinalizationStageError",
+    "Jovie.(unknown context at $7fff1234).MobileAuthFinalizationStageError",
+  ])
+  func normalizesSwiftUnknownContextAddresses(_ value: String) {
+    #expect(
+      SentryEventNormalizer.normalizeUnknownContext(value)
+        == "Jovie.MobileAuthFinalizationStageError"
+    )
+  }
+
+  @Test func fingerprintsMobileAuthByStageAndUnderlyingErrorClass() {
+    #expect(
+      SentryEventNormalizer.mobileAuthFingerprint(
+        exceptionTypes: [
+          "Jovie.(unknown context at $104d1ab9c).MobileAuthFinalizationStageError",
+          "APIClient.AuthExchangeError",
+        ],
+        exceptionValues: [
+          "Native auth exchange failed: OTT user mismatch",
+          "OTT user mismatch",
+        ]
+      ) == [
+        "MobileAuthFinalizationStageError",
+        "exchange",
+        "APIClient.AuthExchangeError",
+      ]
+    )
+  }
+
   @Test func facadeCanUseNoopProvider() {
     Observability.useProviderForTesting(NoopObservabilityProvider())
     defer { Observability.resetForTesting() }


### PR DESCRIPTION
<!-- linear-issue-id:ce16913c-c1de-4d9d-9b9d-cff0f7881084 -->
<!-- linear-issue-identifier:JOV-4305 -->

## Summary
- Normalize Swift closure-context ASLR addresses in iOS Sentry exception type/value fields.
- Fingerprint MobileAuthFinalizationStageError by stable stage and underlying error class.
- Add focused normalizer tests covering three observed address shapes.

## Test plan
- bash scripts/ios-best-practices-lint.sh apps/ios/Jovie — passed
- git diff --check — passed
- iOS simulator tests unavailable in this Linux runner because xcodebuild is not installed.

No UI changes or screenshots.

Fixes JOV-4305
