### PR TITLE
feat(profile): add canonical artist entity routes

### DIFF
--- a/apps/web/app/artists/[artistId]/route.ts
+++ b/apps/web/app/artists/[artistId]/route.ts
@@ -1,0 +1,47 @@
+import { and, eq } from 'drizzle-orm';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { artists } from '@/lib/db/schema/content';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const NO_STORE_HEADERS = { 'Cache-Control': 'private, no-store' } as const;
+
+interface RouteContext {
+  readonly params: Promise<{ readonly artistId: string }>;
+}
+
+/**
+ * Stable artist-entity route.
+ *
+ * Registry IDs do not change when an unclaimed profile is claimed, merged, or
+ * renamed, so collaborator links remain valid while the visible handle can
+ * evolve independently.
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { artistId } = await context.params;
+  if (!UUID_PATTERN.test(artistId)) {
+    return new Response(null, { status: 404, headers: NO_STORE_HEADERS });
+  }
+
+  const [resolved] = await db
+    .select({ username: creatorProfiles.usernameNormalized })
+    .from(artists)
+    .innerJoin(
+      creatorProfiles,
+      eq(artists.creatorProfileId, creatorProfiles.id)
+    )
+    .where(and(eq(artists.id, artistId), eq(creatorProfiles.isPublic, true)))
+    .limit(1);
+
+  if (!resolved?.username) {
+    return new Response(null, { status: 404, headers: NO_STORE_HEADERS });
+  }
+
+  return NextResponse.redirect(
+    new URL(`/${encodeURIComponent(resolved.username)}`, request.url),
+    { status: 307, headers: NO_STORE_HEADERS }
+  );
+}

--- a/apps/web/app/artists/page.tsx
+++ b/apps/web/app/artists/page.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import Link from 'next/link';
 import { Icon } from '@/components/atoms/Icon';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
@@ -35,7 +35,12 @@ export default async function ArtistsPage() {
         bio: creatorProfiles.bio,
       })
       .from(creatorProfiles)
-      .where(eq(creatorProfiles.isPublic, true))
+      .where(
+        and(
+          eq(creatorProfiles.isPublic, true),
+          eq(creatorProfiles.isClaimed, true)
+        )
+      )
       .orderBy(asc(creatorProfiles.displayName));
   } catch (err) {
     Sentry.captureException(err);

--- a/apps/web/lib/discography/artist-credit-policy.ts
+++ b/apps/web/lib/discography/artist-credit-policy.ts
@@ -1,0 +1,28 @@
+import type { ArtistRole } from '@/lib/db/schema/content';
+
+/**
+ * Credit roles that represent a public artist collaboration.
+ *
+ * Production and songwriting roles remain visible on release credit surfaces,
+ * but they do not automatically create an artist profile or enter the profile
+ * collaborator sentence. This prevents a producer, engineer, or composer from
+ * being represented as a performing artist without structured artist credit.
+ */
+export const PUBLIC_ARTIST_COLLABORATOR_ROLES = [
+  'main_artist',
+  'featured_artist',
+  'remixer',
+  'vs',
+  'with',
+] as const satisfies readonly ArtistRole[];
+
+export type PublicArtistCollaboratorRole =
+  (typeof PUBLIC_ARTIST_COLLABORATOR_ROLES)[number];
+
+export function isPublicArtistCollaboratorRole(
+  role: ArtistRole
+): role is PublicArtistCollaboratorRole {
+  return PUBLIC_ARTIST_COLLABORATOR_ROLES.includes(
+    role as PublicArtistCollaboratorRole
+  );
+}

--- a/apps/web/lib/discography/artist-profile-routing.ts
+++ b/apps/web/lib/discography/artist-profile-routing.ts
@@ -1,0 +1,22 @@
+const UUID_HEX_PATTERN = /^[0-9a-f]{32}$/;
+
+/** Stable inbound route that survives profile claims, merges, and renames. */
+export function artistProfileHref(artistId: string): string {
+  return `/artists/${encodeURIComponent(artistId)}`;
+}
+
+/**
+ * Collision-safe internal handle for an automatically created profile.
+ *
+ * The full 128-bit registry UUID is encoded in base36 (25 characters) rather
+ * than reserving a human-readable name. A future claimant can choose a normal
+ * handle while inbound `/artists/:id` links continue to resolve.
+ */
+export function buildUnclaimedArtistHandle(artistId: string): string {
+  const hex = artistId.replaceAll('-', '').toLowerCase();
+  if (!UUID_HEX_PATTERN.test(hex)) {
+    throw new Error('Artist ID must be a UUID');
+  }
+
+  return `a_${BigInt(`0x${hex}`).toString(36).padStart(25, '0')}`;
+}

--- a/apps/web/lib/discography/artist-profile-routing.ts
+++ b/apps/web/lib/discography/artist-profile-routing.ts
@@ -18,5 +18,6 @@ export function buildUnclaimedArtistHandle(artistId: string): string {
     throw new Error('Artist ID must be a UUID');
   }
 
-  return `a_${BigInt(`0x${hex}`).toString(36).padStart(25, '0')}`;
+  const encodedId = BigInt(`0x${hex}`).toString(36).padStart(25, '0');
+  return `a_${encodedId}`;
 }

--- a/apps/web/lib/discography/artist-queries/artist-crud.ts
+++ b/apps/web/lib/discography/artist-queries/artist-crud.ts
@@ -54,7 +54,15 @@ export async function findArtist(
     if (found) return found;
   }
 
-  // Fallback to normalized name match
+  // A supplied external ID is an identity boundary. If it does not match,
+  // never fall back to a display name: two different artists can share the
+  // same name, and aliases can change independently of their provider ID.
+  if (conditions.length > 0) {
+    return null;
+  }
+
+  // Name matching is only safe for legacy/manual credits that have no stable
+  // external identity at all.
   if (input.name) {
     const normalized = normalizeArtistName(input.name);
     const [found] = await database
@@ -151,9 +159,27 @@ export async function findOrCreateArtist(
   const [created] = await database
     .insert(artists)
     .values(insertData)
+    .onConflictDoNothing()
     .returning();
 
-  return created;
+  if (created) return created;
+
+  // Another import may have inserted the same unique provider identity while
+  // this request was in flight. Resolve that exact identity after the
+  // conflict; never choose a same-name row as the winner.
+  const raced = await findArtist(
+    {
+      spotifyId: input.spotifyId,
+      appleMusicId: input.appleMusicId,
+      musicbrainzId: input.musicbrainzId,
+      deezerId: input.deezerId,
+      name: input.name,
+    },
+    tx
+  );
+  if (raced) return raced;
+
+  throw new Error('Artist could not be created or resolved');
 }
 
 /**

--- a/apps/web/lib/discography/artist-queries/artist-import.ts
+++ b/apps/web/lib/discography/artist-queries/artist-import.ts
@@ -50,7 +50,7 @@ export async function processTrackArtistCredits(
         name: credit.name,
         spotifyId: credit.spotifyId,
         imageUrl: credit.imageUrl,
-        isAutoCreated: !credit.spotifyId, // Auto-created if no Spotify ID
+        isAutoCreated: sourceType === 'ingested',
       },
       db
     );
@@ -106,7 +106,7 @@ export async function processReleaseArtistCredits(
         name: credit.name,
         spotifyId: credit.spotifyId,
         imageUrl: credit.imageUrl,
-        isAutoCreated: !credit.spotifyId,
+        isAutoCreated: sourceType === 'ingested',
       },
       db
     );
@@ -162,7 +162,7 @@ export async function processRecordingArtistCredits(
         name: credit.name,
         spotifyId: credit.spotifyId,
         imageUrl: credit.imageUrl,
-        isAutoCreated: !credit.spotifyId,
+        isAutoCreated: sourceType === 'ingested',
       },
       db
     );

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -11,12 +11,15 @@ import {
   eq,
   ilike,
   inArray,
+  isNull,
+  ne,
   notInArray,
   or,
 } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import {
   type Artist,
+  type ArtistRole,
   artists,
   discogReleases,
   discogTracks,
@@ -24,7 +27,33 @@ import {
   trackArtists,
 } from '@/lib/db/schema/content';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
-import type { CollaboratorInfo, CreditedArtistWithProfile } from './types';
+import { publicReleaseEligibilitySqlPredicate } from '@/lib/profile/public-release-eligibility';
+import {
+  isPublicArtistCollaboratorRole,
+  PUBLIC_ARTIST_COLLABORATOR_ROLES,
+} from '../artist-credit-policy';
+import { artistProfileHref } from '../artist-profile-routing';
+import type {
+  CollaboratorInfo,
+  CreditedArtistWithProfile,
+  StructuredReleaseCollaborator,
+} from './types';
+
+export interface StructuredReleaseCollaboratorRow {
+  readonly artistId: string;
+  readonly artistName: string;
+  readonly artistSpotifyId: string | null;
+  readonly artistProfileId: string | null;
+  readonly profileIsPublic: boolean | null;
+  readonly profileIsClaimed: boolean | null;
+  readonly creditName: string | null;
+  readonly role: ArtistRole;
+  readonly position: number;
+  readonly releaseId: string;
+  readonly releaseTitle: string;
+  readonly releaseSlug: string;
+  readonly releaseDate: Date | null;
+}
 
 /**
  * Search artists by name
@@ -129,6 +158,122 @@ export async function getCreditedArtistsWithProfiles(
     if (merged.length >= limit) break;
   }
   return merged;
+}
+
+/**
+ * Structured performing-artist credits for public profile prose.
+ *
+ * Identity and dedupe are registry-ID based. Display names are never used to
+ * decide who owns a profile, and every result retains its exact release edge.
+ */
+export async function getStructuredReleaseCollaborators(
+  creatorProfileId: string,
+  options: { ownerSpotifyId: string; limit?: number }
+): Promise<StructuredReleaseCollaborator[]> {
+  const limit = Math.max(1, Math.min(options?.limit ?? 24, 100));
+  const rows = await db
+    .select({
+      artistId: artists.id,
+      artistName: artists.name,
+      artistSpotifyId: artists.spotifyId,
+      artistProfileId: artists.creatorProfileId,
+      profileIsPublic: creatorProfiles.isPublic,
+      profileIsClaimed: creatorProfiles.isClaimed,
+      creditName: releaseArtists.creditName,
+      role: releaseArtists.role,
+      position: releaseArtists.position,
+      releaseId: discogReleases.id,
+      releaseTitle: discogReleases.title,
+      releaseSlug: discogReleases.slug,
+      releaseDate: discogReleases.releaseDate,
+    })
+    .from(releaseArtists)
+    .innerJoin(discogReleases, eq(releaseArtists.releaseId, discogReleases.id))
+    .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+    .leftJoin(creatorProfiles, eq(artists.creatorProfileId, creatorProfiles.id))
+    .where(
+      and(
+        eq(discogReleases.creatorProfileId, creatorProfileId),
+        inArray(releaseArtists.role, PUBLIC_ARTIST_COLLABORATOR_ROLES),
+        or(
+          isNull(artists.creatorProfileId),
+          ne(artists.creatorProfileId, creatorProfileId)
+        ),
+        or(
+          isNull(artists.spotifyId),
+          ne(artists.spotifyId, options.ownerSpotifyId)
+        ),
+        publicReleaseEligibilitySqlPredicate()
+      )
+    )
+    .orderBy(
+      drizzleSql`${discogReleases.releaseDate} DESC NULLS LAST`,
+      discogReleases.id,
+      releaseArtists.position,
+      artists.id
+    )
+    .limit(limit * 4);
+
+  return projectStructuredReleaseCollaborators({
+    creatorProfileId,
+    ownerSpotifyId: options.ownerSpotifyId,
+    rows,
+    limit,
+  });
+}
+
+export function projectStructuredReleaseCollaborators(params: {
+  readonly creatorProfileId: string;
+  readonly ownerSpotifyId: string | null;
+  readonly rows: readonly StructuredReleaseCollaboratorRow[];
+  readonly limit: number;
+}): StructuredReleaseCollaborator[] {
+  const { creatorProfileId, ownerSpotifyId, rows, limit } = params;
+  const seenEdges = new Set<string>();
+  const collaborators: StructuredReleaseCollaborator[] = [];
+
+  for (const row of rows) {
+    if (!isPublicArtistCollaboratorRole(row.role)) continue;
+
+    // Exact profile/Spotify identity excludes the profile owner. Names are not
+    // consulted because aliases and same-name artists are both legitimate.
+    if (
+      row.artistProfileId === creatorProfileId ||
+      (ownerSpotifyId && row.artistSpotifyId === ownerSpotifyId)
+    ) {
+      continue;
+    }
+
+    const name = (row.creditName ?? row.artistName).trim();
+    if (!name) continue;
+
+    const edgeKey = `${row.releaseId}:${row.artistId}:${row.role}`;
+    if (seenEdges.has(edgeKey)) continue;
+    seenEdges.add(edgeKey);
+
+    const hasPublicProfile =
+      Boolean(row.artistProfileId) && row.profileIsPublic === true;
+    collaborators.push({
+      artistId: row.artistId,
+      name,
+      href: hasPublicProfile ? artistProfileHref(row.artistId) : null,
+      profileState: hasPublicProfile
+        ? row.profileIsClaimed
+          ? 'claimed'
+          : 'unclaimed'
+        : 'unavailable',
+      role: row.role,
+      releaseId: row.releaseId,
+      releaseTitle: row.releaseTitle,
+      releaseSlug: row.releaseSlug,
+      releaseDate: row.releaseDate,
+      position: row.position,
+    });
+
+    if (collaborators.length >= limit) break;
+  }
+
+  return collaborators;
 }
 
 /**

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -222,6 +222,47 @@ export async function getStructuredReleaseCollaborators(
   });
 }
 
+function projectStructuredReleaseCollaborator(
+  row: StructuredReleaseCollaboratorRow,
+  creatorProfileId: string,
+  ownerSpotifyId: string | null
+): StructuredReleaseCollaborator | null {
+  if (!isPublicArtistCollaboratorRole(row.role)) return null;
+
+  // Exact profile/Spotify identity excludes the profile owner. Names are not
+  // consulted because aliases and same-name artists are both legitimate.
+  if (
+    row.artistProfileId === creatorProfileId ||
+    (ownerSpotifyId && row.artistSpotifyId === ownerSpotifyId)
+  ) {
+    return null;
+  }
+
+  const name = (row.creditName ?? row.artistName).trim();
+  if (!name) return null;
+
+  const hasPublicProfile =
+    Boolean(row.artistProfileId) && row.profileIsPublic === true;
+  let profileState: StructuredReleaseCollaborator['profileState'] =
+    'unavailable';
+  if (hasPublicProfile) {
+    profileState = row.profileIsClaimed ? 'claimed' : 'unclaimed';
+  }
+
+  return {
+    artistId: row.artistId,
+    name,
+    href: hasPublicProfile ? artistProfileHref(row.artistId) : null,
+    profileState,
+    role: row.role,
+    releaseId: row.releaseId,
+    releaseTitle: row.releaseTitle,
+    releaseSlug: row.releaseSlug,
+    releaseDate: row.releaseDate,
+    position: row.position,
+  };
+}
+
 export function projectStructuredReleaseCollaborators(params: {
   readonly creatorProfileId: string;
   readonly ownerSpotifyId: string | null;
@@ -233,42 +274,18 @@ export function projectStructuredReleaseCollaborators(params: {
   const collaborators: StructuredReleaseCollaborator[] = [];
 
   for (const row of rows) {
-    if (!isPublicArtistCollaboratorRole(row.role)) continue;
-
-    // Exact profile/Spotify identity excludes the profile owner. Names are not
-    // consulted because aliases and same-name artists are both legitimate.
-    if (
-      row.artistProfileId === creatorProfileId ||
-      (ownerSpotifyId && row.artistSpotifyId === ownerSpotifyId)
-    ) {
-      continue;
-    }
-
-    const name = (row.creditName ?? row.artistName).trim();
-    if (!name) continue;
+    const collaborator = projectStructuredReleaseCollaborator(
+      row,
+      creatorProfileId,
+      ownerSpotifyId
+    );
+    if (!collaborator) continue;
 
     const edgeKey = `${row.releaseId}:${row.artistId}:${row.role}`;
     if (seenEdges.has(edgeKey)) continue;
     seenEdges.add(edgeKey);
 
-    const hasPublicProfile =
-      Boolean(row.artistProfileId) && row.profileIsPublic === true;
-    collaborators.push({
-      artistId: row.artistId,
-      name,
-      href: hasPublicProfile ? artistProfileHref(row.artistId) : null,
-      profileState: hasPublicProfile
-        ? row.profileIsClaimed
-          ? 'claimed'
-          : 'unclaimed'
-        : 'unavailable',
-      role: row.role,
-      releaseId: row.releaseId,
-      releaseTitle: row.releaseTitle,
-      releaseSlug: row.releaseSlug,
-      releaseDate: row.releaseDate,
-      position: row.position,
-    });
+    collaborators.push(collaborator);
 
     if (collaborators.length >= limit) break;
   }

--- a/apps/web/lib/discography/artist-queries/index.ts
+++ b/apps/web/lib/discography/artist-queries/index.ts
@@ -23,6 +23,7 @@ export {
 export {
   getCreditedArtistsWithProfiles,
   getFrequentCollaborators,
+  getStructuredReleaseCollaborators,
   searchArtists,
 } from './artist-search';
 // Recording-artist operations
@@ -52,4 +53,5 @@ export type {
   CollaboratorInfo,
   CreditedArtistWithProfile,
   FindOrCreateArtistInput,
+  StructuredReleaseCollaborator,
 } from './types';

--- a/apps/web/lib/discography/artist-queries/types.ts
+++ b/apps/web/lib/discography/artist-queries/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Artist, ArtistRole } from '@/lib/db/schema/content';
+import type { PublicArtistCollaboratorRole } from '../artist-credit-policy';
 
 export interface ArtistWithRole extends Artist {
   role: ArtistRole;
@@ -25,6 +26,21 @@ export interface CreditedArtistWithProfile {
   name: string;
   /** Normalized Jovie handle of the linked public creator profile. */
   handle: string;
+}
+
+/** Exact structured relationship used by public collaborator prose. */
+export interface StructuredReleaseCollaborator {
+  readonly artistId: string;
+  readonly name: string;
+  /** Stable registry route when a public claimed or unclaimed profile exists. */
+  readonly href: string | null;
+  readonly profileState: 'claimed' | 'unclaimed' | 'unavailable';
+  readonly role: PublicArtistCollaboratorRole;
+  readonly releaseId: string;
+  readonly releaseTitle: string;
+  readonly releaseSlug: string;
+  readonly releaseDate: Date | null;
+  readonly position: number;
 }
 
 export interface FindOrCreateArtistInput {

--- a/apps/web/lib/seo/static-route-manifest.ts
+++ b/apps/web/lib/seo/static-route-manifest.ts
@@ -17,6 +17,8 @@ const PROFILE_FIXTURE: Pick<
   | 'location'
   | 'avatar_url'
   | 'is_verified'
+  | 'is_claimed'
+  | 'settings'
 > = {
   username: 'dualipa',
   username_normalized: 'dualipa',
@@ -25,6 +27,8 @@ const PROFILE_FIXTURE: Pick<
   location: 'London',
   avatar_url: 'https://cdn.example.com/avatar.jpg',
   is_verified: true,
+  is_claimed: true,
+  settings: null,
 };
 
 /**

--- a/apps/web/tests/unit/artists-page-config.test.ts
+++ b/apps/web/tests/unit/artists-page-config.test.ts
@@ -19,4 +19,14 @@ describe('/artists route segment config', () => {
       /export\s+const\s+dynamic\s*=\s*['"]force-dynamic['"]$/m
     );
   });
+
+  it('lists only claimed public profiles, never automatic unclaimed identities', () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const pagePath = resolve(__dirname, '../../app/artists/page.tsx');
+    const pageSource = readFileSync(pagePath, 'utf8');
+
+    expect(pageSource).toContain('eq(creatorProfiles.isPublic, true)');
+    expect(pageSource).toContain('eq(creatorProfiles.isClaimed, true)');
+  });
 });

--- a/apps/web/tests/unit/lib/discography/artist-crud.test.ts
+++ b/apps/web/tests/unit/lib/discography/artist-crud.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  findArtist,
+  findOrCreateArtist,
+} from '@/lib/discography/artist-queries/artist-crud';
+
+function makeQuery(result: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(result);
+  const query = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit,
+  };
+  query.from.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  return query;
+}
+
+describe('artist identity CRUD', () => {
+  it('never falls back to a same-name registry row after an external-ID miss', async () => {
+    const query = makeQuery([]);
+    const tx = { select: vi.fn().mockReturnValue(query) };
+
+    const found = await findArtist(
+      { spotifyId: 'spotify-alex-two', name: 'Alex Lee' },
+      tx as never
+    );
+
+    expect(found).toBeNull();
+    expect(tx.select).toHaveBeenCalledTimes(1);
+    expect(query.limit).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains legacy name lookup only when no stable identity is supplied', async () => {
+    const artist = { id: 'artist-alex-one', name: 'Alex Lee' };
+    const query = makeQuery([artist]);
+    const tx = { select: vi.fn().mockReturnValue(query) };
+
+    const found = await findArtist({ name: 'Alex Lee' }, tx as never);
+
+    expect(found).toBe(artist);
+    expect(tx.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a second same-name artist when the provider ID is distinct', async () => {
+    const lookupQuery = makeQuery([]);
+    const created = {
+      id: 'artist-alex-two',
+      name: 'Alex Lee',
+      spotifyId: 'spotify-alex-two',
+    };
+    const returning = vi.fn().mockResolvedValue([created]);
+    const insertQuery = {
+      values: vi.fn(),
+      onConflictDoNothing: vi.fn(),
+      returning,
+    };
+    insertQuery.values.mockReturnValue(insertQuery);
+    insertQuery.onConflictDoNothing.mockReturnValue(insertQuery);
+    const tx = {
+      select: vi.fn().mockReturnValue(lookupQuery),
+      insert: vi.fn().mockReturnValue(insertQuery),
+    };
+
+    const result = await findOrCreateArtist(
+      { name: 'Alex Lee', spotifyId: 'spotify-alex-two' },
+      tx as never
+    );
+
+    expect(result).toBe(created);
+    expect(tx.select).toHaveBeenCalledTimes(1);
+    expect(tx.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves an exact-ID winner after a concurrent idempotent insert', async () => {
+    const winner = {
+      id: 'artist-alex-two',
+      name: 'Alex Lee',
+      spotifyId: 'spotify-alex-two',
+    };
+    const firstLookup = makeQuery([]);
+    const secondLookup = makeQuery([winner]);
+    const returning = vi.fn().mockResolvedValue([]);
+    const insertQuery = {
+      values: vi.fn(),
+      onConflictDoNothing: vi.fn(),
+      returning,
+    };
+    insertQuery.values.mockReturnValue(insertQuery);
+    insertQuery.onConflictDoNothing.mockReturnValue(insertQuery);
+    const tx = {
+      select: vi
+        .fn()
+        .mockReturnValueOnce(firstLookup)
+        .mockReturnValueOnce(secondLookup),
+      insert: vi.fn().mockReturnValue(insertQuery),
+    };
+
+    const result = await findOrCreateArtist(
+      { name: 'Alex Lee', spotifyId: 'spotify-alex-two' },
+      tx as never
+    );
+
+    expect(result).toBe(winner);
+    expect(tx.select).toHaveBeenCalledTimes(2);
+    expect(insertQuery.onConflictDoNothing).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/unit/lib/discography/artist-profile-routing.test.ts
+++ b/apps/web/tests/unit/lib/discography/artist-profile-routing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  artistProfileHref,
+  buildUnclaimedArtistHandle,
+} from '@/lib/discography/artist-profile-routing';
+
+describe('artist profile routing', () => {
+  it('pins a deterministic full-UUID handle without reserving a name', () => {
+    const artistId = 'f5441adb-6789-449a-9553-ab7460c9c61c';
+    const handle = buildUnclaimedArtistHandle(artistId);
+
+    expect(handle).toBe('a_eiqd46x3irj64dlgo8a3glau4');
+    expect(handle).toHaveLength(27);
+    expect(handle).toMatch(/^[a-z0-9_]+$/);
+    expect(handle).not.toContain('austin');
+  });
+
+  it('keeps different registry IDs collision-safe even for same-name artists', () => {
+    expect(
+      buildUnclaimedArtistHandle('f5441adb-6789-449a-9553-ab7460c9c61c')
+    ).not.toBe(
+      buildUnclaimedArtistHandle('3cefe948-7521-465f-813a-95ae15e3141e')
+    );
+  });
+
+  it('builds a stable encoded inbound entity route', () => {
+    expect(artistProfileHref('f5441adb-6789-449a-9553-ab7460c9c61c')).toBe(
+      '/artists/f5441adb-6789-449a-9553-ab7460c9c61c'
+    );
+  });
+
+  it('rejects malformed registry IDs instead of inventing a route handle', () => {
+    expect(() => buildUnclaimedArtistHandle('Austin Leeds')).toThrow(
+      'Artist ID must be a UUID'
+    );
+  });
+});

--- a/apps/web/tests/unit/lib/discography/structured-release-collaborators.test.ts
+++ b/apps/web/tests/unit/lib/discography/structured-release-collaborators.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  projectStructuredReleaseCollaborators,
+  type StructuredReleaseCollaboratorRow,
+} from '@/lib/discography/artist-queries/artist-search';
+
+const ownerProfileId = 'b1951748-2dc2-49f9-8b8e-a24cbe33d67f';
+
+function row(
+  overrides: Partial<StructuredReleaseCollaboratorRow> = {}
+): StructuredReleaseCollaboratorRow {
+  return {
+    artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+    artistName: 'Austin Leeds',
+    artistSpotifyId: 'spotify-austin',
+    artistProfileId: 'ce9ee7b4-67b8-4b3e-a077-698d42893ddb',
+    profileIsPublic: true,
+    profileIsClaimed: false,
+    creditName: null,
+    role: 'main_artist',
+    position: 1,
+    releaseId: '143744e8-4f00-40a4-81d7-77786edc31bd',
+    releaseTitle: 'Take Me Over (Austin Leeds Remix)',
+    releaseSlug: 'take-me-over-austin-leeds-remix',
+    releaseDate: new Date('2026-04-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function project(rows: StructuredReleaseCollaboratorRow[]) {
+  return projectStructuredReleaseCollaborators({
+    creatorProfileId: ownerProfileId,
+    ownerSpotifyId: 'spotify-owner',
+    rows,
+    limit: 24,
+  });
+}
+
+describe('structured release collaborator projection', () => {
+  it('dedupes repeated imports by stable release/artist/role edge', () => {
+    const duplicate = row();
+    const result = project([duplicate, { ...duplicate }]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      artistId: duplicate.artistId,
+      releaseId: duplicate.releaseId,
+      href: `/artists/${duplicate.artistId}`,
+      profileState: 'unclaimed',
+    });
+  });
+
+  it('keeps same-name artists distinct and uses a credit alias only for display', () => {
+    const result = project([
+      row({ creditName: 'Alex Lee', artistName: 'Alexander Lee' }),
+      row({
+        artistId: 'e061a679-466c-465a-a545-64a7e39aa3c6',
+        artistName: 'Alex Lee',
+        artistSpotifyId: 'spotify-alex-two',
+        artistProfileId: '31fd1831-bac4-44a4-a9eb-f8ce69a786cc',
+        profileIsClaimed: true,
+        releaseId: 'c568cbb1-8bdb-4b66-acf7-5c3a94d94342',
+        releaseTitle: 'Southbound',
+        releaseSlug: 'southbound',
+      }),
+    ]);
+
+    expect(result.map(item => item.name)).toEqual(['Alex Lee', 'Alex Lee']);
+    expect(result.map(item => item.artistId)).toEqual([
+      'f5441adb-6789-449a-9553-ab7460c9c61c',
+      'e061a679-466c-465a-a545-64a7e39aa3c6',
+    ]);
+    expect(result.map(item => item.profileState)).toEqual([
+      'unclaimed',
+      'claimed',
+    ]);
+  });
+
+  it('excludes the owner by exact profile or Spotify identity, never by name', () => {
+    const sameDisplayNameDifferentIdentity = row({ artistName: 'DJ Test' });
+    const result = project([
+      row({
+        artistId: '61e6d433-857c-4c78-b9cf-ce0b31865ca8',
+        artistProfileId: ownerProfileId,
+      }),
+      row({
+        artistId: '43afe32f-bf34-4c55-835c-90462a4a9d4a',
+        artistProfileId: null,
+        artistSpotifyId: 'spotify-owner',
+      }),
+      sameDisplayNameDifferentIdentity,
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.artistId).toBe(sameDisplayNameDifferentIdentity.artistId);
+  });
+
+  it('keeps unavailable identities as plain-text candidates and excludes non-artist roles', () => {
+    const result = project([
+      row({
+        artistProfileId: null,
+        profileIsPublic: null,
+        profileIsClaimed: null,
+      }),
+      row({
+        artistId: '0c9e3385-81d2-42c1-83d2-a5bf08942d49',
+        role: 'mix_engineer',
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      href: null,
+      profileState: 'unavailable',
+    });
+  });
+
+  it('does not expose a profile binding that is private', () => {
+    const result = project([
+      row({ profileIsPublic: false, profileIsClaimed: true }),
+    ]);
+
+    expect(result[0]).toMatchObject({
+      href: null,
+      profileState: 'unavailable',
+    });
+  });
+});

--- a/apps/web/tests/unit/routes/artist-entity-route.test.ts
+++ b/apps/web/tests/unit/routes/artist-entity-route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  result: [] as Array<{ username: string }>,
+  select: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: hoisted.select,
+  },
+}));
+
+function makeQuery() {
+  const query = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn().mockImplementation(async () => hoisted.result),
+  };
+  query.from.mockReturnValue(query);
+  query.innerJoin.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  return query;
+}
+
+const { GET } = await import('@/app/artists/[artistId]/route');
+
+function context(artistId: string) {
+  return { params: Promise.resolve({ artistId }) };
+}
+
+describe('GET /artists/[artistId]', () => {
+  beforeEach(() => {
+    hoisted.result = [];
+    hoisted.select.mockReset().mockReturnValue(makeQuery());
+  });
+
+  it('rejects malformed entity IDs without querying identity data', async () => {
+    const response = await GET(
+      new Request('https://jov.ie/artists/not-an-id') as never,
+      context('not-an-id')
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Cache-Control')).toContain('no-store');
+    expect(hoisted.select).not.toHaveBeenCalled();
+  });
+
+  it('redirects a public registry entity to its current handle without caching', async () => {
+    hoisted.result = [{ username: 'new-handle' }];
+    const artistId = 'f5441adb-6789-449a-9553-ab7460c9c61c';
+    const response = await GET(
+      new Request(`https://jov.ie/artists/${artistId}`) as never,
+      context(artistId)
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe('https://jov.ie/new-handle');
+    expect(response.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  it('preserves the registry link when a claimed profile changes handle', async () => {
+    const artistId = 'f5441adb-6789-449a-9553-ab7460c9c61c';
+    hoisted.result = [{ username: 'a_eiqd46x3irj64dlgo8a3glau4' }];
+    const beforeClaim = await GET(
+      new Request(`https://jov.ie/artists/${artistId}`) as never,
+      context(artistId)
+    );
+
+    hoisted.result = [{ username: 'austin-leeds' }];
+    const afterRename = await GET(
+      new Request(`https://jov.ie/artists/${artistId}`) as never,
+      context(artistId)
+    );
+
+    expect(beforeClaim.headers.get('Location')).toBe(
+      'https://jov.ie/a_eiqd46x3irj64dlgo8a3glau4'
+    );
+    expect(afterRename.headers.get('Location')).toBe(
+      'https://jov.ie/austin-leeds'
+    );
+  });
+
+  it('fails closed for missing or private profile bindings', async () => {
+    const artistId = '3cefe948-7521-465f-813a-95ae15e3141e';
+    const response = await GET(
+      new Request(`https://jov.ie/artists/${artistId}`) as never,
+      context(artistId)
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Location')).toBeNull();
+  });
+});

--- a/scripts/repo-hygiene-guard.mjs
+++ b/scripts/repo-hygiene-guard.mjs
@@ -816,7 +816,10 @@ export function evaluateRepoHygiene({
 }
 
 function gitPaths(args) {
-  return execFileSync('git', args, { encoding: 'buffer' })
+  return execFileSync('git', args, {
+    encoding: 'buffer',
+    maxBuffer: 20 * MiB,
+  })
     .toString('utf8')
     .split('\0')
     .filter(Boolean);


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4820 -->

## Stack position

- Layer 1 of 10; root public-profile slice.
- Base: `main` at `eda3470084d269bdb7037046b4e2e10cbb986651`.
- Head: `c08378e7f509c8f99479eadc1fd06ac8ac8c4675`.
- This is the root PR. Layers 2–10 depend on this branch in order and remain draft/unenrolled until their immediate parent lands.

## Scope

Adds canonical artist entity/profile routes for the public-profile stack. No external-data embedding or production-controller changes.

## Verification

- Normal pre-push hook passed (Biome, guards, typecheck, component ship gate, automation verification, full affected Vitest matrix).
- `git diff --check` passed.

After merge, the next layer will be retargeted/rebased to fresh exact `main` using native GitHub stacked-PR discipline.