### PR TITLE
Stabilize LYB production health admission probe

### DIFF
--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -19,6 +19,21 @@ const reporter = await import('../reporter.mjs');
 const staleLease = await import('../stale-lease-guard.mjs');
 const admitter = await import('../admitter.mjs');
 
+describe('team production health contract', () => {
+  it('uses a direct bounded LYB artifact instead of the redirecting homepage', async () => {
+    const source = await readFile(
+      resolve(ORCHESTRATOR_DIR, 'backlog-orchestrator.mjs'),
+      'utf8'
+    );
+
+    assert.match(
+      source,
+      /healthUrl: 'https:\/\/www\.logyourbody\.com\/robots\.txt'/
+    );
+    assert.doesNotMatch(source, /healthUrl: 'https:\/\/logyourbody\.com'/);
+  });
+});
+
 function makeIssue(overrides = {}) {
   return {
     id: 'test-id',

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -58,7 +58,9 @@ const TEAM_CONFIGS = Object.freeze([
     intakeStates: ['Backlog'],
     backlogStateId: '63ced43e-ab22-48e8-9dcc-a2ce54ee6da9',
     todoStateId: '4b318cc8-0a57-489c-8370-b780e11cff7f',
-    healthUrl: 'https://logyourbody.com',
+    // Probe a small, direct production artifact. The redirecting homepage can
+    // spend almost the entire timeout downloading HTML and flap admission red.
+    healthUrl: 'https://www.logyourbody.com/robots.txt',
     healthKind: 'http-ok',
   }),
 ]);


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4837 -->
## Summary
- probe the direct LYB `robots.txt` production artifact instead of the redirecting full homepage
- keep the existing fail-closed non-2xx/network behavior
- add a source contract preventing regression to the slow homepage path

## Evidence
- old homepage path observed at 4.2-4.7s against a 5s timeout and intermittently blocked admission
- new probe: five 200 responses in 1.03-1.90s
- `node --test scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs` — 35 passed
- `git diff --check`

Fixes JOV-4837