### PR TITLE
fix(sym): quarantine app-server usage limits

### DIFF
--- a/scripts/hermes/codex-rotate
+++ b/scripts/hermes/codex-rotate
@@ -204,7 +204,13 @@ log "START account=$account lease_fd=$account_lock_fd args=$*"
 tmp_err=$(mktemp)
 trap 'rm -f "$tmp_err"' EXIT
 set +e
-"$REAL_CODEX" "$@" 2> >(tee -a "$tmp_err" >&2)
+# Codex CLI reports limits on stderr, while app-server reports the same
+# provider error inside its stdout JSON-RPC stream. Preserve both streams for
+# the caller and inspect both after exit so an exhausted account is quarantined
+# instead of returning repeated zero-token turns.
+"$REAL_CODEX" "$@" \
+  > >(tee -a "$tmp_err") \
+  2> >(tee -a "$tmp_err" >&2)
 rc=$?
 set -e
 

--- a/scripts/hermes/tests/codex-rotate.test.py
+++ b/scripts/hermes/tests/codex-rotate.test.py
@@ -108,6 +108,28 @@ class CodexRotateTests(unittest.TestCase):
         self.assertEqual(state["cooldowns"]["account-a"], 1893553445)
         self.assertEqual(state["last_error"]["account-a"]["reason"], "limit_or_auth")
 
+    def test_app_server_stdout_limit_quarantines_zero_exit_account(self):
+        limited = self.root / "limited-app-server"
+        limited.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo '{\"type\":\"error\",\"message\":\"usage limit; try again at 2030-01-02T03:04:05Z\"}'\n"
+            "exit 0\n"
+        )
+        limited.chmod(0o755)
+        result = subprocess.run(
+            [str(LAUNCHER), "app-server"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env=self.env(CODEX_REAL_BIN=limited),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 75)
+        self.assertIn('"type":"error"', result.stdout)
+        state = json.loads((self.accounts / "state.json").read_text())
+        self.assertEqual(state["cooldowns"]["account-a"], 1893553445)
+        self.assertEqual(state["last_error"]["account-a"]["reason"], "limit_or_auth")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- inspect Codex app-server stdout as well as stderr for provider usage-limit and auth failures
- preserve both streams unchanged for Symphony
- quarantine zero-exit app-server accounts until the provider retry time instead of burning 24 null turns

## Live incident evidence
- `jovie` direct probe: usage limit until Aug 8, 2026 03:36 PT
- `meetjovie` direct probe: normal `OK` response
- JOV-3948 recovered after runtime quarantine: real session, nonzero tokens, command execution

## Validation
- Gem launcher unit tests: 4 passed
- bash syntax: passed
- normal pre-push hooks: passed
- no UI changes; screenshots not applicable

Refs JOV-4841