### PR TITLE
fix(sym): gate dual-team provider fallback

### DIFF
--- a/scripts/hermes/grok-ship-one
+++ b/scripts/hermes/grok-ship-one
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Ship one already-admitted Linear issue through the bounded Grok fallback.
+set -euo pipefail
+
+ID="${1:?issue identifier required}"
+case "$ID" in
+  JOV-[0-9]*) TEAM=JOV; REPO=JovieInc/Jovie ;;
+  LYB-[0-9]*) TEAM=LYB; REPO=JovieInc/LogYourBody ;;
+  *) echo "unsupported issue identifier" >&2; exit 2 ;;
+esac
+
+export PATH="$HOME/.local/bin:$PATH:/usr/bin:/bin"
+set -a
+# shellcheck disable=SC1091
+[ -f "$HOME/.config/symphony/linear.env" ] && . "$HOME/.config/symphony/linear.env"
+set +a
+: "${LINEAR_API_KEY:?LINEAR_API_KEY is required}"
+
+BRANCH="grok/${ID}-fix"
+WS_ROOT="${GROK_SHIP_WS_ROOT:-$HOME/grok-ship-workspaces}/$TEAM"
+WS="$WS_ROOT/$ID"
+LOG_DIR="${GROK_SHIP_LOG_DIR:-$HOME/grok-ship-logs}"
+LOG="$LOG_DIR/$ID.log"
+COOLDOWN="$LOG_DIR/provider-cooldown-until"
+mkdir -p "$LOG_DIR" "$WS_ROOT"
+
+now="$(date +%s)"
+if [ -f "$COOLDOWN" ]; then
+  read -r unavailable_until < "$COOLDOWN" || unavailable_until=0
+  case "$unavailable_until" in (*[!0-9]*|'') unavailable_until=0 ;; esac
+  if [ "$unavailable_until" -gt "$now" ]; then
+    echo "$(date -u +%FT%TZ) $ID provider_cooldown" >> "$LOG"
+    exit 0
+  fi
+fi
+
+if [ "$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq 'length' 2>/dev/null || printf 0)" -gt 0 ]; then
+  echo "$(date -u +%FT%TZ) $ID open_pr_exists" >> "$LOG"
+  exit 0
+fi
+
+export ISSUE_ID="$ID"
+META="$(python3 - <<'PY'
+import json, os, sys, urllib.request
+
+identifier = os.environ["ISSUE_ID"]
+query = """
+query($id: String!) {
+  issue(id: $id) {
+    id identifier title description url
+    state { id name }
+    team { key states { nodes { id name } } }
+    labels { nodes { name } }
+  }
+}
+"""
+request = urllib.request.Request(
+    os.environ.get("LINEAR_API_URL", "https://api.linear.app/graphql"),
+    data=json.dumps({"query": query, "variables": {"id": identifier}}).encode(),
+    headers={"Authorization": os.environ["LINEAR_API_KEY"], "Content-Type": "application/json"},
+)
+with urllib.request.urlopen(request, timeout=20) as response:
+    payload = json.load(response)
+issue = (payload.get("data") or {}).get("issue")
+if payload.get("errors") or not isinstance(issue, dict):
+    raise SystemExit("issue lookup failed")
+team = issue.get("team") or {}
+labels = {str(node.get("name", "")).strip().lower() for node in (issue.get("labels") or {}).get("nodes", [])}
+required = {"symphony", "plan-approved", "admission-approved"}
+blocked = {"human-review-required", "needs:human", "needs-human", "needs:decision", "needs-decision", "hold"}
+if issue.get("identifier") != identifier or team.get("key", "").upper() != identifier.split("-", 1)[0]:
+    raise SystemExit("issue team mismatch")
+if not required.issubset(labels) or labels.intersection(blocked):
+    raise SystemExit("issue is not admitted")
+states = {str(node.get("name", "")).lower(): node.get("id") for node in team.get("states", {}).get("nodes", [])}
+if not states.get("in progress") or not states.get("in review"):
+    raise SystemExit("required workflow states missing")
+print(json.dumps({
+    "id": issue["id"], "title": issue.get("title") or identifier,
+    "description": (issue.get("description") or "")[:6000], "url": issue.get("url") or "",
+    "original_state_id": (issue.get("state") or {}).get("id"),
+    "original_state_name": (issue.get("state") or {}).get("name") or "",
+    "in_progress_state_id": states["in progress"], "in_review_state_id": states["in review"],
+}))
+PY
+)"
+
+json_value() {
+  python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get(sys.argv[2]) or "")' "$META" "$1"
+}
+
+TITLE="$(json_value title)"
+URL="$(json_value url)"
+DESC="$(json_value description)"
+ISSUE_UUID="$(json_value id)"
+ORIGINAL_STATE_ID="$(json_value original_state_id)"
+ORIGINAL_STATE_NAME="$(json_value original_state_name)"
+IN_PROGRESS_STATE_ID="$(json_value in_progress_state_id)"
+IN_REVIEW_STATE_ID="$(json_value in_review_state_id)"
+
+if [ ! -d "$WS/.git" ]; then
+  if [ -e "$WS" ] && [ -n "$(find "$WS" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+    echo "workspace exists without git: $WS" >&2
+    exit 2
+  fi
+  git clone --depth 1 "https://github.com/$REPO.git" "$WS"
+fi
+if [ -n "$(git -C "$WS" status --porcelain)" ]; then
+  echo "workspace has uncommitted changes: $WS" >&2
+  exit 2
+fi
+git -C "$WS" fetch --depth 1 origin main
+git -C "$WS" checkout -B "$BRANCH" origin/main
+
+update_state() {
+  local state_id="$1"
+  ISSUE_UUID="$ISSUE_UUID" STATE_ID="$state_id" python3 - <<'PY'
+import json, os, urllib.request
+query = "mutation($id:String!,$input:IssueUpdateInput!){issueUpdate(id:$id,input:$input){success}}"
+request = urllib.request.Request(
+    os.environ.get("LINEAR_API_URL", "https://api.linear.app/graphql"),
+    data=json.dumps({"query": query, "variables": {"id": os.environ["ISSUE_UUID"], "input": {"stateId": os.environ["STATE_ID"]}}}).encode(),
+    headers={"Authorization": os.environ["LINEAR_API_KEY"], "Content-Type": "application/json"},
+)
+with urllib.request.urlopen(request, timeout=20) as response:
+    payload = json.load(response)
+if payload.get("errors") or not ((payload.get("data") or {}).get("issueUpdate") or {}).get("success"):
+    raise SystemExit("state update failed")
+PY
+}
+
+changed_state=0
+original_state_lower="$(printf '%s' "$ORIGINAL_STATE_NAME" | tr '[:upper:]' '[:lower:]')"
+if [ "$original_state_lower" != "in progress" ]; then
+  update_state "$IN_PROGRESS_STATE_ID"
+  changed_state=1
+fi
+
+PROMPT="You are shipping admitted Linear issue $ID in $REPO.
+
+Title: $TITLE
+URL: $URL
+
+Description:
+$DESC
+
+Work only in this checkout. Make the smallest correct issue-scoped change. Do not weaken or skip gates.
+Create commits on $BRANCH, push normally, and open a draft PR to main with validation evidence and Fixes $ID.
+Do not merge. If blocked, write BLOCKER.md with the exact reason and exit. Start now."
+
+attempt_log="$(mktemp "$LOG_DIR/.${ID}.attempt.XXXXXX")"
+trap 'rm -f "$attempt_log"' EXIT
+echo "START $ID $(date -u +%FT%TZ) repo=$REPO" | tee -a "$LOG"
+set +e
+grok --always-approve --cwd "$WS" -p "$PROMPT" 2>&1 | tee -a "$LOG" "$attempt_log"
+rc=${PIPESTATUS[0]}
+set -e
+
+if grep -Eqi 'usage limit|rate limit|try again later' "$attempt_log"; then
+  temporary="$COOLDOWN.$$.tmp"
+  printf '%s\n' "$((now + 21600))" > "$temporary"
+  mv "$temporary" "$COOLDOWN"
+fi
+
+pr_count="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq 'length' 2>/dev/null || printf 0)"
+if [ "$pr_count" -gt 0 ]; then
+  update_state "$IN_REVIEW_STATE_ID"
+  echo "END $ID rc=$rc pr=open $(date -u +%FT%TZ)" | tee -a "$LOG"
+  exit "$rc"
+fi
+
+if [ "$changed_state" -eq 1 ] && [ -n "$ORIGINAL_STATE_ID" ]; then
+  update_state "$ORIGINAL_STATE_ID"
+fi
+echo "END $ID rc=$rc pr=missing state=restored $(date -u +%FT%TZ)" | tee -a "$LOG"
+[ "$rc" -ne 0 ] && exit "$rc"
+exit 2

--- a/scripts/hermes/symphony-codex-exhausted.py
+++ b/scripts/hermes/symphony-codex-exhausted.py
@@ -24,17 +24,26 @@ MAX_TIMEOUT_SECONDS = 30.0
 CONTROL_TIMEOUT_SECONDS = 10.0
 DEFAULT_GROK_MAX = 2
 MAX_GROK_MAX = 10
-SERVICE = "symphony-ui-pilot.service"
+SERVICES = ("symphony-ui-pilot.service", "symphony-lyb.service")
 LINEAR_API = "https://api.linear.app/graphql"
 LINEAR_ENV_PATH = "~/.config/symphony/linear.env"
 IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 DOTENV_ASSIGNMENT = re.compile(r"^(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 STATE_DIR_NAME = ".symphony-codex-auth-fallback"
-RUNTIME_NAMES = (
+LEGACY_RUNTIME_NAMES = (
     "symphony-codex-exhausted",
     "symphony-codex-exhausted.py",
     "symphony-grok-sidecar",
 )
+RUNTIME_NAMES = (
+    *LEGACY_RUNTIME_NAMES,
+    "grok-ship-one",
+)
+REQUIRED_ADMISSION_LABELS = frozenset(("symphony", "plan-approved", "admission-approved"))
+BLOCKED_ADMISSION_LABELS = frozenset(
+    ("human-review-required", "needs:human", "needs-human", "needs:decision", "needs-decision", "hold")
+)
+SUPPORTED_TEAMS = frozenset(("JOV", "LYB"))
 
 LINEAR_QUERY = """
 query {
@@ -44,7 +53,13 @@ query {
       labels: { name: { eq: "symphony" } }
       state: { name: { in: ["Todo", "In Progress"] } }
     }
-  ) { nodes { identifier } }
+  ) {
+    nodes {
+      identifier
+      team { key }
+      labels { nodes { name } }
+    }
+  }
 }
 """
 
@@ -202,8 +217,27 @@ def _linear_identifiers() -> list[str] | None:
     for node in nodes:
         if not isinstance(node, dict) or not isinstance(node.get("identifier"), str):
             return None
-        if IDENTIFIER.fullmatch(node["identifier"]):
-            identifiers.append(node["identifier"])
+        team = node.get("team")
+        label_connection = node.get("labels")
+        if not isinstance(team, dict) or not isinstance(label_connection, dict):
+            return None
+        team_key = team.get("key")
+        label_nodes = label_connection.get("nodes")
+        if not isinstance(team_key, str) or not isinstance(label_nodes, list):
+            return None
+        labels: set[str] = set()
+        for label in label_nodes:
+            if not isinstance(label, dict) or not isinstance(label.get("name"), str):
+                return None
+            labels.add(label["name"].strip().lower())
+        identifier = node["identifier"]
+        if (
+            IDENTIFIER.fullmatch(identifier)
+            and team_key.upper() in SUPPORTED_TEAMS
+            and REQUIRED_ADMISSION_LABELS.issubset(labels)
+            and BLOCKED_ADMISSION_LABELS.isdisjoint(labels)
+        ):
+            identifiers.append(identifier)
     return identifiers
 
 
@@ -225,16 +259,16 @@ def reconcile() -> int:
         if active:
             print("codex_not_exhausted recovery_deferred grok_ship_active", file=sys.stderr)
             return 0
-        if not _control(_systemctl("start", SERVICE)):
+        if not _control(_systemctl("start", *SERVICES)):
             print("codex_not_exhausted symphony_start_failed", file=sys.stderr)
             return 2
-        if not _control(_systemctl("is-active", "--quiet", SERVICE)):
+        if not _control(_systemctl("is-active", "--quiet", *SERVICES)):
             print("codex_not_exhausted symphony_not_active", file=sys.stderr)
             return 2
         print("codex_not_exhausted symphony_active idle", file=sys.stderr)
         return 0
 
-    if not _control(_systemctl("stop", SERVICE)):
+    if not _control(_systemctl("stop", *SERVICES)):
         print("codex_exhausted symphony_stop_failed", file=sys.stderr)
         return 2
     executable = _grok_ship_one_executable()
@@ -281,11 +315,17 @@ if not controller.is_file():
     raise SystemExit("symphony-codex-auth-fallback is not installed")
 os.execv(sys.executable, [sys.executable, str(controller), *sys.argv[1:]])
 '''.encode()
-    command = 'reconcile "$@"' if name == "symphony-grok-sidecar" else '"$@"'
-    return f'''#!/usr/bin/env bash
+    if name in ("symphony-codex-exhausted", "symphony-grok-sidecar"):
+        command = 'reconcile "$@"' if name == "symphony-grok-sidecar" else '"$@"'
+        return f'''#!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${{BASH_SOURCE[0]}}")" && pwd)"
 exec python3 "$SCRIPT_DIR/{STATE_DIR_NAME}/current/symphony-codex-exhausted.py" {command}
+'''.encode()
+    return f'''#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${{BASH_SOURCE[0]}}")" && pwd)"
+exec "$SCRIPT_DIR/{STATE_DIR_NAME}/current/{name}" "$@"
 '''.encode()
 
 
@@ -327,7 +367,12 @@ def _current_release(state: pathlib.Path, releases: pathlib.Path) -> pathlib.Pat
     if pathlib.PurePath(raw).is_absolute() or len(parts) != 2 or parts[0] != "releases":
         raise InstallValidationError("current target is invalid")
     release = releases / parts[1]
-    if release.parent != releases or not release.is_dir() or not all(_valid_runtime_file(release / n) for n in RUNTIME_NAMES):
+    if (
+        release.parent != releases
+        or not release.is_dir()
+        or not all(_valid_runtime_file(release / n) for n in LEGACY_RUNTIME_NAMES)
+        or any(_path_exists(release / n) and not _valid_runtime_file(release / n) for n in RUNTIME_NAMES)
+    ):
         raise InstallValidationError("current release is incomplete")
     return release
 
@@ -337,11 +382,14 @@ def _preflight_install(destination: pathlib.Path, contents: dict[str, bytes]) ->
     releases = state / "releases"
     current = _current_release(state, releases)
     installed = {n: destination / n for n in RUNTIME_NAMES if _path_exists(destination / n)}
-    if current is None and installed and len(installed) != len(RUNTIME_NAMES):
+    installed_names = set(installed)
+    if current is None and installed and installed_names not in (set(LEGACY_RUNTIME_NAMES), set(RUNTIME_NAMES)):
         raise InstallValidationError("legacy launcher set is partial")
     if any(not _valid_runtime_file(path) for path in installed.values()):
         raise InstallValidationError("installed launcher is invalid")
-    if current is not None and any(not _valid_runtime_file(current / n) for n in contents):
+    if current is not None and any(
+        _path_exists(current / name) and not _valid_runtime_file(current / name) for name in contents
+    ):
         raise InstallValidationError("current release is invalid")
 
 

--- a/scripts/hermes/tests/symphony-codex-auth-fallback.test.py
+++ b/scripts/hermes/tests/symphony-codex-auth-fallback.test.py
@@ -19,17 +19,83 @@ SOURCE_DIR = ROOT / "scripts/hermes"
 CONTROLLER = SOURCE_DIR / "symphony-codex-exhausted.py"
 WRAPPER = SOURCE_DIR / "symphony-codex-exhausted"
 SIDECAR = SOURCE_DIR / "symphony-grok-sidecar"
-RUNTIME_NAMES = (WRAPPER.name, CONTROLLER.name, SIDECAR.name)
+GROK_SHIP = SOURCE_DIR / "grok-ship-one"
+RUNTIME_ARTIFACTS = (WRAPPER, CONTROLLER, SIDECAR, GROK_SHIP)
+RUNTIME_NAMES = tuple(path.name for path in RUNTIME_ARTIFACTS)
 
 
 class LinearHandler(http.server.BaseHTTPRequestHandler):
     requests: list[tuple[str | None, str]] = []
+    nodes = [
+        {
+            "identifier": identifier,
+            "team": {"key": identifier.split("-", 1)[0]},
+            "labels": {"nodes": [{"name": name} for name in labels]},
+        }
+        for identifier, labels in (
+            ("JOV-1", ("symphony", "plan-approved", "admission-approved")),
+            ("JOV-2", ("symphony", "plan-approved", "admission-approved")),
+            ("LYB-3", ("symphony", "plan-approved", "admission-approved")),
+            ("JOV-4", ("symphony", "needs:human")),
+            ("LYB-5", ("symphony", "plan-approved")),
+        )
+    ]
 
     def do_POST(self):  # noqa: N802 - stdlib handler API
         body = self.rfile.read(int(self.headers["Content-Length"])).decode()
         self.__class__.requests.append((self.headers.get("Authorization"), body))
-        payload = {"data": {"issues": {"nodes": [{"identifier": n} for n in ("JOV-1", "JOV-2", "JOV-3")]}}}
+        payload = {"data": {"issues": {"nodes": self.__class__.nodes}}}
         encoded = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, *_args):
+        return
+
+
+class GrokLinearHandler(http.server.BaseHTTPRequestHandler):
+    requests: list[dict] = []
+
+    def do_POST(self):  # noqa: N802 - stdlib handler API
+        payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        self.__class__.requests.append(payload)
+        if "issueUpdate" in payload["query"]:
+            response = {"data": {"issueUpdate": {"success": True}}}
+        else:
+            identifier = payload["variables"]["id"]
+            team = identifier.split("-", 1)[0]
+            response = {
+                "data": {
+                    "issue": {
+                        "id": f"uuid-{identifier}",
+                        "identifier": identifier,
+                        "title": f"Ship {identifier}",
+                        "description": "Bounded admitted work.",
+                        "url": f"https://linear.example/{identifier}",
+                        "state": {"id": f"{team}-todo", "name": "Todo"},
+                        "team": {
+                            "key": team,
+                            "states": {
+                                "nodes": [
+                                    {"id": f"{team}-progress", "name": "In Progress"},
+                                    {"id": f"{team}-review", "name": "In Review"},
+                                ]
+                            },
+                        },
+                        "labels": {
+                            "nodes": [
+                                {"name": "symphony"},
+                                {"name": "plan-approved"},
+                                {"name": "admission-approved"},
+                            ]
+                        },
+                    }
+                }
+            }
+        encoded = json.dumps(response).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(encoded)))
@@ -54,10 +120,6 @@ class FallbackTests(unittest.TestCase):
         self.state = self.root / "state.json"
         self.state.write_text(json.dumps({"active": None, "cooldowns": {"jovie": 1}, "last_error": {}}))
         self.events = self.root / "events.log"
-        grok = self.home / ".local/bin/grok-ship-one"
-        grok.parent.mkdir(parents=True)
-        grok.write_text("#!/bin/sh\nexit 0\n")
-        grok.chmod(0o755)
 
     def tearDown(self):
         self.tmp.cleanup()
@@ -129,7 +191,7 @@ class FallbackTests(unittest.TestCase):
     def distinct_source(self, label):
         source = self.root / f"source-{label}"
         source.mkdir()
-        for path in (WRAPPER, CONTROLLER, SIDECAR):
+        for path in RUNTIME_ARTIFACTS:
             target = source / path.name
             target.write_bytes(path.read_bytes() + f"\n# {label}-{path.name}\n".encode())
             target.chmod(0o755)
@@ -138,6 +200,14 @@ class FallbackTests(unittest.TestCase):
     def linear_url(self):
         LinearHandler.requests = []
         server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), LinearHandler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.shutdown)
+        self.addCleanup(server.server_close)
+        return f"http://127.0.0.1:{server.server_port}/graphql"
+
+    def grok_linear_url(self):
+        GrokLinearHandler.requests = []
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), GrokLinearHandler)
         threading.Thread(target=server.serve_forever, daemon=True).start()
         self.addCleanup(server.shutdown)
         self.addCleanup(server.server_close)
@@ -192,8 +262,8 @@ class FallbackTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(self.events.read_text().splitlines(), [
             "systemctl --user list-units --type=service --state=active grok-ship-*.service --no-legend --no-pager",
-            "systemctl --user start symphony-ui-pilot.service",
-            "systemctl --user is-active --quiet symphony-ui-pilot.service",
+            "systemctl --user start symphony-ui-pilot.service symphony-lyb.service",
+            "systemctl --user is-active --quiet symphony-ui-pilot.service symphony-lyb.service",
         ])
         self.assertIn("idle", result.stderr)
 
@@ -225,10 +295,55 @@ class FallbackTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         events = self.events.read_text().splitlines()
-        self.assertEqual(events[0], "systemctl --user stop symphony-ui-pilot.service")
+        self.assertEqual(events[0], "systemctl --user stop symphony-ui-pilot.service symphony-lyb.service")
         self.assertEqual(len([line for line in events if line.startswith("systemd-run")]), 2)
+        self.assertTrue(any("grok-ship-LYB-3" in line for line in events))
+        self.assertFalse(any("grok-ship-JOV-4" in line or "grok-ship-LYB-5" in line for line in events))
         self.assertNotIn("linear-secret", result.stdout + result.stderr + self.events.read_text())
         self.assertIn("first: 20", LinearHandler.requests[0][1])
+        self.assertIn("labels { nodes { name } }", LinearHandler.requests[0][1])
+
+    def test_managed_grok_worker_routes_jov_and_lyb_and_updates_team_states(self):
+        created = self.root / "pr-created"
+        self.command(
+            "git",
+            'printf "git %s\\n" "$*" >> "$GEM_EVENTS"\n'
+            '[ "$1" != clone ] || mkdir -p "$5/.git"\n',
+        )
+        self.command(
+            "gh",
+            '[ ! -f "$GROK_CREATED" ] && echo 0 || echo 1\n',
+        )
+        self.command(
+            "grok",
+            'printf "grok %s\\n" "$*" >> "$GEM_EVENTS"\n'
+            'touch "$GROK_CREATED"\n',
+        )
+        destination = self.install_runtime()
+        linear_url = self.grok_linear_url()
+        workspace = self.root / "workspaces"
+        logs = self.root / "logs"
+        for identifier, repository in (("JOV-7", "JovieInc/Jovie"), ("LYB-8", "JovieInc/LogYourBody")):
+            created.unlink(missing_ok=True)
+            result = subprocess.run(
+                [destination / GROK_SHIP.name, identifier],
+                capture_output=True,
+                text=True,
+                env=self.env(
+                    GEM_EVENTS=self.events,
+                    GROK_CREATED=created,
+                    GROK_SHIP_WS_ROOT=workspace,
+                    GROK_SHIP_LOG_DIR=logs,
+                    LINEAR_API_KEY="linear-secret",
+                    LINEAR_API_URL=linear_url,
+                ),
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(f"git clone --depth 1 https://github.com/{repository}.git", self.events.read_text())
+            self.assertIn(f"--cwd {workspace / identifier.split('-', 1)[0] / identifier}", self.events.read_text())
+        mutations = [request["variables"]["input"]["stateId"] for request in GrokLinearHandler.requests if "issueUpdate" in request["query"]]
+        self.assertEqual(mutations, ["JOV-progress", "JOV-review", "LYB-progress", "LYB-review"])
 
     def test_linear_env_is_strict_and_malformed_auth_does_not_block_usable_path(self):
         self.command("codex-rotate", "echo GEM_MODEL_READY")
@@ -255,6 +370,19 @@ class FallbackTests(unittest.TestCase):
         result = self.run_install(destination, controller=invalid_source)
         self.assertEqual(result.returncode, 2)
         self.assertEqual(sentinel.read_text(), "keep")
+
+    def test_legacy_three_artifact_release_upgrades_atomically(self):
+        destination = self.root / "legacy-three"
+        release = destination / ".symphony-codex-auth-fallback/releases/legacy"
+        release.mkdir(parents=True)
+        for source in (WRAPPER, CONTROLLER, SIDECAR):
+            for target in (release / source.name, destination / source.name):
+                target.write_bytes(source.read_bytes())
+                target.chmod(0o755)
+        (destination / ".symphony-codex-auth-fallback/current").symlink_to("releases/legacy")
+        result = self.run_install(destination)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_complete_install(destination)
 
     def test_fresh_install_recovers_at_each_atomic_cutover(self):
         for replace_number in range(1, 5):


### PR DESCRIPTION
## Summary
- require `symphony`, `plan-approved`, and `admission-approved` before the provider fallback can launch work
- reject human/decision/hold labels and reconcile both JOV and LYB Symphony services
- manage a team-aware Grok worker for `JovieInc/Jovie` and `JovieInc/LogYourBody`, with team-correct Linear transitions, failed-run state restoration, provider cooldown, and open-PR dedupe
- preserve atomic upgrades from the prior three-artifact runtime bundle

## Incident evidence
The legacy Gem sidecar stopped JOV Symphony and attempted JOV-4814 (`needs:human`) plus JOV-4802 (missing plan/admission approvals). Grok was usage-limited, so both attempts exited without commits, PRs, or Linear state changes. The corrected runtime is already hot-deployed with checksum verification; its live admission query returns `[]`, and the first timer tick reported `codex_not_exhausted symphony_active idle` while both 4041 and 4042 remained healthy.

## Validation
- `python3 scripts/hermes/tests/symphony-codex-auth-fallback.test.py` — 16 passed
- `shellcheck scripts/hermes/grok-ship-one scripts/hermes/symphony-codex-exhausted scripts/hermes/symphony-grok-sidecar` — passed
- `python3 -m py_compile scripts/hermes/symphony-codex-exhausted.py scripts/hermes/tests/symphony-codex-auth-fallback.test.py` — passed
- fail-closed pre-push gate — passed

Bug-to-test: regression coverage added for exact admission labels, blocked labels, dual-service recovery, JOV/LYB repository routing, team state transitions, and legacy atomic upgrade.

Fixes JOV-4841
