### PR TITLE
fix(docs): preserve docs app in Vercel source (JOV-4835)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,6 @@
 # Documentation
 *.md
-docs/
+/docs/
 architecture/
 audits/
 ideation/

--- a/scripts/vercel-source-contract.test.mjs
+++ b/scripts/vercel-source-contract.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+
+describe('Vercel source contract', () => {
+  it('keeps the apps/docs package in the jovie-docs source upload', () => {
+    const ignored = execFileSync(
+      'git',
+      [
+        'ls-files',
+        '-ci',
+        '--exclude-from=.vercelignore',
+        'apps/docs/package.json',
+      ],
+      { encoding: 'utf8' }
+    );
+
+    assert.equal(ignored.trim(), '');
+  });
+});


### PR DESCRIPTION
## Summary

- scope the legacy root docs exclusion to `/docs/`
- keep `apps/docs` in Vercel source uploads for the `jovie-docs` project
- add a deterministic regression test against `.vercelignore` semantics

## Root cause

The Vercel project correctly uses `apps/docs` as its root directory, but `.vercelignore` contained `docs/`, which also matched and removed `apps/docs`. Deployment `dpl_HuXRTo8PyvfVoN9yipXrNENbRsBp` then found no Next.js package at the configured root and failed with `No Next.js version detected`.

## Verification

- before fix: `git ls-files -ci --exclude-from=.vercelignore apps/docs/package.json` returned `apps/docs/package.json`
- after fix: the same contract returns no ignored path
- `node --test scripts/vercel-source-contract.test.mjs`: 1 passed, 0 failed
- Biome: changed test checked, no fixes required
- `git diff --check`: passed

## Risk and rollback

Only Vercel source inclusion changes. Root `/docs/` remains excluded. Revert this PR to restore the prior source filter.

Fixes JOV-4835

<!-- linear-issue-id:JOV-4835 -->
