### PR TITLE
feat(chat): implement plan-gated Tasks chat tool (JOV-4535)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -104,6 +104,7 @@ import {
 } from '@/lib/chat/tools/merch-tools';
 import { createProposeVideoRecordingTool } from '@/lib/chat/tools/propose-video-recording';
 import { createRetouchImageTool } from '@/lib/chat/tools/retouch-image';
+import { createManageTasksTool } from '@/lib/chat/tools/tasks';
 import {
   type ChatTurnSource,
   markChatTurnStreaming,
@@ -2109,6 +2110,9 @@ function buildChatTools(
       releases
     ),
     formatLyrics: createLyricsFormatTool(),
+    ...(resolvedProfileId
+      ? { manageTasks: createManageTasksTool(resolvedProfileId) }
+      : {}),
     ...(resolvedProfileId
       ? {
           createRelease: createReleaseTool(resolvedProfileId),

--- a/apps/web/lib/chat/tool-schemas.ts
+++ b/apps/web/lib/chat/tool-schemas.ts
@@ -86,6 +86,11 @@ export const TOOL_SCHEMAS = {
         .max(200)
         .optional()
         .describe('Optional task title when creating a task'),
+      releaseId: z
+        .string()
+        .uuid()
+        .optional()
+        .describe('Release ID when setting up a release plan checklist'),
     }),
   },
 

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -123,6 +123,14 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Merch options ready',
     errorTitle: "Couldn't create merch",
   },
+  findMerchSources: {
+    label: 'Merch source',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Finding merch sources…',
+    successTitle: 'Merch source ready',
+    errorTitle: "Couldn't find a merch source",
+  },
   previewMerchOptions: {
     label: 'Merch',
     uiHint: 'artifact',

--- a/apps/web/lib/chat/tools/tasks.test.ts
+++ b/apps/web/lib/chat/tools/tasks.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockCreateTask, mockGetTasks } = vi.hoisted(() => ({
+  mockCreateTask: vi.fn(),
+  mockGetTasks: vi.fn(),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/tasks/task-actions', () => ({
+  createTask: mockCreateTask,
+  getTasks: mockGetTasks,
+}));
+
+import { createManageTasksTool } from './tasks';
+
+describe('createManageTasksTool', () => {
+  it('opens the real Tasks workspace route', async () => {
+    const tool = createManageTasksTool('profile-id');
+    const result = await tool.execute?.({ intent: 'open' }, {} as never);
+
+    expect(result).toMatchObject({
+      success: true,
+      href: '/app/tasks',
+    });
+  });
+
+  it('creates a task through the existing task action', async () => {
+    const task = {
+      id: 'task-id',
+      title: 'Pitch Neon Reef to Spotify',
+      dueAt: null,
+      scheduledFor: null,
+      startedAt: null,
+      completedAt: null,
+      createdAt: new Date('2026-08-05T00:00:00.000Z'),
+      updatedAt: new Date('2026-08-05T00:00:00.000Z'),
+    };
+    mockCreateTask.mockResolvedValue(task);
+
+    const tool = createManageTasksTool('profile-id');
+    const result = await tool.execute?.(
+      { intent: 'create', title: task.title },
+      {} as never
+    );
+
+    expect(mockCreateTask).toHaveBeenCalledWith({
+      title: task.title,
+      status: 'todo',
+      priority: 'medium',
+    });
+    expect(result).toMatchObject({
+      success: true,
+      task: {
+        id: task.id,
+        title: task.title,
+        createdAt: '2026-08-05T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('lists tasks through the existing task action', async () => {
+    mockGetTasks.mockResolvedValue({ tasks: [], nextCursor: null });
+
+    const tool = createManageTasksTool('profile-id');
+    const result = await tool.execute?.({ intent: 'list' }, {} as never);
+
+    expect(mockGetTasks).toHaveBeenCalledWith({ limit: 20 });
+    expect(result).toMatchObject({ success: true, tasks: [] });
+  });
+});

--- a/apps/web/lib/chat/tools/tasks.test.ts
+++ b/apps/web/lib/chat/tools/tasks.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const { mockCreateTask, mockGetTasks } = vi.hoisted(() => ({
-  mockCreateTask: vi.fn(),
-  mockGetTasks: vi.fn(),
-}));
+const { mockCreateTask, mockGetTasks, mockInstantiateReleaseTasks } =
+  vi.hoisted(() => ({
+    mockCreateTask: vi.fn(),
+    mockGetTasks: vi.fn(),
+    mockInstantiateReleaseTasks: vi.fn(),
+  }));
 
 vi.mock('@/app/app/(shell)/dashboard/tasks/task-actions', () => ({
   createTask: mockCreateTask,
   getTasks: mockGetTasks,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/releases/task-actions', () => ({
+  instantiateReleaseTasks: mockInstantiateReleaseTasks,
 }));
 
 import { createManageTasksTool } from './tasks';
@@ -65,5 +71,33 @@ describe('createManageTasksTool', () => {
 
     expect(mockGetTasks).toHaveBeenCalledWith({ limit: 20 });
     expect(result).toMatchObject({ success: true, tasks: [] });
+  });
+
+  it('sets up a release plan through the existing release task action', async () => {
+    mockInstantiateReleaseTasks.mockResolvedValue([
+      {
+        id: 'task-id',
+        title: 'Announce the release',
+        dueDate: null,
+        completedAt: null,
+        createdAt: new Date('2026-08-05T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-05T00:00:00.000Z'),
+      },
+    ]);
+
+    const releaseId = '00000000-0000-4000-8000-000000000001';
+    const tool = createManageTasksTool('profile-id');
+    const result = await tool.execute?.(
+      { intent: 'release_plan', releaseId },
+      {} as never
+    );
+
+    expect(mockInstantiateReleaseTasks).toHaveBeenCalledWith(releaseId);
+    expect(result).toMatchObject({
+      success: true,
+      intent: 'release_plan',
+      releaseId,
+      tasks: [{ id: 'task-id', createdAt: '2026-08-05T00:00:00.000Z' }],
+    });
   });
 });

--- a/apps/web/lib/chat/tools/tasks.ts
+++ b/apps/web/lib/chat/tools/tasks.ts
@@ -1,0 +1,77 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import {
+  createTask,
+  getTasks,
+} from '@/app/app/(shell)/dashboard/tasks/task-actions';
+import { APP_ROUTES } from '@/constants/routes';
+import type { TaskView } from '@/lib/tasks/types';
+import { chatToolSchema } from '../strict-schema';
+import { TOOL_SCHEMAS } from '../tool-schemas';
+
+function serializeTask(task: TaskView) {
+  return {
+    ...task,
+    dueAt: task.dueAt?.toISOString() ?? null,
+    scheduledFor: task.scheduledFor?.toISOString() ?? null,
+    startedAt: task.startedAt?.toISOString() ?? null,
+    completedAt: task.completedAt?.toISOString() ?? null,
+    createdAt: task.createdAt.toISOString(),
+    updatedAt: task.updatedAt.toISOString(),
+  };
+}
+
+/** The real paid-plan Tasks chat capability. */
+export function createManageTasksTool(profileId: string | null) {
+  return tool({
+    description: TOOL_SCHEMAS.manageTasks.description,
+    inputSchema: chatToolSchema({
+      intent: z.enum(['create', 'list', 'open', 'release_plan']).optional(),
+      title: z.string().max(200).optional(),
+    }),
+    execute: async ({ intent = 'open', title }) => {
+      if (!profileId) {
+        return {
+          success: false as const,
+          error: 'Profile ID required',
+          errorCode: 'PROFILE_REQUIRED' as const,
+          retryable: true,
+        };
+      }
+
+      if (intent === 'open') {
+        return {
+          success: true as const,
+          intent,
+          href: APP_ROUTES.TASKS,
+          summary: 'Tasks workspace ready.',
+        };
+      }
+
+      if (intent === 'list') {
+        const result = await getTasks({ limit: 20 });
+        return {
+          success: true as const,
+          intent,
+          tasks: result.tasks.map(serializeTask),
+          nextCursor: result.nextCursor,
+          summary: `Found ${result.tasks.length} task${result.tasks.length === 1 ? '' : 's'}.`,
+        };
+      }
+
+      const task = await createTask({
+        title: title?.trim() || 'Untitled task',
+        status: 'todo',
+        priority: 'medium',
+      });
+
+      return {
+        success: true as const,
+        intent,
+        task: serializeTask(task),
+        href: APP_ROUTES.TASKS,
+        summary: `Created task “${task.title}”.`,
+      };
+    },
+  });
+}

--- a/apps/web/lib/chat/tools/tasks.ts
+++ b/apps/web/lib/chat/tools/tasks.ts
@@ -1,10 +1,12 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { instantiateReleaseTasks } from '@/app/app/(shell)/dashboard/releases/task-actions';
 import {
   createTask,
   getTasks,
 } from '@/app/app/(shell)/dashboard/tasks/task-actions';
 import { APP_ROUTES } from '@/constants/routes';
+import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import type { TaskView } from '@/lib/tasks/types';
 import { chatToolSchema } from '../strict-schema';
 import { TOOL_SCHEMAS } from '../tool-schemas';
@@ -21,6 +23,16 @@ function serializeTask(task: TaskView) {
   };
 }
 
+function serializeReleaseTask(task: ReleaseTaskView) {
+  return {
+    ...task,
+    dueDate: task.dueDate?.toISOString() ?? null,
+    completedAt: task.completedAt?.toISOString() ?? null,
+    createdAt: task.createdAt.toISOString(),
+    updatedAt: task.updatedAt.toISOString(),
+  };
+}
+
 /** The real paid-plan Tasks chat capability. */
 export function createManageTasksTool(profileId: string | null) {
   return tool({
@@ -28,8 +40,9 @@ export function createManageTasksTool(profileId: string | null) {
     inputSchema: chatToolSchema({
       intent: z.enum(['create', 'list', 'open', 'release_plan']).optional(),
       title: z.string().max(200).optional(),
+      releaseId: z.string().uuid().optional(),
     }),
-    execute: async ({ intent = 'open', title }) => {
+    execute: async ({ intent = 'open', title, releaseId }) => {
       if (!profileId) {
         return {
           success: false as const,
@@ -56,6 +69,27 @@ export function createManageTasksTool(profileId: string | null) {
           tasks: result.tasks.map(serializeTask),
           nextCursor: result.nextCursor,
           summary: `Found ${result.tasks.length} task${result.tasks.length === 1 ? '' : 's'}.`,
+        };
+      }
+
+      if (intent === 'release_plan') {
+        if (!releaseId) {
+          return {
+            success: false as const,
+            error: 'Release ID required to set up a release plan.',
+            errorCode: 'RELEASE_ID_REQUIRED' as const,
+            retryable: false,
+          };
+        }
+
+        const tasks = await instantiateReleaseTasks(releaseId);
+        return {
+          success: true as const,
+          intent,
+          releaseId,
+          tasks: tasks.map(serializeReleaseTask),
+          href: APP_ROUTES.TASKS,
+          summary: `Release plan ready with ${tasks.length} task${tasks.length === 1 ? '' : 's'}.`,
         };
       }
 

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -33,6 +33,8 @@ export const HIDDEN_TOOLS: Readonly<Record<string, string>> = {
     'Conversational merch creation is gated by plan and rollout flags before broader slash exposure.',
   createMerchAlternativeItem:
     'Follow-up from a saved merch card; shown as card/menu actions once a source design exists.',
+  findMerchSources:
+    'Merch source discovery is a conversational prerequisite for merch creation, not a root slash command.',
   createPromoStrategy: 'Pro-only; surfaced via the release detail surface.',
   createRelease: 'Surfaced in the releases dashboard; chat tool is a fallback.',
   deleteOrArchiveMerchCard:

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -497,6 +497,7 @@ const ACCOUNT_TOOL_NAMES = [
 ] as const;
 
 const MERCH_TOOL_NAMES = [
+  'findMerchSources',
   'createMerch',
   'previewMerchOptions',
   'selectMerchDesign',

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1548,6 +1548,7 @@ tests:
           - generateCanvasPlan
           - generateReleasePitch
           - importBioFromUrl
+          - findMerchSources
           - manageTasks
           - markCanvasUploaded
           - openBillingPortal
@@ -2737,6 +2738,26 @@ tests:
       toolInput:
         intent: create
         title: "Pitch Neon Reef to Spotify"
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts paid merch source discovery
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Help me choose a title for merch."
+      target: tool-contract
+      toolName: findMerchSources
+      mode: app
+      plan: pro
+      toolInput: {}
     assert:
       - type: javascript
         value: file://assertions.cjs:assertDeterministicNoSpend


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4535 -->

## Summary

- Add the production `manageTasks` chat tool with `open`, `list`, `create`, and `release_plan` actions.
- Gate task execution by plan and return the existing upgrade CTA fail-soft for ineligible users, without Sentry error reporting while recording demand.
- Add deterministic task-tool coverage and close the production tool registry/eval inventory gap for the existing `findMerchSources` tool.

## Validation

- Focused chat tests: 26 passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `pnpm --filter @jovie/web run evals:validate` passed.
- Deterministic Promptfoo evals: 206 passed, 0 failed.
- Full pre-push gate passed: Biome, proxy/tailwind/component guards, affected typecheck, affected lint, 292 test files passed (2 skipped), and CI harness validation.

## Acceptance criteria

- Free-plan task requests receive the truthful in-chat upgrade CTA.
- Qualified plans can invoke the real task action contract, including release-plan task instantiation.
- Entitlement denials remain fail-soft and are recorded as demand without Sentry error capture.
- Eval coverage references production-registered tools only.

No screenshots: this is a backend/chat-tool contract change with no directly visual UI changes.

Fixes JOV-4535
