### PR TITLE
feat(profile): automate collaborator profile backfill

### DIFF
--- a/apps/web/app/onboarding/actions/connect-spotify.ts
+++ b/apps/web/app/onboarding/actions/connect-spotify.ts
@@ -18,7 +18,7 @@ import {
   readPendingClaimContext,
 } from '@/lib/claim/context';
 import { claimPrebuiltProfileForUser } from '@/lib/claim/finalize';
-import { db } from '@/lib/db';
+import { type DbOrTransaction, db } from '@/lib/db';
 import { isUniqueViolation } from '@/lib/db/errors';
 import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
@@ -34,16 +34,22 @@ import { isE2EFastOnboardingEnabled } from '@/lib/e2e/runtime';
 import { isSecureEnv } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
 import { refreshFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
+import { lockSpotifyProfileIdentity } from '@/lib/profile/spotify-profile-identity';
+import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
 import { trackServerEvent } from '@/lib/server-analytics';
 import { finalizePostOnboarding } from './post-onboarding';
 
 const SPOTIFY_ALREADY_CLAIMED_MESSAGE =
   'This Spotify artist is already linked to another Jovie account. Please sign in with the original account or choose a different artist.';
+const SPOTIFY_UNCLAIMED_PROFILE_MESSAGE =
+  'This artist already has an unclaimed Jovie profile and requires verified ownership before it can be claimed.';
 const DSP_DISCOVERY_PROVIDERS = [
   'apple_music',
   'deezer',
   'musicbrainz',
 ] as const;
+
+class SpotifyProfileIdentityConflictError extends Error {}
 
 export interface ConnectOnboardingSpotifyArtistParams {
   artistName: string;
@@ -89,6 +95,43 @@ function normalizeSpotifyArtistUrl(rawUrl: string, spotifyArtistId: string) {
   }
 
   return `https://open.spotify.com/artist/${encodeURIComponent(spotifyArtistId)}`;
+}
+
+async function getOtherExactSpotifyProfiles(
+  database: DbOrTransaction,
+  spotifyArtistId: string,
+  currentProfileId: string
+) {
+  return database
+    .select({
+      id: creatorProfiles.id,
+      isClaimed: creatorProfiles.isClaimed,
+      settings: creatorProfiles.settings,
+    })
+    .from(creatorProfiles)
+    .where(
+      and(
+        eq(creatorProfiles.spotifyId, spotifyArtistId),
+        ne(creatorProfiles.id, currentProfileId)
+      )
+    )
+    .limit(2);
+}
+
+async function assertSpotifyProfileIdentityAvailable(
+  tx: DbOrTransaction,
+  spotifyArtistId: string,
+  currentProfileId: string
+): Promise<void> {
+  await lockSpotifyProfileIdentity(tx, spotifyArtistId);
+  const conflicts = await getOtherExactSpotifyProfiles(
+    tx,
+    spotifyArtistId,
+    currentProfileId
+  );
+  if (conflicts.length > 0) {
+    throw new SpotifyProfileIdentityConflictError();
+  }
 }
 
 function deriveSpotifyImportStatus(result: SpotifyImportResult) {
@@ -197,6 +240,19 @@ export async function connectOnboardingSpotifyArtist(
     pendingClaim.creatorProfileId === profile.id &&
     profile.isClaimed !== true;
 
+  if (
+    isDirectClaimAwaitingMatch &&
+    isUnclaimedStructuredCreditProfile(profile.settings)
+  ) {
+    return {
+      success: false,
+      importing: false,
+      message: SPOTIFY_UNCLAIMED_PROFILE_MESSAGE,
+      imported: 0,
+      artistName: params.artistName,
+    };
+  }
+
   if (isDirectClaimAwaitingMatch && !pendingClaim.expectedSpotifyArtistId) {
     return {
       success: false,
@@ -222,22 +278,24 @@ export async function connectOnboardingSpotifyArtist(
   }
 
   const currentSettings = (profile.settings ?? {}) as Record<string, unknown>;
-  const [existingClaim] = await db
-    .select({ id: creatorProfiles.id })
-    .from(creatorProfiles)
-    .where(
-      and(
-        eq(creatorProfiles.spotifyId, params.spotifyArtistId),
-        ne(creatorProfiles.id, profile.id)
-      )
-    )
-    .limit(1);
+  const existingClaims = await getOtherExactSpotifyProfiles(
+    db,
+    params.spotifyArtistId,
+    profile.id
+  );
 
-  if (existingClaim) {
+  if (existingClaims.length > 0) {
+    const hasUnclaimedStructuredProfile = existingClaims.some(
+      existing =>
+        existing.isClaimed !== true &&
+        isUnclaimedStructuredCreditProfile(existing.settings)
+    );
     return {
       success: false,
       importing: false,
-      message: SPOTIFY_ALREADY_CLAIMED_MESSAGE,
+      message: hasUnclaimedStructuredProfile
+        ? SPOTIFY_UNCLAIMED_PROFILE_MESSAGE
+        : SPOTIFY_ALREADY_CLAIMED_MESSAGE,
       imported: 0,
       artistName: params.artistName,
     };
@@ -245,8 +303,20 @@ export async function connectOnboardingSpotifyArtist(
 
   try {
     if (isDirectClaimAwaitingMatch) {
+      const claimedSettings = {
+        ...currentSettings,
+        spotifyArtistName: params.artistName,
+        spotifyImportStatus: 'importing',
+        spotifyImportTotal: 0,
+      };
+
       await withDbSessionTx(
         async tx => {
+          await assertSpotifyProfileIdentityAvailable(
+            tx,
+            params.spotifyArtistId,
+            profile.id
+          );
           await claimPrebuiltProfileForUser(tx, {
             userId: profile.dbUserId,
             creatorProfileId: profile.id,
@@ -264,12 +334,7 @@ export async function connectOnboardingSpotifyArtist(
             .set({
               spotifyId: params.spotifyArtistId,
               spotifyUrl: params.spotifyArtistUrl,
-              settings: {
-                ...currentSettings,
-                spotifyArtistName: params.artistName,
-                spotifyImportStatus: 'importing',
-                spotifyImportTotal: 0,
-              },
+              settings: claimedSettings,
               updatedAt: new Date(),
             })
             .where(eq(creatorProfiles.id, profile.id));
@@ -293,23 +358,36 @@ export async function connectOnboardingSpotifyArtist(
       ]);
       await finalizePostOnboarding(userId, profile.handle);
     } else {
-      await db
-        .update(creatorProfiles)
-        .set({
-          spotifyId: params.spotifyArtistId,
-          spotifyUrl: params.spotifyArtistUrl,
-          settings: {
-            ...currentSettings,
-            spotifyArtistName: params.artistName,
-            spotifyImportStatus: 'importing',
-            spotifyImportTotal: 0,
-          },
-          updatedAt: new Date(),
-        })
-        .where(eq(creatorProfiles.id, profile.id));
+      await withDbSessionTx(
+        async tx => {
+          await assertSpotifyProfileIdentityAvailable(
+            tx,
+            params.spotifyArtistId,
+            profile.id
+          );
+          await tx
+            .update(creatorProfiles)
+            .set({
+              spotifyId: params.spotifyArtistId,
+              spotifyUrl: params.spotifyArtistUrl,
+              settings: {
+                ...currentSettings,
+                spotifyArtistName: params.artistName,
+                spotifyImportStatus: 'importing',
+                spotifyImportTotal: 0,
+              },
+              updatedAt: new Date(),
+            })
+            .where(eq(creatorProfiles.id, profile.id));
+        },
+        { clerkUserId: userId }
+      );
     }
   } catch (error) {
-    if (isSpotifyIdUniqueViolation(error)) {
+    if (
+      error instanceof SpotifyProfileIdentityConflictError ||
+      isSpotifyIdUniqueViolation(error)
+    ) {
       return {
         success: false,
         importing: false,

--- a/apps/web/app/onboarding/actions/connect-spotify.ts
+++ b/apps/web/app/onboarding/actions/connect-spotify.ts
@@ -210,6 +210,25 @@ async function getOwnedProfile(profileId: string, clerkUserId: string) {
   return profile;
 }
 
+function getDirectClaimValidationMessage(params: {
+  readonly expectedSpotifyArtistId: string | null | undefined;
+  readonly isAwaitingMatch: boolean;
+  readonly isStructuredCreditProfile: boolean;
+  readonly selectedSpotifyArtistId: string;
+}): string | null {
+  if (!params.isAwaitingMatch) return null;
+  if (params.isStructuredCreditProfile) {
+    return SPOTIFY_UNCLAIMED_PROFILE_MESSAGE;
+  }
+  if (!params.expectedSpotifyArtistId) {
+    return 'This profile needs a claim link before it can be claimed.';
+  }
+  if (params.expectedSpotifyArtistId !== params.selectedSpotifyArtistId) {
+    return 'Please choose the Spotify artist already attached to this profile.';
+  }
+  return null;
+}
+
 export async function connectOnboardingSpotifyArtist(
   params: ConnectOnboardingSpotifyArtistParams
 ): Promise<ConnectOnboardingSpotifyArtistResult> {
@@ -239,39 +258,20 @@ export async function connectOnboardingSpotifyArtist(
     pendingClaim?.mode === 'direct_profile' &&
     pendingClaim.creatorProfileId === profile.id &&
     profile.isClaimed !== true;
+  const directClaimValidationMessage = getDirectClaimValidationMessage({
+    expectedSpotifyArtistId: pendingClaim?.expectedSpotifyArtistId,
+    isAwaitingMatch: isDirectClaimAwaitingMatch,
+    isStructuredCreditProfile: isUnclaimedStructuredCreditProfile(
+      profile.settings
+    ),
+    selectedSpotifyArtistId: params.spotifyArtistId,
+  });
 
-  if (
-    isDirectClaimAwaitingMatch &&
-    isUnclaimedStructuredCreditProfile(profile.settings)
-  ) {
+  if (directClaimValidationMessage) {
     return {
       success: false,
       importing: false,
-      message: SPOTIFY_UNCLAIMED_PROFILE_MESSAGE,
-      imported: 0,
-      artistName: params.artistName,
-    };
-  }
-
-  if (isDirectClaimAwaitingMatch && !pendingClaim.expectedSpotifyArtistId) {
-    return {
-      success: false,
-      importing: false,
-      message: 'This profile needs a claim link before it can be claimed.',
-      imported: 0,
-      artistName: params.artistName,
-    };
-  }
-
-  if (
-    isDirectClaimAwaitingMatch &&
-    pendingClaim.expectedSpotifyArtistId !== params.spotifyArtistId
-  ) {
-    return {
-      success: false,
-      importing: false,
-      message:
-        'Please choose the Spotify artist already attached to this profile.',
+      message: directClaimValidationMessage,
       imported: 0,
       artistName: params.artistName,
     };

--- a/apps/web/lib/spotify/artist-id.ts
+++ b/apps/web/lib/spotify/artist-id.ts
@@ -27,3 +27,34 @@ export function extractSpotifyArtistId(value: string): string | null {
     return null;
   }
 }
+
+export type SpotifyArtistIdentityResolution =
+  | { readonly status: 'resolved'; readonly spotifyArtistId: string }
+  | { readonly status: 'missing' | 'conflict'; readonly spotifyArtistId: null };
+
+/**
+ * Resolve one exact Spotify artist identity from structured profile fields.
+ *
+ * Legacy profiles may only retain the active Spotify social-link URL, while
+ * newer profiles also populate spotify_id/spotify_url. Conflicting exact IDs
+ * fail closed so callers never choose an owner identity by display name.
+ */
+export function resolveSpotifyArtistIdentity(
+  values: readonly (string | null | undefined)[]
+): SpotifyArtistIdentityResolution {
+  const ids = new Set<string>();
+  for (const value of values) {
+    if (!value) continue;
+    const id = extractSpotifyArtistId(value);
+    if (id) ids.add(id);
+  }
+
+  if (ids.size === 0) {
+    return { status: 'missing', spotifyArtistId: null };
+  }
+  if (ids.size > 1) {
+    return { status: 'conflict', spotifyArtistId: null };
+  }
+
+  return { status: 'resolved', spotifyArtistId: [...ids][0]! };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "dev:local": "node scripts/dev-fast.mjs",
     "dev:local:browse": "tsx scripts/drizzle-migrate.ts || echo '[dev:browse] drizzle:migrate failed - starting dev anyway (see error above)'; E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 node scripts/dev-fast.mjs",
     "dev:local:playwright": "NEXT_PUBLIC_E2E_MODE=1 NEXT_DISABLE_TOOLBAR=1 node scripts/dev-fast.mjs -- --webpack",
+    "backfill:collaborator-profiles": "NODE_OPTIONS=--conditions=react-server tsx scripts/backfill-collaborator-profiles.ts",
     "validate-env": "tsx scripts/validate-env.ts",
     "check:signup-readiness": "tsx scripts/check-signup-readiness.ts",
     "seo:ratchet": "vitest run tests/unit/seo --config=vitest.config.mts",

--- a/apps/web/scripts/backfill-collaborator-profiles.ts
+++ b/apps/web/scripts/backfill-collaborator-profiles.ts
@@ -1,0 +1,262 @@
+#!/usr/bin/env tsx
+
+import { pathToFileURL } from 'node:url';
+import { and, eq, gt, inArray, isNotNull, isNull } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import {
+  artists,
+  discogReleases,
+  releaseArtists,
+} from '@/lib/db/schema/content';
+import { socialLinks } from '@/lib/db/schema/links';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { PUBLIC_ARTIST_COLLABORATOR_ROLES } from '@/lib/discography/artist-credit-policy';
+import { reconcileCreditedArtistProfiles } from '@/lib/discography/collaborator-profile-reconciliation';
+import { publicReleaseEligibilitySqlPredicate } from '@/lib/profile/public-release-eligibility';
+import { resolveSpotifyArtistIdentity } from '@/lib/spotify/artist-id';
+
+interface BackfillArgs {
+  readonly dryRun: boolean;
+  readonly limit: number;
+  readonly cursor: string | null;
+  readonly profileId: string | null;
+}
+
+interface BackfillSummary {
+  readonly mode: 'dry-run' | 'write';
+  readonly scanned: number;
+  readonly resolved: number;
+  readonly processed: number;
+  readonly missingIdentity: number;
+  readonly identityConflicts: number;
+  readonly failed: number;
+  readonly created: number;
+  readonly reused: number;
+  readonly conflicted: number;
+  readonly metadataUnavailable: number;
+  readonly deferredProfiles: number;
+  readonly nextCursor: string | null;
+}
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+const MAX_PROFILE_PASSES = 10;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function readUuid(value: string | undefined, flag: string): string {
+  if (!value || !UUID_PATTERN.test(value)) {
+    throw new Error(`${flag} requires a valid UUID.`);
+  }
+  return value;
+}
+
+export function parseBackfillArgs(argv: readonly string[]): BackfillArgs {
+  let dryRun = true;
+  let explicitlyDryRun = false;
+  let explicitlyApply = false;
+  let limit = DEFAULT_LIMIT;
+  let cursor: string | null = null;
+  let profileId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+
+    if (value === '--') continue;
+    if (value === '--dry-run') {
+      explicitlyDryRun = true;
+      dryRun = true;
+      continue;
+    }
+    if (value === '--apply') {
+      explicitlyApply = true;
+      dryRun = false;
+      continue;
+    }
+    if (value === '--limit') {
+      const parsed = Number.parseInt(argv[index + 1] ?? '', 10);
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+        throw new Error(
+          `--limit must be an integer between 1 and ${MAX_LIMIT}.`
+        );
+      }
+      limit = parsed;
+      index += 1;
+      continue;
+    }
+    if (value === '--cursor') {
+      cursor = readUuid(argv[index + 1], '--cursor');
+      index += 1;
+      continue;
+    }
+    if (value === '--profile-id') {
+      profileId = readUuid(argv[index + 1], '--profile-id');
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  if (explicitlyDryRun && explicitlyApply) {
+    throw new Error('Choose either --dry-run or --apply, not both.');
+  }
+  if (cursor && profileId) {
+    throw new Error('--cursor cannot be combined with --profile-id.');
+  }
+
+  return { dryRun, limit, cursor, profileId };
+}
+
+export async function backfillCollaboratorProfiles({
+  dryRun,
+  limit,
+  cursor,
+  profileId,
+}: BackfillArgs): Promise<BackfillSummary> {
+  const profileConditions = [
+    eq(creatorProfiles.isPublic, true),
+    inArray(releaseArtists.role, PUBLIC_ARTIST_COLLABORATOR_ROLES),
+    isNotNull(artists.spotifyId),
+    isNull(artists.creatorProfileId),
+    publicReleaseEligibilitySqlPredicate(),
+  ];
+  if (profileId) profileConditions.push(eq(creatorProfiles.id, profileId));
+  else if (cursor) profileConditions.push(gt(creatorProfiles.id, cursor));
+
+  const profiles = await db
+    .selectDistinct({
+      id: creatorProfiles.id,
+      usernameNormalized: creatorProfiles.usernameNormalized,
+      spotifyId: creatorProfiles.spotifyId,
+      spotifyUrl: creatorProfiles.spotifyUrl,
+    })
+    .from(creatorProfiles)
+    .innerJoin(
+      discogReleases,
+      eq(discogReleases.creatorProfileId, creatorProfiles.id)
+    )
+    .innerJoin(releaseArtists, eq(releaseArtists.releaseId, discogReleases.id))
+    .innerJoin(artists, eq(artists.id, releaseArtists.artistId))
+    .where(and(...profileConditions))
+    .orderBy(creatorProfiles.id)
+    .limit(profileId ? 1 : limit);
+
+  const profileLinks =
+    profiles.length > 0
+      ? await db
+          .select({
+            creatorProfileId: socialLinks.creatorProfileId,
+            url: socialLinks.url,
+          })
+          .from(socialLinks)
+          .where(
+            and(
+              inArray(
+                socialLinks.creatorProfileId,
+                profiles.map(profile => profile.id)
+              ),
+              eq(socialLinks.platform, 'spotify'),
+              eq(socialLinks.isActive, true),
+              eq(socialLinks.state, 'active')
+            )
+          )
+      : [];
+  const linksByProfile = new Map<string, string[]>();
+  for (const link of profileLinks) {
+    const values = linksByProfile.get(link.creatorProfileId) ?? [];
+    values.push(link.url);
+    linksByProfile.set(link.creatorProfileId, values);
+  }
+
+  let resolved = 0;
+  let processed = 0;
+  let missingIdentity = 0;
+  let identityConflicts = 0;
+  let failed = 0;
+  let created = 0;
+  let reused = 0;
+  let conflicted = 0;
+  let metadataUnavailable = 0;
+  let deferredProfiles = 0;
+
+  for (const profile of profiles) {
+    const identity = resolveSpotifyArtistIdentity([
+      profile.spotifyId,
+      profile.spotifyUrl,
+      ...(linksByProfile.get(profile.id) ?? []),
+    ]);
+    if (identity.status === 'missing') {
+      missingIdentity += 1;
+      continue;
+    }
+    if (identity.status === 'conflict') {
+      identityConflicts += 1;
+      continue;
+    }
+    resolved += 1;
+    if (dryRun) continue;
+
+    try {
+      let pass = 0;
+      let deferred = false;
+      do {
+        const result = await reconcileCreditedArtistProfiles(
+          profile.id,
+          identity.spotifyArtistId
+        );
+        created += result.created;
+        reused += result.reused;
+        conflicted += result.conflicted;
+        metadataUnavailable += result.metadataUnavailable;
+        deferred = result.deferred;
+        pass += 1;
+      } while (deferred && pass < MAX_PROFILE_PASSES);
+
+      if (deferred) deferredProfiles += 1;
+      processed += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(
+        JSON.stringify({
+          event: 'collaborator_profile_backfill_failed',
+          profileId: profile.id,
+          username: profile.usernameNormalized,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    }
+  }
+
+  return {
+    mode: dryRun ? 'dry-run' : 'write',
+    scanned: profiles.length,
+    resolved,
+    processed,
+    missingIdentity,
+    identityConflicts,
+    failed,
+    created,
+    reused,
+    conflicted,
+    metadataUnavailable,
+    deferredProfiles,
+    nextCursor: profileId ? null : (profiles.at(-1)?.id ?? null),
+  };
+}
+
+async function main() {
+  const args = parseBackfillArgs(process.argv.slice(2));
+  const summary = await backfillCollaboratorProfiles(args);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch(error => {
+    console.error('Collaborator profile backfill failed:', error);
+    process.exit(1);
+  });
+}

--- a/apps/web/tests/unit/app/onboarding/actions/connect-spotify.test.ts
+++ b/apps/web/tests/unit/app/onboarding/actions/connect-spotify.test.ts
@@ -23,8 +23,11 @@ const hoisted = vi.hoisted(() => {
   const readPendingClaimContextMock = vi.fn().mockResolvedValue(null);
   const clearPendingClaimContextMock = vi.fn().mockResolvedValue(undefined);
   const claimPrebuiltProfileForUserMock = vi.fn().mockResolvedValue(undefined);
+  const executeMock = vi.fn().mockResolvedValue(undefined);
   const withDbSessionTxMock = vi.fn(async callback =>
     callback({
+      execute: executeMock,
+      select: selectMock,
       update: updateMock,
     })
   );
@@ -79,6 +82,7 @@ const hoisted = vi.hoisted(() => {
     finalizePostOnboardingMock,
     cookiesMock,
     cookiesSetMock,
+    executeMock,
     updateMock,
     updateSetArgs,
     withDbSessionTxMock,
@@ -99,6 +103,7 @@ vi.mock('drizzle-orm', () => ({
   and: vi.fn(),
   eq: vi.fn(),
   ne: vi.fn(),
+  sql: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/cached', () => ({
@@ -213,7 +218,8 @@ function queueOwnedProfile(settings: Record<string, unknown> = {}) {
 }
 
 function queueNoExistingClaim() {
-  hoisted.selectResults.push([]);
+  // One preflight read and one transaction-locked recheck.
+  hoisted.selectResults.push([], []);
 }
 
 function queueLatestSettings(settings: Record<string, unknown> = {}) {
@@ -449,6 +455,118 @@ describe('connectOnboardingSpotifyArtist', () => {
     expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
   });
 
+  it('rejects an exact-ID structured-credit profile without profile-specific proof', async () => {
+    queueOwnedProfile();
+    hoisted.selectResults.push([
+      {
+        id: 'credit_profile_456',
+        isClaimed: false,
+        settings: {
+          unclaimedArtistProfile: {
+            state: 'unclaimed',
+            source: 'structured_spotify_release_credit',
+            artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+            provider: 'spotify',
+            providerArtistId: 'artist_spotify_id',
+            ownershipVerified: false,
+            representationVerified: false,
+            consentObtained: false,
+          },
+        },
+      },
+    ]);
+
+    const { connectOnboardingSpotifyArtist } = await import(
+      '@/app/onboarding/actions/connect-spotify'
+    );
+    const result = await connectOnboardingSpotifyArtist({
+      artistName: 'Artist Name',
+      profileId: 'profile_123',
+      spotifyArtistId: 'artist_spotify_id',
+      spotifyArtistUrl: 'https://open.spotify.com/artist/artist_spotify_id',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      importing: false,
+      message:
+        'This artist already has an unclaimed Jovie profile and requires verified ownership before it can be claimed.',
+      imported: 0,
+      artistName: 'Artist Name',
+    });
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
+    expect(hoisted.withDbSessionTxMock).not.toHaveBeenCalled();
+    expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
+    expect(hoisted.syncReleasesFromSpotifyMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when duplicate exact-ID profiles already exist', async () => {
+    queueOwnedProfile();
+    hoisted.selectResults.push([
+      {
+        id: 'claimed_profile',
+        isClaimed: true,
+        settings: {},
+      },
+      {
+        id: 'unclaimed_profile',
+        isClaimed: false,
+        settings: {
+          unclaimedArtistProfile: {
+            state: 'unclaimed',
+            source: 'structured_spotify_release_credit',
+            artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+            provider: 'spotify',
+            providerArtistId: 'artist_spotify_id',
+            ownershipVerified: false,
+            representationVerified: false,
+            consentObtained: false,
+          },
+        },
+      },
+    ]);
+
+    const { connectOnboardingSpotifyArtist } = await import(
+      '@/app/onboarding/actions/connect-spotify'
+    );
+    const result = await connectOnboardingSpotifyArtist({
+      artistName: 'Artist Name',
+      profileId: 'profile_123',
+      spotifyArtistId: 'artist_spotify_id',
+      spotifyArtistUrl: 'https://open.spotify.com/artist/artist_spotify_id',
+    });
+
+    expect(result.success).toBe(false);
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
+    expect(hoisted.withDbSessionTxMock).not.toHaveBeenCalled();
+    expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
+    expect(hoisted.syncReleasesFromSpotifyMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when an exact-ID profile wins after the preflight read', async () => {
+    queueOwnedProfile();
+    hoisted.selectResults.push(
+      [],
+      [{ id: 'concurrent_winner', isClaimed: false, settings: {} }]
+    );
+
+    const { connectOnboardingSpotifyArtist } = await import(
+      '@/app/onboarding/actions/connect-spotify'
+    );
+    const result = await connectOnboardingSpotifyArtist({
+      artistName: 'Artist Name',
+      profileId: 'profile_123',
+      spotifyArtistId: 'artist_spotify_id',
+      spotifyArtistUrl: 'https://open.spotify.com/artist/artist_spotify_id',
+    });
+
+    expect(result.success).toBe(false);
+    expect(hoisted.executeMock).toHaveBeenCalledOnce();
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
+    expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
+    expect(hoisted.syncReleasesFromSpotifyMock).not.toHaveBeenCalled();
+  });
+
   it('rejects a direct-profile claim awaiting match when no expectedSpotifyArtistId is set yet', async () => {
     queueOwnedProfile();
     hoisted.readPendingClaimContextMock.mockResolvedValueOnce({
@@ -485,6 +603,49 @@ describe('connectOnboardingSpotifyArtist', () => {
     expect(hoisted.withDbSessionTxMock).not.toHaveBeenCalled();
     expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
     expect(hoisted.syncReleasesFromSpotifyMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a self-issued direct claim for an automatic unclaimed profile', async () => {
+    queueOwnedProfile({
+      unclaimedArtistProfile: {
+        state: 'unclaimed',
+        source: 'structured_spotify_release_credit',
+        artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+        provider: 'spotify',
+        providerArtistId: 'artist_spotify_id',
+        ownershipVerified: false,
+        representationVerified: false,
+        consentObtained: false,
+      },
+    });
+    hoisted.readPendingClaimContextMock.mockResolvedValueOnce({
+      mode: 'direct_profile',
+      creatorProfileId: 'profile_123',
+      username: 'artist',
+      expectedSpotifyArtistId: 'artist_spotify_id',
+      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const { connectOnboardingSpotifyArtist } = await import(
+      '@/app/onboarding/actions/connect-spotify'
+    );
+    const result = await connectOnboardingSpotifyArtist({
+      artistName: 'Artist Name',
+      profileId: 'profile_123',
+      spotifyArtistId: 'artist_spotify_id',
+      spotifyArtistUrl: 'https://open.spotify.com/artist/artist_spotify_id',
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      message:
+        'This artist already has an unclaimed Jovie profile and requires verified ownership before it can be claimed.',
+    });
+    expect(hoisted.selectMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.withDbSessionTxMock).not.toHaveBeenCalled();
+    expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
   });
 
   it('rejects a direct-profile claim when the selected Spotify artist does not match the expected one', async () => {

--- a/apps/web/tests/unit/lib/spotify/artist-id.test.ts
+++ b/apps/web/tests/unit/lib/spotify/artist-id.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { extractSpotifyArtistId } from '@/lib/spotify/artist-id';
+import {
+  extractSpotifyArtistId,
+  resolveSpotifyArtistIdentity,
+} from '@/lib/spotify/artist-id';
 
 describe('extractSpotifyArtistId', () => {
   it('extracts an artist id from a direct id input', () => {
@@ -31,5 +34,45 @@ describe('extractSpotifyArtistId', () => {
       )
     ).toBeNull();
     expect(extractSpotifyArtistId('not-a-url')).toBeNull();
+  });
+});
+
+describe('resolveSpotifyArtistIdentity', () => {
+  it('uses an exact active-link URL when legacy profile columns are empty', () => {
+    expect(
+      resolveSpotifyArtistIdentity([
+        null,
+        null,
+        'https://open.spotify.com/artist/4Uwpa6zW3zzCSQvooQNksm',
+      ])
+    ).toEqual({
+      status: 'resolved',
+      spotifyArtistId: '4Uwpa6zW3zzCSQvooQNksm',
+    });
+  });
+
+  it('dedupes matching exact IDs across profile fields', () => {
+    expect(
+      resolveSpotifyArtistIdentity([
+        '4Uwpa6zW3zzCSQvooQNksm',
+        'https://open.spotify.com/artist/4Uwpa6zW3zzCSQvooQNksm?si=profile',
+      ])
+    ).toMatchObject({
+      status: 'resolved',
+      spotifyArtistId: '4Uwpa6zW3zzCSQvooQNksm',
+    });
+  });
+
+  it('fails closed for missing or conflicting exact IDs', () => {
+    expect(resolveSpotifyArtistIdentity([null, ''])).toEqual({
+      status: 'missing',
+      spotifyArtistId: null,
+    });
+    expect(
+      resolveSpotifyArtistIdentity([
+        '4Uwpa6zW3zzCSQvooQNksm',
+        'https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai',
+      ])
+    ).toEqual({ status: 'conflict', spotifyArtistId: null });
   });
 });

--- a/apps/web/tests/unit/scripts/backfill-collaborator-profiles.test.ts
+++ b/apps/web/tests/unit/scripts/backfill-collaborator-profiles.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseBackfillArgs } from '../../../scripts/backfill-collaborator-profiles';
+
+const profileId = '8473a72f-51a0-4ce0-8739-4facfd89a7a5';
+
+describe('collaborator profile backfill arguments', () => {
+  it('is dry-run-first and bounded by default', () => {
+    expect(parseBackfillArgs([])).toEqual({
+      dryRun: true,
+      limit: 10,
+      cursor: null,
+      profileId: null,
+    });
+  });
+
+  it('supports an explicit targeted apply run', () => {
+    expect(
+      parseBackfillArgs(['--', '--apply', '--profile-id', profileId])
+    ).toEqual({
+      dryRun: false,
+      limit: 10,
+      cursor: null,
+      profileId,
+    });
+  });
+
+  it('rejects ambiguous modes, invalid limits, and mixed cursors', () => {
+    expect(() => parseBackfillArgs(['--apply', '--dry-run'])).toThrow(
+      'Choose either --dry-run or --apply'
+    );
+    expect(() => parseBackfillArgs(['--limit', '101'])).toThrow(
+      '--limit must be an integer between 1 and 100'
+    );
+    expect(() =>
+      parseBackfillArgs(['--profile-id', profileId, '--cursor', profileId])
+    ).toThrow('--cursor cannot be combined with --profile-id');
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4820 -->

## Stack position

- Layer 4 of 10, now rebased directly onto the merged Layer 3 result on current `main`.
- Current head: `ba968496760`.
- Keep draft until fresh current-main checks finish.

## Scope

Adds deterministic collaborator-profile backfill, integrates verified direct-claim handling with the canonical Spotify identity boundary, and exposes the bounded backfill command in the layer that actually contains it.

## Repair and verification

- Removed the already-merged parent layers from this PR, reducing it to a 7-file current-main delta.
- Addressed the critical Sonar cognitive-complexity finding by extracting direct-claim validation without weakening fail-closed identity checks.
- Restored the backfill package command here after correctly removing its dangling reference from Layer 3.
- Focused claim, Spotify ID, and backfill suite: 21/21 passed.
- Biome: passed.
- Node 22 web typecheck: passed.
- `git diff --check`: passed.

Fresh protected-branch checks are running on the rebased head.
