### PR TITLE
feat(profile): add collaborator reconciliation contracts

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -18,6 +18,7 @@ import { joviePlaylists } from '@/lib/db/schema/playlists';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { env } from '@/lib/env-server';
 import { publicReleaseEligibilitySqlPredicate } from '@/lib/profile/public-release-eligibility';
+import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
 
 export const revalidate = 3600;
 
@@ -26,6 +27,8 @@ type SitemapCatalog = {
     username: string;
     updatedAt: Date | null;
     avatarUrl: string | null;
+    isClaimed: boolean | null;
+    settings: unknown;
   }>;
   releases: Array<{
     username: string;
@@ -58,6 +61,8 @@ const getSitemapCatalog = unstable_cache(
             username: creatorProfiles.username,
             updatedAt: creatorProfiles.updatedAt,
             avatarUrl: creatorProfiles.avatarUrl,
+            isClaimed: creatorProfiles.isClaimed,
+            settings: creatorProfiles.settings,
           })
           .from(creatorProfiles)
           .where(eq(creatorProfiles.isPublic, true)),
@@ -125,7 +130,16 @@ const getSitemapCatalog = unstable_cache(
           ),
       ]);
 
-      return { profiles, releases, tracks, playlists };
+      return {
+        profiles: profiles.filter(
+          profile =>
+            profile.isClaimed === true ||
+            !isUnclaimedStructuredCreditProfile(profile.settings)
+        ),
+        releases,
+        tracks,
+        playlists,
+      };
     } catch (error) {
       Sentry.captureException(error);
       return { profiles: [], releases: [], tracks: [], playlists: [] };

--- a/apps/web/lib/discography/collaborator-profile-plan.ts
+++ b/apps/web/lib/discography/collaborator-profile-plan.ts
@@ -1,0 +1,45 @@
+export interface CreditedArtistCandidate {
+  readonly artistId: string;
+  readonly name: string;
+  readonly spotifyId: string;
+  readonly imageUrl: string | null;
+}
+
+export interface SpotifyArtistProfileData {
+  readonly id: string;
+  readonly name: string;
+  readonly images?: readonly { readonly url: string }[];
+  readonly popularity?: number;
+  readonly followers?: { readonly total: number };
+  readonly genres?: readonly string[];
+}
+
+export interface CreditedArtistReconciliationPlanItem {
+  readonly candidate: CreditedArtistCandidate;
+  readonly spotifyArtist: SpotifyArtistProfileData | undefined;
+}
+
+/**
+ * Deterministic exact-ID plan for an import run.
+ * Repeated release edges collapse by registry ID; same-name IDs stay distinct.
+ */
+export function buildCreditedArtistReconciliationPlan(
+  rows: readonly CreditedArtistCandidate[],
+  spotifyArtists: readonly SpotifyArtistProfileData[]
+): CreditedArtistReconciliationPlanItem[] {
+  const spotifyArtistById = new Map(
+    spotifyArtists.map(artist => [artist.id, artist])
+  );
+  const byArtistId = new Map<string, CreditedArtistCandidate>();
+
+  for (const row of rows) {
+    if (!byArtistId.has(row.artistId)) {
+      byArtistId.set(row.artistId, row);
+    }
+  }
+
+  return [...byArtistId.values()].map(candidate => ({
+    candidate,
+    spotifyArtist: spotifyArtistById.get(candidate.spotifyId),
+  }));
+}

--- a/apps/web/lib/discography/collaborator-profile-reconciliation.ts
+++ b/apps/web/lib/discography/collaborator-profile-reconciliation.ts
@@ -48,6 +48,14 @@ interface CandidateOutcome {
   readonly handle?: string;
 }
 
+interface CandidateReconciliationState {
+  conflicted: number;
+  created: number;
+  metadataUnavailable: number;
+  reused: number;
+  readonly handlesToInvalidate: Set<string>;
+}
+
 interface LockedRegistryArtist {
   readonly id: string;
   readonly metadata: Record<string, unknown> | null;
@@ -159,7 +167,7 @@ async function markArtistProfileConflict(
     .update(artists)
     .set({
       metadata: {
-        ...(artist.metadata ?? {}),
+        ...artist.metadata,
         [PROFILE_RECONCILIATION_CONFLICT_KEY]: {
           status: 'conflicted',
           reason,
@@ -197,7 +205,7 @@ async function reconcileCandidate(
         .for('update')
         .limit(1);
 
-      if (!lockedArtist || lockedArtist.spotifyId !== candidate.spotifyId) {
+      if (lockedArtist?.spotifyId !== candidate.spotifyId) {
         return { status: 'conflicted' };
       }
       if (lockedArtist.creatorProfileId) {
@@ -351,6 +359,61 @@ async function reconcileCandidate(
   );
 }
 
+function recordCandidateOutcome(
+  state: CandidateReconciliationState,
+  outcome: CandidateOutcome
+): void {
+  switch (outcome.status) {
+    case 'created':
+      state.created += 1;
+      break;
+    case 'reused':
+      state.reused += 1;
+      break;
+    case 'conflicted':
+      state.conflicted += 1;
+      break;
+  }
+  if (outcome.handle) state.handlesToInvalidate.add(outcome.handle);
+}
+
+async function reconcileCandidatePlan(
+  creatorProfileId: string,
+  plan: ReturnType<typeof buildCreditedArtistReconciliationPlan>
+): Promise<CandidateReconciliationState> {
+  const state: CandidateReconciliationState = {
+    created: 0,
+    reused: 0,
+    conflicted: 0,
+    metadataUnavailable: 0,
+    handlesToInvalidate: new Set<string>(),
+  };
+
+  for (const { candidate, spotifyArtist } of plan) {
+    if (!spotifyArtist) state.metadataUnavailable += 1;
+
+    try {
+      recordCandidateOutcome(
+        state,
+        await reconcileCandidate(candidate, spotifyArtist)
+      );
+    } catch (error) {
+      state.conflicted += 1;
+      await captureWarning(
+        'Credited artist profile reconciliation failed closed',
+        error,
+        {
+          creatorProfileId,
+          artistId: candidate.artistId,
+          spotifyId: candidate.spotifyId,
+        }
+      );
+    }
+  }
+
+  return state;
+}
+
 /**
  * Reconcile imported Spotify release credits into claim-safe Jovie profiles.
  *
@@ -385,34 +448,13 @@ export async function reconcileCreditedArtistProfiles(
     spotifyArtists
   );
 
-  let created = 0;
-  let reused = 0;
-  let conflicted = 0;
-  let metadataUnavailable = 0;
-  const handlesToInvalidate = new Set<string>();
-
-  for (const { candidate, spotifyArtist } of plan) {
-    if (!spotifyArtist) metadataUnavailable += 1;
-
-    try {
-      const outcome = await reconcileCandidate(candidate, spotifyArtist);
-      if (outcome.status === 'created') created += 1;
-      else if (outcome.status === 'reused') reused += 1;
-      else conflicted += 1;
-      if (outcome.handle) handlesToInvalidate.add(outcome.handle);
-    } catch (error) {
-      conflicted += 1;
-      await captureWarning(
-        'Credited artist profile reconciliation failed closed',
-        error,
-        {
-          creatorProfileId,
-          artistId: candidate.artistId,
-          spotifyId: candidate.spotifyId,
-        }
-      );
-    }
-  }
+  const {
+    conflicted,
+    created,
+    handlesToInvalidate,
+    metadataUnavailable,
+    reused,
+  } = await reconcileCandidatePlan(creatorProfileId, plan);
 
   const result = {
     candidates: plan.length,

--- a/apps/web/lib/discography/collaborator-profile-reconciliation.ts
+++ b/apps/web/lib/discography/collaborator-profile-reconciliation.ts
@@ -1,0 +1,482 @@
+import 'server-only';
+
+import {
+  and,
+  sql as drizzleSql,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+} from 'drizzle-orm';
+import { invalidateProfileCache } from '@/lib/cache/profile';
+import type { DbOrTransaction } from '@/lib/db';
+import { db } from '@/lib/db';
+import {
+  artists,
+  discogReleases,
+  releaseArtists,
+} from '@/lib/db/schema/content';
+import { socialLinks } from '@/lib/db/schema/links';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { captureWarning } from '@/lib/error-tracking';
+import { withSystemIngestionSession } from '@/lib/ingestion/session';
+import { publicReleaseEligibilitySqlPredicate } from '@/lib/profile/public-release-eligibility';
+import { lockSpotifyProfileIdentity } from '@/lib/profile/spotify-profile-identity';
+import { buildStructuredCreditProfileMarker } from '@/lib/profile/unclaimed-artist-profile';
+import { buildSpotifyArtistUrl, getSpotifyArtistsBatch } from '@/lib/spotify';
+import { logger } from '@/lib/utils/logger';
+import { PUBLIC_ARTIST_COLLABORATOR_ROLES } from './artist-credit-policy';
+import { buildUnclaimedArtistHandle } from './artist-profile-routing';
+import {
+  buildCreditedArtistReconciliationPlan,
+  type CreditedArtistCandidate,
+  type SpotifyArtistProfileData,
+} from './collaborator-profile-plan';
+
+export interface CollaboratorProfileReconciliationResult {
+  readonly candidates: number;
+  readonly created: number;
+  readonly deferred: boolean;
+  readonly reused: number;
+  readonly conflicted: number;
+  readonly metadataUnavailable: number;
+}
+
+interface CandidateOutcome {
+  readonly status: 'created' | 'reused' | 'conflicted';
+  readonly handle?: string;
+}
+
+interface LockedRegistryArtist {
+  readonly id: string;
+  readonly metadata: Record<string, unknown> | null;
+  readonly spotifyId: string | null;
+}
+
+const MAX_CREDITED_ARTISTS_PER_RECONCILIATION = 24;
+const PROFILE_RECONCILIATION_CONFLICT_KEY = 'publicProfileReconciliation';
+
+async function getCreditedArtistCandidates(
+  creatorProfileId: string,
+  ownerSpotifyId: string
+): Promise<{
+  readonly candidates: CreditedArtistCandidate[];
+  readonly deferred: boolean;
+}> {
+  const rows = await db
+    .selectDistinct({
+      artistId: artists.id,
+      name: artists.name,
+      spotifyId: artists.spotifyId,
+      imageUrl: artists.imageUrl,
+    })
+    .from(releaseArtists)
+    .innerJoin(discogReleases, eq(releaseArtists.releaseId, discogReleases.id))
+    .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+    .where(
+      and(
+        eq(discogReleases.creatorProfileId, creatorProfileId),
+        inArray(releaseArtists.role, PUBLIC_ARTIST_COLLABORATOR_ROLES),
+        isNotNull(artists.spotifyId),
+        ne(artists.spotifyId, ownerSpotifyId),
+        isNull(artists.creatorProfileId),
+        drizzleSql`COALESCE(${artists.metadata}->${PROFILE_RECONCILIATION_CONFLICT_KEY}->>'status', '') <> 'conflicted'`,
+        publicReleaseEligibilitySqlPredicate()
+      )
+    )
+    .orderBy(artists.id)
+    .limit(MAX_CREDITED_ARTISTS_PER_RECONCILIATION + 1);
+
+  const candidates = rows
+    .filter(
+      (row): row is CreditedArtistCandidate =>
+        Boolean(row.spotifyId) && row.spotifyId !== ownerSpotifyId
+    )
+    .map(row => ({ ...row, spotifyId: row.spotifyId! }))
+    .slice(0, MAX_CREDITED_ARTISTS_PER_RECONCILIATION);
+
+  return {
+    candidates,
+    deferred: rows.length > MAX_CREDITED_ARTISTS_PER_RECONCILIATION,
+  };
+}
+
+async function bindOwnerRegistryArtist(
+  tx: DbOrTransaction,
+  creatorProfileId: string,
+  spotifyId: string
+): Promise<void> {
+  await lockSpotifyProfileIdentity(tx, spotifyId);
+
+  const [otherExactProfile] = await tx
+    .select({ id: creatorProfiles.id })
+    .from(creatorProfiles)
+    .where(
+      and(
+        eq(creatorProfiles.spotifyId, spotifyId),
+        ne(creatorProfiles.id, creatorProfileId)
+      )
+    )
+    .limit(1);
+  if (otherExactProfile) {
+    throw new Error(
+      'Owner Spotify identity requires an explicit verified profile merge'
+    );
+  }
+
+  const [otherRegistryBinding] = await tx
+    .select({ creatorProfileId: artists.creatorProfileId })
+    .from(artists)
+    .where(
+      and(
+        eq(artists.spotifyId, spotifyId),
+        isNotNull(artists.creatorProfileId),
+        ne(artists.creatorProfileId, creatorProfileId)
+      )
+    )
+    .limit(1);
+  if (otherRegistryBinding) {
+    throw new Error(
+      'Owner registry identity requires an explicit verified profile merge'
+    );
+  }
+
+  await tx
+    .update(artists)
+    .set({ creatorProfileId, updatedAt: new Date() })
+    .where(
+      and(eq(artists.spotifyId, spotifyId), isNull(artists.creatorProfileId))
+    );
+}
+
+async function markArtistProfileConflict(
+  tx: DbOrTransaction,
+  artist: LockedRegistryArtist,
+  reason: 'duplicate_profiles' | 'handle_collision' | 'profile_insert'
+): Promise<void> {
+  await tx
+    .update(artists)
+    .set({
+      metadata: {
+        ...(artist.metadata ?? {}),
+        [PROFILE_RECONCILIATION_CONFLICT_KEY]: {
+          status: 'conflicted',
+          reason,
+          spotifyId: artist.spotifyId,
+          observedAt: new Date().toISOString(),
+        },
+      },
+      updatedAt: new Date(),
+    })
+    .where(eq(artists.id, artist.id));
+}
+
+async function reconcileCandidate(
+  candidate: CreditedArtistCandidate,
+  spotifyArtist: SpotifyArtistProfileData | undefined
+): Promise<CandidateOutcome> {
+  return withSystemIngestionSession(
+    async tx => {
+      // Keep lock ordering identical to onboarding/owner binding: identity
+      // advisory lock first, then registry row lock. This avoids a cycle where
+      // one transaction owns the row while another owns the identity lock.
+      await lockSpotifyProfileIdentity(tx, candidate.spotifyId);
+
+      const [lockedArtist] = await tx
+        .select({
+          id: artists.id,
+          creatorProfileId: artists.creatorProfileId,
+          name: artists.name,
+          spotifyId: artists.spotifyId,
+          imageUrl: artists.imageUrl,
+          metadata: artists.metadata,
+        })
+        .from(artists)
+        .where(eq(artists.id, candidate.artistId))
+        .for('update')
+        .limit(1);
+
+      if (!lockedArtist || lockedArtist.spotifyId !== candidate.spotifyId) {
+        return { status: 'conflicted' };
+      }
+      if (lockedArtist.creatorProfileId) {
+        return { status: 'reused' };
+      }
+
+      const exactProfiles = await tx
+        .select({
+          id: creatorProfiles.id,
+          usernameNormalized: creatorProfiles.usernameNormalized,
+        })
+        .from(creatorProfiles)
+        .where(eq(creatorProfiles.spotifyId, candidate.spotifyId))
+        .limit(2);
+
+      // Multiple exact-ID profiles are an existing data conflict. Never choose
+      // one by name, recency, or claimed state; an operator must resolve it.
+      if (exactProfiles.length > 1) {
+        await markArtistProfileConflict(tx, lockedArtist, 'duplicate_profiles');
+        return { status: 'conflicted' };
+      }
+
+      const exactProfile = exactProfiles[0];
+      if (exactProfile) {
+        await tx
+          .update(artists)
+          .set({
+            creatorProfileId: exactProfile.id,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(artists.id, candidate.artistId),
+              isNull(artists.creatorProfileId)
+            )
+          );
+        return {
+          status: 'reused',
+          handle: exactProfile.usernameNormalized,
+        };
+      }
+
+      const handle = buildUnclaimedArtistHandle(candidate.artistId);
+      const [handleOwner] = await tx
+        .select({ id: creatorProfiles.id })
+        .from(creatorProfiles)
+        .where(eq(creatorProfiles.usernameNormalized, handle))
+        .limit(1);
+
+      // The handle encodes the full registry UUID, so an occupied handle with
+      // no exact Spotify-ID match indicates corrupted or manually forged data.
+      if (handleOwner) {
+        await markArtistProfileConflict(tx, lockedArtist, 'handle_collision');
+        return { status: 'conflicted' };
+      }
+
+      const displayName = spotifyArtist?.name?.trim() || lockedArtist.name;
+      const avatarUrl =
+        spotifyArtist?.images?.find(image => image.url.trim())?.url ??
+        lockedArtist.imageUrl;
+      const spotifyUrl = buildSpotifyArtistUrl(candidate.spotifyId);
+      const now = new Date();
+
+      const [createdProfile] = await tx
+        .insert(creatorProfiles)
+        .values({
+          creatorType: 'creator',
+          username: handle,
+          usernameNormalized: handle,
+          displayName,
+          avatarUrl,
+          spotifyId: candidate.spotifyId,
+          spotifyUrl,
+          genres: spotifyArtist?.genres ? [...spotifyArtist.genres] : null,
+          spotifyFollowers: spotifyArtist?.followers?.total ?? null,
+          spotifyPopularity: spotifyArtist?.popularity ?? null,
+          isPublic: true,
+          isVerified: false,
+          isFeatured: false,
+          isClaimed: false,
+          // Unconsented profiles are excluded from marketing/featured use.
+          marketingOptOut: true,
+          ingestionStatus: 'idle',
+          ingestionSourcePlatform: 'spotify_release_credit',
+          settings: {
+            unclaimedArtistProfile: buildStructuredCreditProfileMarker({
+              artistRegistryId: candidate.artistId,
+              providerArtistId: candidate.spotifyId,
+            }),
+          },
+          theme: {},
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning({
+          id: creatorProfiles.id,
+          usernameNormalized: creatorProfiles.usernameNormalized,
+        });
+
+      if (!createdProfile) {
+        await markArtistProfileConflict(tx, lockedArtist, 'profile_insert');
+        return { status: 'conflicted' };
+      }
+
+      await tx
+        .insert(socialLinks)
+        .values({
+          creatorProfileId: createdProfile.id,
+          platform: 'spotify',
+          platformType: 'spotify',
+          url: spotifyUrl,
+          displayText: '',
+          sortOrder: 0,
+          isActive: true,
+          state: 'active',
+          confidence: '1.00',
+          sourcePlatform: 'spotify',
+          sourceType: 'ingested',
+          evidence: {
+            sources: ['structured_spotify_release_credit'],
+            signals: [candidate.artistId, candidate.spotifyId],
+          },
+          verificationStatus: 'unverified',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoNothing();
+
+      const [boundArtist] = await tx
+        .update(artists)
+        .set({
+          creatorProfileId: createdProfile.id,
+          imageUrl: lockedArtist.imageUrl ?? avatarUrl,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(artists.id, candidate.artistId),
+            isNull(artists.creatorProfileId)
+          )
+        )
+        .returning({ id: artists.id });
+
+      if (!boundArtist) {
+        throw new Error('Artist profile binding lost its identity lock');
+      }
+
+      return { status: 'created', handle: createdProfile.usernameNormalized };
+    },
+    { isolationLevel: 'serializable' }
+  );
+}
+
+/**
+ * Reconcile imported Spotify release credits into claim-safe Jovie profiles.
+ *
+ * Exact provider IDs are the only dedupe key. Missing provider metadata still
+ * produces an explicit minimal profile from the canonical registry row; a
+ * display name is never used to claim, merge, or reserve a human handle.
+ */
+export async function reconcileCreditedArtistProfiles(
+  creatorProfileId: string,
+  ownerSpotifyId: string
+): Promise<CollaboratorProfileReconciliationResult> {
+  const [owner] = await db
+    .select({
+      usernameNormalized: creatorProfiles.usernameNormalized,
+    })
+    .from(creatorProfiles)
+    .where(eq(creatorProfiles.id, creatorProfileId))
+    .limit(1);
+  await withSystemIngestionSession(tx =>
+    bindOwnerRegistryArtist(tx, creatorProfileId, ownerSpotifyId)
+  );
+
+  const candidateSelection = await getCreditedArtistCandidates(
+    creatorProfileId,
+    ownerSpotifyId
+  );
+  const spotifyArtists = await getSpotifyArtistsBatch(
+    candidateSelection.candidates.map(candidate => candidate.spotifyId)
+  );
+  const plan = buildCreditedArtistReconciliationPlan(
+    candidateSelection.candidates,
+    spotifyArtists
+  );
+
+  let created = 0;
+  let reused = 0;
+  let conflicted = 0;
+  let metadataUnavailable = 0;
+  const handlesToInvalidate = new Set<string>();
+
+  for (const { candidate, spotifyArtist } of plan) {
+    if (!spotifyArtist) metadataUnavailable += 1;
+
+    try {
+      const outcome = await reconcileCandidate(candidate, spotifyArtist);
+      if (outcome.status === 'created') created += 1;
+      else if (outcome.status === 'reused') reused += 1;
+      else conflicted += 1;
+      if (outcome.handle) handlesToInvalidate.add(outcome.handle);
+    } catch (error) {
+      conflicted += 1;
+      await captureWarning(
+        'Credited artist profile reconciliation failed closed',
+        error,
+        {
+          creatorProfileId,
+          artistId: candidate.artistId,
+          spotifyId: candidate.spotifyId,
+        }
+      );
+    }
+  }
+
+  const result = {
+    candidates: plan.length,
+    created,
+    deferred: candidateSelection.deferred,
+    reused,
+    conflicted,
+    metadataUnavailable,
+  };
+
+  if (created > 0 || reused > 0) {
+    logger.info('Credited artist profiles reconciled', {
+      creatorProfileId,
+      ...result,
+    });
+  }
+
+  if (conflicted > 0) {
+    await captureWarning(
+      'Credited artist profile identity conflicts detected',
+      {
+        source: 'spotify_release_credit',
+        creatorProfileId,
+        ...result,
+      }
+    );
+  }
+
+  if (candidateSelection.deferred) {
+    await captureWarning('Credited artist profile reconciliation was bounded', {
+      source: 'spotify_release_credit',
+      creatorProfileId,
+      processed: plan.length,
+      limit: MAX_CREDITED_ARTISTS_PER_RECONCILIATION,
+      retry: 'next_spotify_import_or_backfill',
+    });
+  }
+
+  // Refresh both sides of the new relationship: a previously cached owner
+  // page must gain the link immediately, and an exact-ID profile may have a
+  // cached 404 or stale claim state under its current handle.
+  if (created > 0 || reused > 0) {
+    if (owner?.usernameNormalized) {
+      handlesToInvalidate.add(owner.usernameNormalized);
+    }
+    const cacheResults = await Promise.allSettled(
+      [...handlesToInvalidate].map(handle => invalidateProfileCache(handle))
+    );
+    const failedHandles = [...handlesToInvalidate].filter(
+      (_, index) => cacheResults[index]?.status === 'rejected'
+    );
+    if (failedHandles.length > 0) {
+      // CLI backfills have no Next static-generation store. The identity writes
+      // are already committed and must retain an accurate success receipt;
+      // cache refresh remains observable best-effort for the next request.
+      await Promise.allSettled([
+        captureWarning('Credited artist profile cache invalidation deferred', {
+          source: 'spotify_release_credit',
+          creatorProfileId,
+          failedHandles,
+        }),
+      ]);
+    }
+  }
+
+  return result;
+}

--- a/apps/web/lib/profile/spotify-profile-identity.ts
+++ b/apps/web/lib/profile/spotify-profile-identity.ts
@@ -1,0 +1,21 @@
+import 'server-only';
+
+import { sql as drizzleSql } from 'drizzle-orm';
+import type { DbOrTransaction } from '@/lib/db';
+
+/**
+ * Serialize creator-profile decisions for one Spotify artist identity.
+ *
+ * The current database does not expose a schema-owned unique constraint for
+ * creator_profiles.spotify_id. Every automatic-profile create and onboarding
+ * attach in this lane takes the same transaction-scoped lock before its final
+ * exact-ID recheck, so concurrent requests cannot create a second winner.
+ */
+export async function lockSpotifyProfileIdentity(
+  tx: DbOrTransaction,
+  spotifyArtistId: string
+): Promise<void> {
+  await tx.execute(
+    drizzleSql`SELECT pg_advisory_xact_lock(hashtext('jovie:creator-profile-spotify'), hashtext(${spotifyArtistId}))`
+  );
+}

--- a/apps/web/lib/profile/unclaimed-artist-profile.ts
+++ b/apps/web/lib/profile/unclaimed-artist-profile.ts
@@ -1,0 +1,85 @@
+const STRUCTURED_CREDIT_SOURCE = 'structured_spotify_release_credit' as const;
+
+export interface StructuredCreditProfileMarker {
+  readonly artistRegistryId: string;
+  readonly claimedAt?: string;
+  readonly consentObtained: boolean;
+  readonly ownershipVerified: boolean;
+  readonly provider: 'spotify';
+  readonly providerArtistId: string;
+  readonly representationVerified: boolean;
+  readonly source: typeof STRUCTURED_CREDIT_SOURCE;
+  readonly state: 'unclaimed' | 'claimed';
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function buildStructuredCreditProfileMarker(params: {
+  readonly artistRegistryId: string;
+  readonly providerArtistId: string;
+}): StructuredCreditProfileMarker {
+  return {
+    state: 'unclaimed',
+    source: STRUCTURED_CREDIT_SOURCE,
+    artistRegistryId: params.artistRegistryId,
+    provider: 'spotify',
+    providerArtistId: params.providerArtistId,
+    ownershipVerified: false,
+    representationVerified: false,
+    consentObtained: false,
+  };
+}
+
+export function readStructuredCreditProfileMarker(
+  settings: unknown
+): StructuredCreditProfileMarker | null {
+  const marker = asRecord(asRecord(settings)?.unclaimedArtistProfile);
+  if (
+    !marker ||
+    marker.source !== STRUCTURED_CREDIT_SOURCE ||
+    marker.provider !== 'spotify' ||
+    (marker.state !== 'unclaimed' && marker.state !== 'claimed') ||
+    typeof marker.artistRegistryId !== 'string' ||
+    typeof marker.providerArtistId !== 'string' ||
+    typeof marker.ownershipVerified !== 'boolean' ||
+    typeof marker.representationVerified !== 'boolean' ||
+    typeof marker.consentObtained !== 'boolean'
+  ) {
+    return null;
+  }
+
+  return marker as unknown as StructuredCreditProfileMarker;
+}
+
+export function isUnclaimedStructuredCreditProfile(settings: unknown): boolean {
+  const marker = readStructuredCreditProfileMarker(settings);
+  return (
+    marker?.state === 'unclaimed' &&
+    marker.ownershipVerified === false &&
+    marker.representationVerified === false &&
+    marker.consentObtained === false
+  );
+}
+
+export function markStructuredCreditProfileClaimed(
+  settings: Record<string, unknown>,
+  claimedAt: Date
+): Record<string, unknown> {
+  const marker = readStructuredCreditProfileMarker(settings);
+  if (!marker || marker.state !== 'unclaimed') return settings;
+
+  return {
+    ...settings,
+    unclaimedArtistProfile: {
+      ...marker,
+      state: 'claimed',
+      ownershipVerified: true,
+      consentObtained: true,
+      claimedAt: claimedAt.toISOString(),
+    },
+  };
+}

--- a/apps/web/lib/profile/unclaimed-artist-profile.ts
+++ b/apps/web/lib/profile/unclaimed-artist-profile.ts
@@ -39,8 +39,7 @@ export function readStructuredCreditProfileMarker(
 ): StructuredCreditProfileMarker | null {
   const marker = asRecord(asRecord(settings)?.unclaimedArtistProfile);
   if (
-    !marker ||
-    marker.source !== STRUCTURED_CREDIT_SOURCE ||
+    marker?.source !== STRUCTURED_CREDIT_SOURCE ||
     marker.provider !== 'spotify' ||
     (marker.state !== 'unclaimed' && marker.state !== 'claimed') ||
     typeof marker.artistRegistryId !== 'string' ||
@@ -70,7 +69,7 @@ export function markStructuredCreditProfileClaimed(
   claimedAt: Date
 ): Record<string, unknown> {
   const marker = readStructuredCreditProfileMarker(settings);
-  if (!marker || marker.state !== 'unclaimed') return settings;
+  if (marker?.state !== 'unclaimed') return settings;
 
   return {
     ...settings,

--- a/apps/web/tests/app/sitemap.test.ts
+++ b/apps/web/tests/app/sitemap.test.ts
@@ -86,7 +86,9 @@ vi.mock('@/lib/db/schema/profiles', () => ({
     usernameNormalized: 'usernameNormalized',
     updatedAt: 'updatedAt',
     avatarUrl: 'avatarUrl',
+    isClaimed: 'isClaimed',
     isPublic: 'isPublic',
+    settings: 'settings',
     id: 'id',
   },
 }));
@@ -216,6 +218,46 @@ describe('sitemap', () => {
       ).toBeDefined();
       expect(entry.lastModified).toBeInstanceOf(Date);
     }
+  });
+
+  it('excludes automatic unclaimed structured-credit profiles', async () => {
+    getBlogPosts.mockResolvedValue([]);
+    whereMock
+      .mockResolvedValueOnce([
+        {
+          username: 'claimed-artist',
+          updatedAt: new Date('2026-01-01'),
+          isClaimed: true,
+          settings: {},
+        },
+        {
+          username: 'a_unclaimed',
+          updatedAt: new Date('2026-01-01'),
+          isClaimed: false,
+          settings: {
+            unclaimedArtistProfile: {
+              state: 'unclaimed',
+              source: 'structured_spotify_release_credit',
+              artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+              provider: 'spotify',
+              providerArtistId: 'spotify-austin',
+              ownershipVerified: false,
+              representationVerified: false,
+              consentObtained: false,
+            },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const { default: sitemap } = await import('../../app/sitemap');
+    const entries = await sitemap();
+    const urls = entries.map(entry => entry.url);
+
+    expect(urls).toContain('https://jov.ie/claimed-artist');
+    expect(urls).not.toContain('https://jov.ie/a_unclaimed');
   });
 
   it('is non-empty (at minimum static marketing pages are included)', async () => {

--- a/apps/web/tests/unit/lib/discography/collaborator-profile-plan.test.ts
+++ b/apps/web/tests/unit/lib/discography/collaborator-profile-plan.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCreditedArtistReconciliationPlan,
+  type CreditedArtistCandidate,
+} from '@/lib/discography/collaborator-profile-plan';
+
+const austin: CreditedArtistCandidate = {
+  artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+  name: 'Austin Leeds',
+  spotifyId: 'spotify-austin',
+  imageUrl: null,
+};
+
+describe('credited artist reconciliation plan', () => {
+  it('is deterministic and idempotently collapses repeated import edges', () => {
+    const details = [
+      {
+        id: 'spotify-austin',
+        name: 'Austin Leeds',
+        images: [{ url: 'https://i.scdn.co/austin.jpg' }],
+      },
+    ];
+
+    const first = buildCreditedArtistReconciliationPlan(
+      [austin, { ...austin }, { ...austin }],
+      details
+    );
+    const repeated = buildCreditedArtistReconciliationPlan(
+      [{ ...austin }, austin],
+      details
+    );
+
+    expect(first).toEqual(repeated);
+    expect(first).toHaveLength(1);
+    expect(first[0]?.candidate.artistId).toBe(austin.artistId);
+    expect(first[0]?.spotifyArtist?.id).toBe('spotify-austin');
+  });
+
+  it('keeps same-name artists distinct by exact registry/provider IDs', () => {
+    const secondAlex: CreditedArtistCandidate = {
+      artistId: 'e061a679-466c-465a-a545-64a7e39aa3c6',
+      name: 'Alex Lee',
+      spotifyId: 'spotify-alex-two',
+      imageUrl: null,
+    };
+    const firstAlex: CreditedArtistCandidate = {
+      ...austin,
+      name: 'Alex Lee',
+      spotifyId: 'spotify-alex-one',
+    };
+
+    const plan = buildCreditedArtistReconciliationPlan(
+      [firstAlex, secondAlex],
+      []
+    );
+
+    expect(plan.map(item => item.candidate.artistId)).toEqual([
+      firstAlex.artistId,
+      secondAlex.artistId,
+    ]);
+    expect(plan.every(item => item.spotifyArtist === undefined)).toBe(true);
+  });
+
+  it('never joins metadata by display name or alias', () => {
+    const plan = buildCreditedArtistReconciliationPlan(
+      [austin],
+      [{ id: 'spotify-someone-else', name: 'Austin Leeds' }]
+    );
+
+    expect(plan[0]?.spotifyArtist).toBeUndefined();
+  });
+});

--- a/apps/web/tests/unit/profile/unclaimed-artist-profile.test.ts
+++ b/apps/web/tests/unit/profile/unclaimed-artist-profile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStructuredCreditProfileMarker,
+  isUnclaimedStructuredCreditProfile,
+  markStructuredCreditProfileClaimed,
+  readStructuredCreditProfileMarker,
+} from '@/lib/profile/unclaimed-artist-profile';
+
+const marker = buildStructuredCreditProfileMarker({
+  artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+  providerArtistId: 'spotify-austin',
+});
+
+describe('structured-credit unclaimed profile contract', () => {
+  it('creates an explicit non-consent, non-ownership marker', () => {
+    expect(marker).toEqual({
+      state: 'unclaimed',
+      source: 'structured_spotify_release_credit',
+      artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+      provider: 'spotify',
+      providerArtistId: 'spotify-austin',
+      ownershipVerified: false,
+      representationVerified: false,
+      consentObtained: false,
+    });
+    expect(
+      isUnclaimedStructuredCreditProfile({ unclaimedArtistProfile: marker })
+    ).toBe(true);
+  });
+
+  it('rejects malformed or weaker provenance markers', () => {
+    expect(
+      readStructuredCreditProfileMarker({
+        unclaimedArtistProfile: { ...marker, providerArtistId: null },
+      })
+    ).toBeNull();
+    expect(
+      isUnclaimedStructuredCreditProfile({
+        unclaimedArtistProfile: { ...marker, ownershipVerified: true },
+      })
+    ).toBe(false);
+  });
+
+  it('moves only a valid marker to claimed without implying representation', () => {
+    const settings = markStructuredCreditProfileClaimed(
+      { unclaimedArtistProfile: marker, preserved: true },
+      new Date('2026-08-04T12:00:00.000Z')
+    );
+
+    expect(settings).toMatchObject({
+      preserved: true,
+      unclaimedArtistProfile: {
+        state: 'claimed',
+        ownershipVerified: true,
+        representationVerified: false,
+        consentObtained: true,
+        claimedAt: '2026-08-04T12:00:00.000Z',
+      },
+    });
+    expect(isUnclaimedStructuredCreditProfile(settings)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4820 -->

## Stack position

- Layer 2 of 10, now rebased directly onto the merged Layer 1 result on current `main`.
- Current head: `3219c9f9620ed099c41ca6a9e54cf6b82d129026`.
- Keep draft until the fresh current-main checks finish; the next layer remains based on this branch.

## Scope

Adds structured collaborator reconciliation contracts and the sitemap safety wiring for unclaimed artist profiles. Uses canonical entity IDs and preserves claim state; no prose parsing or external-data embedding.

## Repair and verification

- Removed the already-merged Layer 1 commit from this PR, reducing it to an 8-file current-main delta.
- Addressed all 5 Sonar findings, including the critical cognitive-complexity finding, while preserving fail-closed identity behavior.
- Focused sitemap, reconciliation-plan, and unclaimed-profile suite: 11/11 passed.
- Biome: passed.
- Node 22 web typecheck: passed.
- `git diff --check`: passed.

Fresh protected-branch checks are running on the rebased head.
