### PR TITLE
style(profile): refine mobile hero and glass navigation

### DIFF
--- a/apps/web/components/atoms/SocialIcon.stories.tsx
+++ b/apps/web/components/atoms/SocialIcon.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { SocialIcon } from './SocialIcon';
+
+const meta = {
+  title: 'Atoms/SocialIcon',
+  component: SocialIcon,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    platform: 'spotify',
+    size: 24,
+  },
+} satisfies Meta<typeof SocialIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const MUSIC_PLATFORMS = [
+  ['spotify', 'Spotify'],
+  ['apple_music', 'Apple Music'],
+  ['youtube_music', 'YouTube Music'],
+  ['amazon_music', 'Amazon Music'],
+  ['soundcloud', 'SoundCloud'],
+  ['tidal', 'Tidal'],
+  ['deezer', 'Deezer'],
+  ['netease_music', 'NetEase Music'],
+  ['qq_music', 'QQ Music'],
+] as const;
+
+export const Default: Story = {};
+
+export const MusicServices: Story = {
+  render: () => (
+    <fieldset className='grid grid-cols-3 gap-4'>
+      <legend className='sr-only'>Music services</legend>
+      {MUSIC_PLATFORMS.map(([platform, label]) => (
+        <div
+          className='flex min-w-24 flex-col items-center gap-2 text-center text-sm text-secondary-token'
+          key={platform}
+        >
+          <SocialIcon
+            platform={platform}
+            size={24}
+            aria-hidden={false}
+            aria-label={label}
+          />
+          <span>{label}</span>
+        </div>
+      ))}
+    </fieldset>
+  ),
+};
+
+export const UnknownPlatform: Story = {
+  args: {
+    platform: 'unknown-platform',
+    'aria-hidden': false,
+    'aria-label': 'Unknown platform',
+  },
+};

--- a/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
@@ -54,15 +54,19 @@ describe('BottomTabBar — tab rendering', () => {
     expect(screen.getByRole('button', { name: 'Alerts' })).toBeInTheDocument();
   });
 
-  it('omits Alerts when fan capture is unavailable', () => {
+  it('removes fan-capture navigation when alerts are not ownership-safe', () => {
     const { container } = render(
-      <BottomTabBar {...makeProps({ showAlertsTab: false })} />
+      <BottomTabBar {...makeProps({ showAlerts: false })} />
     );
-    expect(
-      screen.queryByRole('button', { name: 'Alerts' })
-    ).not.toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: 'Alerts' })).toBeNull();
     const grid = container.querySelector('[style*="grid-template-columns"]');
     expect(grid?.getAttribute('style')).toContain('repeat(3,');
+  });
+
+  it('omits Alerts when the legacy availability flag is false', () => {
+    render(<BottomTabBar {...makeProps({ showAlertsTab: false })} />);
+    expect(screen.queryByRole('button', { name: 'Alerts' })).toBeNull();
   });
 
   it('does not render a More button', () => {

--- a/apps/web/components/features/profile/nav/BottomTabBar.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.tsx
@@ -118,7 +118,7 @@ export function BottomTabBar({
   return (
     <div
       className={cn(
-        'shrink-0 pb-[max(env(safe-area-inset-bottom),10px)] pt-2',
+        'profile-floating-tab-bar shrink-0 pb-[max(env(safe-area-inset-bottom),10px)] pt-2',
         className
       )}
       data-testid='profile-tab-bar'
@@ -126,10 +126,10 @@ export function BottomTabBar({
       <nav
         aria-label='Profile Navigation'
         data-testid='profile-bottom-nav'
-        className='h-12 rounded-full border border-[color:var(--profile-dock-border)] bg-[color:var(--profile-dock-bg)] p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_14px_34px_rgba(0,0,0,0.32)] backdrop-blur-2xl'
+        className='profile-liquid-glass-nav h-12 rounded-full border p-1 shadow-(--profile-dock-shadow) backdrop-blur-xl backdrop-saturate-150'
       >
         <div
-          className='-my-0.5 grid h-11 items-center gap-1'
+          className='profile-liquid-glass-nav__grid -my-0.5 grid h-11 items-center gap-1'
           style={{
             gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
           }}
@@ -145,7 +145,7 @@ export function BottomTabBar({
                 type='button'
                 onClick={() => onTabSelect(tab.mode)}
                 className={cn(
-                  'relative flex h-full min-w-0 touch-manipulation items-center justify-center rounded-full text-center transition-colors duration-subtle ease-subtle',
+                  'profile-liquid-glass-nav__item relative flex h-full min-w-0 touch-manipulation items-center justify-center rounded-full text-center transition-colors duration-subtle ease-subtle',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                   isActive
                     ? 'text-white dark:text-white'
@@ -157,7 +157,7 @@ export function BottomTabBar({
               >
                 <Icon
                   className={cn(
-                    'h-5 w-5 shrink-0 transition-[color,stroke-width] duration-subtle',
+                    'profile-liquid-glass-nav__icon h-5 w-5 shrink-0 transition-[color,stroke-width] duration-subtle',
                     isActive ? 'text-white dark:text-white' : 'text-white/52'
                   )}
                   strokeWidth={isActive ? 2.35 : 1.8}
@@ -165,7 +165,7 @@ export function BottomTabBar({
                 />
                 <span
                   className={cn(
-                    'sr-only',
+                    'profile-liquid-glass-nav__label sr-only',
                     isActive ? 'font-semibold' : 'font-medium'
                   )}
                 >

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -40,6 +40,7 @@ import {
   readPacTabBarReturnVisit,
   shouldShowColdVisitorTabBar,
 } from '@/lib/profile/pac-tab-bar-experiment';
+import { resolvePublicHeroObjectPosition } from '@/lib/profile/public-hero-media';
 import { getCanonicalProfileDSPs } from '@/lib/profile-dsps';
 import { buildProfileShareContext } from '@/lib/share/context';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
@@ -416,6 +417,7 @@ export function ProfileCompactSurface({
     ]
   );
   const heroImageUrl = surfaceState.heroImageUrl;
+  const heroObjectPosition = resolvePublicHeroObjectPosition(artist.settings);
   const resolvedHeroImageUrl = useMemo(() => {
     const imageUrl = heroImageUrl ?? artist.image_url ?? null;
     return isDefaultAvatarUrl(imageUrl) ? null : imageUrl;
@@ -441,10 +443,10 @@ export function ProfileCompactSurface({
     drawerOpen && drawerView === 'menu' && activeVisiblePrimaryTab !== 'tour';
   const topChromeButtonClassName =
     'profile-top-chrome-icon text-white dark:text-white';
-  // 28px visual glyph box with a 44×44 hit area: box-content + p-2 grows the
-  // hit box to 44px while -m-2 cancels the layout footprint (no shift).
+  // The 20px glyph sits inside an explicit 44×44 target. Targets participate
+  // in the identity grid normally so adjacent social actions never overlap.
   const socialIconClassName =
-    'box-content inline-flex h-7 w-7 items-center justify-center p-2 -m-2 text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+    'inline-flex h-11 w-11 shrink-0 touch-manipulation items-center justify-center rounded-full text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
   // Composition rule: the home hero has one definite token-driven height
   // (h-(--cover-height) = clamp(220px, 34svh, 400px)) on every viewport. It
   // never shrink-wraps — the old short-viewport min-h-0/flex-none band
@@ -483,6 +485,7 @@ export function ProfileCompactSurface({
   }, [onModeSelect]);
   const openNotifications = useCallback(
     (sourceContext?: NotificationSourceContext) => {
+      if (!allowFanCapture) return;
       setNotificationSourceContext(
         sourceContext ?? defaultNotificationSourceContext
       );
@@ -503,10 +506,16 @@ export function ProfileCompactSurface({
       onModeSelect('subscribe');
       onRevealNotifications?.();
     },
-    [defaultNotificationSourceContext, onModeSelect, onRevealNotifications]
+    [
+      allowFanCapture,
+      defaultNotificationSourceContext,
+      onModeSelect,
+      onRevealNotifications,
+    ]
   );
   const handleTabSelect = useCallback(
     (tab: ProfilePrimaryTab) => {
+      if (!allowFanCapture && tab === 'subscribe') return;
       restoreTabBar();
       const nextTab = mapPrimaryTabToAnalyticsTab(tab);
       track('profile_tab_click', {
@@ -520,7 +529,14 @@ export function ProfileCompactSurface({
       });
       onModeSelect(tab);
     },
-    [artist.handle, artist.id, currentAnalyticsTab, onModeSelect, restoreTabBar]
+    [
+      allowFanCapture,
+      artist.handle,
+      artist.id,
+      currentAnalyticsTab,
+      onModeSelect,
+      restoreTabBar,
+    ]
   );
   const handleSocialClick = useCallback(
     (link: LegacySocialLink) => {
@@ -580,43 +596,44 @@ export function ProfileCompactSurface({
         <header
           className={cn(
             'relative overflow-hidden',
-            isHomeMode ? 'min-h-0' : 'shrink-0',
+            isHomeMode
+              ? 'profile-home-fluid-hero min-h-0 flex flex-col'
+              : 'shrink-0',
             heroHeightClassName
           )}
           data-testid='profile-cover'
         >
           {isHomeMode ? (
-            <>
-              <div className='profile-cover-home-media absolute inset-0'>
-                {resolvedHeroImageUrl ? (
-                  <ImageWithFallback
-                    src={resolvedHeroImageUrl}
-                    alt=''
-                    fill
-                    priority
-                    sizes='(max-width: 767px) 100vw, 430px'
-                    className='object-cover object-[50%_20%]'
-                    fallbackVariant='avatar'
-                    fallbackClassName='bg-surface-2'
-                  />
-                ) : (
-                  <div
-                    className='h-full w-full bg-[radial-gradient(circle_at_50%_22%,rgba(255,255,255,0.08),transparent_28%),linear-gradient(145deg,#20242c_0%,#11141a_48%,#050608_100%)]'
-                    aria-hidden='true'
-                  />
-                )}
-              </div>
-
+            <div className='profile-cover-home-media relative min-h-0 flex-1'>
+              {resolvedHeroImageUrl ? (
+                <ImageWithFallback
+                  src={resolvedHeroImageUrl}
+                  alt=''
+                  fill
+                  priority
+                  sizes='(max-width: 767px) 100vw, 430px'
+                  className='object-cover'
+                  style={{ objectPosition: heroObjectPosition }}
+                  fallbackVariant='avatar'
+                  fallbackClassName='bg-surface-2'
+                />
+              ) : (
+                <div
+                  className='h-full w-full bg-[radial-gradient(circle_at_50%_22%,rgba(255,255,255,0.08),transparent_28%),linear-gradient(145deg,#20242c_0%,#11141a_48%,#050608_100%)]'
+                  aria-hidden='true'
+                />
+              )}
               <div
-                className='profile-cover-home-gradient pointer-events-none'
+                className='profile-cover-home-gradient profile-cover-home-gradient--face-safe pointer-events-none'
                 aria-hidden='true'
               />
-            </>
+            </div>
           ) : null}
 
           <div
             className={cn(
-              'profile-cover-chrome relative z-10 flex h-full items-start justify-between px-4',
+              'profile-cover-chrome z-10 flex items-start justify-between px-4',
+              isHomeMode ? 'absolute inset-x-0 top-0' : 'relative h-full',
               isPreviewEmbedded
                 ? 'pt-19'
                 : isHomeMode
@@ -677,11 +694,11 @@ export function ProfileCompactSurface({
 
           {isHomeMode ? (
             <div
-              className='profile-hero-identity-scrim absolute inset-x-0 bottom-0 z-10 px-(--page-pad) pb-5 pt-8 backdrop-blur-[2px] [@media(max-height:820px)]:pb-4 [@media(max-height:760px)]:pb-3'
+              className='profile-hero-identity-scrim relative z-10 shrink-0 px-(--page-pad) py-2'
               data-testid='profile-hero-identity-block'
             >
               <div
-                className='min-w-0 py-2 [overflow-wrap:anywhere]'
+                className='grid min-w-0 gap-1 [overflow-wrap:anywhere]'
                 data-testid='profile-hero-identity-content'
               >
                 <IdentityHeading
@@ -695,7 +712,7 @@ export function ProfileCompactSurface({
                     href={profileHref}
                     prefetch={false}
                     aria-label={`Go to ${artist.name}'s profile`}
-                    className='inline-flex max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md py-2.5 -my-2.5 text-3xl font-semibold leading-none tracking-normal text-(--profile-status-pill-fg) drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
+                    className='inline-flex min-h-11 max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md py-1 text-3xl font-semibold leading-8 tracking-normal text-(--profile-status-pill-fg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
                   >
                     <span className='min-w-0 max-w-full [overflow-wrap:anywhere]'>
                       {artist.name}
@@ -717,13 +734,19 @@ export function ProfileCompactSurface({
                   </Link>
                 </IdentityHeading>
 
-                <div className='mt-2 flex min-w-0 items-center justify-between gap-2 [@media(max-height:820px)]:mt-1'>
-                  <p className='flex min-w-0 items-center gap-1.5 text-xs font-medium leading-4 tracking-normal text-white/74 [@media(max-height:820px)]:text-2xs'>
+                <div className='grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2'>
+                  <p className='flex min-h-11 min-w-0 items-center gap-1.5 text-xs font-medium leading-4 tracking-normal text-white/74 [@media(max-height:820px)]:text-2xs'>
                     <span className='min-w-0 truncate'>{heroSubtitle}</span>
                     {locationLabel ? (
                       <>
-                        <span className='h-1 w-1 shrink-0 rounded-full bg-white/34' />
-                        <MapPin className='h-3.5 w-3.5 shrink-0 text-white/58' />
+                        <span
+                          className='h-1 w-1 shrink-0 rounded-full bg-white/34'
+                          aria-hidden='true'
+                        />
+                        <MapPin
+                          className='h-3.5 w-3.5 shrink-0 text-white/58'
+                          aria-hidden='true'
+                        />
                         <span className='min-w-0 truncate'>
                           {locationLabel}
                         </span>
@@ -733,7 +756,7 @@ export function ProfileCompactSurface({
 
                   {visibleSocialLinks.length > 0 ? (
                     <div
-                      className='flex shrink-0 items-center gap-1'
+                      className='grid shrink-0 auto-cols-[2.75rem] grid-flow-col items-center gap-1'
                       data-testid='profile-hero-social-row'
                     >
                       {visibleSocialLinks.map(link => {
@@ -776,10 +799,11 @@ export function ProfileCompactSurface({
           className={cn(
             'relative z-10 flex flex-col px-(--page-pad)',
             homeContentColumnClassName,
-            isHomeMode ? 'pt-0' : 'pt-2'
+            isHomeMode ? 'profile-home-content-column pt-0' : 'pt-2'
           )}
         >
-          {shouldRenderInteractiveOverlays &&
+          {allowFanCapture &&
+          shouldRenderInteractiveOverlays &&
           activeVisiblePrimaryTab !== 'subscribe' ? (
             <ProfileInlineNotificationsCTA
               artist={artist}
@@ -799,7 +823,7 @@ export function ProfileCompactSurface({
 
           {isHomeMode ? <div className='shrink-0 pb-2' /> : null}
 
-          {showSubscriptionConfirmedBanner ? (
+          {allowFanCapture && showSubscriptionConfirmedBanner ? (
             <div className='shrink-0 pb-3'>
               <SubscriptionConfirmedBanner />
             </div>
@@ -818,16 +842,15 @@ export function ProfileCompactSurface({
               // shell edge, where profile-compact-surface already clips.
               isHomeMode && '-mx-(--page-pad) px-(--page-pad)',
               homeContentScrollClassName,
+              isHomeMode && 'profile-home-content-scroll',
               // Home mode: the scroll region becomes a flex column so the
               // carousel rail can flex into the full remaining height
               // (percentage heights fail against flexed parents).
               isHomeMode && 'flex flex-col',
-              // Exactly ONE tab-bar reservation: when the bar is visible it
-              // is in-flow below the scroll region and IS the reservation
-              // (no extra padding — that double-counted ~74px of dead space).
-              // When the bar is hidden (cold visitor) the padding reserves
-              // the same footprint so the bar appearing causes no shift.
-              showBottomNav ? 'pb-0' : CONTENT_SAFE_AREA_BOTTOM_PADDING,
+              // Exactly one stable reservation. The navigation material floats
+              // above this region, while the padding keeps actionable content
+              // clear whether the experiment initially shows or hides it.
+              CONTENT_SAFE_AREA_BOTTOM_PADDING,
               !isHomeMode &&
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70'
             )}
@@ -853,7 +876,7 @@ export function ProfileCompactSurface({
                 merchCards={merchCards}
                 releases={releases}
                 hasTip={hasTip}
-                pacArtPriority={!resolvedHeroImageUrl}
+                pacArtPriority
               />
             ) : (
               <ProfilePrimaryTabPanel
@@ -884,22 +907,21 @@ export function ProfileCompactSurface({
               />
             )}
           </div>
-
-          {showBottomNav ? (
-            <BottomTabBar
-              activeTab={
-                activeVisiblePrimaryTab === 'about'
-                  ? 'profile'
-                  : activeVisiblePrimaryTab
-              }
-              hasTourDates={hasTourDates}
-              showAlerts={allowFanCapture}
-              isMenuOpen={isMenuActive}
-              showAlertsTab={allowFanCapture}
-              onTabSelect={handleTabSelect}
-            />
-          ) : null}
         </div>
+
+        {showBottomNav ? (
+          <BottomTabBar
+            activeTab={
+              activeVisiblePrimaryTab === 'about'
+                ? 'profile'
+                : activeVisiblePrimaryTab
+            }
+            hasTourDates={hasTourDates}
+            showAlerts={allowFanCapture}
+            isMenuOpen={isMenuActive}
+            onTabSelect={handleTabSelect}
+          />
+        ) : null}
       </div>
 
       {renderMode !== 'preview' && renderInteractiveOverlays ? (

--- a/apps/web/lib/profile/public-hero-media.ts
+++ b/apps/web/lib/profile/public-hero-media.ts
@@ -1,0 +1,44 @@
+export type PublicHeroFocalY = 'high' | 'center' | 'low';
+
+export type PublicHeroObjectPosition = '50% 20%' | '50% 50%' | '50% 80%';
+
+const OBJECT_POSITION_BY_FOCAL_Y: Readonly<
+  Record<PublicHeroFocalY, PublicHeroObjectPosition>
+> = {
+  high: '50% 20%',
+  center: '50% 50%',
+  low: '50% 80%',
+};
+
+export const DEFAULT_PUBLIC_HERO_OBJECT_POSITION: PublicHeroObjectPosition =
+  '50% 20%';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reads only the owner-authored public crop enum. Arbitrary coordinates and
+ * CSS never cross this boundary, and no private photo provenance is exposed.
+ */
+export function readPublicHeroFocalY(
+  settings: unknown
+): PublicHeroFocalY | null {
+  if (!isRecord(settings) || !isRecord(settings.publicHeroMedia)) {
+    return null;
+  }
+
+  const { focalY } = settings.publicHeroMedia;
+  return focalY === 'high' || focalY === 'center' || focalY === 'low'
+    ? focalY
+    : null;
+}
+
+export function resolvePublicHeroObjectPosition(
+  settings: unknown
+): PublicHeroObjectPosition {
+  const focalY = readPublicHeroFocalY(settings);
+  return focalY
+    ? OBJECT_POSITION_BY_FOCAL_Y[focalY]
+    : DEFAULT_PUBLIC_HERO_OBJECT_POSITION;
+}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -46,6 +46,7 @@
   --profile-drawer-radius-desktop: 20px;
   --profile-action-radius: 14px;
   --profile-notification-icon-size: 17px;
+  --profile-hero-identity-min-height: calc(var(--space-24) + var(--space-2));
   --app-dialog-radius: var(--profile-inner-radius);
   --app-shell-sidebar-floating-radius: 14px;
   --page-pad: clamp(16px, 4vw, 32px);
@@ -55,9 +56,10 @@
   --cover-height: clamp(220px, 34svh, 400px);
   --content-max: 720px;
   --profile-bottom-nav-height: calc(
-    3.125rem +
+    var(--space-12) +
+    var(--space-2-5) +
     max(10px, env(safe-area-inset-bottom)) +
-    14px
+    var(--space-2)
   );
 
   /* DS_FOUNDATION_V1: canonical semantic aliases (do not redefine downstream) */
@@ -339,12 +341,8 @@
 }
 
 :where(.profile-hero-identity-scrim) {
-  background: linear-gradient(
-    180deg,
-    transparent 0%,
-    rgba(0, 0, 0, 0.2) 28%,
-    rgba(0, 0, 0, 0.5) 100%
-  );
+  min-height: var(--profile-hero-identity-min-height);
+  background: var(--profile-stage-bg);
 }
 
 /* Single hero legibility gradient, limited to the bottom ~55% of the cover so
@@ -361,6 +359,20 @@
     transparent 0%,
     rgba(3, 4, 6, 0.42) 52%,
     rgba(5, 6, 8, 0.9) 86%,
+    var(--profile-stage-bg) 100%
+  );
+}
+
+/* The public compact hero reserves identity outside the image, so it needs
+   only a shallow media-edge transition. This modifier preserves the shared
+   legacy class contract while ensuring the live surface never lays a tall
+   scrim across the subject. */
+:where(.profile-cover-home-gradient--face-safe) {
+  height: var(--space-8);
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    color-mix(in oklab, var(--profile-stage-bg) 44%, transparent) 54%,
     var(--profile-stage-bg) 100%
   );
 }
@@ -653,6 +665,37 @@
    viewport (--cover-height, clamp(220px, 34svh, 400px)). The hero never
    shrink-wraps; media crops via object-cover and the carousel below owns the
    remaining viewport height. */
+/* The fixed token remains the minimum crop-safe media height. On the home
+   surface, the shell gives every additional vertical pixel to the real hero
+   instead of leaving an ownerless flex region below the primary card. The
+   content column stays intrinsic, so the card and dock never stretch and no
+   fake spacer participates in the layout. */
+:where(
+  [data-testid="profile-compact-surface"][data-mode="profile"]
+    > .profile-home-fluid-hero
+) {
+  flex: 1 1 auto;
+  min-height: var(--cover-height);
+  height: auto;
+  /* The base declaration preserves the established media floor; this
+     supported calc also reserves the non-overlay identity band. */
+  min-height: calc(
+    var(--cover-height) +
+    var(--profile-hero-identity-min-height)
+  );
+}
+
+:where(
+  [data-testid="profile-compact-surface"][data-mode="profile"]
+    > .profile-home-content-column,
+  [data-testid="profile-compact-surface"][data-mode="profile"]
+    .profile-home-content-scroll,
+  [data-testid="profile-compact-surface"][data-mode="profile"]
+    [data-testid="profile-home-rail"]
+) {
+  flex: 0 0 auto;
+}
+
 /* Query-mode profile URLs are served from the ISR home shell, then hydrate into
    the requested mode from window.location. Match the mode header on first paint
    so hydration does not move the compact profile frame. */
@@ -942,10 +985,17 @@ html[data-profile-initial-mode]
   --profile-composer-border: rgba(255, 255, 255, 0.8);
   --profile-composer-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.68), 0 18px 42px rgba(15, 17, 24, 0.12);
-  --profile-dock-bg: rgba(247, 247, 249, 0.78);
-  --profile-dock-border: rgba(255, 255, 255, 0.82);
+  --profile-dock-bg: rgba(247, 247, 249, 0.58);
+  --profile-dock-border: rgba(255, 255, 255, 0.72);
   --profile-dock-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.66), 0 18px 42px rgba(15, 17, 24, 0.12);
+  --profile-dock-active-bg: rgba(255, 255, 255, 0.54);
+  --profile-dock-active-border: rgba(255, 255, 255, 0.72);
+  --profile-dock-active-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  --profile-dock-active-fg: rgba(12, 12, 15, 0.94);
+  --profile-dock-inactive-fg: rgba(12, 12, 15, 0.56);
+  --profile-dock-solid-bg: rgb(247, 247, 249);
+  --profile-dock-solid-border: rgba(12, 12, 15, 0.24);
 
   /* Skeleton/loading states — base fill matches surface-1 */
   --color-skeleton-base: var(--color-bg-surface-1);
@@ -1226,10 +1276,17 @@ html[data-profile-initial-mode]
   --profile-composer-border: rgba(255, 255, 255, 0.1);
   --profile-composer-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 16px 40px rgba(0, 0, 0, 0.28);
-  --profile-dock-bg: rgba(18, 20, 26, 0.76);
-  --profile-dock-border: rgba(255, 255, 255, 0.08);
+  --profile-dock-bg: rgba(30, 32, 40, 0.52);
+  --profile-dock-border: rgba(255, 255, 255, 0.18);
   --profile-dock-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 20px 44px rgba(0, 0, 0, 0.32);
+    inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 14px 34px rgba(0, 0, 0, 0.3);
+  --profile-dock-active-bg: rgba(255, 255, 255, 0.16);
+  --profile-dock-active-border: rgba(255, 255, 255, 0.14);
+  --profile-dock-active-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+  --profile-dock-active-fg: rgba(255, 255, 255, 0.98);
+  --profile-dock-inactive-fg: rgba(255, 255, 255, 0.58);
+  --profile-dock-solid-bg: rgb(24, 26, 32);
+  --profile-dock-solid-border: rgba(255, 255, 255, 0.28);
 
   /* Skeleton/loading states — base fill matches surface-1 */
   --color-skeleton-base: var(--color-bg-surface-1);
@@ -1270,6 +1327,151 @@ html[data-profile-initial-mode]
   --color-bg-selected: var(--noir-ion-selected);
   --color-bg-selected-strong: var(--noir-ion-selected-strong);
   --color-border-interactive: var(--noir-ion-border-interactive);
+}
+
+/* Public-profile navigation is one distinct functional glass layer. It floats
+   over the stable content reservation; child states are tint/selection only
+   and never add another backdrop-filter. */
+:where(.profile-floating-tab-bar) {
+  position: absolute;
+  z-index: 30;
+  right: var(--page-pad);
+  bottom: 0;
+  left: var(--page-pad);
+  pointer-events: none;
+}
+
+:where(.profile-liquid-glass-nav) {
+  height: calc(var(--space-12) + var(--space-2-5));
+  pointer-events: auto;
+  border-color: var(--profile-dock-border);
+  border-radius: var(--radius-full);
+  background: var(--liquid-glass-highlight), var(--profile-dock-bg);
+  box-shadow: var(--profile-dock-shadow);
+}
+
+:where(.profile-liquid-glass-nav__grid) {
+  height: calc(var(--space-10) + var(--space-2-5));
+  margin-block: 0;
+}
+
+:where(.profile-liquid-glass-nav__item) {
+  flex-direction: column;
+  gap: var(--space-0-5);
+  border: var(--space-px) solid transparent;
+  border-radius: var(--radius-full);
+  color: var(--profile-dock-inactive-fg);
+  transition:
+    color var(--duration-subtle) var(--ease-subtle),
+    background-color var(--duration-subtle) var(--ease-subtle),
+    border-color var(--duration-subtle) var(--ease-subtle),
+    box-shadow var(--duration-subtle) var(--ease-subtle);
+}
+
+:where(.profile-liquid-glass-nav__item[aria-current="page"]) {
+  border-color: var(--profile-dock-active-border);
+  background: var(--profile-dock-active-bg);
+  color: var(--profile-dock-active-fg);
+  box-shadow: var(--profile-dock-active-shadow);
+}
+
+:where(.profile-liquid-glass-nav__icon) {
+  color: inherit;
+}
+
+/* Deliberately overrides the retained sr-only utility: visible labels make the
+   four navigation destinations immediate while their accessible names remain
+   unchanged. */
+:where(.profile-liquid-glass-nav__label) {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  border: 0;
+  color: inherit;
+  font-size: var(--text-2xs);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+@media (hover: hover) {
+  :where(.profile-liquid-glass-nav__item:not([aria-current="page"]):hover) {
+    color: var(--profile-dock-active-fg);
+  }
+}
+
+/* Safari/Media Queries 5 plus a deterministic manual hook for testability and
+   clients that expose the OS preference outside CSS. */
+@media (prefers-reduced-transparency: reduce) {
+  :where(.profile-liquid-glass-nav) {
+    border-color: var(--profile-dock-solid-border);
+    background: var(--profile-dock-solid-bg);
+    --tw-backdrop-blur: initial;
+    --tw-backdrop-saturate: initial;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+/* Keep the nav class outside :where() here so the deterministic hooks outrank
+   Tailwind's backdrop utility custom properties even if layer order changes. */
+:root[data-reduced-transparency="true"] .profile-liquid-glass-nav,
+:root.high-contrast .profile-liquid-glass-nav {
+  border-color: var(--profile-dock-solid-border);
+  background: var(--profile-dock-solid-bg);
+  --tw-backdrop-blur: initial;
+  --tw-backdrop-saturate: initial;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+@media (prefers-contrast: more) {
+  :where(.profile-liquid-glass-nav) {
+    border-color: var(--profile-dock-solid-border);
+    background: var(--profile-dock-solid-bg);
+    --tw-backdrop-blur: initial;
+    --tw-backdrop-saturate: initial;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (forced-colors: active) {
+  :where(.profile-liquid-glass-nav) {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+    --tw-backdrop-blur: initial;
+    --tw-backdrop-saturate: initial;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  :where(.profile-liquid-glass-nav__item) {
+    color: CanvasText;
+    forced-color-adjust: auto;
+  }
+
+  :where(.profile-liquid-glass-nav__item[aria-current="page"]) {
+    border-color: Highlight;
+    background: Highlight;
+    color: HighlightText;
+    box-shadow: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where(
+    .profile-liquid-glass-nav,
+    .profile-liquid-glass-nav__item,
+    .profile-liquid-glass-nav__icon
+  ) {
+    transition: none;
+  }
 }
 
 /* ============================================
@@ -1988,6 +2190,7 @@ html[data-profile-initial-mode]
 }
 
 html:not(.dark) .profile-intent-page :where(a, button, span),
+html:not(.dark) [data-testid="profile-menu-drawer"] :where(a, button, span),
 html:not(.dark) [data-testid^="profile-mode-drawer"] :where(a, button, span) {
   transition: none !important;
 }

--- a/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
+++ b/apps/web/tests/unit/profile/profile-compact-surface-hero-layout.test.ts
@@ -81,4 +81,13 @@ describe('ProfileCompactSurface home hero layout', () => {
       /html\[data-profile-initial-mode\][\s\S]{0,200}--cover-height:\s*calc\(3\.5rem/
     );
   });
+
+  it('eagerly loads the first visible home-card artwork', () => {
+    const contents = readFileSync(PROFILE_COMPACT_SURFACE, 'utf8');
+
+    expect(contents).toMatch(
+      /<ProfileHomeRail[\s\S]{0,900}pacArtPriority\s*\/>/
+    );
+    expect(contents).not.toMatch(/pacArtPriority=\{!resolvedHeroImageUrl\}/);
+  });
 });

--- a/apps/web/tests/unit/profile/profile-face-safe-hero-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-face-safe-hero-regression.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd();
+const SURFACE = readFileSync(
+  join(
+    WEB_ROOT,
+    'components/features/profile/templates/ProfileCompactSurface.tsx'
+  ),
+  'utf8'
+);
+const CSS = readFileSync(join(WEB_ROOT, 'styles/design-system.css'), 'utf8');
+
+describe('public profile face-safe hero composition', () => {
+  it('keeps identity on a separate stage band with no media blur', () => {
+    expect(SURFACE).toContain(
+      'profile-hero-identity-scrim relative z-10 shrink-0'
+    );
+    expect(SURFACE).not.toMatch(
+      /profile-hero-identity-scrim[^']*backdrop-blur/
+    );
+    expect(CSS).toMatch(
+      /\.profile-hero-identity-scrim\)[\s\S]{0,160}background:\s*var\(--profile-stage-bg\)/
+    );
+  });
+
+  it('limits the media edge transition to one spacing token', () => {
+    expect(SURFACE).toContain(
+      'profile-cover-home-gradient--face-safe pointer-events-none'
+    );
+    expect(CSS).toMatch(
+      /\.profile-cover-home-gradient--face-safe\)[\s\S]{0,180}height:\s*var\(--space-8\)/
+    );
+  });
+
+  it('applies only the validated object-position result', () => {
+    expect(SURFACE).toContain(
+      'resolvePublicHeroObjectPosition(artist.settings)'
+    );
+    expect(SURFACE).toContain('style={{ objectPosition: heroObjectPosition }}');
+    expect(SURFACE).not.toContain('object-[50%_20%]');
+  });
+});

--- a/apps/web/tests/unit/profile/profile-fluid-hero-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-fluid-hero-regression.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd();
+const SURFACE = join(
+  WEB_ROOT,
+  'components/features/profile/templates/ProfileCompactSurface.tsx'
+);
+const DESIGN_SYSTEM = join(WEB_ROOT, 'styles/design-system.css');
+
+describe('public profile fluid home hero', () => {
+  it('assigns spare compact-shell height to real hero media, never a spacer', () => {
+    const surface = readFileSync(SURFACE, 'utf8');
+    const css = readFileSync(DESIGN_SYSTEM, 'utf8');
+
+    expect(surface).toContain('profile-home-fluid-hero min-h-0');
+    expect(surface).toContain('profile-home-content-column pt-0');
+    expect(surface).toContain('profile-home-content-scroll');
+    expect(css).toMatch(
+      /\.profile-home-fluid-hero[\s\S]{0,160}flex:\s*1 1 auto;[\s\S]{0,80}min-height:\s*var\(--cover-height\)/
+    );
+    expect(css).toMatch(
+      /\.profile-home-content-column[\s\S]{0,360}flex:\s*0 0 auto/
+    );
+    expect(surface).not.toMatch(/profile-home-(?:spacer|filler)/);
+  });
+
+  it('keeps query-mode deep-link collapse authoritative on first paint', () => {
+    const css = readFileSync(DESIGN_SYSTEM, 'utf8');
+
+    expect(css).toMatch(
+      /html\[data-profile-initial-mode\][\s\S]{0,300}\[data-testid="profile-cover"\][\s\S]{0,120}height:\s*calc\(3\.5rem/
+    );
+  });
+});

--- a/apps/web/tests/unit/profile/profile-identity-grid-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-identity-grid-regression.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SURFACE = readFileSync(
+  join(
+    process.cwd(),
+    'components/features/profile/templates/ProfileCompactSurface.tsx'
+  ),
+  'utf8'
+);
+
+describe('public profile identity grid', () => {
+  it('uses explicit non-overlapping 44px social targets', () => {
+    expect(SURFACE).toContain(
+      "'inline-flex h-11 w-11 shrink-0 touch-manipulation"
+    );
+    expect(SURFACE).toContain(
+      'grid shrink-0 auto-cols-[2.75rem] grid-flow-col items-center gap-1'
+    );
+    expect(SURFACE).not.toMatch(/socialIconClassName\s*=\s*[\s\S]{0,240}-m-2/);
+  });
+
+  it('aligns name, metadata, location, and actions to one compact grid', () => {
+    expect(SURFACE).toContain('grid min-w-0 gap-1 [overflow-wrap:anywhere]');
+    expect(SURFACE).toContain(
+      'grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2'
+    );
+    expect(SURFACE).toContain('inline-flex min-h-11 max-w-full min-w-0');
+    expect(SURFACE).toContain('min-h-11 min-w-0 items-center');
+  });
+
+  it('keeps long identity values bounded and decorative separators silent', () => {
+    expect(SURFACE).toContain('[overflow-wrap:anywhere]');
+    expect(SURFACE).toContain("<span className='min-w-0 truncate'>");
+    expect(SURFACE).toMatch(
+      /rounded-full bg-white\/34'[\s\S]{0,60}aria-hidden='true'/
+    );
+    expect(SURFACE).toMatch(/<MapPin[\s\S]{0,100}aria-hidden='true'/);
+  });
+});

--- a/apps/web/tests/unit/profile/profile-liquid-glass-nav-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-liquid-glass-nav-regression.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd();
+const NAV = readFileSync(
+  join(WEB_ROOT, 'components/features/profile/nav/BottomTabBar.tsx'),
+  'utf8'
+);
+const SURFACE = readFileSync(
+  join(
+    WEB_ROOT,
+    'components/features/profile/templates/ProfileCompactSurface.tsx'
+  ),
+  'utf8'
+);
+const CSS = readFileSync(join(WEB_ROOT, 'styles/design-system.css'), 'utf8');
+
+describe('public profile Liquid Glass navigation', () => {
+  it('renders one floating navigation material with no nested glass', () => {
+    expect(NAV).toContain('profile-floating-tab-bar');
+    expect(NAV).toContain(
+      'profile-liquid-glass-nav h-12 rounded-full border p-1 shadow-(--profile-dock-shadow) backdrop-blur-xl backdrop-saturate-150'
+    );
+    expect(SURFACE).toContain('CONTENT_SAFE_AREA_BOTTOM_PADDING');
+    expect(CSS).toMatch(
+      /\.profile-floating-tab-bar\)[\s\S]{0,180}position:\s*absolute[\s\S]{0,120}pointer-events:\s*none/
+    );
+    expect(CSS).not.toMatch(
+      /\.profile-liquid-glass-nav__item\)[\s\S]{0,420}backdrop-filter/
+    );
+  });
+
+  it('keeps explicit 44px-plus targets, visible labels, and one active page', () => {
+    expect(NAV).toContain('profile-liquid-glass-nav__grid -my-0.5 grid h-11');
+    expect(NAV).toContain(
+      'profile-liquid-glass-nav__item relative flex h-full'
+    );
+    expect(NAV).toContain("aria-current={isActive ? 'page' : undefined}");
+    expect(NAV).toContain('profile-liquid-glass-nav__label sr-only');
+    expect(CSS).toMatch(
+      /\.profile-liquid-glass-nav__grid\)[\s\S]{0,120}height:\s*calc\(var\(--space-10\) \+ var\(--space-2-5\)\)/
+    );
+    expect(CSS).toMatch(
+      /\.profile-liquid-glass-nav__label\)[\s\S]{0,320}position:\s*static[\s\S]{0,220}font-size:\s*var\(--text-2xs\)/
+    );
+  });
+
+  it('has reduced transparency, contrast, forced-colors, and motion fallbacks', () => {
+    expect(CSS).toContain('@media (prefers-reduced-transparency: reduce)');
+    expect(CSS).toContain(
+      ':root[data-reduced-transparency="true"] .profile-liquid-glass-nav'
+    );
+    expect(CSS).toContain('@media (prefers-contrast: more)');
+    expect(CSS).toContain('@media (forced-colors: active)');
+    expect(CSS).toMatch(
+      /prefers-reduced-transparency:\s*reduce[\s\S]{0,260}--tw-backdrop-blur:\s*initial[\s\S]{0,100}backdrop-filter:\s*none/
+    );
+    expect(CSS).toMatch(
+      /prefers-reduced-motion:\s*reduce[\s\S]{0,260}profile-liquid-glass-nav[\s\S]{0,200}transition:\s*none/
+    );
+  });
+});

--- a/apps/web/tests/unit/profile/profile-primary-card-width-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-primary-card-width-regression.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const HOME_RAIL = readFileSync(
+  join(process.cwd(), 'components/features/profile/ProfileHomeRail.tsx'),
+  'utf8'
+);
+const CAROUSEL = readFileSync(
+  join(process.cwd(), 'components/organisms/entity-card/EntityCarousel.tsx'),
+  'utf8'
+);
+
+describe('public profile primary card width', () => {
+  it('lets the home rail own the full canonical content width', () => {
+    expect(HOME_RAIL).toContain(
+      "className='flex min-h-0 min-w-0 flex-1 flex-col md:mx-auto md:w-full'"
+    );
+    expect(HOME_RAIL).not.toMatch(/profile-home-rail[\s\S]{0,220}max-w-80/);
+  });
+
+  it('keeps every multi-card footprint full-width and one snap per page', () => {
+    expect(CAROUSEL).toContain("isProfileLandscape && 'w-full'");
+    expect(CAROUSEL).toContain('snap-start snap-always');
+    expect(CAROUSEL).toContain("'gap-(--page-pad) md:gap-4'");
+  });
+});

--- a/apps/web/tests/unit/profile/public-hero-media.test.ts
+++ b/apps/web/tests/unit/profile/public-hero-media.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PUBLIC_HERO_OBJECT_POSITION,
+  readPublicHeroFocalY,
+  resolvePublicHeroObjectPosition,
+} from '@/lib/profile/public-hero-media';
+
+describe('public hero media crop contract', () => {
+  it.each([
+    ['high', '50% 20%'],
+    ['center', '50% 50%'],
+    ['low', '50% 80%'],
+  ] as const)('maps the manual %s fixture to a safe crop', (focalY, expected) => {
+    const settings = { publicHeroMedia: { focalY } };
+
+    expect(readPublicHeroFocalY(settings)).toBe(focalY);
+    expect(resolvePublicHeroObjectPosition(settings)).toBe(expected);
+  });
+
+  it.each([
+    undefined,
+    null,
+    {},
+    { publicHeroMedia: null },
+    { publicHeroMedia: { focalY: 'bottom' } },
+    { publicHeroMedia: { focalY: 'url(https://example.test)' } },
+    { publicHeroMedia: { focalY: '50% 100%' } },
+  ])('uses the deterministic default for missing or malformed metadata', settings => {
+    expect(readPublicHeroFocalY(settings)).toBeNull();
+    expect(resolvePublicHeroObjectPosition(settings)).toBe(
+      DEFAULT_PUBLIC_HERO_OBJECT_POSITION
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make the public-profile hero consume real spare height while keeping identity content outside the image crop
- honor stored hero focal points and replace overlapping social hit boxes with a canonical identity grid
- float one labeled liquid-glass navigation layer above a stable content reservation
- add deterministic reduced-transparency, high-contrast, forced-color, and reduced-motion fallbacks
- keep the primary card full-width and preserve ownership-safe fan-capture guards

## Recovery
Recovered the intended single visual-system commit from layer 7 of the abandoned native stack and rebased it directly onto current main after #15542 merged. The stale stacked view collapsed from 51 files to the intended 13-file UX scope.

## Verification
- 49 focused unit/component/style-contract tests passed across 8 files
- Biome passed on all 13 changed files
- Node 22.23.1 typecheck, Tailwind guard, proxy guard, and repository pre-push checks passed
- desktop 1200x820, mobile 390x844, and short mobile 390x667 browser captures inspected
- seeded public profile reported zero console errors; card bottom remained above the nav and nav bottom remained inside the viewport
- deterministic reduced-transparency mode resolved to a solid background with `backdrop-filter: none`

## Visual judgment
The recovered composition is coherent at all inspected sizes: the face-safe crop is unobstructed, identity text remains legible without a subject-covering scrim, the primary action uses the available width, and the single labeled dock has clear active/inactive states. No clipping, overlap, duplicate concept, or dead affordance was observed.

No checks, reviews, or deployment gates are bypassed. This remains draft until the rewritten head completes fresh source, visual, and merge-queue checks.
