### PR TITLE
fix(hermes): bound issue shipper dispatch passes

### DIFF
--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -67,6 +67,7 @@ import {
   routeForAgent,
   type ShipperConfig,
   SpawnEagainError,
+  selectDispatchBatch,
   shouldEscalateRetry,
   worktreeHasWork,
 } from '../lib/codex-issue-shipper';
@@ -1724,6 +1725,8 @@ async function runShipper(): Promise<void> {
       async () => {
         recoverStaleJobs(config);
         let controlLabelsEnsured = false;
+        const attemptedIssueNumbers = new Set<number>();
+        let remainingDispatchBudget = config.maxIssuesPerRun;
 
         for (;;) {
           const openCodexPrCount = countOpenCodexPrs(config);
@@ -1744,7 +1747,12 @@ async function runShipper(): Promise<void> {
             labelNames(issue).includes(EPIC_LABEL)
           ).length;
           const capacity = systemCapacity(config, openCodexPrCount);
-          const batch = plans.slice(0, capacity.allowedAgents);
+          const batch = selectDispatchBatch({
+            plans,
+            attemptedIssueNumbers,
+            capacity: capacity.allowedAgents,
+            remainingBudget: remainingDispatchBudget,
+          });
 
           logJobEvent({
             job: JOB,
@@ -1770,8 +1778,16 @@ async function runShipper(): Promise<void> {
           if (batch.length === 0) {
             logJobEvent({
               job: JOB,
-              event: 'capacity_throttled',
+              event:
+                remainingDispatchBudget === 0 ||
+                plans.every(plan =>
+                  attemptedIssueNumbers.has(plan.issue.number)
+                )
+                  ? 'dispatch_budget_exhausted'
+                  : 'capacity_throttled',
               capacity,
+              attemptedIssueNumbers: [...attemptedIssueNumbers],
+              remainingDispatchBudget,
             });
             return;
           }
@@ -1797,6 +1813,10 @@ async function runShipper(): Promise<void> {
           }
 
           await dispatchBatch(config, batch);
+          for (const plan of batch) {
+            attemptedIssueNumbers.add(plan.issue.number);
+          }
+          remainingDispatchBudget -= batch.length;
         }
       },
       // Machine-global lock: profile-scoped HERMES_HOME must not yield two

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -605,6 +605,20 @@ export function buildDispatchPlans(
   });
 }
 
+export function selectDispatchBatch(args: {
+  readonly plans: ReadonlyArray<DispatchPlan>;
+  readonly attemptedIssueNumbers: ReadonlySet<number>;
+  readonly capacity: number;
+  readonly remainingBudget: number;
+}): ReadonlyArray<DispatchPlan> {
+  const limit = Math.max(0, Math.min(args.capacity, args.remainingBudget));
+  if (limit === 0) return [];
+
+  return args.plans
+    .filter(plan => !args.attemptedIssueNumbers.has(plan.issue.number))
+    .slice(0, limit);
+}
+
 export function buildGbrainCaptureText(issue: GithubIssue): string {
   return [
     `# Codex Issue Shipper Dispatch: GitHub #${issue.number}`,

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -41,6 +41,7 @@ import {
   RETRY_RELEASE_COMMENT_HEADER,
   routeForAgent,
   SpawnEagainError,
+  selectDispatchBatch,
   selectTaskRoute,
   shellQuote,
   shouldEscalateRetry,
@@ -259,6 +260,41 @@ describe('codex issue shipper planner', () => {
 
     expect(plans).toHaveLength(2);
     expect(plans.map(plan => plan.issue.number)).toEqual([1, 2]);
+  });
+
+  it('bounds a run and never retries an issue already attempted in that run', () => {
+    const plans = buildDispatchPlans(
+      [
+        issue({ number: 1, title: 'Fix docs typo' }),
+        issue({ number: 2, title: 'Update README' }),
+      ],
+      config
+    );
+
+    expect(
+      selectDispatchBatch({
+        plans,
+        attemptedIssueNumbers: new Set([1]),
+        capacity: 5,
+        remainingBudget: 1,
+      }).map(plan => plan.issue.number)
+    ).toEqual([2]);
+    expect(
+      selectDispatchBatch({
+        plans,
+        attemptedIssueNumbers: new Set([1, 2]),
+        capacity: 5,
+        remainingBudget: 1,
+      })
+    ).toEqual([]);
+    expect(
+      selectDispatchBatch({
+        plans,
+        attemptedIssueNumbers: new Set(),
+        capacity: 5,
+        remainingBudget: 0,
+      })
+    ).toEqual([]);
   });
 
   it('defaults to grok composer with resource guardrails', () => {


### PR DESCRIPTION
## Incident

The legacy GitHub issue shipper treated `MAX_ISSUES_PER_RUN` as a per-batch limit while its outer retry loop could immediately reclaim the same system-retryable issue. One process repeatedly retried production-controller incidents, creating 286 stale worktree registry entries and 135 comments on #15521.

## Fix

- track every issue number attempted during a process run
- never select the same issue twice in that run
- decrement one process-wide dispatch budget after each batch
- emit an explicit `dispatch_budget_exhausted` receipt before exit
- keep retries, claims, leases, and all existing safety labels fail-closed

## Proof

- 77 focused issue-shipper tests pass, including the new repeat-attempt regression
- Biome and the repository pre-push affected gate pass
- the affected launch agent remains paused with a sentinel until this PR lands and a bounded live run is observed
- Symphony, merge queue, deterministic admission, and production controller remain independent and active

No gate or human-review label is bypassed. This repairs the automation loop that was turning a blocked lane into repeated noise.