### PR TITLE
fix(profile): link credited artists with claim-safe profiles

### DIFF
--- a/apps/web/app/[username]/_lib/claim-banner-state.ts
+++ b/apps/web/app/[username]/_lib/claim-banner-state.ts
@@ -4,6 +4,7 @@ export type ClaimBannerVariant =
   | 'organic'
   | 'claim_intent'
   | 'direct_in_progress'
+  | 'verified_claim'
   | 'unsupported';
 
 export function resolveClaimBannerState(params: {
@@ -27,7 +28,9 @@ export function resolveClaimBannerState(params: {
   let claimBannerVariant: ClaimBannerVariant | null = null;
 
   if (claimRequiresVerification) {
-    claimBannerVariant = 'unsupported';
+    claimBannerVariant = directClaimSupported
+      ? 'verified_claim'
+      : 'unsupported';
   } else if (
     visitorState === 'claim_intent_token' ||
     claimSearchParam === '1'

--- a/apps/web/app/[username]/claim/route.ts
+++ b/apps/web/app/[username]/claim/route.ts
@@ -15,7 +15,6 @@ import {
   markLeadClaimPageViewedFromToken,
   setLeadAttributionCookieFromToken,
 } from '@/lib/leads/funnel-events';
-import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
 import { hashClaimToken } from '@/lib/security/claim-token';
 import {
   getProfileByUsername,
@@ -163,18 +162,6 @@ export async function GET(
       return redirectTo(request, `/${profile.usernameNormalized}`);
     }
 
-    // Automatic structured-credit profiles are public identity records, not
-    // proof that the visitor controls the artist. A direct-profile cookie can
-    // be self-issued from this public route, so it must never authorize these
-    // profiles. A verified/token-backed claim path can be added separately.
-    if (isUnclaimedStructuredCreditProfile(profile.settings)) {
-      await clearPendingClaimContext();
-      return redirectTo(
-        request,
-        `/${profile.usernameNormalized}?claim=unsupported`
-      );
-    }
-
     if (
       existingPendingClaim &&
       existingPendingClaim.creatorProfileId === profile.id &&
@@ -191,6 +178,9 @@ export async function GET(
       );
     }
 
+    // Structured-credit profiles may enter the same direct flow, but the
+    // pending cookie is only a routing hint. `connectOnboardingSpotifyArtist`
+    // must still prove the exact Spotify ID before ownership is finalized.
     if (!profile.spotifyId) {
       return redirectTo(
         request,

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -283,11 +283,12 @@ async function ArtistPageContent({
   const isClaimed = creatorClerkId !== null;
   const requiresVerifiedOwnership =
     !isClaimed && isUnclaimedStructuredCreditProfile(profile.settings);
-  const directClaimSupported =
-    !requiresVerifiedOwnership &&
-    supportsDirectProfileClaim({
-      spotifyId: profile.spotify_id,
-    });
+  // Structured-credit profiles still expose a claim path when an exact
+  // Spotify identity exists. The route only seeds a pending flow; the
+  // onboarding Spotify action must match that exact ID before claiming.
+  const directClaimSupported = supportsDirectProfileClaim({
+    spotifyId: profile.spotify_id,
+  });
   const visitorState = getProfileVisitorState({
     profile: {
       id: profile.id,
@@ -473,7 +474,7 @@ async function ArtistPageContent({
         visitTrackingToken={visitTrackingToken}
         showSubscriptionConfirmedBanner={!isPublicNoAuthSmoke}
         showShopButton={isShopEnabled(profileSettings)}
-        showClaimFooter={!isClaimed && !requiresVerifiedOwnership}
+        showClaimFooter={!isClaimed && directClaimSupported}
         claimFooterHref={`/${encodeURIComponent(artist.handle)}/claim?next=auth`}
         profileSettings={{
           showOldReleases: profileSettings.showOldReleases === true,

--- a/apps/web/app/artists/[artistId]/route.ts
+++ b/apps/web/app/artists/[artistId]/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { artists } from '@/lib/db/schema/content';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { ensureUnclaimedArtistProfileForEntity } from '@/lib/discography/collaborator-profile-reconciliation';
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     return new Response(null, { status: 404, headers: NO_STORE_HEADERS });
   }
 
-  const [resolved] = await db
+  let [resolved] = await db
     .select({ username: creatorProfiles.usernameNormalized })
     .from(artists)
     .innerJoin(
@@ -35,6 +36,23 @@ export async function GET(request: NextRequest, context: RouteContext) {
     )
     .where(and(eq(artists.id, artistId), eq(creatorProfiles.isPublic, true)))
     .limit(1);
+
+  if (!resolved?.username) {
+    // Legacy catalogs can contain an exact structured credit before the
+    // importer/backfill has materialized its public profile. The ensure path
+    // is identity-bound to this UUID and only accepts an eligible public
+    // release-credit edge; it never creates a name-reserved profile.
+    await ensureUnclaimedArtistProfileForEntity(artistId);
+    [resolved] = await db
+      .select({ username: creatorProfiles.usernameNormalized })
+      .from(artists)
+      .innerJoin(
+        creatorProfiles,
+        eq(artists.creatorProfileId, creatorProfiles.id)
+      )
+      .where(and(eq(artists.id, artistId), eq(creatorProfiles.isPublic, true)))
+      .limit(1);
+  }
 
   if (!resolved?.username) {
     return new Response(null, { status: 404, headers: NO_STORE_HEADERS });

--- a/apps/web/app/onboarding/actions/connect-spotify.ts
+++ b/apps/web/app/onboarding/actions/connect-spotify.ts
@@ -35,7 +35,10 @@ import { isSecureEnv } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
 import { refreshFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
 import { lockSpotifyProfileIdentity } from '@/lib/profile/spotify-profile-identity';
-import { isUnclaimedStructuredCreditProfile } from '@/lib/profile/unclaimed-artist-profile';
+import {
+  isUnclaimedStructuredCreditProfile,
+  markStructuredCreditProfileClaimed,
+} from '@/lib/profile/unclaimed-artist-profile';
 import { trackServerEvent } from '@/lib/server-analytics';
 import { finalizePostOnboarding } from './post-onboarding';
 
@@ -213,13 +216,9 @@ async function getOwnedProfile(profileId: string, clerkUserId: string) {
 function getDirectClaimValidationMessage(params: {
   readonly expectedSpotifyArtistId: string | null | undefined;
   readonly isAwaitingMatch: boolean;
-  readonly isStructuredCreditProfile: boolean;
   readonly selectedSpotifyArtistId: string;
 }): string | null {
   if (!params.isAwaitingMatch) return null;
-  if (params.isStructuredCreditProfile) {
-    return SPOTIFY_UNCLAIMED_PROFILE_MESSAGE;
-  }
   if (!params.expectedSpotifyArtistId) {
     return 'This profile needs a claim link before it can be claimed.';
   }
@@ -261,9 +260,6 @@ export async function connectOnboardingSpotifyArtist(
   const directClaimValidationMessage = getDirectClaimValidationMessage({
     expectedSpotifyArtistId: pendingClaim?.expectedSpotifyArtistId,
     isAwaitingMatch: isDirectClaimAwaitingMatch,
-    isStructuredCreditProfile: isUnclaimedStructuredCreditProfile(
-      profile.settings
-    ),
     selectedSpotifyArtistId: params.spotifyArtistId,
   });
 
@@ -303,12 +299,15 @@ export async function connectOnboardingSpotifyArtist(
 
   try {
     if (isDirectClaimAwaitingMatch) {
-      const claimedSettings = {
-        ...currentSettings,
-        spotifyArtistName: params.artistName,
-        spotifyImportStatus: 'importing',
-        spotifyImportTotal: 0,
-      };
+      const claimedSettings = markStructuredCreditProfileClaimed(
+        {
+          ...currentSettings,
+          spotifyArtistName: params.artistName,
+          spotifyImportStatus: 'importing',
+          spotifyImportTotal: 0,
+        },
+        new Date()
+      );
 
       await withDbSessionTx(
         async tx => {

--- a/apps/web/components/features/profile/ClaimBanner.tsx
+++ b/apps/web/components/features/profile/ClaimBanner.tsx
@@ -30,6 +30,10 @@ const COPY: Record<
     body: 'Finish claiming this profile to connect Spotify and go live.',
     ctaLabel: 'Continue Claim',
   },
+  verified_claim: {
+    body: 'This profile is unclaimed. Verify ownership with the matching Spotify artist to claim it.',
+    ctaLabel: 'Verify & Claim',
+  },
   unsupported: {
     body: 'This profile is unclaimed. Verified ownership is required before it can be claimed.',
     ctaLabel: null,

--- a/apps/web/lib/claim/finalize.test.ts
+++ b/apps/web/lib/claim/finalize.test.ts
@@ -47,6 +47,7 @@ interface ProfileRowOverrides {
   userId?: string | null;
   usernameNormalized?: string;
   displayName?: string | null;
+  settings?: Record<string, unknown> | null;
   isClaimed?: boolean | null;
   claimedAt?: Date | null;
   onboardingCompletedAt?: Date | null;
@@ -58,6 +59,7 @@ function profileRow(overrides: ProfileRowOverrides = {}) {
     userId: null,
     usernameNormalized: 'artistname',
     displayName: 'Old Name',
+    settings: null,
     isClaimed: false,
     claimedAt: null,
     onboardingCompletedAt: null,
@@ -308,6 +310,44 @@ describe('claimPrebuiltProfileForUser', () => {
     });
     expect(mocks.updateSetMock.mock.calls[2]?.[0]).toMatchObject({
       userStatus: 'onboarding_incomplete',
+    });
+  });
+
+  it('transitions structured-credit ownership metadata when the exact profile is claimed', async () => {
+    const mocks = createTxMock([
+      [
+        profileRow({
+          settings: {
+            unclaimedArtistProfile: {
+              state: 'unclaimed',
+              source: 'structured_spotify_release_credit',
+              artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+              provider: 'spotify',
+              providerArtistId: 'artist_spotify_id',
+              ownershipVerified: false,
+              representationVerified: false,
+              consentObtained: false,
+            },
+          },
+        }),
+      ],
+      [],
+    ]);
+
+    await claimPrebuiltProfileForUser(mocks.tx, {
+      ...baseParams,
+      finalizeOnboarding: true,
+    });
+
+    expect(mocks.updateSetMock.mock.calls[1]?.[0]).toMatchObject({
+      settings: {
+        unclaimedArtistProfile: expect.objectContaining({
+          state: 'claimed',
+          ownershipVerified: true,
+          consentObtained: true,
+          claimedAt: FIXED_NOW.toISOString(),
+        }),
+      },
     });
   });
 

--- a/apps/web/lib/claim/finalize.ts
+++ b/apps/web/lib/claim/finalize.ts
@@ -8,6 +8,10 @@ import {
   profileOwnershipLog,
   userProfileClaims,
 } from '@/lib/db/schema/profiles';
+import {
+  isUnclaimedStructuredCreditProfile,
+  markStructuredCreditProfileClaimed,
+} from '@/lib/profile/unclaimed-artist-profile';
 
 type ClaimOperationSource =
   | 'token_backed_onboarding'
@@ -19,6 +23,7 @@ interface ClaimTargetProfile {
   readonly userId: string | null;
   readonly usernameNormalized: string;
   readonly displayName: string | null;
+  readonly settings: Record<string, unknown> | null;
   readonly isClaimed: boolean | null;
   readonly claimedAt: Date | null;
   readonly onboardingCompletedAt: Date | null;
@@ -34,6 +39,7 @@ async function getClaimTargetProfile(
       userId: creatorProfiles.userId,
       usernameNormalized: creatorProfiles.usernameNormalized,
       displayName: creatorProfiles.displayName,
+      settings: creatorProfiles.settings,
       isClaimed: creatorProfiles.isClaimed,
       claimedAt: creatorProfiles.claimedAt,
       onboardingCompletedAt: creatorProfiles.onboardingCompletedAt,
@@ -229,6 +235,13 @@ export async function claimPrebuiltProfileForUser(
 
   await releaseOtherReservedProfiles(tx, params.userId, profile.id);
 
+  const claimSettings = isUnclaimedStructuredCreditProfile(profile.settings)
+    ? markStructuredCreditProfileClaimed(
+        (profile.settings ?? {}) as Record<string, unknown>,
+        now
+      )
+    : null;
+
   await tx
     .update(creatorProfiles)
     .set({
@@ -240,6 +253,7 @@ export async function claimPrebuiltProfileForUser(
       onboardingCompletedAt: params.finalizeOnboarding
         ? (profile.onboardingCompletedAt ?? now)
         : profile.onboardingCompletedAt,
+      ...(claimSettings ? { settings: claimSettings } : {}),
       updatedAt: now,
     })
     .where(eq(creatorProfiles.id, profile.id));

--- a/apps/web/lib/discography/artist-queries/artist-search.ts
+++ b/apps/web/lib/discography/artist-queries/artist-search.ts
@@ -92,7 +92,7 @@ export async function searchArtists(
  *
  * Only artists whose registry row links to a public creator profile are
  * returned — external collaborators without a Jovie account are excluded so
- * bio mentions of them stay plain text. The display name prefers the credit
+ * legacy bio mentions stay plain text. The display name prefers the credit
  * name (stage name) since that is what bios and release credits show.
  */
 export async function getCreditedArtistsWithProfiles(
@@ -243,6 +243,8 @@ function projectStructuredReleaseCollaborator(
 
   const hasPublicProfile =
     Boolean(row.artistProfileId) && row.profileIsPublic === true;
+  const hasPrivateProfileBinding =
+    Boolean(row.artistProfileId) && row.profileIsPublic !== true;
   let profileState: StructuredReleaseCollaborator['profileState'] =
     'unavailable';
   if (hasPublicProfile) {
@@ -252,7 +254,15 @@ function projectStructuredReleaseCollaborator(
   return {
     artistId: row.artistId,
     name,
-    href: hasPublicProfile ? artistProfileHref(row.artistId) : null,
+    // A structured Spotify identity has a canonical entity route even before
+    // its claim-safe profile row is materialized. The route self-heals the
+    // eligible unclaimed profile on first visit; names without an exact
+    // provider identity remain plain text rather than reserving a handle by
+    // display name alone.
+    href:
+      hasPublicProfile || (!hasPrivateProfileBinding && row.artistSpotifyId)
+        ? artistProfileHref(row.artistId)
+        : null,
     profileState,
     reconciliationEligible: Boolean(row.artistSpotifyId),
     role: row.role,

--- a/apps/web/lib/discography/collaborator-profile-reconciliation.ts
+++ b/apps/web/lib/discography/collaborator-profile-reconciliation.ts
@@ -43,6 +43,11 @@ export interface CollaboratorProfileReconciliationResult {
   readonly metadataUnavailable: number;
 }
 
+export interface UnclaimedArtistProfileEnsureResult {
+  readonly status: 'created' | 'reused' | 'conflicted' | 'unavailable';
+  readonly handle: string | null;
+}
+
 interface CandidateOutcome {
   readonly status: 'created' | 'reused' | 'conflicted';
   readonly handle?: string;
@@ -357,6 +362,98 @@ async function reconcileCandidate(
     },
     { isolationLevel: 'serializable' }
   );
+}
+
+/**
+ * Ensure one exact structured-credit entity has a public, claim-safe profile.
+ *
+ * The public `/artists/:artistId` route uses this bounded path when an older
+ * catalog was rendered before the importer/backfill could materialize the
+ * profile. Eligibility is still derived from a public release-credit edge;
+ * arbitrary registry rows and name-only identities are never promoted.
+ */
+export async function ensureUnclaimedArtistProfileForEntity(
+  artistId: string
+): Promise<UnclaimedArtistProfileEnsureResult> {
+  const [candidate] = await db
+    .select({
+      artistId: artists.id,
+      name: artists.name,
+      spotifyId: artists.spotifyId,
+      imageUrl: artists.imageUrl,
+      creatorProfileId: artists.creatorProfileId,
+    })
+    .from(releaseArtists)
+    .innerJoin(discogReleases, eq(releaseArtists.releaseId, discogReleases.id))
+    .innerJoin(artists, eq(releaseArtists.artistId, artists.id))
+    .innerJoin(
+      creatorProfiles,
+      eq(discogReleases.creatorProfileId, creatorProfiles.id)
+    )
+    .where(
+      and(
+        eq(artists.id, artistId),
+        isNull(artists.creatorProfileId),
+        isNotNull(artists.spotifyId),
+        eq(creatorProfiles.isPublic, true),
+        inArray(releaseArtists.role, PUBLIC_ARTIST_COLLABORATOR_ROLES),
+        publicReleaseEligibilitySqlPredicate()
+      )
+    )
+    .limit(1);
+
+  if (!candidate?.spotifyId || candidate.creatorProfileId) {
+    return { status: 'unavailable', handle: null };
+  }
+
+  const [spotifyArtist] = await getSpotifyArtistsBatch([candidate.spotifyId]);
+  let outcome: CandidateOutcome;
+  try {
+    outcome = await reconcileCandidate(
+      {
+        artistId: candidate.artistId,
+        name: candidate.name,
+        spotifyId: candidate.spotifyId,
+        imageUrl: candidate.imageUrl,
+      },
+      spotifyArtist
+    );
+  } catch (error) {
+    await captureWarning(
+      'Structured artist entity profile ensure failed closed',
+      error,
+      { source: 'public_artist_entity_route', artistId }
+    );
+    return { status: 'conflicted', handle: null };
+  }
+
+  if (outcome.status === 'conflicted') {
+    return { status: 'conflicted', handle: outcome.handle ?? null };
+  }
+
+  const [resolved] = await db
+    .select({ usernameNormalized: creatorProfiles.usernameNormalized })
+    .from(artists)
+    .innerJoin(
+      creatorProfiles,
+      eq(artists.creatorProfileId, creatorProfiles.id)
+    )
+    .where(and(eq(artists.id, artistId), eq(creatorProfiles.isPublic, true)))
+    .limit(1);
+
+  if (!resolved?.usernameNormalized) {
+    return { status: 'unavailable', handle: null };
+  }
+
+  await invalidateProfileCache(resolved.usernameNormalized).catch(() => {
+    // The route still has a committed identity binding; cache refresh is
+    // best-effort when this helper runs outside a Next request context.
+  });
+
+  return {
+    status: outcome.status,
+    handle: resolved.usernameNormalized,
+  };
 }
 
 function recordCandidateOutcome(

--- a/apps/web/tests/unit/app/[username]/claim/route.test.ts
+++ b/apps/web/tests/unit/app/[username]/claim/route.test.ts
@@ -117,7 +117,7 @@ describe('Claim route', () => {
     expect(response.headers.get('location')).toBe('http://localhost/');
   });
 
-  it('does not issue direct-claim proof for an automatic unclaimed profile', async () => {
+  it('starts a verified Spotify claim flow for an automatic unclaimed profile', async () => {
     mockGetProfileByUsername.mockResolvedValueOnce({
       id: 'profile_1',
       username: 'a_unclaimed',
@@ -146,10 +146,19 @@ describe('Claim route', () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe(
-      'http://localhost/a_unclaimed?claim=unsupported'
+    const location = response.headers.get('location') ?? '';
+    expect(location).toContain('http://localhost/signup?');
+    expect(location).toContain('handle=a_unclaimed');
+    expect(location).toContain('spotify_url=');
+    expect(location).toContain('artist_name=Austin+Leeds');
+    expect(mockWritePendingClaimContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'direct_profile',
+        creatorProfileId: 'profile_1',
+        username: 'a_unclaimed',
+        expectedSpotifyArtistId: 'spotify_123',
+      })
     );
-    expect(mockClearPendingClaimContext).toHaveBeenCalled();
-    expect(mockWritePendingClaimContext).not.toHaveBeenCalled();
+    expect(mockClearPendingClaimContext).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/unit/app/onboarding/actions/connect-spotify.test.ts
+++ b/apps/web/tests/unit/app/onboarding/actions/connect-spotify.test.ts
@@ -605,7 +605,7 @@ describe('connectOnboardingSpotifyArtist', () => {
     expect(hoisted.syncReleasesFromSpotifyMock).not.toHaveBeenCalled();
   });
 
-  it('rejects a self-issued direct claim for an automatic unclaimed profile', async () => {
+  it('allows an exact-ID verified claim for an automatic unclaimed profile', async () => {
     queueOwnedProfile({
       unclaimedArtistProfile: {
         state: 'unclaimed',
@@ -626,6 +626,25 @@ describe('connectOnboardingSpotifyArtist', () => {
       issuedAt: Date.now(),
       expiresAt: Date.now() + 60_000,
     });
+    queueNoExistingClaim();
+    queueLatestSettings({
+      unclaimedArtistProfile: {
+        state: 'claimed',
+        source: 'structured_spotify_release_credit',
+        artistRegistryId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
+        provider: 'spotify',
+        providerArtistId: 'artist_spotify_id',
+        ownershipVerified: true,
+        representationVerified: false,
+        consentObtained: true,
+      },
+    });
+    hoisted.syncReleasesFromSpotifyMock.mockResolvedValue({
+      imported: 0,
+      releases: [],
+      success: true,
+      total: 0,
+    });
 
     const { connectOnboardingSpotifyArtist } = await import(
       '@/app/onboarding/actions/connect-spotify'
@@ -638,14 +657,18 @@ describe('connectOnboardingSpotifyArtist', () => {
     });
 
     expect(result).toMatchObject({
-      success: false,
-      message:
-        'This artist already has an unclaimed Jovie profile and requires verified ownership before it can be claimed.',
+      success: true,
+      importing: false,
     });
-    expect(hoisted.selectMock).toHaveBeenCalledTimes(1);
-    expect(hoisted.withDbSessionTxMock).not.toHaveBeenCalled();
-    expect(hoisted.claimPrebuiltProfileForUserMock).not.toHaveBeenCalled();
-    expect(hoisted.updateMock).not.toHaveBeenCalled();
+    expect(hoisted.withDbSessionTxMock).toHaveBeenCalledOnce();
+    expect(hoisted.claimPrebuiltProfileForUserMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source: 'direct_profile_spotify_match',
+        creatorProfileId: 'profile_123',
+      })
+    );
+    expect(hoisted.syncReleasesFromSpotifyMock).toHaveBeenCalledOnce();
   });
 
   it('rejects a direct-profile claim when the selected Spotify artist does not match the expected one', async () => {

--- a/apps/web/tests/unit/app/profile-claim-banner-state.test.ts
+++ b/apps/web/tests/unit/app/profile-claim-banner-state.test.ts
@@ -43,16 +43,16 @@ describe('resolveClaimBannerState', () => {
     });
   });
 
-  it('keeps automatic credit profiles visibly unclaimed without a direct claim', () => {
+  it('offers verified ownership for automatic credit profiles with an exact Spotify identity', () => {
     expect(
       resolveClaimBannerState({
         visitorState: 'organic_unclaimed',
-        directClaimSupported: false,
+        directClaimSupported: true,
         claimRequiresVerification: true,
         isClaimed: false,
       })
     ).toEqual({
-      claimBannerVariant: 'unsupported',
+      claimBannerVariant: 'verified_claim',
       shouldShowClaimBanner: true,
     });
   });

--- a/apps/web/tests/unit/lib/discography/collaborator-profile-reconciliation.test.ts
+++ b/apps/web/tests/unit/lib/discography/collaborator-profile-reconciliation.test.ts
@@ -133,9 +133,10 @@ vi.mock('@/lib/profile/public-release-eligibility', () => ({
   publicReleaseEligibilitySqlPredicate: vi.fn(() => 'public-release-only'),
 }));
 
-const { reconcileCreditedArtistProfiles } = await import(
-  '@/lib/discography/collaborator-profile-reconciliation'
-);
+const {
+  ensureUnclaimedArtistProfileForEntity,
+  reconcileCreditedArtistProfiles,
+} = await import('@/lib/discography/collaborator-profile-reconciliation');
 
 const candidate = {
   artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
@@ -161,6 +162,60 @@ describe('credited artist profile reconciliation', () => {
     hoisted.insertedValues.length = 0;
     hoisted.updatedValues.length = 0;
     hoisted.getSpotifyArtistsBatch.mockResolvedValue([]);
+  });
+
+  it('self-heals an eligible legacy entity route with one exact-ID unclaimed profile', async () => {
+    hoisted.dbSelectResults.push(
+      [
+        {
+          artistId: candidate.artistId,
+          name: candidate.name,
+          spotifyId: candidate.spotifyId,
+          imageUrl: null,
+          creatorProfileId: null,
+        },
+      ],
+      [{ usernameNormalized: 'a_eiqd46x3irj64dlgo8a3glau4' }]
+    );
+    hoisted.txSelectResults.push(
+      [
+        {
+          ...candidate,
+          creatorProfileId: null,
+          id: candidate.artistId,
+          metadata: {},
+        },
+      ],
+      [],
+      []
+    );
+    hoisted.txReturningResults.push(
+      [
+        {
+          id: 'created-profile',
+          usernameNormalized: 'a_eiqd46x3irj64dlgo8a3glau4',
+        },
+      ],
+      [{ id: candidate.artistId }]
+    );
+
+    const result = await ensureUnclaimedArtistProfileForEntity(
+      candidate.artistId
+    );
+
+    expect(result).toEqual({
+      status: 'created',
+      handle: 'a_eiqd46x3irj64dlgo8a3glau4',
+    });
+    expect(hoisted.getSpotifyArtistsBatch).toHaveBeenCalledWith([
+      candidate.spotifyId,
+    ]);
+    expect(hoisted.insertedValues[0]).toMatchObject({
+      isClaimed: false,
+      isPublic: true,
+      marketingOptOut: true,
+      spotifyId: candidate.spotifyId,
+    });
   });
 
   it('creates one claim-safe minimal profile for repeated exact-ID credits', async () => {

--- a/apps/web/tests/unit/lib/discography/structured-release-collaborators.test.ts
+++ b/apps/web/tests/unit/lib/discography/structured-release-collaborators.test.ts
@@ -95,7 +95,7 @@ describe('structured release collaborator projection', () => {
     expect(result[0]?.artistId).toBe(sameDisplayNameDifferentIdentity.artistId);
   });
 
-  it('keeps unavailable identities as plain-text candidates and excludes non-artist roles', () => {
+  it('links unavailable exact identities through the stable route and excludes non-artist roles', () => {
     const result = project([
       row({
         artistProfileId: null,
@@ -110,7 +110,7 @@ describe('structured release collaborator projection', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      href: null,
+      href: `/artists/${result[0]?.artistId}`,
       profileState: 'unavailable',
       reconciliationEligible: true,
     });
@@ -127,6 +127,7 @@ describe('structured release collaborator projection', () => {
     ]);
 
     expect(result[0]).toMatchObject({
+      href: null,
       profileState: 'unavailable',
       reconciliationEligible: false,
     });

--- a/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
+++ b/apps/web/tests/unit/profile/profile-aeo-content.test.tsx
@@ -815,15 +815,16 @@ describe('Profile AEO content', () => {
     ]);
   });
 
-  it('renders unavailable or private collaborator identities as plain text', () => {
+  it('links unavailable exact collaborator identities through the stable route', () => {
     const content = buildProfileAeoContent({
       artist: baseArtist,
       releaseCollaborators: [
         {
           artistId: 'f5441adb-6789-449a-9553-ab7460c9c61c',
           name: 'Private Artist',
-          href: null,
+          href: '/artists/f5441adb-6789-449a-9553-ab7460c9c61c',
           profileState: 'unavailable',
+          reconciliationEligible: true,
           role: 'featured_artist',
           releaseId: '353a7c04-b5bb-486e-996d-d23caced7f93',
           releaseTitle: 'Quiet Signal',
@@ -839,7 +840,9 @@ describe('Profile AEO content', () => {
     expect(screen.getByTestId('profile-aeo-content')).toHaveTextContent(
       'Private Artist'
     );
-    expect(screen.queryByRole('link', { name: 'Private Artist' })).toBeNull();
+    expect(
+      screen.getByRole('link', { name: 'Private Artist' })
+    ).toHaveAttribute('href', '/artists/f5441adb-6789-449a-9553-ab7460c9c61c');
     expect(screen.getByRole('link', { name: 'Quiet Signal' })).toHaveAttribute(
       'href',
       '/dj-test/quiet-signal'

--- a/apps/web/tests/unit/routes/artist-entity-route.test.ts
+++ b/apps/web/tests/unit/routes/artist-entity-route.test.ts
@@ -3,12 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => ({
   result: [] as Array<{ username: string }>,
   select: vi.fn(),
+  ensureUnclaimedArtistProfileForEntity: vi.fn(),
 }));
 
 vi.mock('@/lib/db', () => ({
   db: {
     select: hoisted.select,
   },
+}));
+
+vi.mock('@/lib/discography/collaborator-profile-reconciliation', () => ({
+  ensureUnclaimedArtistProfileForEntity:
+    hoisted.ensureUnclaimedArtistProfileForEntity,
 }));
 
 function makeQuery() {
@@ -33,6 +39,7 @@ function context(artistId: string) {
 describe('GET /artists/[artistId]', () => {
   beforeEach(() => {
     hoisted.result = [];
+    hoisted.ensureUnclaimedArtistProfileForEntity.mockReset();
     hoisted.select.mockReset().mockReturnValue(makeQuery());
   });
 
@@ -91,5 +98,32 @@ describe('GET /artists/[artistId]', () => {
 
     expect(response.status).toBe(404);
     expect(response.headers.get('Location')).toBeNull();
+    expect(hoisted.ensureUnclaimedArtistProfileForEntity).toHaveBeenCalledWith(
+      artistId
+    );
+  });
+
+  it('rechecks the stable binding after an eligible unclaimed profile is ensured', async () => {
+    const artistId = 'f5441adb-6789-449a-9553-ab7460c9c61c';
+    const firstQuery = makeQuery();
+    firstQuery.limit.mockResolvedValueOnce([]);
+    const secondQuery = makeQuery();
+    secondQuery.limit.mockResolvedValueOnce([{ username: 'a_unclaimed' }]);
+    hoisted.select
+      .mockReset()
+      .mockReturnValueOnce(firstQuery)
+      .mockReturnValueOnce(secondQuery);
+    hoisted.ensureUnclaimedArtistProfileForEntity.mockResolvedValueOnce({
+      status: 'created',
+      handle: 'a_unclaimed',
+    });
+
+    const response = await GET(
+      new Request(`https://jov.ie/artists/${artistId}`) as never,
+      context(artistId)
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe('https://jov.ie/a_unclaimed');
   });
 });


### PR DESCRIPTION
## Summary

- Link structured artist credits to stable canonical `/artists/<entity-id>` routes on first render.
- Lazily reconcile eligible exact-provider credits into idempotent, collision-safe unclaimed artist profiles; keep name-only, private, changed-role, and non-artist credits unlinked.
- Make the unclaimed profile claim-safe: exact Spotify identity is required, claim finalization transitions the structured-credit marker, and inbound entity URLs survive handle changes.
- Preserve the existing public-profile visual release on `main`; this PR contains no visual asset changes, migrations, external-data embedding, or Graphite dependency.

## Verification

- Full affected pre-push matrix: 8 deterministic Vitest shards, all passed (warnings are existing test-fixture stderr).
- Typecheck, Biome, proxy/Tailwind/component gates, secret scans, boundary/hygiene checks: passed.
- Focused collaborator/entity/claim tests: 160 tests passed across the targeted suites.
- Bug-to-test gate: satisfied.
- Backfill dry-run: 10 scanned / 10 resolved / 0 processed.
- Exact-main and deployed-production proof will be attached after native merge-controller promotion. Authenticated claim behavior and consent/revenue outcomes are intentionally not claimed without authenticated evidence.

## Release order

Root PR; base `main`. Keep this PR draft until CI/review gates pass, then use the native GitHub merge queue/controller. Do not amend the separate production-controller SHA or bypass gates.