### PR TITLE
docs(marketing): codify meaning-first copy workflow

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,6 +151,26 @@ Jovie copy should feel precise, calm, and inevitable.
 - Prefer clarity over warmth when they conflict
 - Prefer usefulness over personality when they conflict
 
+### Meaning Before Media
+
+- Brief the section before writing it: state its job, customer outcome, message
+  subject, visual evidence, and allowed product claims
+- Write the belief the visual must prove, not a caption for the visible object
+- Treat phones, screenshots, annotations, materials, and motion as evidence;
+  never sell the mockup, design treatment, or production process
+- Read only the display headlines in page order. They must form a complete
+  argument in which every line advances a different story beat
+- Reject a headline that could move to another section unchanged or survive an
+  unrelated product-noun swap
+- Cite product evidence for every public claim; compression never licenses an
+  invented implication
+- Bind every visible line to a registered customer outcome, product claim,
+  proof, or action. Brief adjectives and process instructions constrain the
+  work; they are not the message.
+- Use the deterministic gate and adversarial review in
+  [`docs/marketing/AGENT_GUIDE.md`](docs/marketing/AGENT_GUIDE.md#3-lock-meaning-before-writing)
+  before copy enters Taste Inbox
+
 ### Product Copy Rules
 
 - One clear line is better than a headline plus explanatory filler
@@ -184,6 +204,8 @@ The example above says one thing three times. Jovie should say it once.
 ### Anti-Patterns To Avoid
 
 - Generic AI-dashboard styling: oversized rounded cards, visible borders on every container, repeated chrome, and stacked explanatory copy
+- Generic marketing headings that describe the media (`A closer look`, `Built
+  for artists`, `One profile, annotated`) instead of the customer consequence
 - All-caps eyebrows or section labels as a default hierarchy tool
 - Long helper paragraphs inside cards when a short label or one sentence would do
 - Multiple nested surfaces whose only job is to create the feeling of "designed"

--- a/canon/MARKETING.md
+++ b/canon/MARKETING.md
@@ -2,7 +2,7 @@
 
 Status: Canon
 Inherits: [`OPERATING_SYSTEM.md`](./OPERATING_SYSTEM.md)
-Last updated: 2026-07-17
+Last updated: 2026-08-03
 
 Marketing exists to create qualified demand that moves the current company bottleneck.
 
@@ -49,6 +49,15 @@ Unknown means measure first.
 ## Principles
 
 - Specific customer language beats clever copy.
+- Every section starts with the belief it must create and the customer outcome
+  it must make legible. Media is evidence for that message, not the message.
+- Brief/process/style language is never a customer benefit by itself. Every
+  visible line names the registered outcome, verified product claim, proof, or
+  action it serves; semantic role is evaluated in context rather than by
+  brittle word bans.
+- Display headlines must form a connected argument when read without the body
+  copy. A heading that can move between sections unchanged is not specific
+  enough.
 - Observed behavior beats brand preference.
 - Distribution work waits if production/activation is broken.
 - Start with low-risk audiences before high-profile outreach when product stability is uncertain.
@@ -71,10 +80,15 @@ Do not optimize for:
 
 Product defines the value promise. Design makes it legible. Voice makes it clear and truthful. Engineering ensures the promise can be fulfilled.
 
+The executable landing-page copy workflow is in
+[`docs/marketing/AGENT_GUIDE.md`](../docs/marketing/AGENT_GUIDE.md#3-lock-meaning-before-writing).
+
 ---
 
 ## Changelog
 
 | Date | Change | Source |
 |---|---|---|
+| 2026-08-04 | Added outcome-bound semantic guard against prompt/meta-copy leakage; shadow legacy, delta new/changed copy. | Tim White direction |
+| 2026-08-03 | Added meaning-first section intent, headline-story, and evidence rules. | Tim White direction |
 | 2026-07-17 | Created as domain canon under `/canon`. | Tim White |

--- a/docs/artist-profile-copy.md
+++ b/docs/artist-profile-copy.md
@@ -1,156 +1,90 @@
-# Artist Profiles Landing Page Copy
+# Artist Profiles Copy Reference
 
-## Hero
+The live source of truth is
+[`apps/web/data/artistProfileCopy.ts`](../apps/web/data/artistProfileCopy.ts).
+The intent, claim evidence, and audit adapter live in that file too.
 
-- Eyebrow: `Built for artists`
-- Headline: `The link your music deserves.`
-- Subhead: `Streams, drops, support, bookings, and fan capture in a single page.`
-- Primary CTA: `Claim your profile`
-- Signature detail: `jov.ie/you`
-- Top-page proof whisper: `Used by artists on`
+Do not edit this page as a collection of independent slogans. Follow the
+meaning-first workflow in
+[`marketing/AGENT_GUIDE.md`](marketing/AGENT_GUIDE.md#3-lock-meaning-before-writing).
 
-## Adaptive Thesis + Mode Switcher
+## Page argument
 
-### Primary Headline
+Read only the display headlines. Together they should explain why the product
+matters, how it behaves, what the fan can do, and why the artist should claim
+it.
 
-`One profile that adapts to every fan.`
+| Beat | Section job | Live headline |
+| --- | --- | --- |
+| Promise | Establish a music-native destination worth claiming | `Share one music profile everywhere.` |
+| Behavior | Explain that one profile changes its lead action | `Same profile. Different action.` |
+| Consequence | Name the useful action available to each fan | `Fans listen. Show up. Support. Stay close.` |
+| Relationship | Turn a visit into permission to reach the fan again | `Fans opt in. Reach them again.` |
+| Decision | Explain why one contextual action leads | `One action leads. The links follow.` |
+| Proof | Show the product hierarchy the live profile delivers | `Music first. Everything else close.` |
+| Simplicity | State the literal setup sequence | `Claim it. Connect it. Share it.` |
+| Continuity | Make the durable-link consequence memorable | `Same link. Release after release.` |
+| Objections | Answer what remains before the decision | `Before you claim it.` |
+| Action | Close with the action the page has earned | `Free to claim. Yours to share.` |
 
-### Alternate Headlines
+## Supporting copy
 
-- `One profile for every release moment.`
-- `One link, tuned to what matters right now.`
-- `The same link, different job.`
+### Hero
 
-### Supporting Body
+- Body: `New releases and nearby shows can take the lead without changing the profile you share.`
+- Primary action: `Claim your profile`
+- Secondary action: `See It Adapt`
+- Signature: `jov.ie/you`
 
-Before a drop, it becomes a countdown. On release day, it routes fans straight to the right service. On tour, nearby dates come first. At the merch table, one scan can become support and fan capture.
+### Adaptive profile
 
-### Mode Switcher Labels And Copy
+`Before a drop, a countdown can lead. When the music lands, listening takes
+over. On tour, a nearby show can move up. Support stays close.`
 
-- Upcoming Release: `Before a drop, your profile becomes a countdown.`
-- Release Day: `When the song is live, fans go straight to the right service.`
-- Touring: `When you're on the road, nearby dates come first.`
-- Live Support: `At the merch table, one scan becomes support and capture.`
+The four product states are Upcoming Release, Release Day, Touring, and Direct
+Support. Their copy must describe the active product behavior, not the visual
+treatment used to demonstrate it.
 
-## Outcomes Carousel
+### Fan outcomes
 
-### Section Lead
+`Each path starts from one profile, so fans can act without digging through a
+link stack.`
 
-- Headline: `Built around fan outcomes.`
-- Body: `Every state of the profile is designed to reduce friction and move the fan to the next right action.`
+### Permissioned relationship
 
-### Cards
+`With Pro, eligible releases trigger the alert fans asked for.`
 
-- `Straight to listen`
-  Fans land on the right release and the right platform without hunting through a stack of links.
+### One contextual decision
 
-- `Local dates first`
-  Touring fans see the show that matters to them instead of scrolling through cities that do not.
+`A countdown, live release, or nearby show can move ahead of the rest. A
+direct-support link can open from a QR.`
 
-- `Support without friction`
-  When someone is ready to support, the profile turns that moment into action fast.
+### Product truth
 
-- `Capture the fan`
-  A listen, a signup, or a support moment can become a real fan relationship instead of an anonymous click.
+`The current release leads. Listening, shows, support, and updates stay one
+move away.`
 
-- `Keep one link everywhere`
-  Bio, story, flyer, QR code, and release post all point to the same profile.
+### Setup
 
-## Capture Every Fan
+`Start with your artist name and catalog. Leave with one link ready to share.`
 
-- Headline: `Capture every fan, not just the click.`
-- Body: `Fans opt in once. From there, Jovie can keep them close with release alerts and future follow-up. The profile is not just a destination. It is the start of an owned audience.`
+### Durable link
 
-## Opinionated By Design
+`Use it in every bio, story, flyer, and QR. Countdown, listening, nearby
+tickets, and support can take their turn.`
 
-### Headline Options
+### Close
 
-- `Opinionated by design.`
-- `Built to convert, not decorate.`
-- `No template maze.`
+- Headline: `Free to claim. Yours to share.`
+- Action: `Claim your profile`
 
-### Body
+The free-plan FAQ must keep the entitlement boundary explicit: the public
+profile is free with up to 100 fan contacts; Pro adds countdowns, release
+notifications, unlimited contacts, and tips. Contact capture and outbound
+release notifications remain distinct promises.
 
-Jovie is intentionally constrained. No theme builder. No layout rabbit hole. No generic creator-site sprawl. Every profile teaches fans what to tap because the product is built around release moments, show moments, and conversion.
+## Change rule
 
-## Feature / Spec Wall
-
-- Lead: `Built for artists.`
-
-### Tile Copy
-
-- `Fast load`
-  Built to open quickly when attention is thin.
-
-- `Smart routing`
-  Send each fan to the right destination with less friction.
-
-- `Deep-link modes`
-  Listen, tour, support, and subscribe all live behind one profile.
-
-- `Release pages`
-  Each release gets its own clean, shareable destination.
-
-- `Countdowns`
-  Upcoming drops can turn the profile into a pre-release moment.
-
-- `Tour dates`
-  Show nearby dates first and keep ticket intent close.
-
-- `Pay`
-  Turn support moments into action without breaking the flow.
-
-- `Fan capture`
-  Move from anonymous traffic to owned audience.
-
-- `Notifications`
-  Give fans a simple way to stay in the loop.
-
-- `QR sharing`
-  Put one scan on a flyer, merch table, or venue wall.
-
-- `Views, clicks, referrers`
-  Keep a lightweight read on what is working.
-
-## How It Works
-
-- `Claim your profile.`
-  Start with your handle and get the core page live.
-
-- `Connect your music and links.`
-  Import the essentials so the profile reflects your real catalog and surfaces.
-
-- `Share one link everywhere.`
-  Use the same profile in bio, stories, posts, QR, and release campaigns.
-
-## Social Proof
-
-- Default headline: `Built for real artist workflows.`
-- Top-page whisper: `Used by artists on`
-- Lower-section intro: `Real artist profiles. Real release moments.`
-- Artist-proof framing line: `Show real profiles or real quotes. If the proof is not real, do not ship it.`
-- Founder fallback line: `Built from real music-marketing and release workflow experience.`
-
-## FAQ
-
-### How is this different from Linktree?
-
-Linktree is a general-purpose link page. Jovie is built for music release behavior: smart routing, release pages, show moments, support flows, fan capture, and notifications in one profile.
-
-### Can I use this before release day?
-
-Yes. The profile can become a countdown or pre-release surface before the song is live, then switch behavior when release day arrives.
-
-### Can I use it for shows and support?
-
-Yes. Touring, tickets, QR sharing, and support flows all fit inside the same profile instead of living on separate links.
-
-### How long does setup take?
-
-Fast. Claim the profile, connect your music and links, and start sharing one URL.
-
-## Final CTA
-
-- Headline: `Claim your profile.`
-- Body: `One link for every release, show, and fan action.`
-- CTA: `Claim your profile`
+When any display line changes, update this reference in the same change and run
+the meaning-first audit. Supporting copy above is a review snapshot; the typed
+data file remains authoritative.

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -8,11 +8,12 @@ doc-freshness: docs/marketing/AGENT_GUIDE.md
 > This is your SOLE entrypoint. The contract: a composition needs ONLY this
 > file + `apps/web/data/marketing/` (the typed registry). Other docs
 > (`ARCHITECTURE.md`, `SECTION_CATALOG.md`, `RECIPE_CATALOG.md`,
-> `COMPOSITION_RULES.md`) are optional commentary.
+> `COMPOSITION_RULES.md`) are optional commentary. Copy generation follows the
+> typed contract below.
 
 spec-version: 1.0.0 · registry: `apps/web/data/marketing/index.ts`.
 
-## The 3-step procedure
+## The 4-step procedure
 
 ### 1. Receive a Brief
 
@@ -78,7 +79,99 @@ component paths are tagged `wip` and listed in
 
 Local: `pnpm --filter web storybook` → browse the `Marketing/` tree.
 
-### 3. Render the sections
+### 3. Lock meaning before writing
+
+For every rendered section, create a `MarketingCopySectionBrief` before
+generating words. Declare the story beat, section job, customer outcome,
+message subject, visual evidence, allowed claim IDs, meaning signals, and word
+budget.
+
+The customer outcome is a registry record, not a prompt adjective. Every
+visible line (headline, body, label, proof line, and CTA) must declare the
+outcome, verified claim, or concrete action it serves through
+`MarketingCopyLineBinding`. Process/style/audience tokens in a brief constrain
+the writer; they do not become a benefit merely because they appear in the
+brief. A line such as “One concise heading, built for athletes” is a failure:
+it sells the instruction and the wrong audience, not Jovie. The semantic guard
+must pass in delta mode before new or changed copy enters Taste Inbox.
+
+Use shadow mode for untouched legacy pages. Shadow findings are advisory and
+must be counted, not used to block today's unrelated PRs. Delta mode is
+blocking only for the changed sections, after fixture evidence demonstrates an
+acceptable false-positive rate. This is a semantic-role check, not a brittle
+word ban: “adaptive” or “premium” can remain when the sentence is outcome-bound
+and product-truthful.
+Pass `changedSectionIds` to the Taste Inbox producer when a page contains
+untouched legacy sections; never convert those legacy findings into a new-copy
+blocker by accident.
+
+Use `MarketingCopyOutcome` for customer changes and `MarketingCopyAction` for
+real user verbs. Claim IDs remain the product-truth/proof boundary; free-form
+action labels do not satisfy the gate unless their action record is registered
+in the brief.
+
+The message subject and visual evidence are deliberately separate. Write the
+customer belief the section exists to create. Do not caption the phone, card,
+band, screenshot, animation, or other visible object.
+
+Every public promise cites a `MarketingCopyClaim` with direct product or
+verified-data evidence. Then:
+
+1. Generate candidates against the section job and allowed claims.
+2. Compress until every remaining word carries meaning or cadence.
+3. Run `auditMarketingCopyPage(brief, draft)`.
+4. Run `auditMarketingCopySemantics(brief, draft, { enforcement: 'delta' })`.
+   Resolve every `meta-copy`, `brief-parroting`, `style-adjective-substitution`,
+   `audience-product-category-mismatch`, `generic-feature-soup`,
+   `built-for-wrong-noun`, and `headline-layout-copy` finding before review.
+5. Run independent intent, truth, compression, and voice reviews with unique
+   execution receipts across at least two models. Receipts cite every candidate
+   ID and the exact review digest. The digest binds the section brief, claims,
+   evidence, control, and candidate; changing any of them invalidates every
+   receipt. The truth receipt must cover every cited claim ID.
+6. Use `createMarketingCopyTasteInboxItem()` for Tim’s approval. Model
+   agreement cannot promote copy.
+
+The complete visible control and candidate must include every rendered label,
+field state, CTA, and supporting line. Hidden draft fields do not count. An
+`edited` taste decision carries the complete edited copy and must change it.
+Taste decisions carry stable IDs and are applied once. Persisted taste profiles
+reject unknown schema versions, malformed or unsafe counts, and duplicate
+decision receipts; they are never silently coerced.
+
+Compression order: lead with why, delete the introduction, replace abstraction
+with the real action, remove repeated meaning, read aloud, and stop only when
+one more cut would remove meaning or cadence.
+
+Canonical adaptive-profile fixture: `One Profile. For Every Fan.` The supporting
+line must explain the real behavior: show the release, link, or action that
+fits where the fan came from and what they came to do. The heading is allowed
+because it names the customer outcome; it does not describe the profile
+component or the writing brief.
+
+The anti-slop gate rejects artifact-selling, stock promotion (`seamless`,
+`unlock`, `elevate`, `world-class`, `all-in-one`), “not just X,” generic
+`from X to Y`, vague attribution, rhetorical headings, repeated conclusions,
+formulaic threes, chat residue, and em-dash cadence. Run the subject-swap test:
+if an unrelated product noun fits without weakening the line, rewrite it.
+
+Research basis: Apple’s public guidance says to make writing meaningful, clear,
+direct, benefit-led, filler-free, spoken aloud, and reviewed with people. See
+[Design principles](https://developer.apple.com/design/human-interface-guidelines/designing-for-ios),
+[Make a big impact with small writing changes](https://developer.apple.com/videos/play/wwdc2025/340/),
+and [Writing for interfaces](https://developer.apple.com/videos/play/wwdc2022/10037/).
+The slop filter also uses maintained editorial signals from
+[Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
+and Last 30 Days practitioner research: generic sameness, template rhythm,
+invented significance, and prose that outlives its idea.
+
+Typed authority: `apps/web/data/marketing/copy.ts`. The Artist Profiles brief,
+claim evidence, and rendered-copy adapter live with its copy in
+`apps/web/data/artistProfileCopy.ts`. The Taste Inbox producer is live; shared
+consumer ingestion and experiment ranking remain JOV-4796 and must not be
+described as shipped.
+
+### 4. Render the sections
 
 Each `sections[i]` gives you `{sectionId, variantId, ctaPosition, proofVerified,
 degradationRung}`. Look up the section + variant in `MARKETING_SECTIONS`
@@ -280,7 +373,8 @@ are reverse-engineered FROM code, not the reverse.
 - `ARCHITECTURE.md` — master spec + grammar + naming/versioning/precedence/evolution.
 - `SECTION_CATALOG.md` — per-section rationale + exemplar.
 - `RECIPE_CATALOG.md` — per-recipe rationale + arc + decision tree.
-- `COMPOSITION_RULES.md` — composition-rule rationale (7 laws + page-class rules).
+- `COMPOSITION_RULES.md` — composition-rule rationale (9 laws + page-class rules).
+- `AGENT_GUIDE.md` (this file) — meaning-first copy, evidence, panel, Taste
+  Inbox workflow, and sole entrypoint.
 - `DESIGN_GAPS.md` — proposed-section review, conversion workflow, migration matrix.
 - `MODEL_USAGE.md` — model-role and cost evidence ledger.
-- `AGENT_GUIDE.md` (this file) — sole entrypoint.

--- a/docs/marketing/COMPOSITION_RULES.md
+++ b/docs/marketing/COMPOSITION_RULES.md
@@ -10,7 +10,7 @@ doc-freshness: docs/marketing/COMPOSITION_RULES.md
 > `maxContent`), and `composition.ts` (the filter pipeline). This file owns
 > the rationale. Agents: start at [`AGENT_GUIDE.md`](./AGENT_GUIDE.md).
 
-The composition rules cluster into eight laws, each with a reason and a
+The composition rules cluster into nine laws, each with a reason and a
 machine-checkable home.
 
 ## Law 1 — Hero is always first
@@ -147,6 +147,46 @@ accessible figure caption, group name, or meaningful image alt.
 **Home:** `MarketingSurfaceCard`, `MarketingScreenshot`,
 `ProductScreenshotFrame`, `MarketingStoryPrimitives`, screenshot registry, and
 the route's colocated responsive CSS.
+
+## Law 9 — Copy follows intent, not the visible object
+
+Every section declares a story beat, section job, customer outcome, message
+subject, visual evidence, allowed claims, meaning signals, and word budget
+before a model writes copy. The words explain the belief the section must
+create. The media proves that belief. A visible phone, card, interface, device,
+or material is never the default subject of the copy.
+
+Read the page as headlines only. Each line must advance the argument and do a
+different job. If two headings can swap places without changing the story, or
+if an unrelated product noun can replace Jovie's noun, rewrite them.
+
+Public promises cite a typed product claim. Candidates clear deterministic
+anti-slop and compression checks, then independent intent, truth, compression,
+and voice reviews across at least two models. Model agreement is not approval.
+Human taste decides what ships and feeds the next ranking pass.
+
+Instruction leakage is a distinct failure class. Process, style, audience, and
+product-category tokens from a brief may constrain a candidate, but cannot
+become the candidate's benefit by repetition. Every visible line declares its
+outcome/claim/action binding. The semantic guard catches meta-copy, prompt
+parroting, style-adjective substitution, audience/product mismatch,
+feature-soup, a wrong “built for X” noun, and headlines about layout or copy.
+It evaluates role and context rather than banning words: “adaptive” and
+“premium” can pass in outcome-bound body copy.
+
+Legacy pages run this guard in shadow mode so findings can be quantified without
+turning old debt into a surprise blocker. New or changed sections use delta
+mode, which is blocking only after the fixture suite demonstrates acceptable
+false-positive behavior. `createMarketingCopyTasteInboxItem` uses the delta
+path; the review digest includes the outcome registry, instruction tokens, and
+line bindings.
+
+**Reason:** visual-caption copy is usually accurate and strategically useless.
+Meaning-first briefs stop a model from mistaking the evidence for the message,
+while claim citations keep memorable lines inside product truth.
+
+**Home:** `apps/web/data/marketing/copy.ts` and the copy workflow in
+[`AGENT_GUIDE.md`](./AGENT_GUIDE.md).
 
 ## Page-class rules
 


### PR DESCRIPTION
## What

Recovers the documentation layer from #15535, which was merged only into an already-merged non-main stack base and therefore never reached `main`. It is split from the runtime/data recovery in #15537 so both changes remain inside the normal size gate.

- codifies meaning-first marketing composition
- documents adversarial panel review and taste boundaries
- aligns the artist-profile copy guide, agent guide, and composition rules
- preserves founder approval for material visible copy choices

## Proof

- doc freshness check passes (33 cross-link files, 109 AGENTS map lines)
- diff check and repository pre-push/CI harness gates pass
- 5 documentation files; 239 additions and 135 deletions

No production copy changes, deployment actions, or taste approvals are included. Companion runtime/data recovery: #15537.