### PR TITLE
fix(control-plane): treat Fork PR Gate Controller receipt as advisory (JOV-4782)

### DIFF
--- a/scripts/lib/__tests__/pr-check-failures.test.mjs
+++ b/scripts/lib/__tests__/pr-check-failures.test.mjs
@@ -81,6 +81,53 @@ describe('pr-check-failures', () => {
     ).toEqual(['enroll']);
   });
 
+  it('treats a red Fork PR Gate Controller receipt with SKIPPED twin as advisory (JOV-4782)', () => {
+    const required = [
+      { bucket: 'pass', state: 'SUCCESS', name: 'PR Ready' },
+      { bucket: 'pass', state: 'SUCCESS', name: 'Migration Guard' },
+      { bucket: 'pass', state: 'SUCCESS', name: 'Fork PR Gate' },
+      { bucket: 'pass', state: 'SUCCESS', name: 'PR Size Guard' },
+    ];
+    // pull_request-event run fails at create-github-app-token (no
+    // JOVIE_BOT_PRIVATE_KEY); pull_request_target run of the same job is
+    // SKIPPED for non-fork heads. The red controller receipt must not block
+    // enrollment when the required gates are green.
+    const controllerReceipts = [
+      {
+        bucket: 'fail',
+        state: 'FAILURE',
+        name: 'Fork PR Gate Controller',
+        workflow: 'Fork PR Gate',
+        startedAt: '2026-08-03T01:00:00Z',
+        completedAt: '2026-08-03T01:01:00Z',
+      },
+      {
+        bucket: 'skipping',
+        state: 'SKIPPED',
+        name: 'Fork PR Gate Controller',
+        workflow: 'Fork PR Gate',
+        startedAt: '2026-08-03T01:02:00Z',
+        completedAt: '2026-08-03T01:02:00Z',
+      },
+    ];
+
+    expect(
+      classifyQueueCheckBlockers([...required, ...controllerReceipts])
+    ).toEqual([]);
+
+    // The actual gate is the required `Fork PR Gate` commit status: it stays
+    // fail-closed, so the advisory receipt never smuggles a red fork gate.
+    expect(
+      classifyQueueCheckBlockers([
+        { bucket: 'pass', state: 'SUCCESS', name: 'PR Ready' },
+        { bucket: 'pass', state: 'SUCCESS', name: 'Migration Guard' },
+        { bucket: 'fail', state: 'FAILURE', name: 'Fork PR Gate' },
+        { bucket: 'pass', state: 'SUCCESS', name: 'PR Size Guard' },
+        ...controllerReceipts,
+      ])
+    ).toEqual(['Fork PR Gate', 'Fork PR Gate (not successful)']);
+  });
+
   it('derives staged advisory evidence from the manifest and preserves safety gates', () => {
     const harness = JSON.parse(
       readFileSync(`${repoRoot}/.github/ci-harness/manifest.json`, 'utf8')
@@ -121,6 +168,8 @@ describe('pr-check-failures', () => {
     );
     expect(ADVISORY_CHECK_NAMES).toContain('SonarCloud Code Analysis');
     expect(ADVISORY_CHECK_NAMES).toContain('Vercel Agent Review');
+    expect(ADVISORY_CHECK_NAMES).toContain('Fork PR Gate Controller');
+    expect(ADVISORY_CHECK_NAMES).not.toContain('Fork PR Gate');
     expect(ADVISORY_CHECK_NAMES).not.toContain('Brand Scrub');
     expect(
       extractTerminalFailures([

--- a/scripts/lib/pr-check-failures.mjs
+++ b/scripts/lib/pr-check-failures.mjs
@@ -70,6 +70,16 @@ export const ADVISORY_CHECK_NAMES = Object.freeze(
     // Folded into ci-fast's Structural Contract; retained for old PR heads
     // produced before the standalone workflow was retired from source events.
     'actionlint',
+    // The pull_request-event run of fork-pr-gate cannot mint a jovie-bot token
+    // (JOVIE_BOT_PRIVATE_KEY is only exposed to pull_request_target and
+    // merge_group runs, which succeed) and fails at create-github-app-token,
+    // leaving a red `Fork PR Gate Controller` check-run beside its SKIPPED
+    // twin. The controller job is an orchestration receipt: the actual gate is
+    // the required `Fork PR Gate` commit status, which stays fail-closed via
+    // REQUIRED_CHECK_NAMES (missing/not-successful still blocks). Advisory
+    // here is therefore equivalent to "only when the required four are green"
+    // — any red required gate blocks on its own. See JOV-4782.
+    'Fork PR Gate Controller',
     // Legacy evidence names can remain attached to already-open PR heads while
     // the manual-only job names roll out. They remain advisory for enrollment.
     'Lighthouse (public routes PR)',


### PR DESCRIPTION
## Summary

Deps/GHA PRs can be source-green (PR Ready + Migration Guard + PR Size Guard + ci-fast all SUCCESS) while the rollup shows a red `Fork PR Gate Controller` check-run next to its SKIPPED twin. The `pull_request`-event run of fork-pr-gate cannot mint a jovie-bot token (`JOVIE_BOT_PRIVATE_KEY` is only exposed to `pull_request_target`/`merge_group`, which succeed) and fails at `create-github-app-token`. The queue classifier (`scripts/lib/pr-check-failures.mjs`) failed closed on that terminal red receipt, so exact-head rescue enroll bounced and the autoenroll classifier re-dequeued otherwise-green deps PRs (observed twice on #15453).

**Change (bounded):** add `Fork PR Gate Controller` to `ADVISORY_CHECK_NAMES`. The controller job is an orchestration receipt, not a product gate:

- The real fork gate is the required `Fork PR Gate` commit status, which stays **fail-closed** via `REQUIRED_CHECK_NAMES` (missing / pending / not-successful still blocks).
- The four required gates are independently enforced, so a red required gate still blocks on its own — this is equivalent to "advisory when the required four are green".
- No migration/secret/path gate is touched; `MERGE_GATE_CHECK_NAMES` and the required-context policy are unchanged.

## Test plan

- `vitest --root scripts run lib/__tests__/pr-check-failures.test.mjs` — 14/14 pass, incl. new tests:
  - red `Fork PR Gate Controller` + SKIPPED twin with required four green → no blockers
  - red `Fork PR Gate` status itself → still blocks (`Fork PR Gate`, `Fork PR Gate (not successful)`)
  - advisory-set assertions (`Fork PR Gate Controller` in, `Fork PR Gate` out)
- `vitest --root scripts run lib/__tests__/merge-group-workflow-contract.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/merge-queue-backend.test.mjs lib/__tests__/merge-group-admission.test.mjs` — 122/122 pass
- `biome check --write` on touched files — clean
- Pre-commit + pre-push gates — pass

No UI-visible change.

Fixes JOV-4782
https://linear.app/jovie/issue/JOV-4782