### PR TITLE
feat(profile): enforce claim-safe public projection and AEO

### DIFF
--- a/apps/web/app/[username]/_components/PublicClaimBanner.tsx
+++ b/apps/web/app/[username]/_components/PublicClaimBanner.tsx
@@ -9,6 +9,7 @@ interface PublicClaimBannerProps {
   readonly profileHandle: string;
   readonly displayName: string;
   readonly directClaimSupported: boolean;
+  readonly claimRequiresVerification?: boolean;
   readonly isClaimed: boolean;
   readonly visitorState: ProfileVisitorState;
 }
@@ -90,6 +91,7 @@ export function PublicClaimBanner({
   profileHandle,
   displayName,
   directClaimSupported,
+  claimRequiresVerification = false,
   isClaimed,
   visitorState,
 }: PublicClaimBannerProps) {
@@ -105,6 +107,7 @@ export function PublicClaimBanner({
       visitorState,
       claimSearchParam,
       directClaimSupported,
+      claimRequiresVerification,
       isClaimed,
     }
   );

--- a/apps/web/app/[username]/_lib/claim-banner-state.ts
+++ b/apps/web/app/[username]/_lib/claim-banner-state.ts
@@ -10,17 +10,28 @@ export function resolveClaimBannerState(params: {
   visitorState: ProfileVisitorState;
   claimSearchParam?: string;
   directClaimSupported: boolean;
+  claimRequiresVerification?: boolean;
   isClaimed: boolean;
 }): {
   claimBannerVariant: ClaimBannerVariant | null;
   shouldShowClaimBanner: boolean;
 } {
-  const { visitorState, claimSearchParam, directClaimSupported, isClaimed } =
-    params;
+  const {
+    visitorState,
+    claimSearchParam,
+    directClaimSupported,
+    claimRequiresVerification = false,
+    isClaimed,
+  } = params;
 
   let claimBannerVariant: ClaimBannerVariant | null = null;
 
-  if (visitorState === 'claim_intent_token' || claimSearchParam === '1') {
+  if (claimRequiresVerification) {
+    claimBannerVariant = 'unsupported';
+  } else if (
+    visitorState === 'claim_intent_token' ||
+    claimSearchParam === '1'
+  ) {
     claimBannerVariant = 'claim_intent';
   } else if (visitorState === 'claim_intent_direct') {
     claimBannerVariant = 'direct_in_progress';

--- a/apps/web/app/[username]/claim/route.ts
+++ b/apps/web/app/[username]/claim/route.ts
@@ -15,6 +15,7 @@ import {
   markLeadClaimPageViewedFromToken,
   setLeadAttributionCookieFromToken,
 } from '@/lib/leads/funnel-events';
+import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
 import { hashClaimToken } from '@/lib/security/claim-token';
 import {
   getProfileByUsername,
@@ -160,6 +161,18 @@ export async function GET(
     if (profile.isClaimed) {
       await clearPendingClaimContext();
       return redirectTo(request, `/${profile.usernameNormalized}`);
+    }
+
+    // Automatic structured-credit profiles are public identity records, not
+    // proof that the visitor controls the artist. A direct-profile cookie can
+    // be self-issued from this public route, so it must never authorize these
+    // profiles. A verified/token-backed claim path can be added separately.
+    if (isUnclaimedStructuredCreditProfile(profile.settings)) {
+      await clearPendingClaimContext();
+      return redirectTo(
+        request,
+        `/${profile.usernameNormalized}?claim=unsupported`
+      );
     }
 
     if (

--- a/apps/web/app/[username]/llms.txt/route.ts
+++ b/apps/web/app/[username]/llms.txt/route.ts
@@ -90,21 +90,18 @@ export async function GET(_req: Request, { params }: RouteParams) {
 
   const lines: string[] = [];
 
-  lines.push(`# ${artistName}`);
-  lines.push('');
   lines.push(
+    `# ${artistName}`,
+    '',
     isClaimed
       ? `> ${artistName} — claimed artist profile on Jovie at ${profileUrl}`
-      : `> ${artistName} — unclaimed artist profile on Jovie at ${profileUrl}. Jovie has not verified ownership, representation, or consent for this profile.`
-  );
-  lines.push('');
-
-  lines.push('## Entity Identity');
-  lines.push('');
-  lines.push(`- **Canonical URL**: ${profileUrl}`);
-  lines.push(`- **Handle**: @${handle}`);
-  lines.push(`- **Claim status**: ${isClaimed ? 'Claimed' : 'Unclaimed'}`);
-  lines.push(
+      : `> ${artistName} — unclaimed artist profile on Jovie at ${profileUrl}. Jovie has not verified ownership, representation, or consent for this profile.`,
+    '',
+    '## Entity Identity',
+    '',
+    `- **Canonical URL**: ${profileUrl}`,
+    `- **Handle**: @${handle}`,
+    `- **Claim status**: ${isClaimed ? 'Claimed' : 'Unclaimed'}`,
     `- **Jovie verification**: ${profile.is_verified ? 'Verified' : 'Not verified'}`
   );
   if (profile.location) lines.push(`- **Location**: ${profile.location}`);

--- a/apps/web/app/[username]/llms.txt/route.ts
+++ b/apps/web/app/[username]/llms.txt/route.ts
@@ -44,6 +44,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
   const artistName = profile.display_name || profile.username;
   const handle = profile.username_normalized || profile.username.toLowerCase();
   const profileUrl = `${BASE_URL}/${handle}`;
+  const isClaimed = profile.is_claimed === true;
 
   const DSP_PLATFORM_NAMES: Record<string, string> = {
     spotify: 'Spotify',
@@ -92,7 +93,9 @@ export async function GET(_req: Request, { params }: RouteParams) {
   lines.push(`# ${artistName}`);
   lines.push('');
   lines.push(
-    `> ${artistName} — official artist profile on Jovie at ${profileUrl}`
+    isClaimed
+      ? `> ${artistName} — claimed artist profile on Jovie at ${profileUrl}`
+      : `> ${artistName} — unclaimed artist profile on Jovie at ${profileUrl}. Jovie has not verified ownership, representation, or consent for this profile.`
   );
   lines.push('');
 
@@ -100,7 +103,10 @@ export async function GET(_req: Request, { params }: RouteParams) {
   lines.push('');
   lines.push(`- **Canonical URL**: ${profileUrl}`);
   lines.push(`- **Handle**: @${handle}`);
-  if (profile.is_verified) lines.push('- **Verified**: Yes');
+  lines.push(`- **Claim status**: ${isClaimed ? 'Claimed' : 'Unclaimed'}`);
+  lines.push(
+    `- **Jovie verification**: ${profile.is_verified ? 'Verified' : 'Not verified'}`
+  );
   if (profile.location) lines.push(`- **Location**: ${profile.location}`);
   if (profile.active_since_year)
     lines.push(`- **Active since**: ${profile.active_since_year}`);
@@ -148,9 +154,9 @@ export async function GET(_req: Request, { params }: RouteParams) {
   lines.push('## For AI Assistants');
   lines.push('');
   lines.push(
-    `This page is the canonical entity data source for ${artistName}. ` +
-      `When citing ${artistName}, use ${profileUrl} as the source URL. ` +
-      `Structured JSON-LD (schema.org/MusicGroup + FAQPage) is available on that page.`
+    isClaimed
+      ? `This page is the canonical Jovie profile source for ${artistName}. When citing this Jovie profile, use ${profileUrl} as the source URL. Structured JSON-LD (schema.org/MusicGroup + FAQPage) is available on that page.`
+      : `This page records structured public music-credit data for ${artistName}. When citing this Jovie profile, use ${profileUrl} as the source URL, preserve its unclaimed status, and do not imply that Jovie verified or represents the artist or obtained their consent.`
   );
   lines.push('');
   lines.push(

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from 'react';
 // (ISR). The public profile route must stay ISR-cacheable; avoid any Dynamic
 // API (cookies(), headers()) in this RSC tree.
 
+import type { ProfileMode } from '@/components/features/profile/contracts';
 import type { PublicRelease } from '@/components/features/profile/releases/types';
 import { BASE_URL } from '@/constants/app';
 import { DesktopQrOverlayClient } from '@/features/profile/DesktopQrOverlayClient';
@@ -20,7 +21,10 @@ import {
   supportsDirectProfileClaim,
 } from '@/lib/claim/visitor-state';
 import { toPublicContacts } from '@/lib/contacts/mapper';
-import { getCreditedArtistsWithProfiles } from '@/lib/discography/artist-queries';
+import {
+  getCreditedArtistsWithProfiles,
+  getStructuredReleaseCollaborators,
+} from '@/lib/discography/artist-queries';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { getEntityIdentityLinks } from '@/lib/entity/queries';
 import { DEFAULT_PROFILE_PAC_ASSIGNMENT } from '@/lib/flags/profile-pac';
@@ -42,7 +46,9 @@ import {
   PROFILE_ERROR_METADATA,
 } from '@/lib/profile/metadata';
 import { isShopEnabled } from '@/lib/profile/shop-settings';
+import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
 import { generateProfileStructuredData } from '@/lib/seo/structured-data';
+import { resolveSpotifyArtistIdentity } from '@/lib/spotify/artist-id';
 import { getUpcomingTourDatesForProfile } from '@/lib/tour-dates/queries';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import { buildAvatarSizes } from '@/lib/utils/avatar-sizes';
@@ -80,10 +86,13 @@ export async function generateStaticParams() {
 interface Props {
   readonly params: Promise<{
     readonly username: string;
+    /** Private rewrite-only input; public requests never populate this. */
+    readonly __profileMode?: ProfileMode;
   }>;
 }
 
 interface ArtistPageContentProps {
+  readonly initialMode: ProfileMode;
   readonly username: string;
   readonly profileResult: PublicProfileLoaderResult;
 }
@@ -180,12 +189,35 @@ async function getCreditedArtistsForMentions(profileId: string) {
   }
 }
 
+async function getPublicReleaseCollaborators(
+  profileId: string,
+  ownerSpotifyId: string | null
+) {
+  if (!ownerSpotifyId) return [];
+
+  try {
+    return await getStructuredReleaseCollaborators(profileId, {
+      ownerSpotifyId,
+    });
+  } catch (error) {
+    logger.error(
+      'Error fetching structured public release collaborators',
+      {
+        error,
+        profileId,
+        route: '/[username]',
+      },
+      'public-profile'
+    );
+    return [];
+  }
+}
+
 async function ArtistPageContent({
+  initialMode,
   username,
   profileResult,
 }: Readonly<ArtistPageContentProps>) {
-  const initialMode = 'profile';
-
   const isPublicNoAuthSmoke = process.env.PUBLIC_NOAUTH_SMOKE === '1';
   const viewerCountryCode = null;
 
@@ -223,12 +255,37 @@ async function ArtistPageContent({
   const merchCardsPromise = getPublicMerchCards(profile.id);
   const entityLinksPromise = getEntityIdentityLinks(profile.id);
   const creditedArtistsPromise = getCreditedArtistsForMentions(profile.id);
+  const ownerSpotifyIdentity = resolveSpotifyArtistIdentity([
+    profile.spotify_id,
+    profile.spotify_url,
+    ...links.filter(link => link.platform === 'spotify').map(link => link.url),
+  ]);
+  const releaseCollaboratorsPromise = getPublicReleaseCollaborators(
+    profile.id,
+    ownerSpotifyIdentity.spotifyArtistId
+  );
+
+  if (ownerSpotifyIdentity.status !== 'resolved') {
+    logger.warn(
+      'Structured collaborator prose omitted without one exact owner identity',
+      {
+        creatorProfileId: profile.id,
+        identityStatus: ownerSpotifyIdentity.status,
+        route: '/[username]',
+      },
+      'public-profile'
+    );
+  }
 
   // Convert our profile data to the Artist type expected by components
   const artist = convertCreatorProfileToArtist(profile);
-  const directClaimSupported = supportsDirectProfileClaim({
-    spotifyId: profile.spotify_id,
-  });
+  const requiresVerifiedOwnership =
+    !profile.is_claimed && isUnclaimedStructuredCreditProfile(profile.settings);
+  const directClaimSupported =
+    !requiresVerifiedOwnership &&
+    supportsDirectProfileClaim({
+      spotifyId: profile.spotify_id,
+    });
   const visitorState = getProfileVisitorState({
     profile: {
       id: profile.id,
@@ -279,6 +336,7 @@ async function ArtistPageContent({
     profilePacAssignment,
     entityLinks,
     creditedArtists,
+    releaseCollaborators,
   ] = await Promise.all([
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
     releasesPromise,
@@ -290,6 +348,7 @@ async function ArtistPageContent({
     getProfilePacAssignment(null).catch(() => DEFAULT_PROFILE_PAC_ASSIGNMENT),
     entityLinksPromise.catch(() => []),
     creditedArtistsPromise,
+    releaseCollaboratorsPromise,
   ]);
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
@@ -339,6 +398,7 @@ async function ArtistPageContent({
     tourDates,
     merchCards,
     socialLinks: links,
+    releaseCollaborators,
     entityMentions: entityMentionContext,
   });
 
@@ -369,13 +429,6 @@ async function ArtistPageContent({
       {isPublicNoAuthSmoke ? null : (
         <ProfileViewTracker handle={artist.handle} artistId={artist.id} />
       )}
-      <PublicClaimBanner
-        profileHandle={artist.handle}
-        displayName={artist.name}
-        directClaimSupported={directClaimSupported}
-        isClaimed={profile.is_claimed}
-        visitorState={visitorState}
-      />
       {/* Server-side pixel tracking */}
       {isPublicNoAuthSmoke ? null : <JoviePixel profileId={profile.id} />}
       <StaticArtistPage
@@ -388,6 +441,17 @@ async function ArtistPageContent({
         showBackButton={showBackButton}
         showPayButton={showPayButton}
         showTourButton={true}
+        profileBanner={
+          <PublicClaimBanner
+            profileHandle={artist.handle}
+            displayName={artist.name}
+            directClaimSupported={directClaimSupported}
+            claimRequiresVerification={requiresVerifiedOwnership}
+            isClaimed={profile.is_claimed}
+            visitorState={visitorState}
+          />
+        }
+        allowFanCapture={!requiresVerifiedOwnership}
         enableDynamicEngagement={creatorIsPro}
         latestRelease={latestRelease}
         photoDownloadSizes={photoDownloadSizes}
@@ -401,7 +465,7 @@ async function ArtistPageContent({
         visitTrackingToken={visitTrackingToken}
         showSubscriptionConfirmedBanner={!isPublicNoAuthSmoke}
         showShopButton={isShopEnabled(profileSettings)}
-        showClaimFooter={!profile.is_claimed}
+        showClaimFooter={!profile.is_claimed && !requiresVerifiedOwnership}
         claimFooterHref={`/${encodeURIComponent(artist.handle)}/claim?next=auth`}
         profileSettings={{
           showOldReleases: profileSettings.showOldReleases === true,
@@ -426,7 +490,7 @@ async function ArtistPageContent({
 }
 
 export default async function ArtistPage({ params }: Readonly<Props>) {
-  const { username } = await params;
+  const { username, __profileMode: initialMode = 'profile' } = await params;
   assertValidProfileUsername(username);
 
   // Resolve a missing/private profile before the page-level Suspense boundary
@@ -442,7 +506,11 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
 
   return (
     <Suspense fallback={<ProfileLoading />}>
-      <ArtistPageContent username={username} profileResult={profileResult} />
+      <ArtistPageContent
+        initialMode={initialMode}
+        username={username}
+        profileResult={profileResult}
+      />
     </Suspense>
   );
 }

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -279,8 +279,9 @@ async function ArtistPageContent({
 
   // Convert our profile data to the Artist type expected by components
   const artist = convertCreatorProfileToArtist(profile);
+  const isClaimed = creatorClerkId !== null;
   const requiresVerifiedOwnership =
-    !profile.is_claimed && isUnclaimedStructuredCreditProfile(profile.settings);
+    !isClaimed && isUnclaimedStructuredCreditProfile(profile.settings);
   const directClaimSupported =
     !requiresVerifiedOwnership &&
     supportsDirectProfileClaim({
@@ -290,7 +291,7 @@ async function ArtistPageContent({
     profile: {
       id: profile.id,
       username: artist.handle,
-      isClaimed: profile.is_claimed,
+      isClaimed,
       userClerkId: creatorClerkId,
       spotifyId: profile.spotify_id,
     },
@@ -447,7 +448,7 @@ async function ArtistPageContent({
             displayName={artist.name}
             directClaimSupported={directClaimSupported}
             claimRequiresVerification={requiresVerifiedOwnership}
-            isClaimed={profile.is_claimed}
+            isClaimed={isClaimed}
             visitorState={visitorState}
           />
         }
@@ -465,7 +466,7 @@ async function ArtistPageContent({
         visitTrackingToken={visitTrackingToken}
         showSubscriptionConfirmedBanner={!isPublicNoAuthSmoke}
         showShopButton={isShopEnabled(profileSettings)}
-        showClaimFooter={!profile.is_claimed && !requiresVerifiedOwnership}
+        showClaimFooter={!isClaimed && !requiresVerifiedOwnership}
         claimFooterHref={`/${encodeURIComponent(artist.handle)}/claim?next=auth`}
         profileSettings={{
           showOldReleases: profileSettings.showOldReleases === true,
@@ -477,7 +478,7 @@ async function ArtistPageContent({
       <ProfileAeoContent
         content={aeoContent}
         claimHref={
-          !profile.is_claimed && directClaimSupported
+          !isClaimed && directClaimSupported
             ? `/${encodeURIComponent(artist.handle)}/claim?next=auth`
             : undefined
         }
@@ -524,7 +525,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   assertValidProfileUsername(username);
 
   const profileResult = await getProfileAndLinks(username);
-  const { profile, genres, status } = profileResult;
+  const { profile, genres, status, creatorClerkId } = profileResult;
 
   if (status === 'error') {
     return PROFILE_ERROR_METADATA;
@@ -534,5 +535,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     notFound();
   }
 
-  return buildPublicProfileMetadata({ profile, genres });
+  return buildPublicProfileMetadata({
+    profile,
+    genres,
+    isClaimed: creatorClerkId !== null,
+  });
 }

--- a/apps/web/components/atoms/SocialIcon.tsx
+++ b/apps/web/components/atoms/SocialIcon.tsx
@@ -291,7 +291,8 @@ const ICON_DATA: Record<string, { hex: string; path: string }> = {
 };
 
 function normalizePlatformKey(platform: string): string {
-  return platform.toLowerCase().replaceAll(/[\s_-]+/g, '');
+  const normalized = platform.toLowerCase().replaceAll(/[\s_-]+/g, '');
+  return normalized === 'netease' ? 'neteasemusic' : normalized;
 }
 
 /**

--- a/apps/web/components/atoms/SocialIcon.tsx
+++ b/apps/web/components/atoms/SocialIcon.tsx
@@ -291,8 +291,7 @@ const ICON_DATA: Record<string, { hex: string; path: string }> = {
 };
 
 function normalizePlatformKey(platform: string): string {
-  const normalized = platform.toLowerCase().replaceAll(/[\s_-]+/g, '');
-  return normalized === 'netease' ? 'neteasemusic' : normalized;
+  return platform.toLowerCase().replaceAll(/[\s_-]+/g, '');
 }
 
 /**

--- a/apps/web/components/features/profile/ClaimBanner.tsx
+++ b/apps/web/components/features/profile/ClaimBanner.tsx
@@ -19,7 +19,7 @@ const COPY: Record<
   { body: string; ctaLabel: string | null }
 > = {
   organic: {
-    body: 'Is this your profile? Claim it with Spotify in about a minute.',
+    body: 'This profile is unclaimed. Is it yours? Claim it with Spotify.',
     ctaLabel: 'Claim Profile',
   },
   claim_intent: {
@@ -31,7 +31,7 @@ const COPY: Record<
     ctaLabel: 'Continue Claim',
   },
   unsupported: {
-    body: 'This profile needs a claim link before it can be claimed.',
+    body: 'This profile is unclaimed. Verified ownership is required before it can be claimed.',
     ctaLabel: null,
   },
 };
@@ -85,7 +85,7 @@ export function ClaimBanner({
           {ctaHref && resolvedCtaLabel ? (
             <Link
               href={ctaHref}
-              className='inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-btn-primary text-btn-primary-foreground font-semibold text-xs sm:text-sm shadow-sm ring-1 ring-subtle hover:opacity-95 transition-opacity focus-ring-transparent-offset'
+              className='inline-flex min-h-11 items-center gap-2 rounded-full bg-btn-primary px-3.5 py-1.5 text-xs font-semibold text-btn-primary-foreground shadow-sm ring-1 ring-subtle transition-opacity hover:opacity-95 focus-ring-transparent-offset sm:text-sm'
               data-testid='claim-banner-cta'
               aria-label={`${resolvedCtaLabel} for ${name}`}
               onClick={() => {

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Badge } from '@/components/atoms/Badge';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
+import { normalizePlatformKey } from '@/lib/dsp-registry';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
 import { publicLinkAriaLabel } from '@/lib/utils/public-url';
 import { EntityMentionText } from './EntityMentionText';
@@ -78,7 +79,11 @@ export function ProfileAeoContent({
                       className='profile-aeo-content__link inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text) focus-visible:ring-offset-2 focus-visible:ring-offset-(--system-b-cinematic-black)'
                     >
                       <SocialIcon
-                        platform={link.platform}
+                        platform={
+                          normalizePlatformKey(link.platform) === 'netease'
+                            ? 'neteasemusic'
+                            : link.platform
+                        }
                         className='h-5 w-5'
                       />
                       <span className='sr-only'>

--- a/apps/web/components/features/profile/ProfileAeoContent.tsx
+++ b/apps/web/components/features/profile/ProfileAeoContent.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import { Badge } from '@/components/atoms/Badge';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { ProfileAboutShare } from '@/features/profile/ProfileAboutShare';
 import type { ProfileAeoContent as ProfileAeoContentModel } from '@/lib/profile/aeo-content';
@@ -38,16 +39,24 @@ export function ProfileAeoContent({
 
           {content.facts.length > 0 ? (
             <dl
-              className='profile-aeo-content__facts flex flex-col gap-3 border-y py-4 sm:flex-row sm:flex-wrap sm:gap-x-10 sm:gap-y-4'
+              className='profile-aeo-content__facts grid grid-cols-2 gap-2 border-y py-4 sm:grid-cols-3 sm:gap-3 lg:grid-cols-2'
               data-testid='profile-about-facts'
             >
               {content.facts.map(fact => (
-                <div key={fact.label} className='space-y-1'>
+                <div key={fact.label} className='min-w-0 space-y-1.5'>
                   <dt className='profile-aeo-content__fact-label text-xs font-medium'>
                     {fact.label}
                   </dt>
-                  <dd className='profile-aeo-content__fact-value text-mid font-medium'>
-                    {fact.value}
+                  <dd className='min-w-0'>
+                    <Badge
+                      variant='outline'
+                      size='md'
+                      className='profile-aeo-content__fact-value w-full max-w-full justify-start border-(--profile-aeo-border) bg-transparent sm:w-auto'
+                    >
+                      <span className='min-w-0 truncate' title={fact.value}>
+                        {fact.value}
+                      </span>
+                    </Badge>
                   </dd>
                 </div>
               ))}
@@ -66,13 +75,16 @@ export function ProfileAeoContent({
                       href={link.url}
                       target='_blank'
                       rel='noopener noreferrer'
-                      className='profile-aeo-content__link inline-flex min-h-11 items-center gap-2 text-sm font-medium transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text)'
+                      className='profile-aeo-content__link inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--profile-aeo-text) focus-visible:ring-offset-2 focus-visible:ring-offset-(--system-b-cinematic-black)'
                     >
                       <SocialIcon
                         platform={link.platform}
-                        className='h-4 w-4'
+                        className='h-5 w-5'
                       />
-                      {link.label}
+                      <span className='sr-only'>
+                        Listen to {content.artistName} on {link.label} (opens in
+                        a new tab)
+                      </span>
                     </a>
                   </li>
                 ))}
@@ -137,7 +149,7 @@ export function ProfileAeoContent({
                   <span aria-hidden='true'> </span>
                   <a
                     href={item.source.href}
-                    className='profile-aeo-content__source inline-flex font-medium underline underline-offset-4 transition-colors duration-subtle'
+                    className='profile-aeo-content__source -my-2.5 inline-flex min-h-11 items-center py-2.5 font-medium underline underline-offset-4 transition-colors duration-subtle'
                   >
                     Source: {item.source.label}
                   </a>
@@ -167,7 +179,7 @@ export function ProfileAeoContent({
 
               <div className='flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between'>
                 <p className='profile-aeo-claim-card__note text-xs font-medium'>
-                  Free · Spotify verified
+                  Free · Claim with Spotify
                 </p>
                 <Link
                   href={claimHref}

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -47,6 +47,7 @@ interface ProfileHomeRailProps {
   readonly previewActionLabel?: string;
   readonly onPlayClick?: () => void;
   readonly onAlertsClick?: (context: NotificationSourceContext) => void;
+  readonly showAlertsCard?: boolean;
   readonly isSubscribed?: boolean;
   readonly profilePacAssignment?: ProfilePacAssignment;
   readonly viewerLocation?: UserLocation | null;
@@ -173,6 +174,7 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
   tourDates = [],
   renderMode = 'interactive',
   onAlertsClick,
+  showAlertsCard = true,
   isSubscribed = false,
   profilePacAssignment = DEFAULT_PROFILE_PAC_ASSIGNMENT,
   viewerLocation,
@@ -358,21 +360,22 @@ export const ProfileHomeRail = memo(function ProfileHomeRail({
     upcomingTourDates[0] ??
     null;
 
-  const alertsCard = isSubscribed ? null : (
-    <HomeAlertsCard
-      artist={artist}
-      onAlertsClick={onAlertsClick}
-      renderMode={renderMode}
-      sourceContext={{
-        artistId: artist.id,
-        profileId: artist.id,
-        profileSlug: artist.handle,
-        currentTab: 'home',
-        ctaLocation: 'home_alerts_card',
-        intent: 'general_alerts',
-      }}
-    />
-  );
+  const alertsCard =
+    !showAlertsCard || isSubscribed ? null : (
+      <HomeAlertsCard
+        artist={artist}
+        onAlertsClick={onAlertsClick}
+        renderMode={renderMode}
+        sourceContext={{
+          artistId: artist.id,
+          profileId: artist.id,
+          profileSlug: artist.handle,
+          currentTab: 'home',
+          ctaLocation: 'home_alerts_card',
+          intent: 'general_alerts',
+        }}
+      />
+    );
 
   // One screen, one primary focus: the carousel IS the home surface. The PAC
   // card is the featured first card; the alerts card is the last card. Both

--- a/apps/web/components/features/profile/StaticArtistPage.tsx
+++ b/apps/web/components/features/profile/StaticArtistPage.tsx
@@ -67,6 +67,8 @@ export function StaticArtistPage({
   showBackButton,
   showTourButton,
   showFooter,
+  profileBanner,
+  allowFanCapture = true,
   latestRelease,
   enableDynamicEngagement = false,
   subscribeTwoStep = false,
@@ -151,6 +153,8 @@ export function StaticArtistPage({
       merchCards={viewModel.merchCards}
       hideJovieBranding={hideJovieBranding}
       hideMoreMenu={hideMoreMenu}
+      profileBanner={profileBanner}
+      allowFanCapture={allowFanCapture}
       showClaimFooter={showClaimFooter}
       claimFooterHref={claimFooterHref}
     />

--- a/apps/web/components/features/profile/StaticArtistPage.tsx
+++ b/apps/web/components/features/profile/StaticArtistPage.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { ProfileMode } from '@/features/profile/contracts';
 import type { PublicRelease } from '@/features/profile/releases/types';
 import { ProfileCompactTemplate } from '@/features/profile/templates/ProfileCompactTemplate';
@@ -25,6 +26,10 @@ export interface StaticArtistPageProps {
   readonly showBackButton: boolean;
   readonly showTourButton?: boolean;
   readonly showFooter?: boolean;
+  /** Optional claim-safe banner rendered by the compact shell layer. */
+  readonly profileBanner?: ReactNode;
+  /** Whether fan-capture actions are available for this profile. */
+  readonly allowFanCapture?: boolean;
   readonly enableDynamicEngagement?: boolean;
   readonly latestRelease?: DiscogRelease | null;
   readonly photoDownloadSizes?: AvatarSize[];

--- a/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
@@ -54,6 +54,17 @@ describe('BottomTabBar — tab rendering', () => {
     expect(screen.getByRole('button', { name: 'Alerts' })).toBeInTheDocument();
   });
 
+  it('omits Alerts when fan capture is unavailable', () => {
+    const { container } = render(
+      <BottomTabBar {...makeProps({ showAlertsTab: false })} />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Alerts' })
+    ).not.toBeInTheDocument();
+    const grid = container.querySelector('[style*="grid-template-columns"]');
+    expect(grid?.getAttribute('style')).toContain('repeat(3,');
+  });
+
   it('does not render a More button', () => {
     render(<BottomTabBar {...makeProps()} />);
     expect(

--- a/apps/web/components/features/profile/nav/BottomTabBar.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.tsx
@@ -76,6 +76,9 @@ export interface BottomTabBarProps {
   /** Called when the user taps a primary tab. */
   readonly onTabSelect: (mode: ProfilePrimaryTab) => void;
 
+  /** Whether the Alerts destination is available for this profile. */
+  readonly showAlertsTab?: boolean;
+
   /** Optional extra className applied to the outermost wrapper. */
   readonly className?: string;
 }
@@ -99,9 +102,12 @@ export function BottomTabBar({
   hasTourDates: _hasTourDates,
   isMenuOpen = false,
   onTabSelect,
+  showAlertsTab = true,
   className,
 }: BottomTabBarProps) {
-  const visibleTabs = ALL_PRIMARY_TABS;
+  const visibleTabs = showAlertsTab
+    ? ALL_PRIMARY_TABS
+    : ALL_PRIMARY_TABS.filter(tab => tab.mode !== 'subscribe');
   const columnCount = visibleTabs.length;
 
   return (

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -198,6 +198,7 @@ interface ProfileCompactSurfaceProps {
   readonly hideBackButton?: boolean;
   readonly hideJovieBranding?: boolean;
   readonly hideMoreMenu?: boolean;
+  readonly allowFanCapture?: boolean;
   readonly headerSocialLinksOverride?: readonly LegacySocialLink[];
   readonly renderInteractiveOverlays?: boolean;
   readonly renderSemanticHeading?: boolean;
@@ -291,6 +292,7 @@ export function ProfileCompactSurface({
   dataTestId,
   hideBackButton = false,
   hideMoreMenu = false,
+  allowFanCapture = true,
   headerSocialLinksOverride,
   renderInteractiveOverlays = true,
   renderSemanticHeading = true,
@@ -328,7 +330,10 @@ export function ProfileCompactSurface({
     drawerView,
   });
   const hasTourDates = tourDates.length > 0;
-  const activeVisiblePrimaryTab = activePrimaryTab;
+  const activeVisiblePrimaryTab =
+    !allowFanCapture && activePrimaryTab === 'subscribe'
+      ? 'profile'
+      : activePrimaryTab;
   const currentAnalyticsTab = mapPrimaryTabToAnalyticsTab(
     activeVisiblePrimaryTab
   );
@@ -528,7 +533,9 @@ export function ProfileCompactSurface({
   );
   const homeAlertsSubscribed = isSubscribed || showRecentActivationRow;
   const shouldRenderInteractiveOverlays =
-    renderMode === 'interactive' && renderInteractiveOverlays;
+    renderMode === 'interactive' &&
+    renderInteractiveOverlays &&
+    allowFanCapture;
   const homeLatestRelease =
     latestRelease ?? toHomeLatestRelease(getNewestPublicRelease(releases));
   const homeProfileSettings = homeLatestRelease
@@ -833,6 +840,7 @@ export function ProfileCompactSurface({
                 renderMode={renderMode}
                 onPlayClick={onPlayClick}
                 onAlertsClick={openNotifications}
+                showAlertsCard={allowFanCapture}
                 isSubscribed={homeAlertsSubscribed}
                 profilePacAssignment={profilePacAssignment}
                 viewerLocation={viewerLocation}
@@ -881,6 +889,7 @@ export function ProfileCompactSurface({
               }
               hasTourDates={hasTourDates}
               isMenuOpen={isMenuActive}
+              showAlertsTab={allowFanCapture}
               onTabSelect={handleTabSelect}
             />
           ) : null}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -2,6 +2,7 @@
 
 import {
   type CSSProperties,
+  type ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -88,6 +89,8 @@ interface ProfileCompactTemplateProps {
   readonly merchCards?: readonly PublicMerchCard[];
   readonly hideJovieBranding?: boolean;
   readonly hideMoreMenu?: boolean;
+  readonly profileBanner?: ReactNode;
+  readonly allowFanCapture?: boolean;
   readonly visualVariant?: 'default';
   /** Desktop spare-space claim footer (JOV-3544). */
   readonly showClaimFooter?: boolean;
@@ -230,6 +233,8 @@ export function ProfileCompactTemplate({
   merchCards = [],
   hideJovieBranding = false,
   hideMoreMenu = false,
+  profileBanner,
+  allowFanCapture = true,
   visualVariant = 'default',
   showClaimFooter = false,
   claimFooterHref = null,
@@ -771,64 +776,72 @@ export function ProfileCompactTemplate({
             className='public-profile-compact-shell relative flex h-full min-w-0 w-full flex-col overflow-hidden bg-(--profile-content-bg) md:mx-auto md:rounded-(--profile-shell-card-radius) md:border md:border-(--profile-panel-border) md:shadow-(--profile-panel-shadow)'
             data-testid='profile-compact-shell'
           >
-            <ProfileCompactSurface
-              renderMode='interactive'
-              presentation={drawerPresentation}
-              artist={artist}
-              socialLinks={socialLinks}
-              contacts={contacts}
-              showPayButton={showPayButton}
-              latestRelease={latestRelease}
-              profileSettings={profileSettings}
-              featuredPlaylistFallback={featuredPlaylistFallback}
-              enableDynamicEngagement={enableDynamicEngagement}
-              subscribeTwoStep={subscribeTwoStep}
-              alertOptInVariant={resolvedAlertOptInVariant}
-              profilePacAssignment={resolvedProfilePacAssignment}
-              genres={genres}
-              pressPhotos={pressPhotos}
-              allowPhotoDownloads={allowPhotoDownloads}
-              photoDownloadSizes={photoDownloadSizes}
-              tourDates={tourDates}
-              showSubscriptionConfirmedBanner={showSubscriptionConfirmedBanner}
-              viewerCountryCode={viewerCountryCode}
-              merchCards={merchCards}
-              hideJovieBranding={hideJovieBranding}
-              hideMoreMenu={hideMoreMenu}
-              renderInteractiveOverlays
-              renderSemanticHeading={!isDesktopLayout}
-              drawerOpen={drawerOpen}
-              drawerView={drawerView}
-              activeMode={requestedMode}
-              onModeSelect={nextMode => {
-                clearCloseResetTimer();
-                setRequestedMode(nextMode);
-              }}
-              onDrawerOpenChange={handleDrawerOpenChange}
-              onDrawerViewChange={handleDrawerViewChange}
-              onBack={handleBack}
-              onOpenMenu={() => openDrawerMode('menu')}
-              onPlayClick={handlePlayClick}
-              onShare={handleShare}
-              profileHref={profileHref}
-              artistProfilesHref={APP_ROUTES.ARTIST_PROFILES}
-              isSubscribed={isSubscribed}
-              contentPrefs={contentPrefs}
-              onTogglePref={handleTogglePref}
-              onUnsubscribe={handleUnsubscribe}
-              isUnsubscribing={unsubMutation.isPending}
-              onManageNotifications={() => {
-                clearCloseResetTimer();
-                setRequestedMode('subscribe');
-              }}
-              onRegisterReveal={fn => {
-                revealNotificationsRef.current = fn;
-              }}
-              onRevealNotifications={() => {
-                revealNotificationsRef.current?.();
-              }}
-              releases={releases}
-            />
+            {profileBanner ? (
+              <div className='shrink-0'>{profileBanner}</div>
+            ) : null}
+            <div className='relative min-h-0 flex-1'>
+              <ProfileCompactSurface
+                renderMode='interactive'
+                presentation={drawerPresentation}
+                artist={artist}
+                socialLinks={socialLinks}
+                contacts={contacts}
+                showPayButton={showPayButton}
+                latestRelease={latestRelease}
+                profileSettings={profileSettings}
+                featuredPlaylistFallback={featuredPlaylistFallback}
+                enableDynamicEngagement={enableDynamicEngagement}
+                subscribeTwoStep={subscribeTwoStep}
+                alertOptInVariant={resolvedAlertOptInVariant}
+                profilePacAssignment={resolvedProfilePacAssignment}
+                genres={genres}
+                pressPhotos={pressPhotos}
+                allowPhotoDownloads={allowPhotoDownloads}
+                photoDownloadSizes={photoDownloadSizes}
+                tourDates={tourDates}
+                showSubscriptionConfirmedBanner={
+                  showSubscriptionConfirmedBanner
+                }
+                viewerCountryCode={viewerCountryCode}
+                merchCards={merchCards}
+                hideJovieBranding={hideJovieBranding}
+                hideMoreMenu={hideMoreMenu}
+                allowFanCapture={allowFanCapture}
+                renderInteractiveOverlays
+                renderSemanticHeading={!isDesktopLayout}
+                drawerOpen={drawerOpen}
+                drawerView={drawerView}
+                activeMode={requestedMode}
+                onModeSelect={nextMode => {
+                  clearCloseResetTimer();
+                  setRequestedMode(nextMode);
+                }}
+                onDrawerOpenChange={handleDrawerOpenChange}
+                onDrawerViewChange={handleDrawerViewChange}
+                onBack={handleBack}
+                onOpenMenu={() => openDrawerMode('menu')}
+                onPlayClick={handlePlayClick}
+                onShare={handleShare}
+                profileHref={profileHref}
+                artistProfilesHref={APP_ROUTES.ARTIST_PROFILES}
+                isSubscribed={isSubscribed}
+                contentPrefs={contentPrefs}
+                onTogglePref={handleTogglePref}
+                onUnsubscribe={handleUnsubscribe}
+                isUnsubscribing={unsubMutation.isPending}
+                onManageNotifications={() => {
+                  clearCloseResetTimer();
+                  setRequestedMode('subscribe');
+                }}
+                onRegisterReveal={fn => {
+                  revealNotificationsRef.current = fn;
+                }}
+                onRevealNotifications={() => {
+                  revealNotificationsRef.current?.();
+                }}
+                releases={releases}
+              />
+            </div>
           </div>
         }
       />

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -1,5 +1,6 @@
 import { BASE_URL } from '@/constants/app';
 import type { PublicRelease } from '@/features/profile/releases/types';
+import type { StructuredReleaseCollaborator } from '@/lib/discography/artist-queries';
 import {
   getRegistryEntry,
   isDspPlatform,
@@ -73,6 +74,8 @@ export interface BuildProfileAeoContentInput {
   readonly tourDates?: readonly TourDateViewModel[];
   readonly merchCards?: readonly PublicMerchCard[];
   readonly socialLinks?: readonly LegacySocialLink[];
+  /** Exact release-credit edges; never derived from prose or artistNames. */
+  readonly releaseCollaborators?: readonly StructuredReleaseCollaborator[];
   /**
    * Linkable entities for this profile (own releases with slugs, credited
    * artists resolved to Jovie handles). When omitted, descriptions render
@@ -215,26 +218,6 @@ function formatTourLocation(tourDate: TourDateViewModel): string {
   return location ? `${tourDate.venueName} in ${location}` : tourDate.venueName;
 }
 
-function sameArtistName(left: string, right: string): boolean {
-  return left.trim().toLowerCase() === right.trim().toLowerCase();
-}
-
-function getCollaborators(params: {
-  readonly artistName: string;
-  readonly artistHandle: string;
-  readonly releases: readonly PublicRelease[];
-}): string[] {
-  return dedupeStrings(
-    params.releases.flatMap(release => release.artistNames ?? [])
-  )
-    .filter(
-      name =>
-        !sameArtistName(name, params.artistName) &&
-        !sameArtistName(name, params.artistHandle)
-    )
-    .slice(0, 4);
-}
-
 function getUniqueGenres(
   artist: Artist,
   genres: readonly string[] | null | undefined
@@ -373,7 +356,6 @@ function buildDescription(params: {
   readonly releases: readonly PublicRelease[];
   readonly tourDates: readonly TourDateViewModel[];
   readonly merchCards: readonly PublicMerchCard[];
-  readonly collaborators: readonly string[];
   readonly now: Date;
 }): string[] {
   const {
@@ -383,7 +365,6 @@ function buildDescription(params: {
     releases,
     tourDates,
     merchCards,
-    collaborators,
     now,
   } = params;
   const origin = getOrigin(artist);
@@ -431,27 +412,6 @@ function buildDescription(params: {
     description.push(`Profile highlights: ${trimSentence(highlights)}`);
   }
 
-  if (collaborators.length > 0) {
-    const creditReleases = releases
-      .filter(release =>
-        (release.artistNames ?? []).some(
-          name =>
-            !sameArtistName(name, artist.name) &&
-            !sameArtistName(name, artist.handle)
-        )
-      )
-      .slice(0, 2)
-      .map(release => release.title)
-      .filter(Boolean);
-    const releaseContext =
-      creditReleases.length > 0
-        ? ` on ${formatList(creditReleases.map(title => `"${title}"`))}`
-        : '';
-    description.push(
-      `Collaborators credited${releaseContext} include ${formatList(collaborators)}.`
-    );
-  }
-
   const targetPlaylists = dedupeStrings(artist.target_playlists ?? []).slice(
     0,
     3
@@ -463,6 +423,94 @@ function buildDescription(params: {
   }
 
   return description;
+}
+
+interface StructuredCollaboratorParagraph {
+  readonly text: string;
+  readonly segments: readonly EntityMentionSegment[];
+}
+
+function buildStructuredCollaboratorParagraph(
+  artistHandle: string,
+  collaborators: readonly StructuredReleaseCollaborator[]
+): StructuredCollaboratorParagraph | null {
+  const grouped = new Map<
+    string,
+    {
+      name: string;
+      href: string | null;
+      releases: Array<{ id: string; title: string; slug: string }>;
+    }
+  >();
+
+  for (const collaborator of collaborators) {
+    const name = cleanText(collaborator.name);
+    const releaseTitle = cleanText(collaborator.releaseTitle);
+    const releaseSlug = cleanText(collaborator.releaseSlug);
+    if (!name || !releaseTitle || !releaseSlug) continue;
+
+    const existing = grouped.get(collaborator.artistId) ?? {
+      name,
+      href: collaborator.href,
+      releases: [],
+    };
+    if (
+      !existing.releases.some(release => release.id === collaborator.releaseId)
+    ) {
+      existing.releases.push({
+        id: collaborator.releaseId,
+        title: releaseTitle,
+        slug: releaseSlug,
+      });
+    }
+    grouped.set(collaborator.artistId, existing);
+    if (grouped.size >= 4) break;
+  }
+
+  const entries = [...grouped.values()];
+  if (entries.length === 0) return null;
+
+  const segments: EntityMentionSegment[] = [
+    { type: 'text', text: 'Collaborators credited include ' },
+  ];
+
+  entries.forEach((entry, entryIndex) => {
+    if (entryIndex > 0) {
+      const separator =
+        entryIndex === entries.length - 1
+          ? entries.length === 2
+            ? ' and '
+            : ', and '
+          : ', ';
+      segments.push({ type: 'text', text: separator });
+    }
+
+    segments.push(
+      entry.href
+        ? { type: 'artist', text: entry.name, href: entry.href }
+        : { type: 'text', text: entry.name }
+    );
+    segments.push({ type: 'text', text: ' on ' });
+
+    entry.releases.slice(0, 2).forEach((release, releaseIndex) => {
+      if (releaseIndex > 0) {
+        segments.push({ type: 'text', text: ' and ' });
+      }
+      segments.push({ type: 'text', text: '"' });
+      segments.push({
+        type: 'release',
+        text: release.title,
+        href: profilePath(artistHandle, `/${encodeURIComponent(release.slug)}`),
+      });
+      segments.push({ type: 'text', text: '"' });
+    });
+  });
+
+  segments.push({ type: 'text', text: '.' });
+  return {
+    text: segments.map(segment => segment.text).join(''),
+    segments,
+  };
 }
 
 function buildOriginFaq(artist: Artist): ProfileAeoFaqItem {
@@ -576,15 +624,11 @@ export function buildProfileAeoContent({
   tourDates = [],
   merchCards = [],
   socialLinks = [],
+  releaseCollaborators = [],
   entityMentions,
   now = new Date(),
 }: BuildProfileAeoContentInput): ProfileAeoContent {
   const uniqueGenres = getUniqueGenres(artist, genres);
-  const collaborators = getCollaborators({
-    artistName: artist.name,
-    artistHandle: artist.handle,
-    releases,
-  });
   const { listenLinks, followLinks } = buildLinkSections(artist, socialLinks);
 
   const description = buildDescription({
@@ -594,9 +638,15 @@ export function buildProfileAeoContent({
     releases,
     tourDates,
     merchCards,
-    collaborators,
     now,
   });
+  const collaboratorParagraph = buildStructuredCollaboratorParagraph(
+    artist.handle,
+    releaseCollaborators
+  );
+  if (collaboratorParagraph) {
+    description.push(collaboratorParagraph.text);
+  }
   const mentionContext: EntityMentionContext = entityMentions ?? {
     ownHandle: artist.handle,
   };
@@ -608,8 +658,10 @@ export function buildProfileAeoContent({
     listenLinks,
     followLinks,
     description,
-    descriptionSegments: description.map(paragraph =>
-      linkEntityMentions(paragraph, mentionContext)
+    descriptionSegments: description.map((paragraph, index) =>
+      collaboratorParagraph && index === description.length - 1
+        ? collaboratorParagraph.segments
+        : linkEntityMentions(paragraph, mentionContext)
     ),
     faqs: [
       buildOriginFaq(artist),

--- a/apps/web/lib/profile/aeo-content.ts
+++ b/apps/web/lib/profile/aeo-content.ts
@@ -476,33 +476,36 @@ function buildStructuredCollaboratorParagraph(
 
   entries.forEach((entry, entryIndex) => {
     if (entryIndex > 0) {
-      const separator =
-        entryIndex === entries.length - 1
-          ? entries.length === 2
-            ? ' and '
-            : ', and '
-          : ', ';
+      let separator = ', ';
+      if (entryIndex === entries.length - 1) {
+        separator = entries.length === 2 ? ' and ' : ', and ';
+      }
       segments.push({ type: 'text', text: separator });
     }
 
     segments.push(
       entry.href
         ? { type: 'artist', text: entry.name, href: entry.href }
-        : { type: 'text', text: entry.name }
+        : { type: 'text', text: entry.name },
+      { type: 'text', text: ' on ' }
     );
-    segments.push({ type: 'text', text: ' on ' });
 
     entry.releases.slice(0, 2).forEach((release, releaseIndex) => {
       if (releaseIndex > 0) {
         segments.push({ type: 'text', text: ' and ' });
       }
-      segments.push({ type: 'text', text: '"' });
-      segments.push({
-        type: 'release',
-        text: release.title,
-        href: profilePath(artistHandle, `/${encodeURIComponent(release.slug)}`),
-      });
-      segments.push({ type: 'text', text: '"' });
+      segments.push(
+        { type: 'text', text: '"' },
+        {
+          type: 'release',
+          text: release.title,
+          href: profilePath(
+            artistHandle,
+            `/${encodeURIComponent(release.slug)}`
+          ),
+        },
+        { type: 'text', text: '"' }
+      );
     });
   });
 

--- a/apps/web/lib/profile/metadata.test.ts
+++ b/apps/web/lib/profile/metadata.test.ts
@@ -344,6 +344,7 @@ describe('buildPublicProfileMetadata', () => {
         },
       },
       genres: null,
+      isClaimed: false,
     });
     const robots = meta.robots as Record<string, unknown>;
     expect(robots).toMatchObject({ index: false, follow: false });

--- a/apps/web/lib/profile/metadata.test.ts
+++ b/apps/web/lib/profile/metadata.test.ts
@@ -226,6 +226,8 @@ describe('buildPublicProfileMetadata', () => {
     location: null,
     avatar_url: null,
     is_verified: false,
+    is_claimed: true,
+    settings: null,
   };
 
   it('returns Metadata with title equal to username when display_name is null', () => {
@@ -321,6 +323,30 @@ describe('buildPublicProfileMetadata', () => {
     });
     const robots = meta.robots as Record<string, unknown>;
     expect(robots?.index).toBe(true);
+  });
+
+  it('sets noindex for an automatic structured-credit profile until claimed', () => {
+    const meta = buildPublicProfileMetadata({
+      profile: {
+        ...minimalProfile,
+        is_claimed: false,
+        settings: {
+          unclaimedArtistProfile: {
+            state: 'unclaimed',
+            source: 'structured_spotify_release_credit',
+            artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+            provider: 'spotify',
+            providerArtistId: 'spotify-austin',
+            ownershipVerified: false,
+            representationVerified: false,
+            consentObtained: false,
+          },
+        },
+      },
+      genres: null,
+    });
+    const robots = meta.robots as Record<string, unknown>;
+    expect(robots).toMatchObject({ index: false, follow: false });
   });
 
   it('includes genre keywords in keywords array', () => {

--- a/apps/web/lib/profile/metadata.test.ts
+++ b/apps/web/lib/profile/metadata.test.ts
@@ -329,7 +329,6 @@ describe('buildPublicProfileMetadata', () => {
     const meta = buildPublicProfileMetadata({
       profile: {
         ...minimalProfile,
-        is_claimed: false,
         settings: {
           unclaimedArtistProfile: {
             state: 'unclaimed',

--- a/apps/web/lib/profile/metadata.ts
+++ b/apps/web/lib/profile/metadata.ts
@@ -18,6 +18,7 @@
 import type { Metadata } from 'next';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import type { CreatorProfile } from '@/types/db';
+import { isUnclaimedStructuredCreditProfile } from './unclaimed-artist-profile';
 
 // ---------------------------------------------------------------------------
 // Sanitization
@@ -158,6 +159,8 @@ export interface PublicProfileMetadataInput {
     | 'location'
     | 'avatar_url'
     | 'is_verified'
+    | 'is_claimed'
+    | 'settings'
   >;
   readonly genres: string[] | null | undefined;
 }
@@ -192,6 +195,9 @@ export function buildPublicProfileMetadata(
     profile.location,
     genres
   );
+  const isStructuredCreditUnclaimed =
+    profile.is_claimed !== true &&
+    isUnclaimedStructuredCreditProfile(profile.settings);
 
   const baseKeywords = [
     artistName,
@@ -218,11 +224,11 @@ export function buildPublicProfileMetadata(
       canonical: canonicalUrl,
     },
     robots: {
-      index: true,
-      follow: true,
+      index: !isStructuredCreditUnclaimed,
+      follow: !isStructuredCreditUnclaimed,
       googleBot: {
-        index: true,
-        follow: true,
+        index: !isStructuredCreditUnclaimed,
+        follow: !isStructuredCreditUnclaimed,
         'max-video-preview': -1,
         'max-image-preview': 'large',
         'max-snippet': -1,

--- a/apps/web/lib/profile/metadata.ts
+++ b/apps/web/lib/profile/metadata.ts
@@ -159,10 +159,11 @@ export interface PublicProfileMetadataInput {
     | 'location'
     | 'avatar_url'
     | 'is_verified'
-    | 'is_claimed'
     | 'settings'
   >;
   readonly genres: string[] | null | undefined;
+  /** Canonical claim state derived from user_profile_claims by the caller. */
+  readonly isClaimed?: boolean;
 }
 
 /**
@@ -178,7 +179,7 @@ export interface PublicProfileMetadataInput {
 export function buildPublicProfileMetadata(
   input: PublicProfileMetadataInput
 ): Metadata {
-  const { profile, genres } = input;
+  const { profile, genres, isClaimed = true } = input;
 
   // Sanitize display_name and username independently so the fallback chain
   // never reintroduces unsanitized artist-provided text into metadata fields.
@@ -196,8 +197,7 @@ export function buildPublicProfileMetadata(
     genres
   );
   const isStructuredCreditUnclaimed =
-    profile.is_claimed !== true &&
-    isUnclaimedStructuredCreditProfile(profile.settings);
+    !isClaimed && isUnclaimedStructuredCreditProfile(profile.settings);
 
   const baseKeywords = [
     artistName,

--- a/apps/web/lib/seo/static-route-manifest.ts
+++ b/apps/web/lib/seo/static-route-manifest.ts
@@ -79,6 +79,7 @@ export const SEO_STATIC_ROUTE_MANIFEST: readonly SeoStaticRouteDefinition[] = [
       buildPublicProfileMetadata({
         profile: PROFILE_FIXTURE,
         genres: ['Pop'],
+        isClaimed: true,
       }),
   },
 ];

--- a/apps/web/tests/components/profile/ClaimBanner.test.tsx
+++ b/apps/web/tests/components/profile/ClaimBanner.test.tsx
@@ -49,13 +49,14 @@ describe('ClaimBanner', () => {
     expect(screen.getByTestId('claim-banner')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Is this your profile? Claim it with Spotify in about a minute.'
+        'This profile is unclaimed. Is it yours? Claim it with Spotify.'
       )
     ).toBeInTheDocument();
     expect(screen.getByTestId('claim-banner-cta')).toHaveAttribute(
       'href',
       '/testartist/claim?next=auth'
     );
+    expect(screen.getByTestId('claim-banner-cta')).toHaveClass('min-h-11');
   });
 
   it('renders the claim-intent copy for token-backed visitors', () => {
@@ -80,7 +81,7 @@ describe('ClaimBanner', () => {
 
     expect(
       screen.getByText(
-        'This profile needs a claim link before it can be claimed.'
+        'This profile is unclaimed. Verified ownership is required before it can be claimed.'
       )
     ).toBeInTheDocument();
     expect(screen.queryByTestId('claim-banner-cta')).not.toBeInTheDocument();

--- a/apps/web/tests/unit/app/[username]/claim/route.test.ts
+++ b/apps/web/tests/unit/app/[username]/claim/route.test.ts
@@ -5,10 +5,14 @@ const {
   mockGetOptionalAuth,
   mockGetProfileByUsername,
   mockReadPendingClaimContext,
+  mockClearPendingClaimContext,
+  mockWritePendingClaimContext,
 } = vi.hoisted(() => ({
   mockGetOptionalAuth: vi.fn(),
   mockGetProfileByUsername: vi.fn(),
   mockReadPendingClaimContext: vi.fn(),
+  mockClearPendingClaimContext: vi.fn(),
+  mockWritePendingClaimContext: vi.fn(),
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -20,9 +24,9 @@ vi.mock('@/lib/auth/cached', () => ({
 }));
 
 vi.mock('@/lib/claim/context', () => ({
-  clearPendingClaimContext: vi.fn(),
+  clearPendingClaimContext: mockClearPendingClaimContext,
   readPendingClaimContext: mockReadPendingClaimContext,
-  writePendingClaimContext: vi.fn(),
+  writePendingClaimContext: mockWritePendingClaimContext,
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -68,6 +72,7 @@ describe('Claim route', () => {
       spotifyId: 'spotify_123',
       spotifyUrl: 'https://open.spotify.com/artist/spotify_123',
       isClaimed: false,
+      settings: {},
     });
   });
 
@@ -110,5 +115,41 @@ describe('Claim route', () => {
     );
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe('http://localhost/');
+  });
+
+  it('does not issue direct-claim proof for an automatic unclaimed profile', async () => {
+    mockGetProfileByUsername.mockResolvedValueOnce({
+      id: 'profile_1',
+      username: 'a_unclaimed',
+      usernameNormalized: 'a_unclaimed',
+      displayName: 'Austin Leeds',
+      spotifyId: 'spotify_123',
+      spotifyUrl: 'https://open.spotify.com/artist/spotify_123',
+      isClaimed: false,
+      settings: {
+        unclaimedArtistProfile: {
+          state: 'unclaimed',
+          source: 'structured_spotify_release_credit',
+          artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+          provider: 'spotify',
+          providerArtistId: 'spotify_123',
+          ownershipVerified: false,
+          representationVerified: false,
+          consentObtained: false,
+        },
+      },
+    });
+
+    const response = await GET(
+      new NextRequest('http://localhost/a_unclaimed/claim?next=auth'),
+      { params: Promise.resolve({ username: 'a_unclaimed' }) }
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/a_unclaimed?claim=unsupported'
+    );
+    expect(mockClearPendingClaimContext).toHaveBeenCalled();
+    expect(mockWritePendingClaimContext).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/app/profile-claim-banner-state.test.ts
+++ b/apps/web/tests/unit/app/profile-claim-banner-state.test.ts
@@ -43,6 +43,20 @@ describe('resolveClaimBannerState', () => {
     });
   });
 
+  it('keeps automatic credit profiles visibly unclaimed without a direct claim', () => {
+    expect(
+      resolveClaimBannerState({
+        visitorState: 'organic_unclaimed',
+        directClaimSupported: false,
+        claimRequiresVerification: true,
+        isClaimed: false,
+      })
+    ).toEqual({
+      claimBannerVariant: 'unsupported',
+      shouldShowClaimBanner: true,
+    });
+  });
+
   it('returns organic for direct-claim-supported public visitors', () => {
     expect(
       resolveClaimBannerState({

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -159,6 +159,26 @@ describe('ProfileHomeRail', () => {
     expect(screen.getAllByText('Never Say A Word')).toHaveLength(1);
   });
 
+  it('omits the alerts card when fan capture is unavailable', () => {
+    render(
+      <ProfileHomeRail
+        artist={makeArtist()}
+        latestRelease={makeRelease()}
+        profileSettings={{ showOldReleases: true }}
+        featuredPlaylistFallback={null}
+        tourDates={[]}
+        hasPlayableDestinations
+        renderMode='preview'
+        isSubscribed={false}
+        showAlertsCard={false}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('profile-home-alerts-fallback-card')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders alerts as the same compact landscape row (no gradient)', () => {
     render(
       <ProfileHomeRail

--- a/apps/web/tests/unit/profile/artist-llms-txt-route.test.ts
+++ b/apps/web/tests/unit/profile/artist-llms-txt-route.test.ts
@@ -35,6 +35,7 @@ const baseProfile = {
   bio: 'Late-night club records.',
   location: 'Los Angeles, CA',
   is_verified: true,
+  is_claimed: true,
   is_public: true,
   active_since_year: 2018,
   spotify_url: 'https://open.spotify.com/artist/test',
@@ -131,6 +132,48 @@ describe('GET /{username}/llms.txt', () => {
     );
     const body = await res.text();
     expect(body).toContain('# DJ Test');
+  });
+
+  it('labels claimed profiles without implying more than the stored verification state', async () => {
+    mockGetProfileAndLinks.mockResolvedValueOnce({
+      profile: baseProfile,
+      links: [],
+      genres: null,
+      latestRelease: null,
+    });
+    const res = await GET(
+      new Request('https://jov.ie/djtest/llms.txt'),
+      makeParams('djtest')
+    );
+    const body = await res.text();
+    expect(body).toContain('claimed artist profile on Jovie');
+    expect(body).toContain('**Claim status**: Claimed');
+    expect(body).toContain('**Jovie verification**: Verified');
+  });
+
+  it('makes unclaimed identity and consent boundaries explicit', async () => {
+    mockGetProfileAndLinks.mockResolvedValueOnce({
+      profile: {
+        ...baseProfile,
+        is_claimed: false,
+        is_verified: false,
+      },
+      links: [],
+      genres: null,
+      latestRelease: null,
+    });
+    const res = await GET(
+      new Request('https://jov.ie/djtest/llms.txt'),
+      makeParams('djtest')
+    );
+    const body = await res.text();
+    expect(body).toContain('unclaimed artist profile on Jovie');
+    expect(body).toContain(
+      'Jovie has not verified ownership, representation, or consent'
+    );
+    expect(body).toContain('**Claim status**: Unclaimed');
+    expect(body).toContain('**Jovie verification**: Not verified');
+    expect(body).not.toContain('official artist profile');
   });
 
   it('includes DSP streaming links from profile columns', async () => {

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ProfileAeoContent } from '@/features/profile/ProfileAeoContent';
+import { projectStructuredReleaseCollaborators } from '@/lib/discography/artist-queries/artist-search';
 import type { PublicMerchCard } from '@/lib/merch/types';
 import {
   buildProfileAeoContent,
@@ -114,6 +115,20 @@ function buildContent(): ProfileAeoContentModel {
         releaseDate: '2025-09-01T00:00:00.000Z',
         artworkUrl: null,
         artistNames: ['DJ Test'],
+      },
+    ],
+    releaseCollaborators: [
+      {
+        artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+        name: 'Guest Vocalist',
+        href: '/artists/f5441adb-6789-449a-9553-ab7460c9c61c',
+        profileState: 'unclaimed',
+        role: 'featured_artist',
+        releaseId: 'release-1',
+        releaseTitle: 'Neon Circuit',
+        releaseSlug: 'neon-circuit',
+        releaseDate: new Date('2026-05-01T00:00:00.000Z'),
+        position: 1,
       },
     ],
     tourDates,
@@ -380,16 +395,36 @@ describe('Profile AEO content', () => {
     expect(facts).toHaveTextContent('Active Since');
     expect(facts).toHaveTextContent('Hometown');
     expect(facts).toHaveTextContent('Based In');
+    expect(facts.querySelectorAll('dt')).toHaveLength(4);
+    expect(facts.querySelectorAll('dd')).toHaveLength(4);
+    for (const definition of facts.querySelectorAll('dd')) {
+      expect(definition.firstElementChild).toHaveClass(
+        'profile-aeo-content__fact-value'
+      );
+    }
 
     const listen = screen.getByTestId('profile-about-listen');
     expect(listen).toBeVisible();
-    const spotifyLink = screen.getByRole('link', { name: 'Spotify' });
+    const spotifyLink = screen.getByRole('link', {
+      name: 'Listen to DJ Test on Spotify (opens in a new tab)',
+    });
     expect(spotifyLink).toHaveAttribute(
       'href',
       'https://open.spotify.com/artist/test'
     );
     expect(spotifyLink).toHaveAttribute('target', '_blank');
     expect(spotifyLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(spotifyLink).toHaveClass('h-11', 'w-11');
+    expect(spotifyLink).not.toHaveTextContent(/^Spotify$/);
+
+    const appleMusicLink = screen.getByRole('link', {
+      name: 'Listen to DJ Test on Apple Music (opens in a new tab)',
+    });
+    expect(appleMusicLink).toHaveAttribute(
+      'href',
+      'https://music.apple.com/artist/test'
+    );
+    expect(appleMusicLink).toHaveClass('h-11', 'w-11');
 
     const follow = screen.getByTestId('profile-about-follow');
     expect(follow).toBeVisible();
@@ -398,6 +433,87 @@ describe('Profile AEO content', () => {
     ).toHaveAttribute('href', 'https://instagram.com/djtest');
 
     expect(screen.getByTestId('profile-about-share')).toBeVisible();
+  });
+
+  it('keeps every canonical music service icon-only, named, and 44px', () => {
+    const services = [
+      ['soundcloud', 'SoundCloud', 'https://soundcloud.com/dj-test'],
+      ['spotify', 'Spotify', 'https://open.spotify.com/artist/test'],
+      ['apple_music', 'Apple Music', 'https://music.apple.com/artist/test'],
+      [
+        'youtube_music',
+        'YouTube Music',
+        'https://music.youtube.com/channel/test',
+      ],
+      ['amazon_music', 'Amazon Music', 'https://music.amazon.com/artists/test'],
+      ['tidal', 'Tidal', 'https://tidal.com/browse/artist/test'],
+      ['deezer', 'Deezer', 'https://www.deezer.com/artist/test'],
+      ['netease', 'NetEase Music', 'https://music.163.com/artist?id=1'],
+      ['qq_music', 'QQ Music', 'https://y.qq.com/n/ryqq/singer/test'],
+    ] as const;
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        spotify_url: undefined,
+        apple_music_url: undefined,
+        youtube_url: undefined,
+      },
+      socialLinks: services.map(([platform, , url], index) => ({
+        id: `service-${index}`,
+        artist_id: baseArtist.id,
+        platform,
+        url,
+        clicks: 0,
+        created_at: '2024-01-01T00:00:00.000Z',
+      })),
+      now,
+    });
+
+    expect(content.listenLinks.map(link => link.label)).toEqual(
+      services.map(([, label]) => label)
+    );
+
+    render(<ProfileAeoContent content={content} />);
+
+    for (const [, label, url] of services) {
+      const accessibleName = `Listen to DJ Test on ${label} (opens in a new tab)`;
+      const link = screen.getByRole('link', { name: accessibleName });
+      expect(link).toHaveAttribute('href', url);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(link).toHaveClass('h-11', 'w-11');
+      expect(link.querySelector('.sr-only')).toHaveTextContent(accessibleName);
+      expect(link.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+      expect(link.querySelector('svg')).toHaveAttribute('fill', 'currentColor');
+    }
+  });
+
+  it('keeps long localized fact values inside the semantic badge grid', () => {
+    const longLocation =
+      '東京都渋谷区神宮前・Berlin Kreuzberg・مدينة لوس أنجلوس الطويلة';
+    const content = buildProfileAeoContent({
+      artist: {
+        ...baseArtist,
+        hometown: longLocation,
+        location: null,
+      },
+      genres: ['música electrónica experimental de larga duración'],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+
+    const facts = screen.getByTestId('profile-about-facts');
+    const locationValue = screen.getByTitle(longLocation);
+    expect(facts.tagName).toBe('DL');
+    expect(facts).toHaveClass(
+      'grid-cols-2',
+      'sm:grid-cols-3',
+      'lg:grid-cols-2'
+    );
+    expect(locationValue.parentElement).toHaveClass('max-w-full');
+    expect(locationValue).toHaveClass('min-w-0', 'truncate');
+    expect(locationValue.closest('dd')).not.toBeNull();
   });
 
   it('hides the facts, listen, and follow sections when there is no data', () => {
@@ -491,14 +607,19 @@ describe('Profile AEO content', () => {
       screen.getByRole('heading', { name: 'About DJ Test' })
     ).toBeVisible();
     expect(screen.getByText('Where is DJ Test from?')).toBeVisible();
-    expect(
-      screen.getByRole('link', { name: 'Source: Jovie release page' })
-    ).toHaveAttribute('href', '/dj-test/neon-circuit');
+    const releaseSource = screen.getByRole('link', {
+      name: 'Source: Jovie release page',
+    });
+    expect(releaseSource).toHaveAttribute('href', '/dj-test/neon-circuit');
+    expect(releaseSource).toHaveClass('min-h-11');
 
     const html = renderToStaticMarkup(<ProfileAeoContent content={content} />);
     expect(html).toContain('data-testid="profile-aeo-content"');
     expect(html).toContain('Where can I buy DJ Test merch?');
     expect(html).toContain('Source: Official merch card');
+    expect(
+      screen.getByRole('link', { name: 'Guest Vocalist' })
+    ).toHaveAttribute('href', '/artists/f5441adb-6789-449a-9553-ab7460c9c61c');
   });
 
   it('links entity mentions in the description while keeping plain-text paragraphs', () => {
@@ -566,8 +687,167 @@ describe('Profile AEO content', () => {
     }
   });
 
+  it('builds collaborator prose directly from exact release-credit edges', () => {
+    const creditRows = [
+      {
+        artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+        name: 'Austin Leeds',
+        releaseId: '353a7c04-b5bb-486e-996d-d23caced7f93',
+        releaseTitle: 'Take Me Over (Austin Leeds Remix)',
+        releaseSlug: 'take-me-over-austin-leeds-remix',
+      },
+      {
+        artistId: '3cefe948-7521-465f-813a-95ae15e3141e',
+        name: 'Vigel',
+        releaseId: 'b01379fe-be8f-498e-86b5-888509c2f907',
+        releaseTitle: 'Seaside Heights',
+        releaseSlug: 'seaside-heights-3',
+      },
+      {
+        artistId: '137bafa6-46b7-4c5c-a08c-654875a694bf',
+        name: 'Lynx',
+        releaseId: '7f2f25b8-bad3-4096-a754-288645b8ab67',
+        releaseTitle: 'Wheels Up',
+        releaseSlug: 'wheels-up',
+      },
+      {
+        artistId: '3836027a-8351-4c0b-8922-c3259387bbf8',
+        name: 'Bowles',
+        releaseId: '86360da0-e045-44a0-9fee-45041b09e7b0',
+        releaseTitle: 'The Sound',
+        releaseSlug: 'the-sound',
+      },
+    ].map((credit, position) => ({
+      ...credit,
+      artistName: credit.name,
+      artistSpotifyId: `spotify-collaborator-${position}`,
+      artistProfileId: `profile-collaborator-${position}`,
+      profileIsPublic: true,
+      profileIsClaimed: false,
+      creditName: null,
+      role: 'main_artist' as const,
+      releaseDate: new Date(`2026-0${position + 1}-01T00:00:00.000Z`),
+      position,
+    }));
+    const credits = projectStructuredReleaseCollaborators({
+      creatorProfileId: 'owner-profile',
+      ownerSpotifyId: 'spotify-owner',
+      rows: creditRows,
+      limit: 4,
+    });
+
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      releaseCollaborators: credits,
+      now,
+    });
+    const paragraph = content.description.at(-1);
+
+    expect(paragraph).toBe(
+      'Collaborators credited include Austin Leeds on "Take Me Over (Austin Leeds Remix)", Vigel on "Seaside Heights", Lynx on "Wheels Up", and Bowles on "The Sound".'
+    );
+    expect(paragraph).not.toContain(
+      'Lynx on "Take Me Over (Austin Leeds Remix)"'
+    );
+    expect(paragraph).not.toContain('Bowles on "Seaside Heights"');
+
+    const segments = content.descriptionSegments.at(-1) ?? [];
+    for (const credit of credits) {
+      expect(segments).toContainEqual({
+        type: 'artist',
+        text: credit.name,
+        href: credit.href,
+      });
+      expect(segments).toContainEqual({
+        type: 'release',
+        text: credit.releaseTitle,
+        href: `/dj-test/${credit.releaseSlug}`,
+      });
+    }
+  });
+
+  it('keeps same-name collaborators distinct by stable artist ID', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      releaseCollaborators: [
+        {
+          artistId: '57d7fa47-5df1-40d9-b32c-c6e0e76ae024',
+          name: 'Alex Lee',
+          href: '/artists/57d7fa47-5df1-40d9-b32c-c6e0e76ae024',
+          profileState: 'claimed',
+          role: 'featured_artist',
+          releaseId: 'release-alex-one',
+          releaseTitle: 'Northbound',
+          releaseSlug: 'northbound',
+          releaseDate: now,
+          position: 1,
+        },
+        {
+          artistId: 'e061a679-466c-465a-a545-64a7e39aa3c6',
+          name: 'Alex Lee',
+          href: '/artists/e061a679-466c-465a-a545-64a7e39aa3c6',
+          profileState: 'unclaimed',
+          role: 'main_artist',
+          releaseId: 'release-alex-two',
+          releaseTitle: 'Southbound',
+          releaseSlug: 'southbound',
+          releaseDate: now,
+          position: 0,
+        },
+      ],
+      now,
+    });
+
+    const artistSegments = (content.descriptionSegments.at(-1) ?? []).filter(
+      segment => segment.type === 'artist'
+    );
+    expect(artistSegments).toEqual([
+      {
+        type: 'artist',
+        text: 'Alex Lee',
+        href: '/artists/57d7fa47-5df1-40d9-b32c-c6e0e76ae024',
+      },
+      {
+        type: 'artist',
+        text: 'Alex Lee',
+        href: '/artists/e061a679-466c-465a-a545-64a7e39aa3c6',
+      },
+    ]);
+  });
+
+  it('renders unavailable or private collaborator identities as plain text', () => {
+    const content = buildProfileAeoContent({
+      artist: baseArtist,
+      releaseCollaborators: [
+        {
+          artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+          name: 'Private Artist',
+          href: null,
+          profileState: 'unavailable',
+          role: 'featured_artist',
+          releaseId: '353a7c04-b5bb-486e-996d-d23caced7f93',
+          releaseTitle: 'Quiet Signal',
+          releaseSlug: 'quiet-signal',
+          releaseDate: now,
+          position: 1,
+        },
+      ],
+      now,
+    });
+
+    render(<ProfileAeoContent content={content} />);
+    expect(screen.getByTestId('profile-aeo-content')).toHaveTextContent(
+      'Private Artist'
+    );
+    expect(screen.queryByRole('link', { name: 'Private Artist' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'Quiet Signal' })).toHaveAttribute(
+      'href',
+      '/dj-test/quiet-signal'
+    );
+  });
+
   it('defaults to plain-text segments when no entity context is provided', () => {
-    const content = buildContent();
+    const content = buildProfileAeoContent({ artist: baseArtist, now });
 
     expect(content.descriptionSegments).toHaveLength(
       content.description.length
@@ -594,7 +874,7 @@ describe('Profile AEO content', () => {
         name: 'jov.ie/you',
       })
     ).toBeVisible();
-    expect(screen.getByText('Free · Spotify verified')).toBeVisible();
+    expect(screen.getByText('Free · Claim with Spotify')).toBeVisible();
     expect(
       screen.getByRole('link', {
         name: 'Claim the DJ Test profile and sign up for Jovie',

--- a/apps/web/tests/unit/profile/public-profile-page.test.ts
+++ b/apps/web/tests/unit/profile/public-profile-page.test.ts
@@ -303,7 +303,7 @@ describe('Public Profile Page Logic', () => {
 
     it('offers the editorial AEO claim card only for unclaimed direct-claim profiles', () => {
       expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
-        '!profile.is_claimed && directClaimSupported'
+        '!isClaimed && directClaimSupported'
       );
       expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain('/claim?next=auth');
     });


### PR DESCRIPTION
## Summary
- expose collaborator credits and structured AEO content from the canonical artist model
- keep unclaimed profiles metadata-safe while presenting a narrow claim path
- carry claim-banner and fan-capture policy through the actual compact renderer
- remove Alerts and subscribe capture affordances when fan capture is not allowed
- retain canonical icon handling at the public projection boundary

## Recovery
This final layer was rebased directly onto current main after PR #15533 merged. Eleven Sonar findings were repaired locally, including complexity, repeated append operations, a deprecated claim field, and staged renderer props that had been ignored.

## Verification
- 192 focused tests passed across metadata, claim routing/state, AEO, public profile, home rail, banner, and bottom navigation
- Biome passed on all 24 changed files
- Node 22.23.1 web typecheck passed
- full repository pre-push gate passed

## Safety
Unclaimed profiles cannot expose fan-capture entry points. No taste approval is asserted by this PR; CI visual review remains advisory evidence and required production/deployment gates remain intact.