### PR TITLE
fix(profile): self-heal legacy collaborator links

### DIFF
--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -45,6 +45,7 @@ import {
   buildPublicProfileMetadata,
   PROFILE_ERROR_METADATA,
 } from '@/lib/profile/metadata';
+import { schedulePublicCollaboratorProfileReconciliation } from '@/lib/profile/public-collaborator-reconciliation';
 import { isShopEnabled } from '@/lib/profile/shop-settings';
 import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
 import { generateProfileStructuredData } from '@/lib/seo/structured-data';
@@ -354,6 +355,12 @@ async function ArtistPageContent({
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
   );
+
+  schedulePublicCollaboratorProfileReconciliation({
+    creatorProfileId: profile.id,
+    ownerSpotifyId: ownerSpotifyIdentity.spotifyArtistId,
+    collaborators: releaseCollaborators,
+  });
 
   // Serialize releases for client (query returns newest-first via DESC NULLS LAST)
   const releases: PublicRelease[] = allReleases.map(r => ({

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -254,6 +254,7 @@ function projectStructuredReleaseCollaborator(
     name,
     href: hasPublicProfile ? artistProfileHref(row.artistId) : null,
     profileState,
+    reconciliationEligible: Boolean(row.artistSpotifyId),
     role: row.role,
     releaseId: row.releaseId,
     releaseTitle: row.releaseTitle,

--- a/apps/web/lib/discography/artist-queries/types.ts
+++ b/apps/web/lib/discography/artist-queries/types.ts
@@ -35,6 +35,8 @@ export interface StructuredReleaseCollaborator {
   /** Stable registry route when a public claimed or unclaimed profile exists. */
   readonly href: string | null;
   readonly profileState: 'claimed' | 'unclaimed' | 'unavailable';
+  /** True only when the exact provider identity can drive reconciliation. */
+  readonly reconciliationEligible?: boolean;
   readonly role: PublicArtistCollaboratorRole;
   readonly releaseId: string;
   readonly releaseTitle: string;

--- a/apps/web/lib/profile/public-collaborator-reconciliation.ts
+++ b/apps/web/lib/profile/public-collaborator-reconciliation.ts
@@ -1,0 +1,78 @@
+import { after } from 'next/server';
+import type { StructuredReleaseCollaborator } from '@/lib/discography/artist-queries';
+import { reconcileCreditedArtistProfiles } from '@/lib/discography/collaborator-profile-reconciliation';
+import { captureWarning } from '@/lib/error-tracking';
+
+interface SchedulePublicCollaboratorReconciliationInput {
+  readonly creatorProfileId: string;
+  readonly ownerSpotifyId: string | null;
+  readonly collaborators: readonly StructuredReleaseCollaborator[];
+}
+
+const RECONCILIATION_CONTEXT = {
+  source: 'public_profile_render',
+  route: '/[username]',
+} as const;
+
+/**
+ * Repair legacy catalogs after a public render observes a structured credit
+ * with no public profile binding. The render never waits for this work: the
+ * existing importer/backfill remains authoritative, while `after()` provides
+ * a bounded self-healing path for older catalogs that predate reconciliation.
+ */
+export function schedulePublicCollaboratorProfileReconciliation({
+  creatorProfileId,
+  ownerSpotifyId,
+  collaborators,
+}: SchedulePublicCollaboratorReconciliationInput): boolean {
+  // `generateStaticParams` prerenders public profiles during the production
+  // build. Do not mutate production data from that build-time render; the
+  // importer/backfill owns static-generation repair, while runtime ISR renders
+  // can safely use the request-scoped `after()` lifecycle below.
+  if (process.env.NEXT_PHASE === 'phase-production-build') return false;
+
+  if (
+    !ownerSpotifyId ||
+    !collaborators.some(
+      collaborator =>
+        collaborator.profileState === 'unavailable' &&
+        collaborator.reconciliationEligible === true
+    )
+  ) {
+    return false;
+  }
+
+  try {
+    after(() =>
+      reconcileCreditedArtistProfiles(creatorProfileId, ownerSpotifyId)
+        .then(result => {
+          if (result.created > 0 || result.reused > 0) return;
+
+          if (result.conflicted > 0 || result.metadataUnavailable > 0) {
+            return captureWarning(
+              'Public collaborator profile reconciliation completed without a link',
+              undefined,
+              {
+                ...RECONCILIATION_CONTEXT,
+                creatorProfileId,
+                ...result,
+              }
+            );
+          }
+        })
+        .catch(error =>
+          captureWarning(
+            'Public collaborator profile reconciliation failed',
+            error,
+            { ...RECONCILIATION_CONTEXT, creatorProfileId }
+          )
+        )
+    );
+    return true;
+  } catch {
+    // Static generation and non-request callers do not have an `after()`
+    // lifecycle. The importer/backfill still owns those paths; never fail a
+    // public profile render because a best-effort repair could not be queued.
+    return false;
+  }
+}

--- a/apps/web/tests/unit/lib/discography/structured-release-collaborators.test.ts
+++ b/apps/web/tests/unit/lib/discography/structured-release-collaborators.test.ts
@@ -112,6 +112,23 @@ describe('structured release collaborator projection', () => {
     expect(result[0]).toMatchObject({
       href: null,
       profileState: 'unavailable',
+      reconciliationEligible: true,
+    });
+  });
+
+  it('does not mark name-only credits as reconciliation candidates', () => {
+    const result = project([
+      row({
+        artistSpotifyId: null,
+        artistProfileId: null,
+        profileIsPublic: null,
+        profileIsClaimed: null,
+      }),
+    ]);
+
+    expect(result[0]).toMatchObject({
+      profileState: 'unavailable',
+      reconciliationEligible: false,
     });
   });
 

--- a/apps/web/tests/unit/lib/profile/public-collaborator-reconciliation.test.ts
+++ b/apps/web/tests/unit/lib/profile/public-collaborator-reconciliation.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  after: vi.fn(),
+  captureWarning: vi.fn(() => Promise.resolve()),
+  reconcileCreditedArtistProfiles: vi.fn(),
+}));
+
+vi.mock('next/server', () => ({ after: hoisted.after }));
+vi.mock('@/lib/error-tracking', () => ({
+  captureWarning: hoisted.captureWarning,
+}));
+vi.mock('@/lib/discography/collaborator-profile-reconciliation', () => ({
+  reconcileCreditedArtistProfiles: hoisted.reconcileCreditedArtistProfiles,
+}));
+
+const { schedulePublicCollaboratorProfileReconciliation } = await import(
+  '@/lib/profile/public-collaborator-reconciliation'
+);
+
+const unavailableCollaborator = {
+  artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+  name: 'Austin Leeds',
+  href: null,
+  profileState: 'unavailable' as const,
+  reconciliationEligible: true,
+  role: 'featured_artist' as const,
+  releaseId: 'release-1',
+  releaseTitle: 'Take Me Over (Austin Leeds Remix)',
+  releaseSlug: 'take-me-over-austin-leeds-remix',
+  releaseDate: null,
+  position: 1,
+};
+
+describe('public collaborator profile reconciliation scheduling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.after.mockImplementation((callback: () => void) => {
+      callback();
+    });
+  });
+
+  it('does not queue work when the owner identity or collaborator profiles are complete', () => {
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: null,
+        collaborators: [unavailableCollaborator],
+      })
+    ).toBe(false);
+    expect(hoisted.after).not.toHaveBeenCalled();
+
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: 'spotify-owner',
+        collaborators: [
+          { ...unavailableCollaborator, profileState: 'claimed' },
+        ],
+      })
+    ).toBe(false);
+    expect(hoisted.after).not.toHaveBeenCalled();
+  });
+
+  it('queues exact-ID reconciliation after the render without blocking it', async () => {
+    hoisted.reconcileCreditedArtistProfiles.mockResolvedValue({
+      candidates: 1,
+      created: 1,
+      deferred: false,
+      reused: 0,
+      conflicted: 0,
+      metadataUnavailable: 0,
+    });
+
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: 'spotify-owner',
+        collaborators: [unavailableCollaborator],
+      })
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(hoisted.reconcileCreditedArtistProfiles).toHaveBeenCalledWith(
+        'owner-profile',
+        'spotify-owner'
+      );
+    });
+    expect(hoisted.captureWarning).not.toHaveBeenCalled();
+  });
+
+  it('reports failed closed reconciliation without failing the profile render', async () => {
+    hoisted.reconcileCreditedArtistProfiles.mockRejectedValue(
+      new Error('provider unavailable')
+    );
+
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: 'spotify-owner',
+        collaborators: [unavailableCollaborator],
+      })
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(hoisted.captureWarning).toHaveBeenCalledWith(
+        'Public collaborator profile reconciliation failed',
+        expect.any(Error),
+        expect.objectContaining({
+          creatorProfileId: 'owner-profile',
+          route: '/[username]',
+        })
+      );
+    });
+  });
+
+  it('silently falls back to the importer/backfill outside a request scope', () => {
+    hoisted.after.mockImplementation(() => {
+      throw new Error('after() was called outside a request scope');
+    });
+
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: 'spotify-owner',
+        collaborators: [unavailableCollaborator],
+      })
+    ).toBe(false);
+    expect(hoisted.reconcileCreditedArtistProfiles).not.toHaveBeenCalled();
+    expect(hoisted.captureWarning).not.toHaveBeenCalled();
+  });
+
+  it('does not retry credits that have no exact provider identity', () => {
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: 'spotify-owner',
+        collaborators: [
+          { ...unavailableCollaborator, reconciliationEligible: false },
+        ],
+      })
+    ).toBe(false);
+    expect(hoisted.after).not.toHaveBeenCalled();
+  });
+
+  it('never mutates data during the production build prerender', () => {
+    const originalPhase = process.env.NEXT_PHASE;
+    process.env.NEXT_PHASE = 'phase-production-build';
+
+    expect(
+      schedulePublicCollaboratorProfileReconciliation({
+        creatorProfileId: 'owner-profile',
+        ownerSpotifyId: 'spotify-owner',
+        collaborators: [unavailableCollaborator],
+      })
+    ).toBe(false);
+    expect(hoisted.after).not.toHaveBeenCalled();
+    expect(hoisted.reconcileCreditedArtistProfiles).not.toHaveBeenCalled();
+
+    if (originalPhase === undefined) delete process.env.NEXT_PHASE;
+    else process.env.NEXT_PHASE = originalPhase;
+  });
+});


### PR DESCRIPTION
## Summary  - schedule exact-ID collaborator profile reconciliation after a public profile render only when an unavailable credit is reconcilable - guard production-build prerenders so static generation never mutates profile data - keep name-only credits plain text and non-retryable; preserve structured credit roles and collision-safe profile routing  This is an isolated follow-up to the already-merged JOV-4820 profile stack. It does not amend the frozen production-verified SHA and does not embed external data.  ## Verification  - focused collaborator/AEO/scheduler Vitest: 33 assertions passed - web typecheck passed on Node 22.23.1 / pnpm 9.15.4 - Biome + ESLint + pre-push gates passed - affected full test bundle passed (pre-push) - bug-to-test gate: not applicable (not classified as bug-fix PR by repository classifier)  ## Release order  Root PR against main; merge through native GitHub queue/controller. Production proof must be a fresh exact-main controller run after merge.