### PR TITLE
Fix docs 404 by preserving Nextra config

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -57,6 +57,9 @@ scripts/
 *.cjs
 cleanup_old_branches*.sh
 
+# The docs project needs its Nextra wrapper to compile MDX app routes.
+!apps/docs/next.config.mjs
+
 # Build-critical web postbuild script
 !apps/web/scripts/
 !apps/web/scripts/sync-standalone-assets.mjs

--- a/scripts/vercel-source-contract.test.mjs
+++ b/scripts/vercel-source-contract.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 describe('Vercel source contract', () => {
-  it('keeps the apps/docs package in the jovie-docs source upload', () => {
+  it('keeps the docs build config and root route in the source upload', () => {
     const ignored = execFileSync(
       'git',
       [
@@ -12,6 +12,8 @@ describe('Vercel source contract', () => {
         '-ci',
         '--exclude-from=.vercelignore',
         'apps/docs/package.json',
+        'apps/docs/next.config.mjs',
+        'apps/docs/app/page.mdx',
       ],
       { encoding: 'utf8' }
     );


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4835 -->
## Summary
- preserve `apps/docs/next.config.mjs` in the Vercel source upload
- keep Nextra enabled so MDX app routes compile instead of producing only `/404`
- extend the source contract to cover the build config and root MDX route

## Evidence
- production deployment `dpl_AAWexiS5iMacJKhg3B5EVGBcWSHz` built only `/404`
- `node --test scripts/vercel-source-contract.test.mjs` (2 passed)
- `git diff --check`

Fixes JOV-4835