### PR TITLE
feat(marketing): formalize closed-loop generation gates

### DIFF
--- a/apps/web/data/marketing/generation.ts
+++ b/apps/web/data/marketing/generation.ts
@@ -1,0 +1,345 @@
+/**
+ * Closed-loop marketing generation contracts.
+ *
+ * The pipeline separates product truth, narrative, copy, section design,
+ * asset generation, and review so no stage approves or silently rewrites its
+ * own work. Model selection is capability-based; model names never belong in
+ * a page recipe or generation request.
+ */
+
+export const MARKETING_GENERATION_SPEC_VERSION = '1.0.0';
+
+export const MARKETING_GENERATION_STAGES = [
+  'truth',
+  'narrative',
+  'copy',
+  'section-design',
+  'asset-generation',
+  'adversarial-review',
+  'taste-admission',
+] as const;
+
+export type MarketingGenerationStage =
+  (typeof MARKETING_GENERATION_STAGES)[number];
+
+export const MARKETING_STAGE_ATTEMPT_LIMITS: Readonly<
+  Record<MarketingGenerationStage, number>
+> = {
+  truth: 1,
+  narrative: 3,
+  copy: 3,
+  'section-design': 3,
+  'asset-generation': 3,
+  'adversarial-review': 3,
+  'taste-admission': 1,
+};
+
+export const MARKETING_CREATIVE_ROLES = [
+  'truth-curator',
+  'narrative-architect',
+  'copy-compiler',
+  'section-designer',
+  'asset-generator',
+  'adversarial-reviewer',
+  'final-polisher',
+] as const;
+
+export type MarketingCreativeRole = (typeof MARKETING_CREATIVE_ROLES)[number];
+
+export const MARKETING_MODEL_CAPABILITIES = [
+  'structured-output',
+  'long-context-planning',
+  'narrative-sequencing',
+  'editorial-compression',
+  'truth-review',
+  'visual-ui-reasoning',
+  'reference-image-fidelity',
+  'vision-review',
+  'image-generation',
+] as const;
+
+export type MarketingModelCapability =
+  (typeof MARKETING_MODEL_CAPABILITIES)[number];
+
+export const MARKETING_ROLE_REQUIREMENTS: Readonly<
+  Record<MarketingCreativeRole, readonly MarketingModelCapability[]>
+> = {
+  'truth-curator': ['structured-output', 'truth-review'],
+  'narrative-architect': [
+    'structured-output',
+    'long-context-planning',
+    'narrative-sequencing',
+  ],
+  'copy-compiler': ['structured-output', 'editorial-compression'],
+  'section-designer': ['structured-output', 'visual-ui-reasoning'],
+  'asset-generator': ['image-generation', 'reference-image-fidelity'],
+  'adversarial-reviewer': [
+    'truth-review',
+    'visual-ui-reasoning',
+    'vision-review',
+  ],
+  'final-polisher': ['editorial-compression', 'truth-review', 'vision-review'],
+};
+
+export interface MarketingModelCandidate {
+  readonly id: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly healthy: boolean;
+  readonly capabilities: readonly MarketingModelCapability[];
+  readonly roleScores?: Readonly<
+    Partial<Record<MarketingCreativeRole, number>>
+  >;
+  readonly tasteAcceptanceRate?: number;
+  /** Lower is cheaper. */
+  readonly costRank: number;
+  /** Lower is faster. */
+  readonly latencyRank: number;
+}
+
+export function selectMarketingModelCandidate(input: {
+  readonly role: MarketingCreativeRole;
+  readonly candidates: readonly MarketingModelCandidate[];
+  readonly excludedModelIds?: readonly string[];
+}): MarketingModelCandidate | null {
+  const required = MARKETING_ROLE_REQUIREMENTS[input.role];
+  const excluded = new Set(input.excludedModelIds ?? []);
+
+  return (
+    input.candidates
+      .filter(candidate => {
+        const capabilities = new Set(candidate.capabilities);
+        return (
+          candidate.healthy &&
+          !excluded.has(candidate.id) &&
+          required.every(capability => capabilities.has(capability))
+        );
+      })
+      .toSorted((a, b) => {
+        const scoreDelta =
+          (b.roleScores?.[input.role] ?? 0) - (a.roleScores?.[input.role] ?? 0);
+        if (scoreDelta !== 0) return scoreDelta;
+
+        const tasteDelta =
+          (b.tasteAcceptanceRate ?? 0) - (a.tasteAcceptanceRate ?? 0);
+        if (tasteDelta !== 0) return tasteDelta;
+
+        if (a.costRank !== b.costRank) return a.costRank - b.costRank;
+        if (a.latencyRank !== b.latencyRank) {
+          return a.latencyRank - b.latencyRank;
+        }
+        return a.id.localeCompare(b.id);
+      })[0] ?? null
+  );
+}
+
+export interface MarketingNarrativeSectionPlan {
+  readonly sectionInstanceId: string;
+  readonly sectionId: string;
+  readonly question: string;
+  readonly sectionJob: string;
+  readonly primaryResponsibility: string;
+  readonly newInformation: string;
+  readonly customerBelief: string;
+  readonly evidenceRefs: readonly string[];
+  readonly mustNotRepeat: readonly string[];
+}
+
+export interface MarketingNarrativePlan {
+  readonly pageId: string;
+  readonly sections: readonly MarketingNarrativeSectionPlan[];
+}
+
+export interface MarketingGenerationFinding {
+  readonly code: string;
+  readonly stage: MarketingGenerationStage;
+  readonly sectionInstanceId?: string;
+  readonly message: string;
+}
+
+function normalized(value: string): string {
+  return value.trim().toLocaleLowerCase().replaceAll(/\s+/g, ' ');
+}
+
+function findDuplicateNarrativeValues(
+  sections: readonly MarketingNarrativeSectionPlan[],
+  select: (section: MarketingNarrativeSectionPlan) => string,
+  code: string,
+  label: string
+): MarketingGenerationFinding[] {
+  const seen = new Map<string, string>();
+  const findings: MarketingGenerationFinding[] = [];
+
+  for (const section of sections) {
+    const value = normalized(select(section));
+    const firstSectionId = seen.get(value);
+    if (firstSectionId) {
+      findings.push({
+        code,
+        stage: 'narrative',
+        sectionInstanceId: section.sectionInstanceId,
+        message: `${label} repeats ${firstSectionId}. Every section must advance a different story beat.`,
+      });
+    } else if (value) {
+      seen.set(value, section.sectionInstanceId);
+    }
+  }
+
+  return findings;
+}
+
+export function auditMarketingNarrativePlan(
+  plan: MarketingNarrativePlan
+): readonly MarketingGenerationFinding[] {
+  const findings: MarketingGenerationFinding[] = [];
+  const instanceIds = new Set<string>();
+
+  for (const section of plan.sections) {
+    if (instanceIds.has(section.sectionInstanceId)) {
+      findings.push({
+        code: 'duplicate-section-instance',
+        stage: 'narrative',
+        sectionInstanceId: section.sectionInstanceId,
+        message: 'Section instance IDs must be unique and occurrence-aware.',
+      });
+    }
+    instanceIds.add(section.sectionInstanceId);
+
+    for (const [field, value] of [
+      ['question', section.question],
+      ['section job', section.sectionJob],
+      ['primary responsibility', section.primaryResponsibility],
+      ['new information', section.newInformation],
+      ['customer belief', section.customerBelief],
+    ] as const) {
+      if (!value.trim()) {
+        findings.push({
+          code: 'incomplete-narrative-section',
+          stage: 'narrative',
+          sectionInstanceId: section.sectionInstanceId,
+          message: `The ${field} is required.`,
+        });
+      }
+    }
+
+    if (section.evidenceRefs.length === 0) {
+      findings.push({
+        code: 'missing-narrative-evidence',
+        stage: 'narrative',
+        sectionInstanceId: section.sectionInstanceId,
+        message:
+          'Every section needs a distinct evidence object before copy or design.',
+      });
+    }
+  }
+
+  findings.push(
+    ...findDuplicateNarrativeValues(
+      plan.sections,
+      section => section.question,
+      'duplicate-section-question',
+      'The section question'
+    ),
+    ...findDuplicateNarrativeValues(
+      plan.sections,
+      section => section.primaryResponsibility,
+      'duplicate-primary-responsibility',
+      'The primary responsibility'
+    ),
+    ...findDuplicateNarrativeValues(
+      plan.sections,
+      section => section.customerBelief,
+      'duplicate-customer-belief',
+      'The customer belief'
+    )
+  );
+
+  return findings;
+}
+
+export const MARKETING_TASTE_GATE_IDS = [
+  'truth',
+  'narrative-non-overlap',
+  'copy-meaning',
+  'copy-panel',
+  'design-system',
+  'product-truth',
+  'asset-consent',
+  'responsive-accessibility',
+  'visual-review',
+  'digest-integrity',
+] as const;
+
+export type MarketingTasteGateId = (typeof MARKETING_TASTE_GATE_IDS)[number];
+
+export interface MarketingGateReceipt {
+  readonly gateId: MarketingTasteGateId;
+  readonly verdict: 'pass' | 'fail';
+  readonly executionId: string;
+  readonly candidateDigest: string;
+  readonly reviewerModelId?: string;
+  readonly findings: readonly string[];
+}
+
+export function auditMarketingTasteAdmission(input: {
+  readonly candidateDigest: string;
+  readonly generatorModelId: string;
+  readonly receipts: readonly MarketingGateReceipt[];
+}): readonly MarketingGenerationFinding[] {
+  const findings: MarketingGenerationFinding[] = [];
+
+  for (const gateId of MARKETING_TASTE_GATE_IDS) {
+    const receipts = input.receipts.filter(
+      receipt => receipt.gateId === gateId
+    );
+    if (receipts.length !== 1) {
+      findings.push({
+        code:
+          receipts.length === 0 ? 'missing-taste-gate' : 'duplicate-taste-gate',
+        stage: 'taste-admission',
+        message: `${gateId} requires exactly one receipt.`,
+      });
+      continue;
+    }
+
+    const [receipt] = receipts;
+    if (!receipt) continue;
+    if (receipt.verdict !== 'pass') {
+      findings.push({
+        code: 'failed-taste-gate',
+        stage: 'taste-admission',
+        message: `${gateId} failed: ${receipt.findings.join(' ')}`,
+      });
+    }
+    if (!receipt.executionId.trim()) {
+      findings.push({
+        code: 'missing-gate-execution',
+        stage: 'taste-admission',
+        message: `${gateId} is missing an execution receipt.`,
+      });
+    }
+    if (receipt.candidateDigest !== input.candidateDigest) {
+      findings.push({
+        code: 'stale-gate-receipt',
+        stage: 'taste-admission',
+        message: `${gateId} reviewed a different candidate digest.`,
+      });
+    }
+  }
+
+  const visualReview = input.receipts.find(
+    receipt => receipt.gateId === 'visual-review'
+  );
+  if (
+    visualReview?.reviewerModelId &&
+    visualReview.reviewerModelId === input.generatorModelId
+  ) {
+    findings.push({
+      code: 'self-reviewed-visual',
+      stage: 'taste-admission',
+      message: 'The asset generator cannot be its own visual reviewer.',
+    });
+  }
+
+  return findings;
+}

--- a/apps/web/data/marketing/index.ts
+++ b/apps/web/data/marketing/index.ts
@@ -83,6 +83,29 @@ export type {
 } from './designGaps';
 export { getProposedSection, PROPOSED_SECTIONS } from './designGaps';
 export type {
+  MarketingCreativeRole,
+  MarketingGateReceipt,
+  MarketingGenerationFinding,
+  MarketingGenerationStage,
+  MarketingModelCandidate,
+  MarketingModelCapability,
+  MarketingNarrativePlan,
+  MarketingNarrativeSectionPlan,
+  MarketingTasteGateId,
+} from './generation';
+export {
+  auditMarketingNarrativePlan,
+  auditMarketingTasteAdmission,
+  MARKETING_CREATIVE_ROLES,
+  MARKETING_GENERATION_SPEC_VERSION,
+  MARKETING_GENERATION_STAGES,
+  MARKETING_MODEL_CAPABILITIES,
+  MARKETING_ROLE_REQUIREMENTS,
+  MARKETING_STAGE_ATTEMPT_LIMITS,
+  MARKETING_TASTE_GATE_IDS,
+  selectMarketingModelCandidate,
+} from './generation';
+export type {
   ArcBeat,
   CtaCadence,
   MarketingRecipe,

--- a/apps/web/tests/unit/marketing/generation-pipeline.test.ts
+++ b/apps/web/tests/unit/marketing/generation-pipeline.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  auditMarketingNarrativePlan,
+  auditMarketingTasteAdmission,
+  MARKETING_GENERATION_STAGES,
+  MARKETING_STAGE_ATTEMPT_LIMITS,
+  MARKETING_TASTE_GATE_IDS,
+  type MarketingGateReceipt,
+  type MarketingModelCandidate,
+  type MarketingNarrativePlan,
+  selectMarketingModelCandidate,
+} from '@/data/marketing';
+
+const candidates: readonly MarketingModelCandidate[] = [
+  {
+    id: 'cheap-copy',
+    provider: 'provider-a',
+    model: 'copy-small',
+    healthy: true,
+    capabilities: ['structured-output', 'editorial-compression'],
+    roleScores: { 'copy-compiler': 0.8 },
+    tasteAcceptanceRate: 0.75,
+    costRank: 1,
+    latencyRank: 1,
+  },
+  {
+    id: 'best-copy',
+    provider: 'provider-b',
+    model: 'copy-large',
+    healthy: true,
+    capabilities: ['structured-output', 'editorial-compression'],
+    roleScores: { 'copy-compiler': 0.96 },
+    tasteAcceptanceRate: 0.9,
+    costRank: 3,
+    latencyRank: 3,
+  },
+  {
+    id: 'unhealthy-copy',
+    provider: 'provider-c',
+    model: 'copy-offline',
+    healthy: false,
+    capabilities: ['structured-output', 'editorial-compression'],
+    roleScores: { 'copy-compiler': 1 },
+    tasteAcceptanceRate: 1,
+    costRank: 1,
+    latencyRank: 1,
+  },
+];
+
+const narrative = (overrides: Partial<MarketingNarrativePlan> = {}) => ({
+  pageId: 'artist-profiles',
+  sections: [
+    {
+      sectionInstanceId: 'hero-0',
+      sectionId: 'hero',
+      question: 'Why is this different?',
+      sectionJob: 'Define the category promise.',
+      primaryResponsibility: 'adaptation',
+      newInformation: 'One profile can prioritize a different action.',
+      customerBelief: 'This is not a static link page.',
+      evidenceRefs: ['profile-live', 'profile-tour'],
+      mustNotRepeat: ['adaptation'],
+    },
+    {
+      sectionInstanceId: 'feature-grid-0',
+      sectionId: 'feature-grid',
+      question: 'What can the profile hold?',
+      sectionJob: 'Show the product scope.',
+      primaryResponsibility: 'content coverage',
+      newInformation: 'Music, shows, support, and contact live together.',
+      customerBelief: 'This is a real artist destination.',
+      evidenceRefs: ['profile-live'],
+      mustNotRepeat: ['adaptation'],
+    },
+  ],
+  ...overrides,
+});
+
+describe('marketing generation pipeline', () => {
+  it('keeps the closed-loop stage order stable and repair budgets bounded', () => {
+    expect(MARKETING_GENERATION_STAGES).toEqual([
+      'truth',
+      'narrative',
+      'copy',
+      'section-design',
+      'asset-generation',
+      'adversarial-review',
+      'taste-admission',
+    ]);
+    expect(Math.max(...Object.values(MARKETING_STAGE_ATTEMPT_LIMITS))).toBe(3);
+    expect(MARKETING_STAGE_ATTEMPT_LIMITS.truth).toBe(1);
+    expect(MARKETING_STAGE_ATTEMPT_LIMITS['taste-admission']).toBe(1);
+  });
+
+  it('routes by capability and role quality rather than a hardcoded model name', () => {
+    expect(
+      selectMarketingModelCandidate({
+        role: 'copy-compiler',
+        candidates,
+      })?.id
+    ).toBe('best-copy');
+
+    expect(
+      selectMarketingModelCandidate({
+        role: 'copy-compiler',
+        candidates,
+        excludedModelIds: ['best-copy'],
+      })?.id
+    ).toBe('cheap-copy');
+
+    expect(
+      selectMarketingModelCandidate({
+        role: 'adversarial-reviewer',
+        candidates,
+      })
+    ).toBeNull();
+  });
+
+  it('rejects repeated narrative responsibilities before copy begins', () => {
+    const repeated = narrative({
+      sections: [
+        ...narrative().sections,
+        {
+          sectionInstanceId: 'comparison-0',
+          sectionId: 'comparison',
+          question: 'How does the profile adapt?',
+          sectionJob: 'Explain the same mechanism again.',
+          primaryResponsibility: 'adaptation',
+          newInformation: 'A different fan sees a different action.',
+          customerBelief: 'The profile changes with context.',
+          evidenceRefs: ['profile-tour'],
+          mustNotRepeat: ['adaptation'],
+        },
+      ],
+    });
+
+    expect(
+      auditMarketingNarrativePlan(repeated).map(finding => finding.code)
+    ).toContain('duplicate-primary-responsibility');
+    expect(auditMarketingNarrativePlan(narrative())).toEqual([]);
+  });
+
+  it('admits one digest-bound survivor only after all ten gates pass', () => {
+    const receipts: readonly MarketingGateReceipt[] =
+      MARKETING_TASTE_GATE_IDS.map(gateId => ({
+        gateId,
+        verdict: 'pass',
+        executionId: `execution-${gateId}`,
+        candidateDigest: 'digest-a',
+        reviewerModelId:
+          gateId === 'visual-review' ? 'vision-reviewer' : undefined,
+        findings: [],
+      }));
+
+    expect(
+      auditMarketingTasteAdmission({
+        candidateDigest: 'digest-a',
+        generatorModelId: 'image-generator',
+        receipts,
+      })
+    ).toEqual([]);
+
+    expect(
+      auditMarketingTasteAdmission({
+        candidateDigest: 'digest-b',
+        generatorModelId: 'vision-reviewer',
+        receipts,
+      }).map(finding => finding.code)
+    ).toEqual(
+      expect.arrayContaining(['stale-gate-receipt', 'self-reviewed-visual'])
+    );
+  });
+});

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -193,6 +193,22 @@ modes, neverUse rules.
 - Content budgets: over-budget slot = check failure. Use `text-wrap: balance`.
 - CTA: `primaryCtaLabel` repeated verbatim throughout the page (one primary).
 
+### 4.5 Closed-loop generation
+
+Generated landing pages must move through the typed stages in
+`apps/web/data/marketing/generation.ts`: product truth, narrative, copy,
+section design, asset generation, adversarial review, then Taste admission.
+Select models by the required capability and current role score; page recipes
+must never name a provider or model. Narrative planning happens before copy and
+must give every section a unique question, responsibility, belief change, and
+evidence object. A failed stage may repair at most three times.
+
+Only one candidate may reach Taste. It needs one digest-bound passing receipt
+for every gate in `MARKETING_TASTE_GATE_IDS`, including independent visual
+review, product truth, design-system fidelity, responsive accessibility, and
+asset consent. The asset generator cannot review its own output. Automated
+review admits work for human taste; it never substitutes for that decision.
+
 ### Product callout assembly
 
 Use the shared callout library instead of creating one-off marketing chrome:


### PR DESCRIPTION
## What changed
- formalize truth → narrative → copy → section design → asset generation → independent review → Taste admission
- route creative work by capabilities and measured role quality instead of hardcoded model names
- reject repeated section responsibilities before copy begins
- require ten digest-bound receipts before one candidate can enter Taste

## Verification
- 65 focused marketing tests passed
- focused strict TypeScript check passed
- Biome check passed
- diff whitespace check passed

## Notes
This is the typed contract and gate layer. The admin component gallery/generation UI remains a separate implementation step.