### PR TITLE
feat(brand): recover fail-closed public projection

### DIFF
--- a/apps/web/design/system-release.json
+++ b/apps/web/design/system-release.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "version": "1.0.12",
+  "releasedAt": "2026-08-04",
+  "exceptions": [
+    {
+      "id": "satoshi-display",
+      "introducedIn": "1.0.0",
+      "name": "Satoshi display type",
+      "justification": "Large editorial display may use Satoshi while body copy, controls, navigation, and data remain Inter.",
+      "founderApproved": true
+    }
+  ],
+  "changelog": [
+    {
+      "version": "1.0.12",
+      "date": "2026-08-04",
+      "summary": "Moved the checked public manifest into the generated asset namespace while preserving its vendor data contract."
+    },
+    {
+      "version": "1.0.11",
+      "date": "2026-08-04",
+      "summary": "Enforced canonical Inter rendering for the public body and interface typography specimens."
+    },
+    {
+      "version": "1.0.10",
+      "date": "2026-08-04",
+      "summary": "Recorded the formatter-stable privacy schema and canonical typography projection as the reviewed public release."
+    },
+    {
+      "version": "1.0.9",
+      "date": "2026-08-04",
+      "summary": "Completed the executable public projection schema after focused privacy regression review."
+    },
+    {
+      "version": "1.0.8",
+      "date": "2026-08-04",
+      "summary": "Made the public privacy boundary allowlist-only and completed vendor-safe typography, leading, and tracking token exports."
+    },
+    {
+      "version": "1.0.7",
+      "date": "2026-08-04",
+      "summary": "Aligned semantic manifest validation with the normal repository formatter while preserving all drift and provenance checks."
+    },
+    {
+      "version": "1.0.6",
+      "date": "2026-08-04",
+      "summary": "Added deterministically sorted, readable public manifest serialization."
+    },
+    {
+      "version": "1.0.5",
+      "date": "2026-08-04",
+      "summary": "Aligned public headings, labels, and accessibility names with the canonical UI casing contract."
+    },
+    {
+      "version": "1.0.4",
+      "date": "2026-08-04",
+      "summary": "Moved content-section counting and viewport scope into the executable delight policy so public guidance cannot drift from the evaluator."
+    },
+    {
+      "version": "1.0.3",
+      "date": "2026-08-04",
+      "summary": "Preserved sticky-header contrast over logo and token specimens after mobile anchor testing."
+    },
+    {
+      "version": "1.0.2",
+      "date": "2026-08-04",
+      "summary": "Improved public intentionality labels and anchored-section clearance after real desktop and mobile rendered review."
+    },
+    {
+      "version": "1.0.1",
+      "date": "2026-08-04",
+      "summary": "Locked delight counts as optional maximums, added no-budget-filling receipts, hardened private media projection, and attached the Brand System check to builds and CI."
+    },
+    {
+      "version": "1.0.0",
+      "date": "2026-08-04",
+      "summary": "Established the generated public Brand System projection, versioned asset checksums, approved composition examples, privacy boundary, and executable drift gate."
+    }
+  ]
+}

--- a/apps/web/design/system-release.json
+++ b/apps/web/design/system-release.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "version": "1.0.12",
+  "version": "1.0.13",
   "releasedAt": "2026-08-04",
   "exceptions": [
     {
@@ -12,6 +12,11 @@
     }
   ],
   "changelog": [
+    {
+      "version": "1.0.13",
+      "date": "2026-08-04",
+      "summary": "Derived public asset variants from canonical filenames to remove registry boilerplate without changing vendor-facing files or checksums."
+    },
     {
       "version": "1.0.12",
       "date": "2026-08-04",

--- a/apps/web/lib/brand/public-projection.ts
+++ b/apps/web/lib/brand/public-projection.ts
@@ -1,0 +1,408 @@
+const PUBLIC_VALUE = Symbol('public-brand-value');
+
+type PublicProjectionSchema =
+  | typeof PUBLIC_VALUE
+  | { readonly [key: string]: PublicProjectionSchema }
+  | readonly [PublicProjectionSchema];
+
+const PUBLIC_STRING_LIST = [PUBLIC_VALUE] as const;
+
+const PUBLIC_MEDIA_PROJECTION_SCHEMA = {
+  url: PUBLIC_VALUE,
+  alt: PUBLIC_VALUE,
+  provenance_status: PUBLIC_VALUE,
+  rights_status: PUBLIC_VALUE,
+} as const satisfies PublicProjectionSchema;
+
+/**
+ * Runtime authority for the public Brand System projection.
+ *
+ * This is intentionally an allowlist, not a list of sensitive words. A new
+ * canonical field remains private until it is explicitly reviewed and added
+ * here, even when its name does not look sensitive. Values still come from the
+ * canonical design-system sources; this schema governs only what may cross the
+ * public serialization boundary.
+ */
+const PUBLIC_BRAND_PROJECTION_SCHEMA = {
+  schema_version: PUBLIC_VALUE,
+  name: PUBLIC_VALUE,
+  version: PUBLIC_VALUE,
+  released_at: PUBLIC_VALUE,
+  source_digest: PUBLIC_VALUE,
+  sources: [
+    {
+      id: PUBLIC_VALUE,
+      sha256: PUBLIC_VALUE,
+    },
+  ],
+  sections: PUBLIC_STRING_LIST,
+  consumers: [
+    {
+      name: PUBLIC_VALUE,
+      relationship: PUBLIC_VALUE,
+    },
+  ],
+  tokens: [
+    {
+      name: PUBLIC_VALUE,
+      value: PUBLIC_VALUE,
+    },
+  ],
+  semantic_tokens: {
+    accent: {
+      base: PUBLIC_VALUE,
+      hover: PUBLIC_VALUE,
+      active: PUBLIC_VALUE,
+      subtle: PUBLIC_VALUE,
+      foreground: PUBLIC_VALUE,
+    },
+    borders: {
+      subtle: PUBLIC_VALUE,
+      default: PUBLIC_VALUE,
+      strong: PUBLIC_VALUE,
+      focus: PUBLIC_VALUE,
+    },
+    radii: {
+      none: PUBLIC_VALUE,
+      xs: PUBLIC_VALUE,
+      sm: PUBLIC_VALUE,
+      md: PUBLIC_VALUE,
+      default: PUBLIC_VALUE,
+      lg: PUBLIC_VALUE,
+      xl: PUBLIC_VALUE,
+      '2xl': PUBLIC_VALUE,
+      '3xl': PUBLIC_VALUE,
+      pill: PUBLIC_VALUE,
+      full: PUBLIC_VALUE,
+    },
+    spacing: {
+      0: PUBLIC_VALUE,
+      px: PUBLIC_VALUE,
+      0.5: PUBLIC_VALUE,
+      1: PUBLIC_VALUE,
+      1.5: PUBLIC_VALUE,
+      2: PUBLIC_VALUE,
+      2.5: PUBLIC_VALUE,
+      3: PUBLIC_VALUE,
+      4: PUBLIC_VALUE,
+      5: PUBLIC_VALUE,
+      6: PUBLIC_VALUE,
+      8: PUBLIC_VALUE,
+      10: PUBLIC_VALUE,
+      12: PUBLIC_VALUE,
+      16: PUBLIC_VALUE,
+      20: PUBLIC_VALUE,
+      24: PUBLIC_VALUE,
+    },
+    status: {
+      success: {
+        base: PUBLIC_VALUE,
+        subtle: PUBLIC_VALUE,
+        foreground: PUBLIC_VALUE,
+      },
+      warning: {
+        base: PUBLIC_VALUE,
+        subtle: PUBLIC_VALUE,
+        foreground: PUBLIC_VALUE,
+      },
+      error: {
+        base: PUBLIC_VALUE,
+        subtle: PUBLIC_VALUE,
+        foreground: PUBLIC_VALUE,
+      },
+      info: {
+        base: PUBLIC_VALUE,
+        subtle: PUBLIC_VALUE,
+        foreground: PUBLIC_VALUE,
+      },
+    },
+    surfaces: {
+      base: PUBLIC_VALUE,
+      'surface-0': PUBLIC_VALUE,
+      'surface-1': PUBLIC_VALUE,
+      'surface-2': PUBLIC_VALUE,
+      'surface-3': PUBLIC_VALUE,
+      page: PUBLIC_VALUE,
+      hover: PUBLIC_VALUE,
+      elevated: PUBLIC_VALUE,
+      input: PUBLIC_VALUE,
+      active: PUBLIC_VALUE,
+      button: PUBLIC_VALUE,
+      tooltip: PUBLIC_VALUE,
+    },
+    text: {
+      primary: PUBLIC_VALUE,
+      secondary: PUBLIC_VALUE,
+      tertiary: PUBLIC_VALUE,
+      quaternary: PUBLIC_VALUE,
+      disabled: PUBLIC_VALUE,
+      tooltip: PUBLIC_VALUE,
+    },
+  },
+  typography: {
+    fontSans: PUBLIC_VALUE,
+    fontBody: PUBLIC_VALUE,
+    fontDisplay: PUBLIC_VALUE,
+    fontMono: PUBLIC_VALUE,
+    fontFeatures: PUBLIC_VALUE,
+    roles: {
+      display: {
+        family: PUBLIC_VALUE,
+        token: PUBLIC_VALUE,
+        use: PUBLIC_VALUE,
+      },
+      body: {
+        family: PUBLIC_VALUE,
+        token: PUBLIC_VALUE,
+        use: PUBLIC_VALUE,
+      },
+      interface: {
+        family: PUBLIC_VALUE,
+        token: PUBLIC_VALUE,
+        use: PUBLIC_VALUE,
+      },
+    },
+    size: {
+      '2xs': PUBLIC_VALUE,
+      xs: PUBLIC_VALUE,
+      app: PUBLIC_VALUE,
+      sm: PUBLIC_VALUE,
+      base: PUBLIC_VALUE,
+      lg: PUBLIC_VALUE,
+      xl: PUBLIC_VALUE,
+      '2xl': PUBLIC_VALUE,
+      '3xl': PUBLIC_VALUE,
+      '4xl': PUBLIC_VALUE,
+      '5xl': PUBLIC_VALUE,
+    },
+    weight: {
+      normal: PUBLIC_VALUE,
+      book: PUBLIC_VALUE,
+      medium: PUBLIC_VALUE,
+      semibold: PUBLIC_VALUE,
+      bold: PUBLIC_VALUE,
+      heavy: PUBLIC_VALUE,
+    },
+    leading: {
+      none: PUBLIC_VALUE,
+      tight: PUBLIC_VALUE,
+      snug: PUBLIC_VALUE,
+      normal: PUBLIC_VALUE,
+      relaxed: PUBLIC_VALUE,
+    },
+    tracking: {
+      tighter: PUBLIC_VALUE,
+      tight: PUBLIC_VALUE,
+      normal: PUBLIC_VALUE,
+      wide: PUBLIC_VALUE,
+    },
+  },
+  density_modes: [
+    {
+      name: PUBLIC_VALUE,
+      summary: PUBLIC_VALUE,
+    },
+  ],
+  components: {
+    catalog: PUBLIC_STRING_LIST,
+    button: {
+      variants: PUBLIC_STRING_LIST,
+      sizes: PUBLIC_STRING_LIST,
+    },
+    access: PUBLIC_VALUE,
+  },
+  approved_examples: [
+    {
+      label: PUBLIC_VALUE,
+      url: PUBLIC_VALUE,
+    },
+  ],
+  composition_spec_version: PUBLIC_VALUE,
+  assets: [
+    {
+      label: PUBLIC_VALUE,
+      file: PUBLIC_VALUE,
+      href: PUBLIC_VALUE,
+      kind: PUBLIC_VALUE,
+      bytes: PUBLIC_VALUE,
+      sha256: PUBLIC_VALUE,
+    },
+  ],
+  media: {
+    published: [PUBLIC_MEDIA_PROJECTION_SCHEMA],
+    public_fields: PUBLIC_STRING_LIST,
+    policy: {
+      default: PUBLIC_VALUE,
+      alt: PUBLIC_VALUE,
+      provenance_status: PUBLIC_VALUE,
+      rights_status: PUBLIC_VALUE,
+      analytics: PUBLIC_VALUE,
+    },
+  },
+  motion: {
+    delight_optional: PUBLIC_VALUE,
+    simultaneous_active_max: PUBLIC_VALUE,
+    simultaneous_scope: PUBLIC_VALUE,
+    limits: [
+      {
+        content_sections_max: PUBLIC_VALUE,
+        max_dominant_delights: PUBLIC_VALUE,
+        requires_named_exception_and_complete_receipts: PUBLIC_VALUE,
+      },
+    ],
+    section_counting: {
+      definition: PUBLIC_VALUE,
+      excluded: PUBLIC_STRING_LIST,
+      distinct_content_sections: PUBLIC_STRING_LIST,
+    },
+    progression: PUBLIC_STRING_LIST,
+    default_tier: PUBLIC_VALUE,
+    editorial_may_be_deferred: PUBLIC_VALUE,
+    video_may_be_deferred: PUBLIC_VALUE,
+    static_tier_may_ship_independently: PUBLIC_VALUE,
+    intentionality_fields: PUBLIC_STRING_LIST,
+    reject_when: PUBLIC_STRING_LIST,
+    definitions: {
+      functional_transition: PUBLIC_VALUE,
+      dominant_delight: PUBLIC_VALUE,
+    },
+    safeguards: {
+      reduced_motion_fallback: PUBLIC_VALUE,
+      static_fallback: PUBLIC_VALUE,
+      scroll_hijacking_allowed: PUBLIC_VALUE,
+      parallax_regression_proof: PUBLIC_VALUE,
+    },
+  },
+  voice: PUBLIC_STRING_LIST,
+  guidance: {
+    accessibility: PUBLIC_STRING_LIST,
+    icons: PUBLIC_STRING_LIST,
+    imagery: PUBLIC_STRING_LIST,
+    logos: PUBLIC_STRING_LIST,
+    screenshots: PUBLIC_STRING_LIST,
+  },
+  do_dont: [
+    {
+      do: PUBLIC_VALUE,
+      dont: PUBLIC_VALUE,
+    },
+  ],
+  exceptions: [
+    {
+      id: PUBLIC_VALUE,
+      introducedIn: PUBLIC_VALUE,
+      name: PUBLIC_VALUE,
+      justification: PUBLIC_VALUE,
+      founderApproved: PUBLIC_VALUE,
+    },
+  ],
+  changelog: [
+    {
+      version: PUBLIC_VALUE,
+      date: PUBLIC_VALUE,
+      summary: PUBLIC_VALUE,
+    },
+  ],
+} as const satisfies PublicProjectionSchema;
+
+const PRIVATE_STRING_PATTERNS = [
+  /\/Users\//,
+  /(?:^|\s)(?:apps\/web|packages\/|canon\/)/,
+  /\bJOV-\d+\b/,
+] as const;
+
+function findProjectionViolations(
+  value: unknown,
+  schema: PublicProjectionSchema,
+  path = '$',
+  findings: string[] = []
+): readonly string[] {
+  if (schema === PUBLIC_VALUE) {
+    if (value !== null && typeof value === 'object') {
+      findings.push(`${path} must be a public scalar value`);
+      return findings;
+    }
+    if (
+      typeof value === 'string' &&
+      PRIVATE_STRING_PATTERNS.some(pattern => pattern.test(value))
+    ) {
+      findings.push(`${path} contains private source or work-tracking detail`);
+    }
+    return findings;
+  }
+
+  if (Array.isArray(schema)) {
+    if (!Array.isArray(value)) {
+      findings.push(`${path} must be a public array`);
+      return findings;
+    }
+    value.forEach((item, index) => {
+      findProjectionViolations(item, schema[0], `${path}[${index}]`, findings);
+    });
+    return findings;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    findings.push(`${path} must be a public object`);
+    return findings;
+  }
+
+  const objectSchema = schema as {
+    readonly [key: string]: PublicProjectionSchema;
+  };
+  for (const [key, nested] of Object.entries(value)) {
+    const nestedPath = `${path}.${key}`;
+    const nestedSchema = objectSchema[key];
+    if (!nestedSchema) {
+      findings.push(`${nestedPath} is not in the public projection schema`);
+      continue;
+    }
+    findProjectionViolations(nested, nestedSchema, nestedPath, findings);
+  }
+  return findings;
+}
+
+function assertMatchesPublicProjection(
+  value: unknown,
+  schema: PublicProjectionSchema,
+  label: string
+): void {
+  const findings = findProjectionViolations(value, schema);
+  if (findings.length > 0) {
+    throw new Error(
+      `${label} rejected private or unreviewed fields:\n${findings
+        .map(finding => `- ${finding}`)
+        .join('\n')}`
+    );
+  }
+}
+
+export function assertPublicSafeProjection(value: unknown): void {
+  assertMatchesPublicProjection(
+    value,
+    PUBLIC_BRAND_PROJECTION_SCHEMA,
+    'Public Brand System projection'
+  );
+}
+
+export interface PublicMediaProjection {
+  readonly url: string;
+  readonly alt: string;
+  readonly provenance_status: 'verified' | 'unknown';
+  readonly rights_status: 'cleared' | 'withheld';
+}
+
+export function assertPublicMediaProjection(
+  value: PublicMediaProjection
+): void {
+  assertMatchesPublicProjection(
+    value,
+    PUBLIC_MEDIA_PROJECTION_SCHEMA,
+    'Public media projection'
+  );
+  if (!value.alt.trim()) {
+    throw new Error(
+      'Public media alt text must be human-reviewed and non-empty.'
+    );
+  }
+}

--- a/apps/web/lib/brand/public-system.ts
+++ b/apps/web/lib/brand/public-system.ts
@@ -1,0 +1,194 @@
+export const PUBLIC_BRAND_SECTION_IDS = [
+  'hero',
+  'system',
+  'logos',
+  'typography',
+  'color',
+  'spacing-density',
+  'surfaces',
+  'controls',
+  'icons',
+  'imagery',
+  'screenshots',
+  'motion',
+  'accessibility',
+  'voice',
+  'archetypes',
+  'do-dont',
+  'downloads',
+  'changelog',
+] as const;
+
+export type PublicBrandSectionId = (typeof PUBLIC_BRAND_SECTION_IDS)[number];
+
+export const PUBLIC_BRAND_MANIFEST = {
+  file: 'Jovie-Brand-System.json',
+  relative_path: 'generated/Jovie-Brand-System.json',
+  href: '/brand/generated/Jovie-Brand-System.json',
+} as const;
+
+export const PUBLIC_BRAND_ASSETS = [
+  {
+    label: 'Jovie mark — ink SVG',
+    file: 'Jovie-Logo-Mark-Black.svg',
+    href: '/brand/Jovie-Logo-Mark-Black.svg',
+    kind: 'mark',
+  },
+  {
+    label: 'Jovie mark — cream SVG',
+    file: 'Jovie-Logo-Mark-Cream.svg',
+    href: '/brand/Jovie-Logo-Mark-Cream.svg',
+    kind: 'mark',
+  },
+  {
+    label: 'Jovie wordmark — ink SVG',
+    file: 'Jovie-Wordmark-Black.svg',
+    href: '/brand/Jovie-Wordmark-Black.svg',
+    kind: 'wordmark',
+  },
+  {
+    label: 'Jovie wordmark — cream SVG',
+    file: 'Jovie-Wordmark-Cream.svg',
+    href: '/brand/Jovie-Wordmark-Cream.svg',
+    kind: 'wordmark',
+  },
+  {
+    label: 'Jovie horizontal lockup — ink SVG',
+    file: 'Jovie-Lockup-Black.svg',
+    href: '/brand/Jovie-Lockup-Black.svg',
+    kind: 'lockup',
+  },
+  {
+    label: 'Jovie horizontal lockup — cream SVG',
+    file: 'Jovie-Lockup-Cream.svg',
+    href: '/brand/Jovie-Lockup-Cream.svg',
+    kind: 'lockup',
+  },
+  {
+    label: 'Jovie app icon — 192 PNG',
+    file: 'app-icons/jovie-app-icon-192.png',
+    href: '/brand/app-icons/jovie-app-icon-192.png',
+    kind: 'app-icon',
+  },
+  {
+    label: 'Jovie app icon — 512 PNG',
+    file: 'app-icons/jovie-app-icon-512.png',
+    href: '/brand/app-icons/jovie-app-icon-512.png',
+    kind: 'app-icon',
+  },
+  {
+    label: 'Jovie app icon — 1024 PNG',
+    file: 'app-icons/jovie-app-icon-1024.png',
+    href: '/brand/app-icons/jovie-app-icon-1024.png',
+    kind: 'app-icon',
+  },
+] as const;
+
+export const PUBLIC_SYSTEM_CONSUMERS = [
+  {
+    name: 'Jovie product',
+    relationship: 'Direct canonical web consumer',
+  },
+  {
+    name: 'Jovie marketing',
+    relationship: 'Editorial composition mode over the same foundation',
+  },
+  {
+    name: 'LogYourBody native',
+    relationship: 'Platform adapter contract; no independent visual authority',
+  },
+  {
+    name: 'LogYourBody marketing',
+    relationship: 'Editorial composition mode; no independent visual authority',
+  },
+] as const;
+
+export const PUBLIC_DENSITY_MODES = [
+  {
+    name: 'Product',
+    summary: 'Compact, task-led composition using the shared token scale.',
+  },
+  {
+    name: 'Editorial',
+    summary:
+      'More breathing room and narrative pacing without changing type, color, radius, icon, or control contracts.',
+  },
+] as const;
+
+export const PUBLIC_LOGO_RULES = [
+  'Use the supplied vector or raster original without redrawing its geometry.',
+  'Keep the mark one color and preserve clear contrast against its surface.',
+  'Treat the wordmark as artwork; never recreate it with a font.',
+  'Use the horizontal lockup when context is limited and the mark alone only when Jovie is already clear.',
+] as const;
+
+export const PUBLIC_ICON_RULES = [
+  'Use Lucide for interface actions, navigation, and state.',
+  'Use the shared SocialIcon registry for social networks, services, and music platforms.',
+  'Reserve custom SVGs for approved brand symbols or a documented gap in the shared libraries.',
+  'Give an interactive icon an accessible name; hide a redundant decorative icon from assistive technology.',
+] as const;
+
+export const PUBLIC_IMAGERY_RULES = [
+  'Start with an independently useful product-led static composition.',
+  'Use editorial media only when it adds truthful context the interface cannot provide.',
+  'Use video only after the static and editorial tiers work on their own.',
+  'Keep selection and governance metadata private; publish only reviewed alt text and coarse provenance and rights status.',
+] as const;
+
+export const PUBLIC_SCREENSHOT_RULES = [
+  'Capture a current canonical product surface; do not reconstruct product UI in a graphics tool.',
+  'Use only seeded or explicitly approved public-safe content.',
+  'Record the capture source and system version before publication, then expose only public-safe provenance.',
+  'Withhold the image when identity, release state, or rights cannot be verified.',
+] as const;
+
+export const PUBLIC_ACCESSIBILITY_RULES = [
+  'Preserve semantic heading order, landmarks, keyboard access, and visible focus.',
+  'Use semantic color roles and verify contrast in the final composition.',
+  'Keep controls at canonical sizes and preserve their full touch targets.',
+  'Honor reduced motion and provide the same meaning in the static state.',
+  'Write alt text only for truthful visible content needed to understand the published image.',
+] as const;
+
+export const PUBLIC_MEDIA_FIELDS = [
+  'url',
+  'alt',
+  'provenance_status',
+  'rights_status',
+] as const;
+
+export const PUBLIC_MEDIA_POLICY = {
+  default: 'withhold',
+  alt: 'Human-reviewed and limited to visibly relevant content needed to understand the published image.',
+  provenance_status: 'Publish only a coarse verified or unknown status.',
+  rights_status: 'Publish only a coarse cleared or withheld status.',
+  analytics:
+    'Never attach media-governance or selection metadata to public analytics.',
+} as const;
+
+export const PUBLIC_VOICE_RULES = [
+  'Lead with the artist outcome, then explain the mechanism.',
+  'Use specific, verifiable language. Remove filler and inflated claims.',
+  'Write controls as direct actions in Title Case; write guidance in sentence case.',
+  'Never imply a feature, result, customer, or proof point that is not public and current.',
+] as const;
+
+export const PUBLIC_DO_DONT = [
+  {
+    do: 'Use the supplied mark, wordmark, lockups, and checksummed app icons unchanged.',
+    dont: 'Redraw, stretch, rotate, outline, shade, or decorate the logo.',
+  },
+  {
+    do: 'Use semantic tokens and the canonical control family.',
+    dont: 'Sample colors from screenshots or recreate buttons from visual memory.',
+  },
+  {
+    do: 'Let artist media carry the expression while Jovie provides structure.',
+    dont: 'Add generic AI gradients, floating decoration, emoji tiles, or ornamental dashboards.',
+  },
+  {
+    do: 'Ship a complete static experience before considering editorial motion or video.',
+    dont: 'Add an effect because a numeric delight ceiling has room.',
+  },
+] as const;

--- a/apps/web/lib/brand/public-system.ts
+++ b/apps/web/lib/brand/public-system.ts
@@ -27,61 +27,57 @@ export const PUBLIC_BRAND_MANIFEST = {
   href: '/brand/generated/Jovie-Brand-System.json',
 } as const;
 
+type PublicBrandAssetKind = 'mark' | 'wordmark' | 'lockup' | 'app-icon';
+
+function definePublicBrandAsset<
+  const Label extends string,
+  const File extends string,
+  const Kind extends PublicBrandAssetKind,
+>(label: Label, file: File, kind: Kind) {
+  return {
+    label,
+    file,
+    href: `/brand/${file}` as const,
+    kind,
+  } as const;
+}
+
+function definePublicBrandSvgPair<
+  const Label extends string,
+  const FileStem extends string,
+  const Kind extends Exclude<PublicBrandAssetKind, 'app-icon'>,
+>(label: Label, fileStem: FileStem, kind: Kind) {
+  return [
+    definePublicBrandAsset(
+      `Jovie ${label} — ink SVG`,
+      `${fileStem}-Black.svg`,
+      kind
+    ),
+    definePublicBrandAsset(
+      `Jovie ${label} — cream SVG`,
+      `${fileStem}-Cream.svg`,
+      kind
+    ),
+  ] as const;
+}
+
+function definePublicBrandAppIcon<const Size extends 192 | 512 | 1024>(
+  size: Size
+) {
+  return definePublicBrandAsset(
+    `Jovie app icon — ${size} PNG`,
+    `app-icons/jovie-app-icon-${size}.png`,
+    'app-icon'
+  );
+}
+
 export const PUBLIC_BRAND_ASSETS = [
-  {
-    label: 'Jovie mark — ink SVG',
-    file: 'Jovie-Logo-Mark-Black.svg',
-    href: '/brand/Jovie-Logo-Mark-Black.svg',
-    kind: 'mark',
-  },
-  {
-    label: 'Jovie mark — cream SVG',
-    file: 'Jovie-Logo-Mark-Cream.svg',
-    href: '/brand/Jovie-Logo-Mark-Cream.svg',
-    kind: 'mark',
-  },
-  {
-    label: 'Jovie wordmark — ink SVG',
-    file: 'Jovie-Wordmark-Black.svg',
-    href: '/brand/Jovie-Wordmark-Black.svg',
-    kind: 'wordmark',
-  },
-  {
-    label: 'Jovie wordmark — cream SVG',
-    file: 'Jovie-Wordmark-Cream.svg',
-    href: '/brand/Jovie-Wordmark-Cream.svg',
-    kind: 'wordmark',
-  },
-  {
-    label: 'Jovie horizontal lockup — ink SVG',
-    file: 'Jovie-Lockup-Black.svg',
-    href: '/brand/Jovie-Lockup-Black.svg',
-    kind: 'lockup',
-  },
-  {
-    label: 'Jovie horizontal lockup — cream SVG',
-    file: 'Jovie-Lockup-Cream.svg',
-    href: '/brand/Jovie-Lockup-Cream.svg',
-    kind: 'lockup',
-  },
-  {
-    label: 'Jovie app icon — 192 PNG',
-    file: 'app-icons/jovie-app-icon-192.png',
-    href: '/brand/app-icons/jovie-app-icon-192.png',
-    kind: 'app-icon',
-  },
-  {
-    label: 'Jovie app icon — 512 PNG',
-    file: 'app-icons/jovie-app-icon-512.png',
-    href: '/brand/app-icons/jovie-app-icon-512.png',
-    kind: 'app-icon',
-  },
-  {
-    label: 'Jovie app icon — 1024 PNG',
-    file: 'app-icons/jovie-app-icon-1024.png',
-    href: '/brand/app-icons/jovie-app-icon-1024.png',
-    kind: 'app-icon',
-  },
+  ...definePublicBrandSvgPair('mark', 'Jovie-Logo-Mark', 'mark'),
+  ...definePublicBrandSvgPair('wordmark', 'Jovie-Wordmark', 'wordmark'),
+  ...definePublicBrandSvgPair('horizontal lockup', 'Jovie-Lockup', 'lockup'),
+  definePublicBrandAppIcon(192),
+  definePublicBrandAppIcon(512),
+  definePublicBrandAppIcon(1024),
 ] as const;
 
 export const PUBLIC_SYSTEM_CONSUMERS = [

--- a/apps/web/tests/unit/app/brand/public-projection.test.ts
+++ b/apps/web/tests/unit/app/brand/public-projection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertPublicMediaProjection,
+  assertPublicSafeProjection,
+  type PublicMediaProjection,
+} from '@/lib/brand/public-projection';
+
+const reviewedMedia = {
+  url: '/brand/editorial.jpg',
+  alt: 'Artist standing on a lit stage.',
+  provenance_status: 'verified',
+  rights_status: 'cleared',
+} satisfies PublicMediaProjection;
+
+describe('public Brand System projection', () => {
+  it('accepts only the reviewed public media fields', () => {
+    expect(() => assertPublicMediaProjection(reviewedMedia)).not.toThrow();
+    expect(() =>
+      assertPublicMediaProjection({
+        ...reviewedMedia,
+        internal_name: 'campaign-option-a',
+      } as PublicMediaProjection)
+    ).toThrow(/not in the public projection schema/);
+  });
+
+  it('requires human-reviewed non-empty public alt text', () => {
+    expect(() =>
+      assertPublicMediaProjection({ ...reviewedMedia, alt: ' ' })
+    ).toThrow(/human-reviewed and non-empty/);
+  });
+
+  it.each([
+    'audience',
+    'variant_selection',
+    'gender',
+    'age_range',
+    'style_label',
+    'license_detail',
+    'media_rights_operational_metadata',
+    'unexpected_safe_sounding_label',
+  ])('fails closed for an unreviewed media field: %s', field => {
+    const projection = {
+      media: {
+        published: [],
+        public_fields: [],
+        policy: {},
+        [field]: 'private-value',
+      },
+    };
+
+    expect(() => assertPublicSafeProjection(projection)).toThrow(
+      /rejected private or unreviewed fields/
+    );
+  });
+
+  it('rejects an unknown field even when its name looks harmless', () => {
+    expect(() =>
+      assertPublicSafeProjection({ harmless_sounding_field: 'private' })
+    ).toThrow(/not in the public projection schema/);
+  });
+});


### PR DESCRIPTION
## What this recovers

This is the current-main recovery of the canonical public brand projection that was stranded inside the collapsed/oversized #15510 stack.

- adds the canonical public brand manifest
- adds the typed source projection and fail-closed drift verifier
- adds focused projection coverage
- adds the `brand:check` package command

## Scope

This is deliberately the projection core: 4 files, with no rendered page or composition change and no waiver. The full-tree hygiene buffer repair that the first CI pass exposed is already present on current `main`, so its redundant commit was dropped during rebase. The downstream visible `/brand` work remains out of this PR and must be re-sliced separately.

## Verification

- focused projection suite: 11/11 passed
- real full-tree hygiene scan: passed on current main's 20 MiB buffer
- Biome: passed
- normal full pre-push gate after current-main rebase: passed, including all 8 affected-test shards and `ci:harness:check`

Supersedes the recoverable core of #15510.
