### PR TITLE
fix(control-plane): route Symphony by product team (JOV-4601)

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
@@ -99,6 +99,24 @@ describe('deterministic no-model gates', () => {
     );
   });
 
+  it('accepts equivalent bold scope and acceptance sections used by LYB', () => {
+    const candidate = issue({
+      identifier: 'LYB-13',
+      project: null,
+      description: `**Problem** — The gesture uses the wrong denominator.
+
+**Proposed fix** — Divide by the rendered track width and clamp the result.
+
+**Acceptance** — Drag positions map linearly from zero to one.`,
+    });
+    const result = deterministicGates.buildDeterministicPlanEvidence(candidate);
+    assert.equal(result.reason, null);
+    assert.match(result.evidence.scope, /rendered track width/);
+    assert.deepEqual(result.evidence.acceptance, [
+      'Drag positions map linearly from zero to one.',
+    ]);
+  });
+
   it('fails closed on team routing, ownership, epic, sensitive, stale, and incomplete work', () => {
     const cases = [
       issue({ identifier: 'OPS-1' }),

--- a/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import * as admissionGate from '../admission-gate.mjs';
+import * as admitter from '../admitter.mjs';
 import * as deterministicGates from '../deterministic-gates.mjs';
 import * as planGate from '../plan-gate.mjs';
 
@@ -38,18 +39,22 @@ Normalize the unstable token before sending the event.
 }
 
 function plannedIssue(overrides = {}) {
-  const base = issue();
+  const seed = {};
+  if (overrides.identifier !== undefined)
+    seed.identifier = overrides.identifier;
+  if (overrides.project !== undefined) seed.project = overrides.project;
+  const base = issue(seed);
   const { evidence } = deterministicGates.buildDeterministicPlanEvidence(base);
   const receipt = planGate.buildPlanGateReceipt(base, evidence);
   return issue({
-    labels: {
+    ...overrides,
+    labels: overrides.labels || {
       nodes: [
         ...base.labels.nodes,
         { id: 'plan-id', name: planGate.PLAN_APPROVED_LABEL },
       ],
     },
-    comments: { nodes: [{ body: receipt }] },
-    ...overrides,
+    comments: overrides.comments || { nodes: [{ body: receipt }] },
   });
 }
 
@@ -69,9 +74,34 @@ describe('deterministic no-model gates', () => {
     );
   });
 
-  it('fails closed on project, ownership, epic, sensitive, stale, and incomplete work', () => {
+  it('routes LYB evidence to LogYourBody without requiring a Linear project', () => {
+    const candidate = issue({
+      identifier: 'LYB-12',
+      project: null,
+    });
+    const result = deterministicGates.buildDeterministicPlanEvidence(candidate);
+    assert.equal(result.reason, null);
+    assert.equal(result.evidence.repo, 'JovieInc/LogYourBody');
+    assert.equal(result.evidence.project, 'LYB');
+    assert.equal(admitter.isConcreteJovieIssue(candidate), true);
+    assert.equal(
+      planGate.validatePlanCandidate(candidate, result.evidence),
+      null
+    );
+    assert.equal(
+      admissionGate.validateAdmissionCandidate(
+        plannedIssue({
+          identifier: 'LYB-12',
+          project: null,
+        })
+      ),
+      null
+    );
+  });
+
+  it('fails closed on team routing, ownership, epic, sensitive, stale, and incomplete work', () => {
     const cases = [
-      issue({ project: { name: 'LogYourBody' } }),
+      issue({ identifier: 'OPS-1' }),
       issue({ assignee: { id: 'tim', name: 'Tim White' } }),
       issue({ labels: { nodes: [{ name: 'type:epic' }] } }),
       issue({ title: 'Rotate a production credential' }),

--- a/scripts/backlog-orchestrator/admission-gate.mjs
+++ b/scripts/backlog-orchestrator/admission-gate.mjs
@@ -53,8 +53,8 @@ function isTimOwned(issue) {
 }
 
 export function validateAdmissionCandidate(issue) {
-  if (!issue?.id || !/^JOV-\d+$/.test(issue.identifier || ''))
-    return 'not-concrete-jovie-issue';
+  if (!issue?.id || !/^(?:JOV|LYB)-\d+$/.test(issue.identifier || ''))
+    return 'not-concrete-routed-issue';
   if (!ALLOWED_STATES.has(issue.state?.name || issue.state))
     return 'ambiguous-or-active-state';
   if (isTimOwned(issue)) return 'tim-owned';

--- a/scripts/backlog-orchestrator/admitter.mjs
+++ b/scripts/backlog-orchestrator/admitter.mjs
@@ -1,9 +1,9 @@
 /**
  * Deterministic admission boundary for Symphony.
  *
- * Workstream bundles are useful reports, but only one concrete JOV issue may
- * cross this boundary. Admission is fail-closed on ownership, plan evidence,
- * and mutation read-back.
+ * Workstream bundles are useful reports, but only one concrete issue per
+ * routed product team may cross this boundary. Admission is fail-closed on
+ * ownership, plan evidence, and mutation read-back.
  */
 
 import { isProductionRed, scoreIssue } from './scorer.mjs';
@@ -48,7 +48,7 @@ function commentText(issue) {
 }
 
 export function isConcreteJovieIssue(issue) {
-  return Boolean(issue?.id && /^JOV-\d+$/.test(issue.identifier || ''));
+  return Boolean(issue?.id && /^(?:JOV|LYB)-\d+$/.test(issue.identifier || ''));
 }
 
 function isTimOwned(issue) {
@@ -194,7 +194,7 @@ export async function admitIssue({
   now = new Date().toISOString(),
 }) {
   if (!isConcreteJovieIssue(issue))
-    return { status: 'rejected', reason: 'not-concrete-jovie-issue' };
+    return { status: 'rejected', reason: 'not-concrete-routed-issue' };
   if (!hasAdmissionEvidence(issue, classification).eligible) {
     return { status: 'rejected', reason: 'plan-or-admission-evidence-missing' };
   }

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -178,7 +178,7 @@ async function isTeamProductionRed(team) {
     });
     if (!response.ok) return true;
     if (team.healthKind === 'json-status') {
-      const data = await response.json();
+      const data = /** @type {{ status?: string }} */ (await response.json());
       return data.status !== 'ok';
     }
     return false;

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -42,9 +42,33 @@ import * as workstreamer from './workstreamer.mjs';
 // ----- Config -----
 const CACHE_FILE = resolve(__dirname, '.orchestrator-cache.json');
 
-const TEAM_ID = 'bdc09edc-f91c-4a06-b308-74b4fcf093f8'; // JOV team
-const BACKLOG_STATE_ID = '1551ed21-7743-4573-82d8-8949410d3b8d'; // Backlog
-const TODO_STATE_ID = 'c6c00506-dc9f-4910-8ff7-3874dd77174c'; // Todo
+const TEAM_CONFIGS = Object.freeze([
+  Object.freeze({
+    key: 'JOV',
+    id: 'bdc09edc-f91c-4a06-b308-74b4fcf093f8',
+    intakeStates: ['Triage'],
+    backlogStateId: '1551ed21-7743-4573-82d8-8949410d3b8d',
+    todoStateId: 'c6c00506-dc9f-4910-8ff7-3874dd77174c',
+    healthUrl: 'https://jov.ie/api/health',
+    healthKind: 'json-status',
+  }),
+  Object.freeze({
+    key: 'LYB',
+    id: '119e4dea-db83-4718-885a-70869d74445e',
+    intakeStates: ['Backlog'],
+    backlogStateId: '63ced43e-ab22-48e8-9dcc-a2ce54ee6da9',
+    todoStateId: '4b318cc8-0a57-489c-8370-b780e11cff7f',
+    healthUrl: 'https://logyourbody.com',
+    healthKind: 'http-ok',
+  }),
+]);
+
+function teamForIdentifier(identifier) {
+  const key = /^([A-Za-z][A-Za-z0-9]*)-\d+$/.exec(identifier || '')?.[1];
+  return TEAM_CONFIGS.find(
+    team => team.key === String(key || '').toUpperCase()
+  );
+}
 
 // ----- Cache -----
 function loadCache() {
@@ -120,6 +144,9 @@ async function runApprovePlan(issueArg, evidenceFile, evidenceJson, isDryRun) {
     : JSON.parse(evidenceJson);
   const issue = await linear.fetchIssue(issueArg);
   if (!issue) throw new Error(`Issue ${issueArg} not found`);
+  const team = teamForIdentifier(issue.identifier);
+  if (!team)
+    throw new Error(`Issue ${issue.identifier} has no repository route`);
   const reason = planGate.validatePlanCandidate(issue, evidence);
   if (isDryRun) {
     console.log(
@@ -139,13 +166,29 @@ async function runApprovePlan(issueArg, evidenceFile, evidenceJson, isDryRun) {
     issue,
     evidence,
     client: linear,
-    teamId: TEAM_ID,
+    teamId: team.id,
   });
   console.log(JSON.stringify(receipt, null, 2));
 }
 
-async function admissionPreflight() {
-  const productionRed = await scorer.isProductionRed();
+async function isTeamProductionRed(team) {
+  try {
+    const response = await fetch(team.healthUrl, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) return true;
+    if (team.healthKind === 'json-status') {
+      const data = await response.json();
+      return data.status !== 'ok';
+    }
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+async function admissionPreflight(team) {
+  const productionRed = await isTeamProductionRed(team);
   if (productionRed) {
     return {
       open: false,
@@ -153,7 +196,7 @@ async function admissionPreflight() {
       load: { count: 0, identifiers: [] },
     };
   }
-  const symphonyIssues = await linear.fetchTeamSymphonyIssues(TEAM_ID);
+  const symphonyIssues = await linear.fetchTeamSymphonyIssues(team.id);
   const load = deterministicGates.admissionIntentLoad(symphonyIssues);
   return {
     open: load.count < admitter.MAX_CONCURRENT_SHIPPING,
@@ -166,50 +209,78 @@ async function admissionPreflight() {
 }
 
 async function runGateNext(isDryRun, issueArg) {
-  const preflight = await admissionPreflight();
+  const teams = issueArg
+    ? [teamForIdentifier(issueArg)].filter(Boolean)
+    : TEAM_CONFIGS;
+  if (teams.length === 0)
+    throw new Error(`Issue ${issueArg} has no repository route`);
+  const results = [];
+  for (const team of teams) {
+    try {
+      results.push(await runTeamGateNext(team, isDryRun, issueArg));
+    } catch (error) {
+      results.push({
+        team: team.key,
+        status: 'blocked',
+        stage: 'team-error',
+        reason: error.message,
+        mutations: 0,
+      });
+    }
+  }
+  console.log(
+    JSON.stringify(
+      {
+        schema: 'deterministic-gates/run/v2',
+        status: results.some(result => result.status === 'admitted')
+          ? 'admitted'
+          : results.some(result => result.status === 'would-admit')
+            ? 'would-admit'
+            : 'blocked',
+        teams: results,
+        mutations: isDryRun
+          ? 0
+          : results.some(result => result.mutations === 'verified')
+            ? 'verified'
+            : 0,
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function runTeamGateNext(team, isDryRun, issueArg) {
+  const preflight = await admissionPreflight(team);
   if (!preflight.open) {
-    console.log(
-      JSON.stringify(
-        {
-          schema: 'deterministic-gates/run/v1',
-          status: 'blocked',
-          stage: 'preflight',
-          reason: preflight.reason,
-          active: preflight.load.identifiers,
-          mutations: 0,
-        },
-        null,
-        2
-      )
-    );
-    return;
+    return {
+      team: team.key,
+      status: 'blocked',
+      stage: 'preflight',
+      reason: preflight.reason,
+      active: preflight.load.identifiers,
+      mutations: 0,
+    };
   }
 
   const issues = issueArg
     ? [await linear.fetchIssue(issueArg)].filter(Boolean)
-    : await linear.fetchTeamGateCandidates(TEAM_ID);
+    : await linear.fetchTeamGateCandidates(team.id);
   const selection = deterministicGates.selectDeterministicPlanCandidate(
     issues,
     { issueIdentifier: issueArg }
   );
   if (!selection.selected) {
-    console.log(
-      JSON.stringify(
-        {
-          schema: 'deterministic-gates/run/v1',
-          status: 'blocked',
-          stage: 'selection',
-          reason: issueArg
-            ? 'requested issue is not eligible'
-            : 'no eligible issue',
-          decisions: selection.decisions,
-          mutations: 0,
-        },
-        null,
-        2
-      )
-    );
-    return;
+    return {
+      team: team.key,
+      status: 'blocked',
+      stage: 'selection',
+      reason: issueArg
+        ? 'requested issue is not eligible'
+        : 'no eligible issue',
+      decisions: selection.decisions,
+      mutations: 0,
+    };
   }
 
   const selected = selection.selected;
@@ -217,58 +288,44 @@ async function runGateNext(isDryRun, issueArg) {
   const planReason =
     plan.reason || planGate.validatePlanCandidate(selected, plan.evidence);
   if (planReason) {
-    console.log(
-      JSON.stringify(
-        {
-          schema: 'deterministic-gates/run/v1',
-          status: 'blocked',
-          stage: 'plan',
-          issue: selected.identifier,
-          reason: planReason,
-          mutations: 0,
-        },
-        null,
-        2
-      )
-    );
-    return;
+    return {
+      team: team.key,
+      status: 'blocked',
+      stage: 'plan',
+      issue: selected.identifier,
+      reason: planReason,
+      mutations: 0,
+    };
   }
 
   if (isDryRun) {
-    console.log(
-      JSON.stringify(
-        {
-          schema: 'deterministic-gates/run/v1',
-          status: 'would-admit',
-          issue: selected.identifier,
-          plan: plan.evidence,
-          mutations: 0,
-        },
-        null,
-        2
-      )
-    );
-    return;
+    return {
+      team: team.key,
+      status: 'would-admit',
+      issue: selected.identifier,
+      plan: plan.evidence,
+      mutations: 0,
+    };
   }
 
   const planResult = await planGate.approvePlan({
     issue: selected,
     evidence: plan.evidence,
     client: linear,
-    teamId: TEAM_ID,
+    teamId: team.id,
   });
   if (planResult.status === 'rejected')
     throw new Error(`plan gate rejected: ${planResult.reason}`);
 
   let current = await linear.fetchIssue(selected.identifier);
-  const finalPreflight = await admissionPreflight();
+  const finalPreflight = await admissionPreflight(team);
   if (!finalPreflight.open)
     throw new Error(`admission preflight blocked: ${finalPreflight.reason}`);
 
   const admissionResult = await admissionGate.approveAdmission({
     issue: current,
     client: linear,
-    teamId: TEAM_ID,
+    teamId: team.id,
   });
   if (admissionResult.status === 'rejected')
     throw new Error(`admission gate rejected: ${admissionResult.reason}`);
@@ -283,8 +340,8 @@ async function runGateNext(isDryRun, issueArg) {
     issue: current,
     classification,
     client: linear,
-    teamId: TEAM_ID,
-    todoStateId: TODO_STATE_ID,
+    teamId: team.id,
+    todoStateId: team.todoStateId,
   });
   if (!['admitted', 'already-admitted'].includes(lease.status))
     throw new Error(`lease rejected: ${lease.reason}`);
@@ -302,27 +359,30 @@ async function runGateNext(isDryRun, issueArg) {
   )
     throw new Error('final gate-and-lease verification failed');
 
-  console.log(
-    JSON.stringify(
-      {
-        schema: 'deterministic-gates/run/v1',
-        status: 'admitted',
-        issue: selected.identifier,
-        planGate: planResult.status,
-        admissionGate: admissionResult.status,
-        lease: lease.status,
-        active: load.identifiers,
-        mutations: 'verified',
-      },
-      null,
-      2
-    )
-  );
+  return {
+    team: team.key,
+    status: 'admitted',
+    issue: selected.identifier,
+    planGate: planResult.status,
+    admissionGate: admissionResult.status,
+    lease: lease.status,
+    active: load.identifiers,
+    mutations: 'verified',
+  };
 }
 
 async function runAudit(cache, isDryRun) {
   console.log('Scanning Linear backlog...');
-  const allIssues = await linear.fetchTeamActiveIssues(TEAM_ID);
+  const teamFetches = await Promise.allSettled(
+    TEAM_CONFIGS.map(team => linear.fetchTeamActiveIssues(team.id))
+  );
+  const allIssues = teamFetches.flatMap((result, index) => {
+    if (result.status === 'fulfilled') return result.value;
+    console.error(
+      `Failed to fetch ${TEAM_CONFIGS[index].key}: ${result.reason.message}`
+    );
+    return [];
+  });
   console.log(`Fetched ${allIssues.length} issues`);
 
   const classifications = [];
@@ -386,40 +446,113 @@ async function runAudit(cache, isDryRun) {
 }
 
 async function runReconcile(cache, isDryRun, issueArg) {
-  let issues;
   if (issueArg) {
     const issue = await linear.fetchIssue(issueArg);
-    issues = issue ? [issue] : [];
     if (!issue) {
       console.log(`Issue ${issueArg} not found`);
       return;
     }
-  } else {
-    console.log('Fetching Triage issues...');
-    issues = await linear.fetchTeamTriageIssues(TEAM_ID);
+    const team = teamForIdentifier(issue.identifier);
+    if (!team)
+      throw new Error(`Issue ${issue.identifier} has no repository route`);
+    console.log('Processing 1 issue');
+    const receipt = await reconciler.reconcileIssues({
+      issues: [issue],
+      client: linear,
+      isDryRun,
+      backlogStateId: team.backlogStateId,
+    });
+    console.log('Reconciliation receipt:');
+    console.log(JSON.stringify(receipt, null, 2));
+    console.log('Reconciliation complete.');
+    return;
   }
 
-  console.log(`Processing ${issues.length} issues`);
-
-  const receipt = await reconciler.reconcileIssues({
-    issues,
-    client: linear,
-    isDryRun,
-    backlogStateId: BACKLOG_STATE_ID,
-  });
-
+  console.log('Fetching Triage issues for JOV and LYB...');
+  const teamReceipts = [];
+  for (const team of TEAM_CONFIGS) {
+    try {
+      const issues = await linear.fetchTeamTriageIssues(
+        team.id,
+        1000,
+        team.intakeStates
+      );
+      const receipt = await reconciler.reconcileIssues({
+        issues,
+        client: linear,
+        isDryRun,
+        backlogStateId: team.backlogStateId,
+      });
+      teamReceipts.push({ team: team.key, status: 'ok', ...receipt });
+    } catch (error) {
+      teamReceipts.push({
+        team: team.key,
+        status: 'failed',
+        error: error.message,
+        issueCount: 0,
+        classified: 0,
+        skipped: 0,
+        wouldMove: 0,
+        mutations: 0,
+      });
+    }
+  }
+  const totals = teamReceipts.reduce(
+    (sum, receipt) => ({
+      issueCount: sum.issueCount + receipt.issueCount,
+      classified: sum.classified + receipt.classified,
+      skipped: sum.skipped + receipt.skipped,
+      wouldMove: sum.wouldMove + receipt.wouldMove,
+      mutations: sum.mutations + receipt.mutations,
+    }),
+    { issueCount: 0, classified: 0, skipped: 0, wouldMove: 0, mutations: 0 }
+  );
+  console.log(`Processing ${totals.issueCount} issues`);
   console.log('Reconciliation receipt:');
-  console.log(JSON.stringify(receipt, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        schema: 'backlog-orchestrator/reconcile-multiteam/v1',
+        mode: isDryRun ? 'dry-run' : 'mutating',
+        ...totals,
+        teams: teamReceipts,
+      },
+      null,
+      2
+    )
+  );
   console.log('Reconciliation complete.');
 }
 
 async function runAdmitNext(cache, isDryRun) {
   console.log('Checking admission eligibility...');
+  const teamResults = [];
+  for (const team of TEAM_CONFIGS) {
+    try {
+      teamResults.push(await runTeamAdmitNext(team, isDryRun));
+    } catch (error) {
+      teamResults.push({
+        team: team.key,
+        status: 'blocked',
+        reason: error.message,
+        mutations: 0,
+      });
+    }
+  }
 
+  const result = { teams: teamResults };
+  saveCache({
+    ...cache,
+    lastAdmit: { at: new Date().toISOString(), result },
+  });
+  return result;
+}
+
+async function runTeamAdmitNext(team, isDryRun) {
   // Release only provably stale machine leases before ordinary admission. This
   // is intentionally scoped to unassigned In Progress issues; it never touches
   // Tim-assigned or otherwise ambiguous work.
-  const inProgressIssues = await linear.fetchTeamInProgressIssues(TEAM_ID);
+  const inProgressIssues = await linear.fetchTeamInProgressIssues(team.id);
   if (isDryRun) {
     const planned = inProgressIssues
       .map(issue => ({
@@ -432,6 +565,7 @@ async function runAdmitNext(cache, isDryRun) {
     const staleLeaseResult = await staleLeaseGuard.sweepStaleLeases({
       issues: inProgressIssues,
       client: linear,
+      todoStateId: team.todoStateId,
     });
     console.log(
       `Stale-lease sweep: recovered ${staleLeaseResult.recovered.length}, ` +
@@ -439,7 +573,7 @@ async function runAdmitNext(cache, isDryRun) {
     );
   }
 
-  const allIssues = await linear.fetchTeamActiveIssues(TEAM_ID);
+  const allIssues = await linear.fetchTeamActiveIssues(team.id);
   const classifications = [];
   for (const issue of allIssues) {
     const stored = classifier.parseStoredClassification(issue);
@@ -459,6 +593,7 @@ async function runAdmitNext(cache, isDryRun) {
     workstreams,
     {
       currentlyShipping: state.count,
+      productionRed: await isTeamProductionRed(team),
     }
   );
 
@@ -471,8 +606,8 @@ async function runAdmitNext(cache, isDryRun) {
         issue: item.issue,
         classification: item,
         client: linear,
-        teamId: TEAM_ID,
-        todoStateId: TODO_STATE_ID,
+        teamId: team.id,
+        todoStateId: team.todoStateId,
       });
       console.log(`  ${receipt.status}: ${item.identifier}`);
     } catch (err) {
@@ -486,14 +621,7 @@ async function runAdmitNext(cache, isDryRun) {
     console.log('  (dry-run — no mutations performed)');
   }
 
-  // Update cache
-  const newCache = {
-    ...cache,
-    lastAdmit: { at: new Date().toISOString(), result },
-  };
-  saveCache(newCache);
-
-  return result;
+  return { team: team.key, ...result };
 }
 
 main().catch(err => {

--- a/scripts/backlog-orchestrator/deterministic-gates.mjs
+++ b/scripts/backlog-orchestrator/deterministic-gates.mjs
@@ -79,19 +79,32 @@ function isTimOwned(issue) {
   );
 }
 
+function sectionHeader(line) {
+  const markdown = /^#{2,3}\s+(.+?)\s*$/.exec(line);
+  if (markdown) return { name: markdown[1].trim(), inline: '' };
+  const bold = /^\s*\*\*([^*]+?)\*\*\s*(?:[—:-]\s*)?(.*)$/.exec(line);
+  if (!bold) return null;
+  return {
+    name: bold[1].replace(/:\s*$/, '').trim(),
+    inline: bold[2].trim(),
+  };
+}
+
 function section(description, names) {
   const wanted = new Set(names.map(name => name.toLowerCase()));
   const lines = String(description || '').split('\n');
   const start = lines.findIndex(line => {
-    const match = /^#{2,3}\s+(.+?)\s*$/.exec(line);
-    return match && wanted.has(match[1].toLowerCase());
+    const header = sectionHeader(line);
+    return header && wanted.has(header.name.toLowerCase());
   });
   if (start < 0) return '';
-  const end = lines.findIndex(
-    (line, index) => index > start && /^#{2,3}\s+/.test(line)
-  );
-  return lines
-    .slice(start + 1, end < 0 ? undefined : end)
+  const end = lines.findIndex((line, index) => {
+    if (index <= start) return false;
+    return Boolean(sectionHeader(line));
+  });
+  const inline = sectionHeader(lines[start])?.inline;
+  return [inline, ...lines.slice(start + 1, end < 0 ? undefined : end)]
+    .filter(Boolean)
     .join('\n')
     .trim();
 }
@@ -143,9 +156,15 @@ export function validateDeterministicPlanCandidate(
   )
     return 'stale-or-invalid-created-at';
 
-  if (!section(issue.description, ['Proposed fix', 'Implementation plan']))
+  if (
+    !section(issue.description, [
+      'Proposed fix',
+      'Implementation plan',
+      'Scope',
+    ])
+  )
     return 'scope-section-missing';
-  if (!section(issue.description, ['Acceptance criteria']))
+  if (!section(issue.description, ['Acceptance', 'Acceptance criteria']))
     return 'acceptance-section-missing';
   return null;
 }
@@ -156,9 +175,10 @@ export function buildDeterministicPlanEvidence(issue) {
   const scope = section(issue.description, [
     'Implementation plan',
     'Proposed fix',
+    'Scope',
   ]);
   const acceptance = cleanList(
-    section(issue.description, ['Acceptance criteria'])
+    section(issue.description, ['Acceptance', 'Acceptance criteria'])
   );
   const route = teamRouteForIssue(issue);
   return {

--- a/scripts/backlog-orchestrator/deterministic-gates.mjs
+++ b/scripts/backlog-orchestrator/deterministic-gates.mjs
@@ -24,14 +24,35 @@ const PROTECTED_LABELS = new Set([
   'tim-owned',
   'type:epic',
 ]);
-export const SYMPHONY_PROJECT = {
-  name: 'Infra & CI/CD',
-  slugId: '82c6fbd42405',
-};
+export const TEAM_ROUTES = Object.freeze({
+  JOV: Object.freeze({
+    key: 'JOV',
+    name: 'Jovie',
+    repo: 'JovieInc/Jovie',
+  }),
+  LYB: Object.freeze({
+    key: 'LYB',
+    name: 'LYB',
+    repo: 'JovieInc/LogYourBody',
+  }),
+});
 const PROHIBITED_TEXT =
   /credential|secret|password|api[ -]?key|access token|private key|billing|payment|checkout|database migration|schema migration|production deploy|publish externally|delete (?:customer|production|user) data|destructive|synthetic|bundle|workstream|batch|epic-only/i;
-const ACTIVE_PR = /github\.com\/JovieInc\/Jovie\/pull\/\d+/i;
 const MAX_CANDIDATE_AGE_DAYS = 60;
+
+export function teamRouteForIssue(issue) {
+  const key =
+    issue?.team?.key ||
+    /^([A-Za-z][A-Za-z0-9]*)-\d+$/.exec(issue?.identifier || '')?.[1];
+  return TEAM_ROUTES[String(key || '').toUpperCase()] || null;
+}
+
+function activePullRequestPattern(route) {
+  return new RegExp(
+    `github\\.com/${route.repo.replace('/', '\\/')}\\/pull\\/\\d+`,
+    'i'
+  );
+}
 
 function labelsOf(issue) {
   return (issue?.labels?.nodes || issue?.labels || [])
@@ -87,18 +108,12 @@ export function validateDeterministicPlanCandidate(
   issue,
   { now = new Date().toISOString() } = {}
 ) {
-  if (!issue?.id || !/^JOV-\d+$/.test(issue.identifier || ''))
-    return 'not-concrete-jovie-issue';
+  if (!issue?.id || !teamRouteForIssue(issue))
+    return 'not-concrete-routed-issue';
   if (!['Triage', 'Backlog', 'Todo'].includes(issue.state?.name || issue.state))
     return 'inactive-or-active-state';
   if (isTimOwned(issue)) return 'tim-owned';
   if (issue.assignee) return 'already-assigned';
-  if (
-    issue.project?.name !== SYMPHONY_PROJECT.name ||
-    issue.project?.slugId !== SYMPHONY_PROJECT.slugId
-  )
-    return 'project-not-allowlisted';
-
   const labels = labelsOf(issue);
   if (!labels.some(label => READY_LABELS.has(label)))
     return 'readiness-label-missing';
@@ -110,7 +125,12 @@ export function validateDeterministicPlanCandidate(
 
   const text = `${issue.title || ''}\n${issue.description || ''}`;
   if (PROHIBITED_TEXT.test(text)) return 'sensitive-or-external-work';
-  if (commentsOf(issue).some(comment => ACTIVE_PR.test(commentBody(comment))))
+  const route = teamRouteForIssue(issue);
+  if (
+    commentsOf(issue).some(comment =>
+      activePullRequestPattern(route).test(commentBody(comment))
+    )
+  )
     return 'active-pull-request';
 
   const createdAt = new Date(issue.createdAt || 0).getTime();
@@ -140,14 +160,15 @@ export function buildDeterministicPlanEvidence(issue) {
   const acceptance = cleanList(
     section(issue.description, ['Acceptance criteria'])
   );
+  const route = teamRouteForIssue(issue);
   return {
     reason: null,
     evidence: {
       verified: true,
       concrete: true,
       bounded: true,
-      repo: 'JovieInc/Jovie',
-      project: issue.project.name,
+      repo: route.repo,
+      project: issue.project?.name || route.name,
       owner: 'Gem',
       scope: scope.slice(0, 1800),
       acceptance,

--- a/scripts/backlog-orchestrator/linear-client.mjs
+++ b/scripts/backlog-orchestrator/linear-client.mjs
@@ -228,21 +228,27 @@ export async function graphql(
 }
 
 /**
- * Fetch all issues in Triage state for a team.
+ * Fetch all issues in the configured deterministic intake states for a team.
+ * Jovie enables Linear's Triage state; new teams can use Backlog until that
+ * workspace-level feature is enabled without changing the control-plane path.
  * Paginates to get all results.
  */
-export async function fetchTeamTriageIssues(teamId, maxResults = 1000) {
+export async function fetchTeamTriageIssues(
+  teamId,
+  maxResults = 1000,
+  stateNames = ['Triage']
+) {
   const issues = [];
   let cursor = null;
   while (issues.length < maxResults) {
     const data = await graphql(
       `
-      query($teamId: String!, $cursor: String) {
+      query($teamId: String!, $cursor: String, $stateNames: [String!]!) {
         team(id: $teamId) {
           issues(
             first: 50,
             after: $cursor,
-            filter: { state: { name: { eq: "Triage" } } }
+            filter: { state: { name: { in: $stateNames } } }
           ) {
             nodes {
               id
@@ -274,7 +280,7 @@ export async function fetchTeamTriageIssues(teamId, maxResults = 1000) {
         }
       }
     `,
-      { teamId, cursor }
+      { teamId, cursor, stateNames }
     );
     const edge = data.team.issues;
     issues.push(...edge.nodes);

--- a/scripts/backlog-orchestrator/plan-gate.mjs
+++ b/scripts/backlog-orchestrator/plan-gate.mjs
@@ -27,6 +27,15 @@ const CREDENTIAL_PATTERN =
   /credential|secret|password|api[ -]?key|access token|private key/i;
 const SYNTHETIC_PATTERN = /synthetic|bundle|workstream|batch|epic-only/i;
 const TIM_PATTERN = /tim(?:\s|-|_)*white|itstimwhite|^tim$/i;
+const REPO_BY_TEAM = Object.freeze({
+  JOV: 'JovieInc/Jovie',
+  LYB: 'JovieInc/LogYourBody',
+});
+
+function canonicalRepoForIssue(issue) {
+  const key = /^([A-Za-z][A-Za-z0-9]*)-\d+$/.exec(issue?.identifier || '')?.[1];
+  return REPO_BY_TEAM[String(key || '').toUpperCase()] || null;
+}
 
 function labelsOf(issue) {
   return (issue?.labels?.nodes || issue?.labels || [])
@@ -89,8 +98,8 @@ function issueText(issue) {
 
 /** Return a stable reason when a candidate cannot cross the plan boundary. */
 export function validatePlanCandidate(issue, evidence) {
-  if (!issue?.id || !/^JOV-\d+$/.test(issue.identifier || ''))
-    return 'not-concrete-jovie-issue';
+  const canonicalRepo = canonicalRepoForIssue(issue);
+  if (!issue?.id || !canonicalRepo) return 'not-concrete-routed-issue';
   if (!evidence || evidence.verified !== true) return 'evidence-not-verified';
   if (evidence.concrete !== true) return 'evidence-not-concrete';
   if (evidence.bounded !== true) return 'evidence-not-bounded';
@@ -126,7 +135,7 @@ export function validatePlanCandidate(issue, evidence) {
   if (hasActivePullRequest(issue)) return 'active-pull-request';
   if (evidence.synthetic === true || evidence.ambiguous === true)
     return 'synthetic-or-ambiguous-evidence';
-  if (evidence.repo !== 'JovieInc/Jovie') return 'repo-not-canonical';
+  if (evidence.repo !== canonicalRepo) return 'repo-not-canonical';
   if (issue.project?.name && issue.project.name !== evidence.project)
     return 'project-mismatch';
   return null;


### PR DESCRIPTION
## Summary

- route deterministic intake and admission by Linear team: JOV to `JovieInc/Jovie`, LYB to `JovieInc/LogYourBody`
- remove the Jovie-only project requirement so null-project issues can still be safely routed by team
- enforce independent health checks, capacity, stale-lease recovery, reconciliation, and admission receipts per repository
- use LYB Backlog as its deterministic intake state because the new team has no Linear Triage state yet
- keep unknown teams, protected work, ambiguous plans, active PRs, and unhealthy repositories fail-closed

## Why

The live queue contained 33 JOV Triage issues, but every candidate was rejected by a hard-coded Jovie project allowlist. The same hard-coding also made the newly created LYB team invisible and allowed Jovie repository health/capacity to pause LogYourBody shipping.

## Verification

- Node `v22.23.1`
- Biome: 7 changed files checked, no fixes required
- `node --test scripts/backlog-orchestrator/__tests__/*.test.mjs`: 54 passed, 0 failed
- `pnpm --filter @jovie/web run test:bug-to-test`: not applicable
- `node --check scripts/backlog-orchestrator/backlog-orchestrator.mjs`: passed
- `git diff --check`: passed
- live exact-branch dry-run: 34 JOV Triage + 4 LYB Backlog issues reconciled independently with 0 mutations
- live exact-branch LYB-1 gate: `would-admit`, canonical repo `JovieInc/LogYourBody`, bounded scope and acceptance extracted

## Risk and rollback

Risk is bounded to the deterministic backlog/Symphony control plane. Per-team mutation rereads remain mandatory, concurrency stays capped at one issue per repository, and a team failure is recorded without stopping its sibling. Revert this PR to restore the prior JOV-only route.

Fixes JOV-4601

<!-- linear-issue-id:JOV-4601 -->
