### PR TITLE
test(profile): cover rendered resilience and CLS

### DIFF
--- a/apps/web/tests/e2e/profile-cls-audit.spec.ts
+++ b/apps/web/tests/e2e/profile-cls-audit.spec.ts
@@ -192,37 +192,14 @@ test.describe('Profile CLS Audit @nightly', () => {
 
     await installInteractionClsObserver(page);
 
-    // Open listen drawer — try clicking Listen button, fall back to query param
-    const listenButton = page.locator('[data-testid="listen-button"]').first();
-    const hasListenButton = await listenButton
-      .isVisible({ timeout: 5_000 })
-      .catch(() => false);
-
-    if (hasListenButton) {
-      await listenButton.click();
-    } else {
-      // Try text-based selector
-      const textButton = page
-        .locator('button, a')
-        .filter({ hasText: /listen/i })
-        .first();
-      const hasTextButton = await textButton
-        .isVisible({ timeout: 5_000 })
-        .catch(() => false);
-
-      if (hasTextButton) {
-        await textButton.click();
-      } else {
-        // Navigate with query param to trigger listen mode
-        await smokeNavigate(page, `/${TEST_PROFILES.DUALIPA}?mode=listen`);
-        await waitForHydration(page);
-      }
-    }
+    // Exercise the canonical mobile tab transition. Broad text matching can
+    // select a release-card "Listen" link and silently leave the profile shell.
+    await page.getByRole('button', { name: 'Music', exact: true }).click();
 
     // Wait for drawer content to appear — fail if the transition never happens
     const drawerLocator = page
       .locator(
-        '[role="dialog"], [data-testid="listen-drawer"], [data-state="open"]'
+        '[role="dialog"], [data-testid="listen-drawer"], [data-testid="profile-mode-drawer-listen"], [data-testid="profile-mode-drawer-releases"], [data-state="open"]'
       )
       .first();
     const drawerAppeared = await drawerLocator
@@ -236,19 +213,18 @@ test.describe('Profile CLS Audit @nightly', () => {
       return;
     }
 
-    // Close the drawer
-    await page.keyboard.press('Escape');
+    // Return through the canonical tab control. The compact profile surface is
+    // a persistent mode view, not a modal that Escape is expected to dismiss.
+    await page.getByRole('button', { name: 'Home', exact: true }).click();
 
     // Wait for drawer to close and layout to settle
     await page
       .locator(
-        '[role="dialog"], [data-testid="listen-drawer"], [data-state="open"]'
+        '[role="dialog"], [data-testid="listen-drawer"], [data-testid="profile-mode-drawer-listen"], [data-testid="profile-mode-drawer-releases"], [data-state="open"]'
       )
       .first()
       .waitFor({ state: 'hidden', timeout: 5_000 })
-      .catch(() => {
-        // Drawer may already be closed
-      });
+      .catch(() => undefined);
 
     const cls = await collectInteractionCls(page);
 

--- a/apps/web/tests/e2e/profile-liquid-glass-fallback.spec.ts
+++ b/apps/web/tests/e2e/profile-liquid-glass-fallback.spec.ts
@@ -1,0 +1,62 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const PROFILE_ROUTE = '/dualipa';
+const NAV_SELECTOR = '[data-testid="profile-bottom-nav"]';
+
+type NavMaterial = {
+  readonly backdropFilter: string;
+  readonly backgroundColor: string;
+  readonly backgroundImage: string;
+};
+
+async function readNavMaterial(page: Page) {
+  return page.locator(NAV_SELECTOR).evaluate<NavMaterial>(element => {
+    const style = getComputedStyle(element);
+    return {
+      backdropFilter:
+        style.backdropFilter ||
+        style.getPropertyValue('-webkit-backdrop-filter'),
+      backgroundColor: style.backgroundColor,
+      backgroundImage: style.backgroundImage,
+    };
+  });
+}
+
+test.describe('public profile Liquid Glass fallbacks', () => {
+  test.use({
+    storageState: { cookies: [], origins: [] },
+    viewport: { width: 390, height: 844 },
+  });
+
+  test('manual reduced-transparency and high-contrast hooks remove glass at runtime', async ({
+    page,
+  }) => {
+    await page.goto(PROFILE_ROUTE, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator(NAV_SELECTOR)).toBeVisible();
+
+    const glass = await readNavMaterial(page);
+    expect(glass.backdropFilter).not.toBe('none');
+
+    for (const mode of ['reduced-transparency', 'high-contrast'] as const) {
+      await page.evaluate(activeMode => {
+        const root = document.documentElement;
+        root.removeAttribute('data-reduced-transparency');
+        root.classList.remove('high-contrast');
+        if (activeMode === 'reduced-transparency') {
+          root.dataset.reducedTransparency = 'true';
+        } else {
+          root.classList.add('high-contrast');
+        }
+      }, mode);
+
+      await expect
+        .poll(async () => (await readNavMaterial(page)).backdropFilter)
+        .toBe('none');
+
+      const solid = await readNavMaterial(page);
+      expect(solid.backgroundImage).toBe('none');
+      expect(solid.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+      expect(solid.backgroundColor).not.toMatch(/rgba\([^)]*,\s*0(?:\.\d+)?\)/);
+    }
+  });
+});

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -859,8 +859,11 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
           const cover = document.querySelector<HTMLElement>(
             '[data-testid="profile-cover"]'
           );
-          const coverImage = cover?.querySelector<HTMLElement>('img');
-          const coverRect = cover?.getBoundingClientRect();
+          const mediaStage = cover?.querySelector<HTMLElement>(
+            '.profile-cover-home-media'
+          );
+          const coverImage = mediaStage?.querySelector<HTMLElement>('img');
+          const mediaRect = mediaStage?.getBoundingClientRect();
           const imageRect = coverImage?.getBoundingClientRect();
           const dockHost = document.querySelector<HTMLElement>(
             '[data-testid="profile-tab-bar"]'
@@ -893,12 +896,12 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
               ? pacCopy.scrollHeight <= pacCopy.clientHeight + 1
               : false,
             heroFilled: Boolean(
-              coverRect &&
+              mediaRect &&
                 imageRect &&
-                imageRect.left <= coverRect.left + 1 &&
-                imageRect.right >= coverRect.right - 1 &&
-                imageRect.top <= coverRect.top + 1 &&
-                imageRect.bottom >= coverRect.bottom - 1 &&
+                imageRect.left <= mediaRect.left + 1 &&
+                imageRect.right >= mediaRect.right - 1 &&
+                imageRect.top <= mediaRect.top + 1 &&
+                imageRect.bottom >= mediaRect.bottom - 1 &&
                 coverImage &&
                 getComputedStyle(coverImage).objectFit === 'cover'
             ),
@@ -968,14 +971,22 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
 
       const targetScrollLeft = await carousel.evaluate(el => {
         const cards = [...el.querySelectorAll<HTMLElement>(':scope > li')];
-        const target =
+        const requestedTarget =
           (cards.at(-1)?.offsetLeft ?? 0) - (cards[0]?.offsetLeft ?? 0);
+        const target = Math.min(
+          requestedTarget,
+          el.scrollWidth - el.clientWidth
+        );
         el.scrollTo({ left: target, behavior: 'auto' });
         return target;
       });
       await expect
-        .poll(() => carousel.evaluate(el => el.scrollLeft))
-        .toBeCloseTo(targetScrollLeft, 0);
+        .poll(async () =>
+          Math.abs(
+            (await carousel.evaluate(el => el.scrollLeft)) - targetScrollLeft
+          )
+        )
+        .toBeLessThanOrEqual(1);
 
       const last = await readGeometry();
       expect(
@@ -989,7 +1000,7 @@ test.describe('Public Profile Home Carousel @smoke @critical', () => {
       expect(
         last.cards[1]?.right,
         `${viewport.label} last right`
-      ).toBeLessThanOrEqual(last.rail.right);
+      ).toBeLessThanOrEqual(last.rail.right + 1);
       expect(
         last.cards[1]?.targets.length,
         `${viewport.label} last card exposes an action`

--- a/apps/web/tests/e2e/profile-public-resilience.spec.ts
+++ b/apps/web/tests/e2e/profile-public-resilience.spec.ts
@@ -1,0 +1,188 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { AUDIENCE_ANON_COOKIE } from '@/constants/app';
+import {
+  TEST_AUTH_BYPASS_MODE,
+  TEST_MODE_HEADER,
+  TEST_USER_ID_HEADER,
+} from '@/lib/auth/test-mode-constants';
+import { expect, test } from './setup';
+import { TEST_PROFILES, waitForHydration } from './utils/smoke-test-utils';
+
+const FIXED_AUDIENCE_ID = '5f2a65d3-9b89-4b19-9bca-e5a40d7cdce1';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: 'serial' });
+
+async function addStableAudienceCookie(
+  context: BrowserContext,
+  baseURL: string
+) {
+  await context.addCookies([
+    {
+      name: AUDIENCE_ANON_COOKIE,
+      value: FIXED_AUDIENCE_ID,
+      url: baseURL,
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function readPublicContract(page: Page) {
+  return {
+    heading: await page.locator('h1').first().textContent(),
+    mode: await page
+      .getByTestId('profile-compact-surface')
+      .getAttribute('data-mode'),
+    homeRailCount: await page.getByTestId('profile-home-rail').count(),
+    pacCount: await page.getByTestId('profile-pac').count(),
+    profileLink: await page
+      .getByTestId('profile-identity-link')
+      .getAttribute('href'),
+    editControlCount: await page
+      .getByRole('link', { name: /edit profile/i })
+      .or(page.getByRole('button', { name: /edit profile/i }))
+      .count(),
+  };
+}
+
+async function readProfileGeometry(page: Page) {
+  return page.evaluate(() => {
+    const rect = (selector: string) => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) return null;
+      const box = element.getBoundingClientRect();
+      return {
+        height: Math.round(box.height * 100) / 100,
+        width: Math.round(box.width * 100) / 100,
+      };
+    };
+
+    return {
+      shell: rect('[data-testid="profile-compact-shell"]'),
+      cover: rect('[data-testid="profile-cover"]'),
+      media: rect('.profile-cover-home-media'),
+      overflowX: document.documentElement.scrollWidth - innerWidth,
+    };
+  });
+}
+
+test.describe('public profile resilience', () => {
+  test.setTimeout(180_000);
+
+  test('is auth-independent for anonymous and authenticated visitors', async ({
+    browser,
+  }, testInfo) => {
+    test.skip(
+      process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
+      'Requires E2E_USE_TEST_AUTH_BYPASS=1'
+    );
+
+    const baseURL = testInfo.project.use.baseURL;
+    expect(typeof baseURL).toBe('string');
+
+    const anonymousContext = await browser.newContext({
+      baseURL: baseURL as string,
+      storageState: { cookies: [], origins: [] },
+      viewport: { width: 390, height: 844 },
+    });
+    const authenticatedContext = await browser.newContext({
+      baseURL: baseURL as string,
+      extraHTTPHeaders: {
+        [TEST_MODE_HEADER]: TEST_AUTH_BYPASS_MODE,
+        [TEST_USER_ID_HEADER]: 'profile-public-resilience-user',
+      },
+      storageState: { cookies: [], origins: [] },
+      viewport: { width: 390, height: 844 },
+    });
+
+    try {
+      await Promise.all([
+        addStableAudienceCookie(anonymousContext, baseURL as string),
+        addStableAudienceCookie(authenticatedContext, baseURL as string),
+      ]);
+      const anonymousPage = await anonymousContext.newPage();
+      const authenticatedPage = await authenticatedContext.newPage();
+
+      const [anonymousResponse, authenticatedResponse] = await Promise.all([
+        anonymousPage.goto(`/${TEST_PROFILES.DUALIPA}`, {
+          waitUntil: 'domcontentloaded',
+        }),
+        authenticatedPage.goto(`/${TEST_PROFILES.DUALIPA}`, {
+          waitUntil: 'domcontentloaded',
+        }),
+      ]);
+      expect(anonymousResponse?.status()).toBe(200);
+      expect(authenticatedResponse?.status()).toBe(200);
+
+      await Promise.all([
+        waitForHydration(anonymousPage),
+        waitForHydration(authenticatedPage),
+      ]);
+      expect(await readPublicContract(authenticatedPage)).toEqual(
+        await readPublicContract(anonymousPage)
+      );
+    } finally {
+      await anonymousContext.close();
+      await authenticatedContext.close();
+    }
+  });
+
+  test('keeps the hero and controls stable when profile media fails', async ({
+    browser,
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    expect(typeof baseURL).toBe('string');
+
+    const normalContext = await browser.newContext({
+      baseURL: baseURL as string,
+      storageState: { cookies: [], origins: [] },
+      viewport: { width: 390, height: 844 },
+    });
+    const brokenMediaContext = await browser.newContext({
+      baseURL: baseURL as string,
+      storageState: { cookies: [], origins: [] },
+      viewport: { width: 390, height: 844 },
+    });
+
+    try {
+      await Promise.all([
+        addStableAudienceCookie(normalContext, baseURL as string),
+        addStableAudienceCookie(brokenMediaContext, baseURL as string),
+      ]);
+      const normalPage = await normalContext.newPage();
+      const brokenMediaPage = await brokenMediaContext.newPage();
+      await brokenMediaPage.route(
+        url => url.pathname === '/_next/image',
+        route => route.fulfill({ status: 404, body: '' })
+      );
+
+      await normalPage.goto('/tim', { waitUntil: 'domcontentloaded' });
+      await brokenMediaPage.goto('/tim', { waitUntil: 'domcontentloaded' });
+      await Promise.all([
+        waitForHydration(normalPage),
+        waitForHydration(brokenMediaPage),
+      ]);
+
+      const brokenHero = brokenMediaPage.locator('.profile-cover-home-media');
+      await expect(brokenHero.locator('img')).toHaveCount(0);
+      await expect(brokenHero.locator('[role="img"]')).toBeVisible();
+      await expect(
+        brokenMediaPage.getByTestId('profile-hero-identity-block')
+      ).toBeVisible();
+      await expect(
+        brokenMediaPage.getByRole('button', { name: 'Menu' })
+      ).toBeVisible();
+
+      const [normalGeometry, brokenGeometry] = await Promise.all([
+        readProfileGeometry(normalPage),
+        readProfileGeometry(brokenMediaPage),
+      ]);
+      expect(brokenGeometry).toEqual(normalGeometry);
+      expect(brokenGeometry.overflowX).toBeLessThanOrEqual(0);
+    } finally {
+      await normalContext.close();
+      await brokenMediaContext.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add rendered public-profile resilience coverage for anonymous and authenticated visitors
- prove failed profile media preserves hero geometry, identity controls, and horizontal stability
- exercise reduced-transparency and high-contrast Liquid Glass fallbacks at runtime
- tighten CLS and strict mobile viewport coverage across the supported iPhone matrix

## Recovery
Recovered the intended single test-layer commit from layer 8 of the abandoned native stack and rebased it directly onto exact main after #15543 merged. The stale stacked view collapses to the intended four E2E files with no product-code changes.

## Verification
- 92 focused Playwright cases passed under Chromium across the four changed specs
- 3 production-only CLS measurements skipped by their existing dev-mode guard; no assertion failed
- the run enabled test-auth bypass and mobile performance budgets, covering auth parity, failed media, runtime accessibility fallbacks, and the complete strict mobile viewport matrix
- Biome passed on all four changed files
- Node 22.23.1 and the frozen lockfile were used

No required check, review, or deployment gate is bypassed. The rewritten head remains draft until its fresh source checks complete.

## Native stack position
- Immediate parent before retarget: 
- Retargeted base: 
- Parent merge proof: #15543 -> 
- Current head: 
- Child remains draft until source checks pass; native merge queue is the merge authority.

## Native stack position
- Immediate parent before retarget: f56e0f9dc8358f346dcc9b6721e6dc54d0065f01
- Retargeted base: main
- Parent merge proof: #15543 -> a7370529497ee3c0b97347ed702a83e7e2c4f8b0
- Current head: 52e02a217811f1077f4f945d7237efcb179169d6
- Child remains draft until source checks pass; native merge queue is the merge authority.