### PR TITLE
fix(docs): use docs-specific Vercel build config (JOV-4835)

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,7 @@
+{
+  "framework": "nextjs",
+  "installCommand": "cd ../.. && corepack enable && corepack pnpm install",
+  "buildCommand": "corepack pnpm run build",
+  "ignoreCommand": "bash -c 'R=$VERCEL_GIT_COMMIT_REF;if [[ $R == main || $R == production ]]; then exit 1; fi;cd ../.. && npx turbo-ignore @jovie/docs'",
+  "outputDirectory": ".next"
+}

--- a/scripts/vercel-source-contract.test.mjs
+++ b/scripts/vercel-source-contract.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 describe('Vercel source contract', () => {
@@ -16,5 +17,15 @@ describe('Vercel source contract', () => {
     );
 
     assert.equal(ignored.trim(), '');
+  });
+
+  it('builds the docs package instead of inheriting the web project config', () => {
+    const config = JSON.parse(readFileSync('apps/docs/vercel.json', 'utf8'));
+
+    assert.equal(config.framework, 'nextjs');
+    assert.equal(config.buildCommand, 'corepack pnpm run build');
+    assert.equal(config.outputDirectory, '.next');
+    assert.match(config.ignoreCommand, /@jovie\/docs/);
+    assert.doesNotMatch(config.buildCommand, /@jovie\/web/);
   });
 });


### PR DESCRIPTION
## Summary
- add an app-local Vercel config for the `apps/docs` project
- build `@jovie/docs` from the configured project root instead of inheriting the repository web-app command
- extend the Vercel source contract to pin the docs build/output/ignore configuration

## Root cause
After #15553 allowed `apps/docs` into the source upload, exact-main deployment `dpl_79XbVwcFxk4wUrAeuwDjLpmZr4xD` reached dependency installation but inherited the root `@jovie/web` build command and OOMed with exit 137. This PR isolates the docs build.

## Verification
- `node --test scripts/vercel-source-contract.test.mjs` — 2 passed
- `git diff --check` — passed
- local docs build unavailable in this worktree because dependencies are not installed; source CI and the exact-main Vercel deployment remain required proof

Fixes JOV-4835
https://linear.app/jovie/issue/JOV-4835/fix-jovie-docs-vercel-source-exclusion-in-vercelignore