### PR TITLE
fix(profile): tighten public profile carousel chrome

### DIFF
--- a/apps/web/components/features/profile/SubscriptionConfirmedBanner.test.tsx
+++ b/apps/web/components/features/profile/SubscriptionConfirmedBanner.test.tsx
@@ -1,0 +1,38 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SubscriptionConfirmedBanner } from './SubscriptionConfirmedBanner';
+
+describe('SubscriptionConfirmedBanner', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/tim');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('does not reserve layout space when the confirmation query is absent', () => {
+    render(<SubscriptionConfirmedBanner />);
+
+    expect(screen.queryByText(/Notifications on!/)).not.toBeInTheDocument();
+    expect(document.querySelector('.shrink-0.pb-3')).not.toBeInTheDocument();
+  });
+
+  it('adds its spacing wrapper only while the confirmation is visible', async () => {
+    window.history.replaceState({}, '', '/tim?subscribed=confirmed');
+    render(<SubscriptionConfirmedBanner />);
+
+    await act(async () => {});
+    const message = screen.getByText(/Notifications on!/);
+    expect(message.closest('.shrink-0.pb-3')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(screen.queryByText(/Notifications on!/)).not.toBeInTheDocument();
+    expect(document.querySelector('.shrink-0.pb-3')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/features/profile/SubscriptionConfirmedBanner.tsx
+++ b/apps/web/components/features/profile/SubscriptionConfirmedBanner.tsx
@@ -24,16 +24,18 @@ export function SubscriptionConfirmedBanner() {
   if (!visible) return null;
 
   return (
-    <output
-      aria-live='polite'
-      className='block w-full px-4 py-3 mb-4 rounded-xl bg-green-50 dark:bg-green-950/40 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-200 text-sm text-center animate-in fade-in slide-in-from-top-2 duration-slower'
-    >
-      <span className='inline-flex items-center gap-2'>
-        <Bell className='w-4 h-4' aria-hidden='true' />
-        <span className='font-medium'>
-          Notifications on! You&apos;ll receive updates from this artist.
+    <div className='shrink-0 pb-3'>
+      <output
+        aria-live='polite'
+        className='block w-full px-4 py-3 mb-4 rounded-xl bg-green-50 dark:bg-green-950/40 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-200 text-sm text-center animate-in fade-in slide-in-from-top-2 duration-slower'
+      >
+        <span className='inline-flex items-center gap-2'>
+          <Bell className='w-4 h-4' aria-hidden='true' />
+          <span className='font-medium'>
+            Notifications on! You&apos;ll receive updates from this artist.
+          </span>
         </span>
-      </span>
-    </output>
+      </output>
+    </div>
   );
 }

--- a/apps/web/components/features/profile/pac/ProfilePacCard.tsx
+++ b/apps/web/components/features/profile/pac/ProfilePacCard.tsx
@@ -162,7 +162,7 @@ function PrimaryPill({
   ariaLabel?: string;
 }>) {
   const className = cn(
-    'inline-flex h-11 shrink-0 items-center justify-center gap-1.5 rounded-full bg-white px-4 text-sm font-semibold text-black shadow-sm transition-opacity duration-subtle hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:opacity-60'
+    'inline-flex h-11 shrink-0 items-center justify-center gap-1.5 rounded-full bg-white px-3 text-2xs font-[590] leading-none text-black shadow-sm transition-opacity duration-subtle hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:opacity-60'
   );
 
   if (href && href.startsWith('/')) {
@@ -826,7 +826,7 @@ export function ProfilePacCard({
           'relative aspect-square flex-none overflow-hidden bg-surface-2',
           isProfileLandscape
             ? cn(
-                'self-stretch w-auto rounded',
+                'self-stretch w-auto rounded-(--profile-action-radius)',
                 usesFullWidthCaptureLayout && 'invisible'
               )
             : 'w-full border-b border-subtle'

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -694,11 +694,11 @@ export function ProfileCompactSurface({
 
           {isHomeMode ? (
             <div
-              className='profile-hero-identity-scrim relative z-10 shrink-0 px-(--page-pad) py-2'
+              className='profile-hero-identity-scrim relative z-10 shrink-0 px-(--page-pad) py-1'
               data-testid='profile-hero-identity-block'
             >
               <div
-                className='grid min-w-0 gap-1 [overflow-wrap:anywhere]'
+                className='grid min-w-0 gap-0.5 [overflow-wrap:anywhere]'
                 data-testid='profile-hero-identity-content'
               >
                 <IdentityHeading
@@ -712,7 +712,7 @@ export function ProfileCompactSurface({
                     href={profileHref}
                     prefetch={false}
                     aria-label={`Go to ${artist.name}'s profile`}
-                    className='inline-flex min-h-11 max-w-full min-w-0 flex-wrap items-start gap-1 rounded-md py-1 text-3xl font-semibold leading-8 tracking-normal text-(--profile-status-pill-fg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
+                    className='inline-flex min-h-11 max-w-full min-w-0 flex-wrap items-center gap-1 rounded-md py-0 text-3xl font-semibold leading-8 tracking-normal text-(--profile-status-pill-fg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-2xl [@media(max-height:760px)]:text-2xl'
                   >
                     <span className='min-w-0 max-w-full [overflow-wrap:anywhere]'>
                       {artist.name}
@@ -821,12 +821,10 @@ export function ProfileCompactSurface({
             />
           ) : null}
 
-          {isHomeMode ? <div className='shrink-0 pb-2' /> : null}
+          {isHomeMode ? <div className='shrink-0 pb-1' /> : null}
 
           {allowFanCapture && showSubscriptionConfirmedBanner ? (
-            <div className='shrink-0 pb-3'>
-              <SubscriptionConfirmedBanner />
-            </div>
+            <SubscriptionConfirmedBanner />
           ) : null}
 
           <div

--- a/apps/web/components/organisms/entity-card/EntityCard.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.test.tsx
@@ -277,6 +277,8 @@ describe('EntityCard', () => {
       expect(cta).toHaveAttribute('href', '/tim/merch/m1');
       expect(cta.className).toContain('h-11');
       expect(cta.className).toContain('flex-none');
+      expect(cta.className).toContain('px-3');
+      expect(cta.className).toContain('text-2xs');
     });
 
     it('renders a target-less CTA as plain muted meta text, not button chrome', () => {

--- a/apps/web/components/organisms/entity-card/EntityCard.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCard.tsx
@@ -115,7 +115,7 @@ function EntityCtaControl({
   }
 
   const className = cn(
-    'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
+    'inline-flex shrink-0 items-center justify-center rounded-full border border-(--linear-btn-primary-border) bg-btn-primary px-3 text-2xs font-[590] leading-none text-btn-primary-foreground transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
     // Landscape profile actions keep the native 44px touch-target floor.
     // Portrait unified cards retain their compact 36px action row.
     unified
@@ -247,7 +247,7 @@ export function EntityCard({
     ? cn(getProfileCardShapeClassName(shape), 'overflow-hidden')
     : null;
   const artClassName = isProfileLandscape
-    ? 'aspect-square self-stretch w-auto rounded'
+    ? 'aspect-square self-stretch w-auto rounded-(--profile-action-radius)'
     : isUnified
       ? // Unified anatomy: the art zone is a full-width square (album art is
         // square by default; non-square art object-covers the square zone).
@@ -522,7 +522,7 @@ export function EntityCard({
               ) : (
                 <span
                   className={cn(
-                    'inline-flex shrink-0 items-center justify-center rounded-full bg-btn-primary px-4 text-xs font-[560] text-btn-primary-foreground transition-colors duration-subtle group-hover:bg-btn-primary-hover',
+                    'inline-flex shrink-0 items-center justify-center rounded-full bg-btn-primary px-3 text-2xs font-[590] leading-none text-btn-primary-foreground transition-colors duration-subtle group-hover:bg-btn-primary-hover',
                     isProfileLandscape ? 'h-11 w-fit' : 'h-9 w-full'
                   )}
                 >

--- a/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.geometry.test.tsx
@@ -232,7 +232,9 @@ describe('EntityCarousel profile geometry', () => {
 
     const image = screen.getByRole('img', { name: 'Release one' });
     expect(image.parentElement?.className).toContain('aspect-square');
-    expect(image.parentElement?.className).toMatch(/(?:^|\s)rounded(?:\s|$)/);
+    expect(image.parentElement?.className).toContain(
+      'rounded-(--profile-action-radius)'
+    );
     expect(image.parentElement?.className).toContain('border-0');
     expect(image.parentElement?.className).not.toContain('border-r');
 
@@ -266,7 +268,7 @@ describe('EntityCarousel profile geometry', () => {
     ).toBe(true);
   });
 
-  it('reveals restrained desktop controls for full-width landscape discovery', () => {
+  it('renders external dot controls for full-width landscape discovery', () => {
     render(<EntityCarousel items={items} layout='profile-landscape' />);
 
     const carousel = screen.getByTestId('entity-carousel');
@@ -282,16 +284,22 @@ describe('EntityCarousel profile geometry', () => {
       value: 320,
     });
 
-    const previous = screen.getByRole('button', { name: 'Previous Item' });
-    const next = screen.getByRole('button', { name: 'Next Item' });
+    const controls = screen.getByTestId('profile-carousel-controls');
+    const previousArrow = screen.getByRole('button', {
+      name: 'Previous Item',
+    });
+    const nextArrow = screen.getByRole('button', { name: 'Next Item' });
+    const previous = screen.getByRole('button', { name: 'Go to item 1' });
+    const next = screen.getByRole('button', { name: 'Go to item 2' });
     expect(carousel.parentElement).toHaveClass('h-fit');
-    expect(previous).toBeDisabled();
-    expect(next).toBeEnabled();
-    expect(previous.className).toContain(
-      '[@media(min-width:768px)_and_(hover:hover)_and_(pointer:fine)]:inline-flex'
-    );
-    expect(next.className).not.toContain('md:inline-flex');
-    expect(previous.className).toContain('group-hover/carousel:opacity-100');
+    expect(controls).not.toContainElement(carousel);
+    expect(carousel.nextElementSibling).toBe(controls);
+    expect(previousArrow).toBeDisabled();
+    expect(nextArrow).toBeEnabled();
+    expect(previous).toHaveAttribute('aria-current', 'true');
+    expect(next).not.toHaveAttribute('aria-current');
+    expect(previous).toHaveClass('h-11', 'w-11');
+    expect(next).toHaveClass('h-11', 'w-11');
     expect(screen.getByText('Item 1 of 2')).toBeInTheDocument();
 
     fireEvent.click(next);
@@ -300,8 +308,10 @@ describe('EntityCarousel profile geometry', () => {
       left: 320,
       behavior: 'smooth',
     });
-    expect(previous).toBeEnabled();
-    expect(next).toBeDisabled();
+    expect(previous).not.toHaveAttribute('aria-current');
+    expect(next).toHaveAttribute('aria-current', 'true');
+    expect(previousArrow).toBeEnabled();
+    expect(nextArrow).toBeDisabled();
     expect(screen.getByText('Item 2 of 2')).toBeInTheDocument();
   });
 
@@ -470,7 +480,7 @@ describe('EntityCarousel profile geometry', () => {
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
     const card = screen.getByTestId('entity-card-music');
     const media = card.querySelector('.aspect-square');
-    expect(media?.className).toMatch(/(?:^|\s)rounded(?:\s|$)/);
+    expect(media?.className).toContain('rounded-(--profile-action-radius)');
     expect(media?.className).toContain('border-0');
     expect(
       screen.getByRole('heading', {

--- a/apps/web/components/organisms/entity-card/EntityCarousel.stories.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.stories.tsx
@@ -33,6 +33,9 @@ const meta = {
   parameters: {
     layout: 'centered',
     backgrounds: { default: 'light' },
+    jovie: {
+      uncoveredProps: ['disabled'],
+    },
   },
   decorators: [
     Story => (
@@ -57,11 +60,11 @@ export const ProfileLandscape: Story = {
     layout: 'profile-landscape',
   },
   play: async ({ canvasElement }) => {
-    const previous = canvasElement.querySelector<HTMLButtonElement>(
-      'button[aria-label="Previous Item"]'
+    const first = canvasElement.querySelector<HTMLButtonElement>(
+      'button[aria-label="Go to item 1"]'
     );
-    if (!previous?.disabled) {
-      throw new Error('Previous carousel control must be disabled at rest');
+    if (first?.getAttribute('aria-current') !== 'true') {
+      throw new Error('First carousel dot must be selected at rest');
     }
   },
 };

--- a/apps/web/components/organisms/entity-card/EntityCarousel.tsx
+++ b/apps/web/components/organisms/entity-card/EntityCarousel.tsx
@@ -66,7 +66,7 @@ export function EntityCarousel({
   const prefersReducedMotion = useReducedMotion();
   const [currentIndex, setCurrentIndex] = useState(0);
   const slotCount = items.length + (leading ? 1 : 0) + (trailing ? 1 : 0);
-  const showsDesktopControls = layout === 'profile-landscape' && slotCount > 1;
+  const showsProfileControls = layout === 'profile-landscape' && slotCount > 1;
 
   useEffect(() => {
     setCurrentIndex(index => Math.min(index, Math.max(slotCount - 1, 0)));
@@ -108,7 +108,7 @@ export function EntityCarousel({
 
   useEffect(() => {
     const track = trackRef.current;
-    if (!showsDesktopControls || !track) {
+    if (!showsProfileControls || !track) {
       snapStepRef.current = 0;
       return;
     }
@@ -139,7 +139,7 @@ export function EntityCarousel({
         scrollFrameRef.current = null;
       }
     };
-  }, [showsDesktopControls, slotCount]);
+  }, [showsProfileControls, slotCount]);
 
   useEffect(() => {
     if (!onCardImpression || items.length === 0) {
@@ -250,6 +250,11 @@ export function EntityCarousel({
     CARD_ITEM_CLASSNAME,
     isProfileLandscape && 'w-full'
   );
+  const visibleDotCount = Math.min(slotCount, 3);
+  const visibleDotStart = Math.min(
+    Math.max(currentIndex - 1, 0),
+    Math.max(slotCount - visibleDotCount, 0)
+  );
 
   return (
     <div
@@ -267,7 +272,7 @@ export function EntityCarousel({
         )}
         data-testid={dataTestId ?? 'entity-carousel'}
         data-layout={layout}
-        onScroll={showsDesktopControls ? handleScroll : undefined}
+        onScroll={showsProfileControls ? handleScroll : undefined}
       >
         {leading ? (
           <li
@@ -319,30 +324,60 @@ export function EntityCarousel({
         ) : null}
       </ul>
 
-      {showsDesktopControls ? (
-        <>
+      {showsProfileControls ? (
+        <div
+          className='mt-1 flex min-h-11 items-center justify-center gap-1 px-1'
+          data-testid='profile-carousel-controls'
+        >
           <button
             type='button'
             aria-label='Previous Item'
             disabled={currentIndex === 0}
             onClick={() => scrollToIndex(currentIndex - 1)}
-            className='absolute left-1 top-1/2 z-10 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-secondary-token opacity-0 shadow-(--profile-pearl-shadow) backdrop-blur-xl transition-opacity duration-subtle [@media(min-width:768px)_and_(hover:hover)_and_(pointer:fine)]:inline-flex hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:pointer-events-none disabled:invisible group-focus-within/carousel:opacity-100 group-hover/carousel:opacity-100'
+            className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent hover:text-primary-token disabled:pointer-events-none disabled:opacity-30'
           >
             <ChevronLeft className='h-4 w-4' aria-hidden='true' />
           </button>
+          <nav
+            aria-label='Profile Items'
+            className='flex min-h-11 items-center justify-center gap-0.5'
+          >
+            {Array.from({ length: visibleDotCount }, (_, offset) => {
+              const index = visibleDotStart + offset;
+              const isCurrent = index === currentIndex;
+              return (
+                <button
+                  key={index}
+                  type='button'
+                  aria-label={`Go to item ${index + 1}`}
+                  aria-current={isCurrent ? 'true' : undefined}
+                  onClick={() => scrollToIndex(index)}
+                  className='flex h-11 w-11 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+                >
+                  <span
+                    aria-hidden='true'
+                    className={cn(
+                      'h-1.5 w-1.5 rounded-full bg-(--profile-pearl-border)',
+                      isCurrent && 'h-2 w-2 bg-(--profile-pearl-primary-bg)'
+                    )}
+                  />
+                </button>
+              );
+            })}
+          </nav>
           <button
             type='button'
             aria-label='Next Item'
             disabled={currentIndex === slotCount - 1}
             onClick={() => scrollToIndex(currentIndex + 1)}
-            className='absolute right-1 top-1/2 z-10 hidden h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-secondary-token opacity-0 shadow-(--profile-pearl-shadow) backdrop-blur-xl transition-opacity duration-subtle [@media(min-width:768px)_and_(hover:hover)_and_(pointer:fine)]:inline-flex hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:pointer-events-none disabled:invisible group-focus-within/carousel:opacity-100 group-hover/carousel:opacity-100'
+            className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent hover:text-primary-token disabled:pointer-events-none disabled:opacity-30'
           >
             <ChevronRight className='h-4 w-4' aria-hidden='true' />
           </button>
           <span className='sr-only' aria-live='polite'>
             Item {currentIndex + 1} of {slotCount}
           </span>
-        </>
+        </div>
       ) : null}
     </div>
   );

--- a/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileHomeRail.test.tsx
@@ -154,6 +154,12 @@ describe('ProfileHomeRail', () => {
     const pacMedia = pacCard.querySelector('.aspect-square');
     expect(pacMedia?.className).toContain('self-stretch');
     expect(pacMedia?.className).toContain('w-auto');
+    expect(pacMedia?.className).toContain('rounded-(--profile-action-radius)');
+    expect(screen.getByRole('link', { name: 'Listen' })).toHaveClass(
+      'h-11',
+      'px-3',
+      'text-2xs'
+    );
     // The featured release renders once, inside the PAC card (not as a
     // duplicate plain catalog card).
     expect(screen.getAllByText('Never Say A Word')).toHaveLength(1);

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -395,6 +395,35 @@ describe('ProfileCompactTemplate', () => {
     ).toHaveAttribute('href', `/${mockArtist.handle}`);
   });
 
+  it('keeps the home identity grid tight without shrinking interaction targets', () => {
+    render(
+      <ProfileCompactTemplate
+        mode='profile'
+        artist={mockArtist}
+        socialLinks={[
+          {
+            id: 'instagram',
+            artist_id: mockArtist.id,
+            platform: 'instagram',
+            url: 'https://instagram.com/test-artist',
+            clicks: 0,
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+        ]}
+        contacts={[]}
+      />
+    );
+
+    const identity = screen.getByTestId('profile-hero-identity-block');
+    expect(identity).toHaveClass('py-1');
+    expect(
+      screen.getByRole('link', { name: `Go to ${mockArtist.name}'s profile` })
+    ).toHaveClass('min-h-11', 'items-center', 'py-0');
+    expect(
+      within(screen.getByTestId('profile-hero-social-row')).getByRole('link')
+    ).toHaveClass('h-11', 'w-11');
+  });
+
   it('keeps the artist photo in color with profile text over the image', async () => {
     render(
       <ProfileCompactTemplate

--- a/apps/web/tests/unit/profile/profile-identity-grid-regression.test.ts
+++ b/apps/web/tests/unit/profile/profile-identity-grid-regression.test.ts
@@ -22,7 +22,7 @@ describe('public profile identity grid', () => {
   });
 
   it('aligns name, metadata, location, and actions to one compact grid', () => {
-    expect(SURFACE).toContain('grid min-w-0 gap-1 [overflow-wrap:anywhere]');
+    expect(SURFACE).toContain('grid min-w-0 gap-0.5 [overflow-wrap:anywhere]');
     expect(SURFACE).toContain(
       'grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2'
     );

--- a/apps/web/touch-target-ratchet.baseline.json
+++ b/apps/web/touch-target-ratchet.baseline.json
@@ -1,4 +1,4 @@
 {
   "_comment": "Touch-target ratchet baseline — interactive elements with explicit sub-44px heights (scripts/lint-touch-target.ts). Ratchet only goes down: fix elements (min 44px hit area, WCAG 2.5.5), then run `pnpm --filter web run lint:touch-target -- --update`.",
-  "count": 225
+  "count": 199
 }


### PR DESCRIPTION
## Summary
- tighten the public-profile identity band and compact landscape CTAs using existing tokens
- move profile carousel controls below the card into external 44px arrows and dot navigation
- align profile media to the concentric action radius and remove empty confirmation spacing on ordinary visits

## Verification
- `pnpm --filter web exec vitest run components/organisms/entity-card/EntityCarousel.geometry.test.tsx tests/unit/profile/ProfileHomeRail.test.tsx tests/unit/profile/profile-compact-template.test.tsx components/features/profile/SubscriptionConfirmedBanner.test.tsx`
- pre-commit secret, a11y, Biome, ESLint, and typecheck gates passed
- pre-push component ship gate and affected verification bundle passed, 104 tests
- rendered local fixture receipts at 390x844, 430x932, 768x1024, and 1159x863 are recorded in `~/.gstack/projects/jovie/designs/design-audit-20260805-profile-polish/`

## Scope note
This is an isolated visual/interaction polish slice. The frozen production-verified SHA and the separate collaborator-data lane are unchanged. No deployment is claimed by this PR.
