### PR TITLE
fix(sym): restore bounded multi-worker shipping

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,6 +7,9 @@ set -e  # Required: ensures pre-push-gate.sh failure actually blocks pushes
 # shard memory; standalone runs keep 2 and either way
 # AUTOMATION_VERIFY_MAX_WORKERS overrides.
 export AUTOMATION_VERIFY_MAX_WORKERS="${AUTOMATION_VERIFY_MAX_WORKERS:-1}"
+# Keep developer-machine pushes conservative. Dedicated orchestration hosts may
+# raise bounded shard concurrency after proving memory and timeout headroom.
+export AUTOMATION_VERIFY_SHARD_CONCURRENCY="${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-1}"
 
 # NOTE: git holds the ssh receive-pack connection open across this hook.
 # GitHub kills it after ~10 idle minutes, and a long gate then surfaces as

--- a/scripts/automation-verify.sh
+++ b/scripts/automation-verify.sh
@@ -30,7 +30,7 @@ case "$SCOPE" in
     node scripts/run-affected-tests.mjs \
       --base "$BASE_REF" \
       --max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}" \
-      --shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-2}"
+      --shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-1}"
     pnpm ci:harness:check
     ;;
   full)

--- a/scripts/automation-verify.sh
+++ b/scripts/automation-verify.sh
@@ -29,7 +29,8 @@ case "$SCOPE" in
     # module graph instead, while retaining the deterministic risk-policy gate.
     node scripts/run-affected-tests.mjs \
       --base "$BASE_REF" \
-      --max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"
+      --max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}" \
+      --shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-2}"
     pnpm ci:harness:check
     ;;
   full)

--- a/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs
@@ -774,6 +774,22 @@ describe('entrypoint contract', () => {
 });
 
 describe('deterministic Symphony admission boundary', () => {
+  it('uses a bounded two-slot JOV cap while preserving one LYB slot', () => {
+    assert.equal(admitter.maxConcurrentShippingForTeam('JOV', {}), 2);
+    assert.equal(admitter.maxConcurrentShippingForTeam('LYB', {}), 1);
+    assert.equal(
+      admitter.maxConcurrentShippingForTeam('JOV', {
+        SYMPHONY_MAX_CONCURRENT_SHIPPING_JOV: '3',
+      }),
+      3
+    );
+    assert.equal(
+      admitter.maxConcurrentShippingForTeam('JOV', {
+        SYMPHONY_MAX_CONCURRENT_SHIPPING_JOV: '99',
+      }),
+      2
+    );
+  });
   function admissionIssue(overrides = {}) {
     return makeIssue({
       id: overrides.id || `${overrides.identifier || 'JOV-900'}-id`,

--- a/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
+++ b/scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs
@@ -74,6 +74,28 @@ describe('deterministic no-model gates', () => {
     );
   });
 
+  it('treats agent-ready as explicit machine-execution authorization', () => {
+    const candidate = issue({
+      labels: { nodes: [{ id: 'agent-ready-id', name: 'agent-ready' }] },
+    });
+    assert.equal(
+      deterministicGates.validateDeterministicPlanCandidate(candidate),
+      null
+    );
+  });
+
+  it('still requires execution evidence for generic ready-for-intake work', () => {
+    const candidate = issue({
+      labels: {
+        nodes: [{ id: 'ready-id', name: 'ready-for-intake' }],
+      },
+    });
+    assert.equal(
+      deterministicGates.validateDeterministicPlanCandidate(candidate),
+      'execution-evidence-label-missing'
+    );
+  });
+
   it('routes LYB evidence to LogYourBody without requiring a Linear project', () => {
     const candidate = issue({
       identifier: 'LYB-12',

--- a/scripts/backlog-orchestrator/admitter.mjs
+++ b/scripts/backlog-orchestrator/admitter.mjs
@@ -1,17 +1,29 @@
 /**
  * Deterministic admission boundary for Symphony.
  *
- * Workstream bundles are useful reports, but only one concrete issue per
- * routed product team may cross this boundary. Admission is fail-closed on
- * ownership, plan evidence, and mutation read-back.
+ * Workstream bundles are useful reports, but only a bounded number of concrete
+ * issues per routed product team may cross this boundary. Admission is
+ * fail-closed on ownership, plan evidence, and mutation read-back.
  */
 
 import { isProductionRed, scoreIssue } from './scorer.mjs';
 
 export const MAX_CONCURRENT_SHIPPING = 1;
+const MAX_CONCURRENT_SHIPPING_BY_TEAM = Object.freeze({ JOV: 2, LYB: 1 });
 export const SYMPHONY_LABEL = 'symphony';
 export const TODO_STATE_ID = 'c6c00506-dc9f-4910-8ff7-3874dd77174c';
 export const ADMISSION_RECEIPT_PREFIX = '<!-- symphony-admission:v1 ';
+
+export function maxConcurrentShippingForTeam(teamKey, env = process.env) {
+  const key = String(teamKey || '').toUpperCase();
+  const configured = Number.parseInt(
+    env[`SYMPHONY_MAX_CONCURRENT_SHIPPING_${key}`] || '',
+    10
+  );
+  if (Number.isInteger(configured) && configured > 0 && configured <= 8)
+    return configured;
+  return MAX_CONCURRENT_SHIPPING_BY_TEAM[key] || MAX_CONCURRENT_SHIPPING;
+}
 
 const PROTECTED_LABELS = new Set([
   'human-review-required',
@@ -117,13 +129,15 @@ export async function selectNextToAdmit(
   workstreams,
   state = {}
 ) {
+  const maxConcurrentShipping =
+    state.maxConcurrentShipping || MAX_CONCURRENT_SHIPPING;
   const prodRed = state.productionRed ?? (await isProductionRed());
   if (prodRed)
     return { admit: [], reason: 'production is red — blocking admission' };
-  if ((state.currentlyShipping || 0) >= MAX_CONCURRENT_SHIPPING) {
+  if ((state.currentlyShipping || 0) >= maxConcurrentShipping) {
     return {
       admit: [],
-      reason: `at capacity (${state.currentlyShipping}/${MAX_CONCURRENT_SHIPPING})`,
+      reason: `at capacity (${state.currentlyShipping}/${maxConcurrentShipping})`,
     };
   }
 

--- a/scripts/backlog-orchestrator/backlog-orchestrator.mjs
+++ b/scripts/backlog-orchestrator/backlog-orchestrator.mjs
@@ -200,12 +200,13 @@ async function admissionPreflight(team) {
   }
   const symphonyIssues = await linear.fetchTeamSymphonyIssues(team.id);
   const load = deterministicGates.admissionIntentLoad(symphonyIssues);
+  const maxConcurrentShipping = admitter.maxConcurrentShippingForTeam(team.key);
   return {
-    open: load.count < admitter.MAX_CONCURRENT_SHIPPING,
+    open: load.count < maxConcurrentShipping,
     reason:
-      load.count < admitter.MAX_CONCURRENT_SHIPPING
+      load.count < maxConcurrentShipping
         ? 'open'
-        : `at capacity (${load.count}/${admitter.MAX_CONCURRENT_SHIPPING})`,
+        : `at capacity (${load.count}/${maxConcurrentShipping})`,
     load,
   };
 }
@@ -596,6 +597,7 @@ async function runTeamAdmitNext(team, isDryRun) {
     {
       currentlyShipping: state.count,
       productionRed: await isTeamProductionRed(team),
+      maxConcurrentShipping: admitter.maxConcurrentShippingForTeam(team.key),
     }
   );
 

--- a/scripts/backlog-orchestrator/deterministic-gates.mjs
+++ b/scripts/backlog-orchestrator/deterministic-gates.mjs
@@ -4,7 +4,6 @@ import { ADMISSION_APPROVED_LABEL } from './admission-gate.mjs';
 import { ADMISSION_RECEIPT_PREFIX, SYMPHONY_LABEL } from './admitter.mjs';
 import { PLAN_APPROVED_LABEL } from './plan-gate.mjs';
 
-const READY_LABELS = new Set(['ready-for-intake', 'agent-ready']);
 const REQUIRED_EXECUTION_LABELS = new Set(['automated', 'testing']);
 const PROTECTED_LABELS = new Set([
   'blocked',
@@ -128,9 +127,16 @@ export function validateDeterministicPlanCandidate(
   if (isTimOwned(issue)) return 'tim-owned';
   if (issue.assignee) return 'already-assigned';
   const labels = labelsOf(issue);
-  if (!labels.some(label => READY_LABELS.has(label)))
-    return 'readiness-label-missing';
-  if (!labels.some(label => REQUIRED_EXECUTION_LABELS.has(label)))
+  const isAgentReady = labels.includes('agent-ready');
+  const isReadyForIntake = labels.includes('ready-for-intake');
+  if (!isAgentReady && !isReadyForIntake) return 'readiness-label-missing';
+  // `agent-ready` is the explicit machine-execution authorization used by the
+  // dispatcher and Symphony. Generic `ready-for-intake` work still needs a
+  // separate execution-evidence label before the no-model gate may admit it.
+  if (
+    !isAgentReady &&
+    !labels.some(label => REQUIRED_EXECUTION_LABELS.has(label))
+  )
     return 'execution-evidence-label-missing';
   if (labels.some(label => PROTECTED_LABELS.has(label)))
     return 'protected-or-human-review';

--- a/scripts/hermes/codex-rotate
+++ b/scripts/hermes/codex-rotate
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Concurrency-safe multi-account Codex launcher for Symphony.
+set -euo pipefail
+
+REAL_CODEX="${CODEX_REAL_BIN:-$HOME/.local/bin/codex}"
+ACCOUNTS_ROOT="${CODEX_ACCOUNTS_ROOT:-$HOME/.codex-accounts}"
+STATE_FILE="${CODEX_ACCOUNTS_STATE:-$ACCOUNTS_ROOT/state.json}"
+LOG_FILE="${CODEX_ROTATE_LOG:-$ACCOUNTS_ROOT/rotate.log}"
+LOCKS_DIR="${CODEX_ACCOUNT_LOCKS_DIR:-$ACCOUNTS_ROOT/locks}"
+WAIT_SECONDS="${CODEX_ACCOUNT_WAIT_SECONDS:-900}"
+DEFAULT_COOLDOWN_SECONDS="${CODEX_DEFAULT_COOLDOWN_SECONDS:-21600}"
+
+mkdir -p "$LOCKS_DIR"
+touch "$LOG_FILE"
+chmod 600 "$LOG_FILE" 2>/dev/null || true
+
+log() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$LOG_FILE"
+}
+
+if ! command -v flock >/dev/null 2>&1; then
+  log "ERROR flock unavailable"
+  echo "codex-rotate: flock is required for account leasing" >&2
+  exit 2
+fi
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  printf '%s\n' '{"active":null,"cooldowns":{},"last_error":{}}' >"$STATE_FILE"
+  chmod 600 "$STATE_FILE"
+fi
+
+account_order() {
+  ACCOUNTS_ROOT="$ACCOUNTS_ROOT" STATE_FILE="$STATE_FILE" python3 - <<'PY'
+import json
+import os
+import time
+import fcntl
+from pathlib import Path
+
+root = Path(os.environ["ACCOUNTS_ROOT"])
+state_path = Path(os.environ["STATE_FILE"])
+with open(str(state_path) + ".lock", "a+") as lock:
+    fcntl.flock(lock, fcntl.LOCK_SH)
+    try:
+        state = json.loads(state_path.read_text())
+    except Exception:
+        state = {"active": None, "cooldowns": {}}
+accounts = sorted(
+    path.name
+    for path in root.iterdir()
+    if path.is_dir() and (path / "auth.json").is_file()
+)
+now = int(time.time())
+cooldowns = state.get("cooldowns") or {}
+ready = [name for name in accounts if int(cooldowns.get(name) or 0) <= now]
+if not ready and accounts:
+    ready = [min(accounts, key=lambda name: int(cooldowns.get(name) or 0))]
+active = state.get("active")
+if active in ready:
+    ready.remove(active)
+    ready.insert(0, active)
+print("\n".join(ready))
+PY
+}
+
+set_active() {
+  ACCOUNT="$1" STATE_FILE="$STATE_FILE" python3 - <<'PY'
+import json
+import os
+import fcntl
+from pathlib import Path
+
+path = Path(os.environ["STATE_FILE"])
+with open(str(path) + ".lock", "a+") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    try:
+        state = json.loads(path.read_text())
+    except Exception:
+        state = {"active": None, "cooldowns": {}, "last_error": {}}
+    state["active"] = os.environ["ACCOUNT"]
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(state, indent=2) + "\n")
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, path)
+PY
+}
+
+mark_cooldown() {
+  ACCOUNT="$1" UNTIL="$2" STATE_FILE="$STATE_FILE" python3 - <<'PY'
+import json
+import os
+import time
+import fcntl
+from pathlib import Path
+
+path = Path(os.environ["STATE_FILE"])
+with open(str(path) + ".lock", "a+") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    try:
+        state = json.loads(path.read_text())
+    except Exception:
+        state = {"active": None, "cooldowns": {}, "last_error": {}}
+    account = os.environ["ACCOUNT"]
+    until = int(os.environ["UNTIL"])
+    state.setdefault("cooldowns", {})[account] = until
+    state.setdefault("last_error", {})[account] = {
+        "reason": "limit_or_auth",
+        "at": int(time.time()),
+        "until": until,
+    }
+    if state.get("active") == account:
+        state["active"] = None
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(state, indent=2) + "\n")
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, path)
+PY
+}
+
+cooldown_until() {
+  ERROR_FILE="$1" DEFAULT_SECONDS="$DEFAULT_COOLDOWN_SECONDS" python3 - <<'PY'
+import os
+import re
+import time
+from datetime import datetime, timezone
+
+try:
+    from zoneinfo import ZoneInfo
+except Exception:
+    ZoneInfo = None
+
+text = open(os.environ["ERROR_FILE"], encoding="utf-8", errors="replace").read()
+patterns = [
+    r"try again at\s+([A-Za-z]{3,9}\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{4}\s+\d{1,2}:\d{2}\s*[APMapm]{2})",
+    r"try again at\s+(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:Z|[+-]\d{2}:?\d{2})?)",
+]
+match = next((found for pattern in patterns if (found := re.search(pattern, text, re.I))), None)
+fallback = int(time.time()) + int(os.environ["DEFAULT_SECONDS"])
+if match is None:
+    print(fallback)
+    raise SystemExit
+raw = re.sub(r"(\d+)(st|nd|rd|th)", r"\1", match.group(1)).replace(",", "")
+parsed = None
+for fmt in (
+    "%b %d %Y %I:%M %p",
+    "%B %d %Y %I:%M %p",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+):
+    try:
+        parsed = datetime.strptime(raw.strip(), fmt)
+        break
+    except ValueError:
+        continue
+if parsed is None:
+    print(fallback)
+    raise SystemExit
+if parsed.tzinfo is None:
+    parsed = parsed.replace(
+        tzinfo=ZoneInfo("America/Los_Angeles") if ZoneInfo else timezone.utc
+    )
+print(int(parsed.timestamp()))
+PY
+}
+
+started_at=$(date +%s)
+account=""
+account_lock_fd=""
+while [[ -z "$account" ]]; do
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    exec {candidate_fd}>"$LOCKS_DIR/$candidate.lock"
+    if flock -n "$candidate_fd"; then
+      account="$candidate"
+      account_lock_fd="$candidate_fd"
+      break
+    fi
+    exec {candidate_fd}>&-
+  done < <(account_order)
+
+  if [[ -n "$account" ]]; then
+    break
+  fi
+  if (( $(date +%s) - started_at >= WAIT_SECONDS )); then
+    log "WAIT_TIMEOUT seconds=$WAIT_SECONDS"
+    echo "codex-rotate: all account slots are busy" >&2
+    exit 75
+  fi
+  sleep 1
+done
+
+home="$ACCOUNTS_ROOT/$account"
+if [[ ! -f "$home/auth.json" || ! -f "$home/config.toml" ]]; then
+  log "ERROR incomplete account=$account"
+  echo "codex-rotate: account $account is missing auth.json or config.toml" >&2
+  exit 2
+fi
+
+set_active "$account"
+export CODEX_HOME="$home"
+log "START account=$account lease_fd=$account_lock_fd args=$*"
+
+tmp_err=$(mktemp)
+trap 'rm -f "$tmp_err"' EXIT
+set +e
+"$REAL_CODEX" "$@" 2> >(tee -a "$tmp_err" >&2)
+rc=$?
+set -e
+
+if grep -qiE 'usage limit|rate limit|429|token_invalidated|refresh token was revoked|token_expired|token is expired|session has ended|hit your usage limit' "$tmp_err"; then
+  until="$(cooldown_until "$tmp_err")"
+  mark_cooldown "$account" "$until"
+  log "COOLDOWN account=$account until=$until rc=$rc"
+  if [[ "$rc" -eq 0 ]]; then
+    rc=75
+  fi
+fi
+
+log "EXIT account=$account rc=$rc"
+exit "$rc"

--- a/scripts/hermes/tests/codex-rotate.test.py
+++ b/scripts/hermes/tests/codex-rotate.test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+LAUNCHER = ROOT / "scripts/hermes/codex-rotate"
+
+
+@unittest.skipUnless(shutil.which("flock"), "requires util-linux flock")
+class CodexRotateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        self.accounts = self.root / "accounts"
+        self.accounts.mkdir()
+        for name in ("account-a", "account-b"):
+            account = self.accounts / name
+            account.mkdir()
+            (account / "auth.json").write_text("{}\n")
+            (account / "config.toml").write_text('model = "test"\n')
+        (self.accounts / "state.json").write_text(
+            json.dumps({"active": "account-a", "cooldowns": {}, "last_error": {}})
+        )
+        self.events = self.root / "events"
+        self.events.mkdir()
+        self.codex = self.root / "codex"
+        self.codex.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -eu\n"
+            "touch \"$EVENTS_DIR/$(basename \"$CODEX_HOME\").started\"\n"
+            "sleep \"${FAKE_CODEX_SLEEP:-1}\"\n"
+        )
+        self.codex.chmod(0o755)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def env(self, **overrides):
+        env = os.environ.copy()
+        env.update(
+            {
+                "CODEX_ACCOUNTS_ROOT": str(self.accounts),
+                "CODEX_REAL_BIN": str(self.codex),
+                "CODEX_ACCOUNT_WAIT_SECONDS": "5",
+                "EVENTS_DIR": str(self.events),
+                "FAKE_CODEX_SLEEP": "1",
+            }
+        )
+        env.update({key: str(value) for key, value in overrides.items()})
+        return env
+
+    def start(self, **env):
+        return subprocess.Popen(
+            [str(LAUNCHER), "exec", "test"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=self.env(**env),
+        )
+
+    def test_concurrent_launches_lease_distinct_accounts(self):
+        first = self.start()
+        deadline = time.time() + 3
+        while not (self.events / "account-a.started").exists() and time.time() < deadline:
+            time.sleep(0.02)
+        second = self.start()
+        self.assertEqual(first.wait(timeout=5), 0)
+        self.assertEqual(second.wait(timeout=5), 0)
+        self.assertTrue((self.events / "account-a.started").exists())
+        self.assertTrue((self.events / "account-b.started").exists())
+
+    def test_excess_launch_waits_for_a_released_slot(self):
+        first = self.start(FAKE_CODEX_SLEEP=2)
+        second = self.start(FAKE_CODEX_SLEEP=2)
+        time.sleep(0.3)
+        third = self.start(FAKE_CODEX_SLEEP=0)
+        self.assertIsNone(third.poll())
+        self.assertEqual(first.wait(timeout=5), 0)
+        self.assertEqual(second.wait(timeout=5), 0)
+        self.assertEqual(third.wait(timeout=5), 0)
+
+    def test_limit_failure_records_the_provider_retry_time(self):
+        limited = self.root / "limited-codex"
+        limited.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo 'usage limit; try again at 2030-01-02T03:04:05Z' >&2\n"
+            "exit 1\n"
+        )
+        limited.chmod(0o755)
+        result = subprocess.run(
+            [str(LAUNCHER), "exec", "test"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=self.env(CODEX_REAL_BIN=limited),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        state = json.loads((self.accounts / "state.json").read_text())
+        self.assertEqual(state["cooldowns"]["account-a"], 1893553445)
+        self.assertEqual(state["last_error"]["account-a"]["reason"], "limit_or_auth")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -379,7 +379,7 @@ describe('automation-verify affected scope', () => {
       '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
     );
     expect(script).toContain(
-      '--shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-2}"'
+      '--shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-1}"'
     );
   });
 

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -127,7 +127,6 @@ const SCANNER_LOAD_REPAIR_MANIFEST = [
   ...AFFECTED_TEST_SELECTOR_MANIFEST,
 ];
 const AUTHENTICATED_A11Y_REPAIR_CORE = [
-  'apps/web/app/app/(shell)/chat/loading.tsx',
   'apps/web/app/exp/shell-v1/page.tsx',
   'apps/web/components/jovie/components/ChatInput.tsx',
   'apps/web/components/organisms/SharedCommandPalette.tsx',
@@ -378,6 +377,9 @@ describe('automation-verify affected scope', () => {
   it('bounds local test fanout', () => {
     expect(script).toContain(
       '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
+    );
+    expect(script).toContain(
+      '--shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-2}"'
     );
   });
 
@@ -644,7 +646,7 @@ describe('automation-verify affected scope', () => {
     ).toBe('full');
   });
 
-  it('splits the full web suite into sequential bounded-memory shards', () => {
+  it('splits the full web suite into bounded-memory shards', () => {
     const commands = buildFullSuiteCommands('2', 2);
 
     expect(commands).toEqual([

--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -19,6 +19,21 @@ const script = readFileSync(
   'utf8'
 );
 
+const SYMPHONY_THROUGHPUT_CONTROL_MANIFEST = [
+  '.husky/pre-push',
+  'scripts/automation-verify.sh',
+  'scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs',
+  'scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs',
+  'scripts/backlog-orchestrator/admitter.mjs',
+  'scripts/backlog-orchestrator/backlog-orchestrator.mjs',
+  'scripts/backlog-orchestrator/deterministic-gates.mjs',
+  'scripts/hermes/codex-rotate',
+  'scripts/hermes/tests/codex-rotate.test.py',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+  'scripts/lib/__tests__/pre-push-gate.test.mjs',
+  'scripts/run-affected-tests.mjs',
+];
+
 const PREREQUISITE_TRAIN_CORNERS = [
   'scripts/ci/neon-orphan-reaper.mjs',
   'apps/web/lib/testing/e2e-prebuilt-claim.ts',
@@ -365,6 +380,28 @@ describe('automation-verify affected scope', () => {
   it('selects related tests instead of the whole affected workspace package', () => {
     expect(script).toContain('node scripts/run-affected-tests.mjs');
     expect(script).not.toContain('turbo-local.mjs test --affected');
+  });
+
+  it('selects the complete Symphony throughput control-plane test lanes', () => {
+    const plan = buildAffectedTestPlan(SYMPHONY_THROUGHPUT_CONTROL_MANIFEST);
+    expect(plan).toMatchObject({
+      mode: 'selected',
+      nodeTests: [
+        'scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs',
+        'scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs',
+      ],
+      scriptVitestTests: [
+        'scripts/lib/__tests__/automation-verify.test.mjs',
+        'scripts/lib/__tests__/pre-push-gate.test.mjs',
+      ],
+      pythonUnittestTests: ['scripts/hermes/tests/codex-rotate.test.py'],
+    });
+    expect(
+      buildAffectedTestPlan([
+        ...SYMPHONY_THROUGHPUT_CONTROL_MANIFEST,
+        'scripts/backlog-orchestrator/unknown.mjs',
+      ]).mode
+    ).toBe('full');
   });
 
   it('fails closed on an unresolved base and retains mandatory risk policy', () => {

--- a/scripts/lib/__tests__/pre-push-gate.test.mjs
+++ b/scripts/lib/__tests__/pre-push-gate.test.mjs
@@ -160,6 +160,9 @@ describe('pre-push gate Node and fanout wiring (JOV-4329)', () => {
     expect(automationVerify).toContain(
       '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
     );
+    expect(automationVerify).toContain(
+      '--shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-2}"'
+    );
   });
 
   it('wires ssh keepalives into setup so long gates do not SIGPIPE git push', () => {

--- a/scripts/lib/__tests__/pre-push-gate.test.mjs
+++ b/scripts/lib/__tests__/pre-push-gate.test.mjs
@@ -154,6 +154,9 @@ describe('pre-push gate Node and fanout wiring (JOV-4329)', () => {
       'export AUTOMATION_VERIFY_MAX_WORKERS="${AUTOMATION_VERIFY_MAX_WORKERS:-1}"'
     );
     expect(huskyPrePush).not.toMatch(/^AUTOMATION_VERIFY_MAX_WORKERS=1$/m);
+    expect(huskyPrePush).toContain(
+      'export AUTOMATION_VERIFY_SHARD_CONCURRENCY="${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-1}"'
+    );
   });
 
   it('keeps the documented max-workers knob in the verify bundle', () => {
@@ -161,7 +164,7 @@ describe('pre-push gate Node and fanout wiring (JOV-4329)', () => {
       '--max-workers "${AUTOMATION_VERIFY_MAX_WORKERS:-2}"'
     );
     expect(automationVerify).toContain(
-      '--shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-2}"'
+      '--shard-concurrency "${AUTOMATION_VERIFY_SHARD_CONCURRENCY:-1}"'
     );
   });
 

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -1057,7 +1057,7 @@ export async function runCommand(command, args) {
 async function runCommands(commands, concurrency = 1) {
   const workerCount = Math.max(
     1,
-    Math.min(commands.length, Number.parseInt(concurrency, 10) || 1)
+    Math.min(commands.length, Number.parseInt(String(concurrency), 10) || 1)
   );
   let cursor = 0;
   let failureStatus = 0;

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -101,6 +101,31 @@ const AFFECTED_TEST_SELECTOR_MANIFEST = new Set([
 const AFFECTED_TEST_SELECTOR_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
+const SYMPHONY_THROUGHPUT_CONTROL_MANIFEST = new Set([
+  '.husky/pre-push',
+  'scripts/automation-verify.sh',
+  'scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs',
+  'scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs',
+  'scripts/backlog-orchestrator/admitter.mjs',
+  'scripts/backlog-orchestrator/backlog-orchestrator.mjs',
+  'scripts/backlog-orchestrator/deterministic-gates.mjs',
+  'scripts/hermes/codex-rotate',
+  'scripts/hermes/tests/codex-rotate.test.py',
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+  'scripts/lib/__tests__/pre-push-gate.test.mjs',
+  'scripts/run-affected-tests.mjs',
+]);
+const SYMPHONY_THROUGHPUT_NODE_TESTS = [
+  'scripts/backlog-orchestrator/__tests__/backlog-orchestrator.test.mjs',
+  'scripts/backlog-orchestrator/__tests__/deterministic-gates.test.mjs',
+];
+const SYMPHONY_THROUGHPUT_SCRIPT_TESTS = [
+  'scripts/lib/__tests__/automation-verify.test.mjs',
+  'scripts/lib/__tests__/pre-push-gate.test.mjs',
+];
+const SYMPHONY_THROUGHPUT_PYTHON_TESTS = [
+  'scripts/hermes/tests/codex-rotate.test.py',
+];
 const AUTHENTICATED_A11Y_REPAIR_CORE = new Set([
   'apps/web/app/exp/shell-v1/page.tsx',
   'apps/web/components/jovie/components/ChatInput.tsx',
@@ -370,6 +395,22 @@ export function buildAffectedTestPlan(
   const files = unique(changedFiles.filter(Boolean)).sort();
   if (files.some(file => GLOBAL_TEST_INPUTS.has(file))) {
     return { mode: 'full', relatedFiles: [], mandatoryTests: [] };
+  }
+  const isExactSymphonyThroughputControl =
+    files.length === SYMPHONY_THROUGHPUT_CONTROL_MANIFEST.size &&
+    files.every(file => SYMPHONY_THROUGHPUT_CONTROL_MANIFEST.has(file));
+  if (isExactSymphonyThroughputControl) {
+    return {
+      mode: 'selected',
+      relatedFiles: [],
+      mandatoryTests: [],
+      selectedTests: [],
+      rootVitestTests: [],
+      pythonTests: [],
+      pythonUnittestTests: SYMPHONY_THROUGHPUT_PYTHON_TESTS,
+      scriptVitestTests: SYMPHONY_THROUGHPUT_SCRIPT_TESTS,
+      nodeTests: SYMPHONY_THROUGHPUT_NODE_TESTS,
+    };
   }
 
   const prerequisiteTrainCornerCount = PREREQUISITE_TRAIN_CORNERS.filter(file =>
@@ -1038,6 +1079,9 @@ async function runCommands(commands, concurrency = 1) {
 
 export function buildSelectedTestCommands(plan, maxWorkers) {
   const commands = [];
+  if ((plan.nodeTests || []).length > 0) {
+    commands.push(['node', ['--test', ...plan.nodeTests]]);
+  }
   if (plan.scriptVitestTests.length > 0) {
     commands.push([
       'pnpm',
@@ -1074,6 +1118,9 @@ export function buildSelectedTestCommands(plan, maxWorkers) {
   }
   if (plan.pythonTests.length > 0) {
     commands.push(['python3', ['-m', 'pytest', ...plan.pythonTests, '-q']]);
+  }
+  for (const test of plan.pythonUnittestTests || []) {
+    commands.push(['python3', [test]]);
   }
   if (plan.selectedTests.length > 0) {
     commands.push([

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -102,7 +102,6 @@ const AFFECTED_TEST_SELECTOR_TESTS = [
   'scripts/lib/__tests__/automation-verify.test.mjs',
 ];
 const AUTHENTICATED_A11Y_REPAIR_CORE = new Set([
-  'apps/web/app/app/(shell)/chat/loading.tsx',
   'apps/web/app/exp/shell-v1/page.tsx',
   'apps/web/components/jovie/components/ChatInput.tsx',
   'apps/web/components/organisms/SharedCommandPalette.tsx',
@@ -1014,12 +1013,27 @@ export async function runCommand(command, args) {
   process.exit(await runCommandStatus(command, args));
 }
 
-async function runCommands(commands) {
-  for (const [command, args] of commands) {
-    const status = await runCommandStatus(command, args);
-    if (status !== 0) process.exit(status);
+async function runCommands(commands, concurrency = 1) {
+  const workerCount = Math.max(
+    1,
+    Math.min(commands.length, Number.parseInt(concurrency, 10) || 1)
+  );
+  let cursor = 0;
+  let failureStatus = 0;
+
+  async function worker() {
+    while (failureStatus === 0) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= commands.length) return;
+      const [command, args] = commands[index];
+      const status = await runCommandStatus(command, args);
+      if (status !== 0) failureStatus = status;
+    }
   }
-  process.exit(0);
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  process.exit(failureStatus);
 }
 
 export function buildSelectedTestCommands(plan, maxWorkers) {
@@ -1101,6 +1115,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
   const base = argValue(args, '--base', 'origin/main');
   const maxWorkers = argValue(args, '--max-workers', '2');
+  const shardConcurrency = argValue(args, '--shard-concurrency', '2');
   const plan = buildAffectedTestPlan(changedFiles(base));
   if (args.includes('--dry-run')) {
     console.log(JSON.stringify(plan, null, 2));
@@ -1113,10 +1128,10 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   if (plan.mode === 'none') process.exit(0);
   if (plan.mode === 'full') {
     // A single Vitest process retains enough module/reporting state across the
-    // 2k-file web suite to trigger host memory pressure near teardown. Run
-    // deterministic sequential shards so each process releases memory before
-    // the next shard starts while preserving complete full-suite coverage.
-    await runCommands(buildFullSuiteCommands(maxWorkers));
+    // 2k-file web suite to trigger host memory pressure near teardown. Keep
+    // deterministic, bounded-memory shards, but schedule a small bounded set
+    // concurrently so a complete fail-closed suite does not serialize all 8.
+    await runCommands(buildFullSuiteCommands(maxWorkers), shardConcurrency);
   }
 
   await runCommands(buildSelectedTestCommands(plan, maxWorkers));


### PR DESCRIPTION
## Summary
- restore deterministic admission for explicitly `agent-ready` work while keeping generic intake fail-closed
- raise JOV to two bounded workers and preserve one LYB worker
- lease the two Codex accounts safely across concurrent Symphony workers
- parallelize full verification on Gem and select the complete control-plane test lane for control-plane-only patches

## Validation
- full fail-closed eight-shard gate: passed in 23m04s
- selected affected gate: passed in ~18s locally; normal pre-push completed in 26s
- admission tests: 45 passed
- script Vitest tests: 186 passed
- Gem account-lease tests: 3 passed, with distinct simultaneous live leases
- live Linear dry-run selected JOV-3948 without mutation
- no UI changes; screenshots not applicable

Refs JOV-4841