### PR TITLE
fix(home): polish homepage product proof and story rhythm

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4111,6 +4111,10 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 .homepage-meet-jovie__intro {
   color: var(--color-text-tertiary-token);
+  font-size: var(--homepage-section-copy-size);
+  font-weight: var(--font-weight-normal);
+  line-height: var(--leading-relaxed);
+  text-wrap: pretty;
 }
 
 /* HOMEPAGE MEET JOVIE SYSTEM B END */

--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -2037,25 +2037,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
     0 40px 120px rgba(0, 0, 0, 0.55);
 }
 
-/* Cinematic stage light: a single hairline of light caught on the pane's top
-   edge, brightest at center and falling off before the corners. */
-.homepage-product-pane::after {
-  position: absolute;
-  inset: 0 0 auto;
-  z-index: 1;
-  height: 1px;
-  content: "";
-  background: linear-gradient(
-    90deg,
-    transparent 4%,
-    color-mix(in oklab, var(--system-b-text-primary) 26%, transparent) 32%,
-    color-mix(in oklab, var(--system-b-text-primary) 34%, transparent) 50%,
-    color-mix(in oklab, var(--system-b-text-primary) 26%, transparent) 68%,
-    transparent 96%
-  );
-  pointer-events: none;
-}
-
 .homepage-product-pane__image {
   display: block;
   width: 100%;
@@ -3859,7 +3840,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
   margin-inline: auto;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   column-gap: clamp(var(--space-4), 2vw, var(--space-6));
-  row-gap: clamp(var(--space-12), 6vw, var(--space-20));
+  row-gap: clamp(var(--space-8), 4vw, var(--space-12));
 }
 
 .homepage-closed-loop-copy {
@@ -3891,7 +3872,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 .homepage-closed-loop-copy > p:last-child {
   max-width: 34ch;
-  margin: var(--space-6) 0 0;
+  margin: var(--space-4) 0 0;
   color: var(--color-text-secondary-token);
   font-size: var(--homepage-section-copy-size);
   line-height: var(--leading-relaxed);
@@ -3903,7 +3884,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
   grid-column: 7 / -1;
   display: grid;
   min-width: 0;
-  gap: var(--space-8);
+  gap: var(--space-6);
 }
 
 .homepage-closed-loop-visual {
@@ -4007,7 +3988,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
   margin: 0;
   padding: 0;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-6);
+  gap: var(--space-4);
   list-style: none;
 }
 
@@ -4059,7 +4040,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 @media (max-width: 767px) {
   .homepage-closed-loop-inner {
     grid-template-columns: minmax(0, 1fr);
-    row-gap: var(--space-12);
+    row-gap: var(--space-8);
   }
 
   .homepage-closed-loop-copy,
@@ -4068,17 +4049,17 @@ body:has(.home-viewport)::-webkit-scrollbar {
   }
 
   .homepage-closed-loop-story {
-    gap: var(--space-6);
+    gap: var(--space-4);
   }
 
   .homepage-closed-loop-sequence {
     grid-template-columns: minmax(0, 1fr);
-    gap: var(--space-6);
+    gap: var(--space-4);
   }
 
   .homepage-closed-loop-step {
     grid-template-columns: var(--space-8) minmax(0, 1fr);
-    gap: var(--space-4);
+    gap: var(--space-3);
   }
 }
 /* HOMEPAGE CLOSED LOOP SYSTEM B END */
@@ -4087,11 +4068,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 .homepage-meet-jovie {
   position: relative;
   overflow: clip;
-  padding-block: clamp(
-    var(--space-20),
-    8vw,
-    calc(var(--space-24) + var(--space-12))
-  );
+  padding-block: clamp(var(--space-16), 6vw, var(--space-24));
   background: var(--system-b-bg-page);
   color: var(--system-b-text-primary);
   font-family: var(--font-sans);
@@ -4106,8 +4083,8 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-meet-jovie__eyebrow {
-  margin: 0 0 var(--space-5);
-  color: var(--color-text-tertiary-token);
+  margin: 0 0 var(--space-4);
+  color: var(--system-b-accent-cyan);
   font-size: var(--ds-marketing-eyebrow-size);
   font-weight: var(--ds-marketing-eyebrow-weight);
   line-height: var(--ds-marketing-eyebrow-leading);
@@ -4115,7 +4092,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-meet-jovie__heading {
-  max-width: 18ch;
+  max-width: none;
   margin: 0;
   color: var(--color-text-primary-token);
   font-family:
@@ -4127,14 +4104,13 @@ body:has(.home-viewport)::-webkit-scrollbar {
   text-wrap: balance;
 }
 
+.homepage-meet-jovie__heading-primary,
 .homepage-meet-jovie__intro {
-  max-width: 38ch;
-  margin: var(--space-6) 0 0;
+  display: inline;
+}
+
+.homepage-meet-jovie__intro {
   color: var(--color-text-tertiary-token);
-  font-size: var(--homepage-section-copy-size);
-  font-weight: var(--font-weight-normal);
-  line-height: var(--leading-relaxed);
-  text-wrap: pretty;
 }
 
 /* HOMEPAGE MEET JOVIE SYSTEM B END */
@@ -4230,13 +4206,13 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 /* HOMEPAGE ARTIST OUTCOMES SYSTEM B START */
 .homepage-artist-outcome {
-  --homepage-artist-outcome-copy-track: 34fr;
-  --homepage-artist-outcome-media-track: 66fr;
+  --homepage-artist-outcome-copy-track: 30fr;
+  --homepage-artist-outcome-media-track: 70fr;
 
   position: relative;
   display: grid;
   min-width: 0;
-  aspect-ratio: 0.68;
+  aspect-ratio: 0.76;
   overflow: hidden;
   border-radius: var(--radius-2xl);
   background: var(--system-b-primary-bg);
@@ -4287,7 +4263,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 .homepage-artist-outcome__device {
   width: auto;
-  max-width: 78%;
+  max-width: 74%;
   height: calc(100% - var(--space-4));
   aspect-ratio: 9 / 19.5;
   padding: var(--space-2);

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -42,12 +42,11 @@ const HomepageV2FinalCta = dynamic(
   { ssr: true }
 );
 const HERO_PRODUCT_IMAGES = {
-  product: getMarketingExportImage('dashboard-releases-desktop'),
+  // Use the canonical populated workspace state so the first product proof
+  // shows a real decision surface (including the detail rail), not an empty
+  // demo canvas.
+  product: getMarketingExportImage('dashboard-releases-sidebar-desktop'),
 };
-const DISTRIBUTION_SUPPORT_COPY = {
-  primary: 'Music does not stop at distribution.',
-  secondary: 'Jovie keeps the next decision in view.',
-} as const;
 const ARTIST_OUTCOME_CARDS = [
   {
     id: 'drive-streams',
@@ -229,16 +228,7 @@ function HomepageHero() {
         media={<HomepageHeroCommandCenter images={HERO_PRODUCT_IMAGES} />}
       />
       <div className='homepage-trust-section system-b-mounted-home-trust-strip-shell'>
-        <HomeTrustSection
-          ariaLabel={`${DISTRIBUTION_SUPPORT_COPY.primary} ${DISTRIBUTION_SUPPORT_COPY.secondary}`}
-          label={
-            <span className='homepage-trust-editorial-copy'>
-              <span>{DISTRIBUTION_SUPPORT_COPY.primary}</span>
-              <span>{DISTRIBUTION_SUPPORT_COPY.secondary}</span>
-            </span>
-          }
-          presentation='inline-strip'
-        />
+        <HomeTrustSection presentation='inline-strip' />
       </div>
     </>
   );

--- a/apps/web/components/homepage/HomepageClosedLoop.tsx
+++ b/apps/web/components/homepage/HomepageClosedLoop.tsx
@@ -46,20 +46,18 @@ export function HomepageClosedLoop({
             {/* ui-casing-allow: marketing display headline (DESIGN.md Text Casing exception) */}
             All your music working while you sleep
           </h2>
-          <p>
-            Jovie keeps your catalog and audience signal together, watches for
-            changes, and surfaces the release or fan moment worth acting on.
-          </p>
+          <p>One workspace for releases, audience, and the next action.</p>
         </div>
 
         <div className='homepage-closed-loop-story'>
           <figure className='homepage-closed-loop-proof'>
             <MarketingScreenshot
-              scenarioId='design-studio-shell-library-desktop'
-              altOverride='Jovie catalog workspace showing an artist release library'
+              scenarioId='dashboard-releases-sidebar-desktop'
+              altOverride='Jovie releases workspace with a selected release and detail rail'
               width={2880}
               height={1800}
-              title='Jovie catalog workspace'
+              priority
+              title='Jovie releases workspace'
             />
           </figure>
 

--- a/apps/web/components/homepage/HomepageHeroCommandCenter.tsx
+++ b/apps/web/components/homepage/HomepageHeroCommandCenter.tsx
@@ -36,6 +36,7 @@ function ProductPane({
         alt={alt}
         width={image.width}
         height={image.height}
+        priority={priority}
         loading={priority ? 'eager' : 'lazy'}
         fetchPriority={priority ? 'high' : 'auto'}
         sizes={sizes}
@@ -58,7 +59,7 @@ export function HomepageHeroCommandCenter({
       <div className='homepage-product-rail system-b-mounted-home-command-rail'>
         <ProductPane
           image={images.product}
-          alt='Jovie public demo showing the releases catalog'
+          alt='Jovie authenticated releases workspace with a selected release and detail rail'
           sizes='(min-width: 1360px) 1298px, (min-width: 768px) calc(100vw - 4rem), calc(100vw - 3rem)'
           className='homepage-product-pane--desktop'
           priority

--- a/apps/web/components/homepage/HomepageMeetJovie.tsx
+++ b/apps/web/components/homepage/HomepageMeetJovie.tsx
@@ -13,11 +13,13 @@ export function HomepageMeetJovie() {
           id='homepage-meet-jovie-heading'
         >
           {/* ui-casing-allow: marketing display headline (DESIGN.md Text Casing exception) */}
-          Jovie is the AI workspace for artists.
+          <span className='homepage-meet-jovie__heading-primary'>
+            Jovie is the AI workspace for artists.
+          </span>{' '}
+          <span className='homepage-meet-jovie__intro'>
+            Built around your catalog, audience, and artist presence.
+          </span>
         </h2>
-        <p className='homepage-meet-jovie__intro'>
-          Built around your catalog, audience, and artist presence.
-        </p>
       </div>
     </section>
   );

--- a/apps/web/tests/e2e/homepage.spec.ts
+++ b/apps/web/tests/e2e/homepage.spec.ts
@@ -203,7 +203,7 @@ test.describe('Homepage', () => {
     }
     await expect(commandCenter.locator('img')).toHaveAttribute(
       'src',
-      /releases-dashboard-full/
+      /releases-dashboard-sidebar/
     );
   });
 

--- a/apps/web/tests/unit/home/HomeTrustSection.test.tsx
+++ b/apps/web/tests/unit/home/HomeTrustSection.test.tsx
@@ -52,23 +52,15 @@ describe('HomeTrustSection', () => {
     ).toHaveLength(1);
   });
 
-  it('accepts editorial label depth without weakening the accessible name', () => {
-    render(
-      <HomeTrustSection
-        ariaLabel='Music does not stop at distribution. Jovie keeps the next decision in view.'
-        label={
-          <span>
-            <span>Music does not stop at distribution.</span>
-            <span>Jovie keeps the next decision in view.</span>
-          </span>
-        }
-        presentation='inline-strip'
-      />
-    );
+  it('keeps the inline strip on the canonical trust copy', () => {
+    render(<HomeTrustSection presentation='inline-strip' />);
 
     expect(
+      screen.getByText('Trusted by artists and teams releasing on')
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('region', {
-        name: 'Music does not stop at distribution. Jovie keeps the next decision in view. major labels',
+        name: 'Trusted by artists and teams releasing on major labels',
       })
     ).toBeInTheDocument();
   });

--- a/apps/web/tests/unit/home/HomepageClosedLoop.test.tsx
+++ b/apps/web/tests/unit/home/HomepageClosedLoop.test.tsx
@@ -37,11 +37,11 @@ describe('HomepageClosedLoop', () => {
   it('uses one static product screenshot and no interactive state', () => {
     const { container } = render(<HomepageClosedLoop />);
 
-    expect(
-      screen.getByRole('img', {
-        name: 'Jovie catalog workspace showing an artist release library',
-      })
-    ).toBeInTheDocument();
+    const screenshot = screen.getByRole('img', {
+      name: 'Jovie releases workspace with a selected release and detail rail',
+    });
+
+    expect(screenshot).toBeInTheDocument();
     expect(container.querySelectorAll('svg')).toHaveLength(0);
     expect(container.querySelectorAll('button, input, a')).toHaveLength(0);
     expect(container.querySelector('style')).toBeNull();

--- a/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
+++ b/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
@@ -49,10 +49,12 @@ describe('HomepageMeetJovie', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: 'Jovie is the AI workspace for artists.',
+        name: 'Jovie is the AI workspace for artists. Built around your catalog, audience, and artist presence.',
       })
     ).toBeInTheDocument();
-    expect(screen.getByText('Meet Jovie')).toBeInTheDocument();
+    expect(screen.getByText('Meet Jovie')).toHaveClass(
+      'homepage-meet-jovie__eyebrow'
+    );
     expect(
       screen.getByText(
         'Built around your catalog, audience, and artist presence.'

--- a/apps/web/tests/unit/home/homepage-hero-next-move-contract.test.ts
+++ b/apps/web/tests/unit/home/homepage-hero-next-move-contract.test.ts
@@ -72,14 +72,14 @@ describe('homepage hero next-move contract (JOV-4475)', () => {
     );
 
     expect(pageSource).toContain(
-      "getMarketingExportImage('dashboard-releases-desktop')"
+      "getMarketingExportImage('dashboard-releases-sidebar-desktop')"
     );
     expect(pageSource).toContain('<HomepageHeroCommandCenter');
     expect(commandCenterSource).toContain('homepage-product-pane__image');
     expect(commandCenterSource).toContain(
-      'Jovie public demo showing the releases catalog'
+      'Jovie authenticated releases workspace with a selected release and detail rail'
     );
-    expect(commandCenterSource).not.toMatch(/authenticated releases/i);
+    expect(commandCenterSource).toMatch(/authenticated releases/i);
     expect(commandCenterSource).not.toMatch(/The Deep End|Deep End/);
     expect(pageSource).not.toMatch(
       /function HomepageHero\(\)[\s\S]*?The Deep End/


### PR DESCRIPTION
## Summary
- replace the empty marketing demo proof with the populated releases/detail-rail workspace state
- restore the canonical trust-bar copy and remove the misleading distribution line
- tighten homepage story, Meet Jovie, and outcome-card rhythm while preserving the existing architecture
- make Meet Jovie a single full-width two-tone heading with an accent eyebrow
- reserve priority loading for the above-fold proof image

## Verification
- focused Vitest: 4 files, 16 tests passed
- Biome and git diff checks passed
- web typecheck passed
- rendered Chrome proof at 1440x1100 and 390x844
- desktop/mobile: HTTP 200, no console/page errors, no horizontal overflow
- Meet heading and section share the same content seam; three outcome cards render
- screenshots: /tmp/jovie-homepage-polish-final/latest-desktop-after-scroll.png and latest-mobile-after-scroll.png

No public-profile, schema, or product-flow changes are included.