### PR TITLE
ci(affected-tests): select homepage System B style guards for home surface changes

### DIFF
--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -822,6 +822,38 @@ describe('automation-verify affected scope', () => {
     );
   });
 
+  it('selects the homepage System B style guards for a home.css-only change', () => {
+    const plan = buildAffectedTestPlan(['apps/web/app/(home)/home.css']);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual(
+      expect.arrayContaining([
+        'apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts',
+        'apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts',
+        'apps/web/tests/unit/home/dead-home-actions-system-b-style-guard.test.ts',
+      ])
+    );
+    expect(
+      plan.selectedTests.filter(file =>
+        file.startsWith('apps/web/tests/unit/home/')
+      )
+    ).toHaveLength(17);
+  });
+
+  it('selects the homepage System B style guards for homepage component changes', () => {
+    const plan = buildAffectedTestPlan([
+      'apps/web/components/homepage/HomepageMeetJovie.tsx',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toContain(
+      'apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts'
+    );
+    expect(plan.selectedTests).toContain(
+      'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts'
+    );
+  });
+
   it('keeps the authenticated accessibility repair on focused unit coverage', () => {
     const plan = buildAffectedTestPlan([
       ...AUTHENTICATED_A11Y_REPAIR_CORE,

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -94,6 +94,40 @@ const VERCEL_CONGESTION_CONTROL_ROOT_VITEST_TESTS = [
 const VERCEL_CONGESTION_CONTROL_PYTHON_TESTS = [
   'scripts/tests/test_vercel_prebuilt_deploy.py',
 ];
+// Homepage System B style guards read the homepage surface (page/component
+// sources and app/(home)/home.css) from disk, so Vitest's module graph never
+// connects them to those inputs. A source/CSS change that breaks a guard
+// otherwise sails through affected-test selection and only fails on the
+// merge-group full suite (PR #15566 looped enroll→group-red 3× on 2026-08-06).
+const HOMEPAGE_SYSTEM_B_STYLE_GUARD_TESTS = [
+  'apps/web/tests/unit/home/bento-feature-grid-system-b-style-guard.test.tsx',
+  'apps/web/tests/unit/home/claim-handle-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/dead-home-actions-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/home-profile-showcase-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-closed-loop-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-faq-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-grid-spine-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-pricing-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts',
+  'apps/web/tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx',
+  'apps/web/tests/unit/home/release-operating-system-showcase-system-b-style-guard.test.tsx',
+];
+const HOMEPAGE_SYSTEM_B_GUARD_EXACT_INPUTS = new Set([
+  'apps/web/components/marketing/ClientFaqAccordion.tsx',
+  'apps/web/components/marketing/FaqSection.tsx',
+]);
+const isHomepageSystemBGuardInput = file =>
+  file.startsWith('apps/web/app/(home)/') ||
+  file.startsWith('apps/web/components/homepage/') ||
+  file.startsWith('apps/web/components/features/home/') ||
+  file.startsWith('apps/web/components/marketing/homepage-v2/') ||
+  HOMEPAGE_SYSTEM_B_GUARD_EXACT_INPUTS.has(file);
 const AFFECTED_TEST_SELECTOR_MANIFEST = new Set([
   'scripts/run-affected-tests.mjs',
   'scripts/lib/__tests__/automation-verify.test.mjs',
@@ -640,6 +674,10 @@ export function buildAffectedTestPlan(
       'apps/web/tests/unit/design-system/arbitrary-values-ratchet.test.ts'
     );
   }
+  const hasHomepageSystemBGuardInput = files.some(isHomepageSystemBGuardInput);
+  if (hasHomepageSystemBGuardInput) {
+    mandatoryTests.push(...HOMEPAGE_SYSTEM_B_STYLE_GUARD_TESTS);
+  }
   if (
     files.some(file =>
       file.startsWith('apps/web/eslint-rules/canonical-ui-label-casing')
@@ -976,6 +1014,7 @@ export function buildAffectedTestPlan(
       : hasSelectedTests &&
           (relatedFiles.length > 0 ||
             hasCiCancellationHealerChange ||
+            hasHomepageSystemBGuardInput ||
             isExactPrerequisiteTrain ||
             isExactVercelCongestionControl ||
             isExactAffectedTestSelector ||


### PR DESCRIPTION
## Problem

PR #15566 dropped guard-required tokens from `apps/web/app/(home)/home.css`. Source-branch CI stayed green because affected-test selection never connected the CSS file to the mounted homepage System B style guards — those guards read the CSS/component sources from disk (`readFileSync`), so Vitest's related-module graph can't see the dependency. The merge-group full suite then failed 3 times (00:03 / 00:24 / 00:45 UTC) while Merge Queue Auto-Enroll kept re-enrolling the green source head: an enroll → group-red → dequeue loop.

## Change

`scripts/run-affected-tests.mjs`: changes to the homepage surface — `apps/web/app/(home)/`, `apps/web/components/homepage/`, `apps/web/components/features/home/`, `apps/web/components/marketing/homepage-v2/`, plus the two marketing FAQ components the guards read — now select all 17 `tests/unit/home/*style-guard*` tests as mandatory. A `home.css`-only change resolves to `selected` mode instead of `none`.

## Verification

- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/automation-verify.test.mjs` → 177/177 pass (2 new regression tests: css-only change selects guards; homepage component change selects guards + ratchet).
- `buildAffectedTestPlan` on the exact #15566 diff: mode=`selected`, includes `mounted-home-artist-outcomes-system-b-style-guard.test.ts` (23 selected tests; previously 6, guard missing).
- Biome check clean on both files; repo pre-push gate passed.

## Out of scope (reported, not changed)

The drain (`scripts/drain-pr-queue.sh`) classifies eligibility from source-head checks only (`gh pr checks`); merge-group failures are invisible to it, so a source-green/group-red PR is re-enrolled indefinitely. That loop guard belongs with the in-flight failure-disposition work (`codex/fix-failure-disposition`).