### PR TITLE
feat(library): default Library view mode to grid (JOV-4845)

### DIFF
--- a/apps/web/app/app/(shell)/library/library-grid-preferences.ts
+++ b/apps/web/app/app/(shell)/library/library-grid-preferences.ts
@@ -7,7 +7,7 @@ export const LIBRARY_GRID_DENSITY_STORAGE_KEY = 'jovie:library-grid-density';
 export const LIBRARY_VIEW_MODE_STORAGE_KEY = 'jovie:library-view-mode';
 
 export const DEFAULT_LIBRARY_GRID_DENSITY: LibraryGridDensity = 'comfortable';
-export const DEFAULT_LIBRARY_VIEW_MODE: LibraryViewMode = 'list';
+export const DEFAULT_LIBRARY_VIEW_MODE: LibraryViewMode = 'grid';
 
 export const LIBRARY_GRID_DENSITY_OPTIONS: readonly {
   readonly value: LibraryGridDensity;

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -13,6 +13,7 @@ import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LibrarySurface } from '@/app/app/(shell)/library/LibrarySurface';
 import type { LibraryReleaseAsset } from '@/app/app/(shell)/library/library-data';
+import { LIBRARY_VIEW_MODE_STORAGE_KEY } from '@/app/app/(shell)/library/library-grid-preferences';
 import { LIBRARY_SAVED_VIEW_STORAGE_KEY } from '@/app/app/(shell)/library/library-saved-views';
 import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchSurfaceFromContext';
 import { APP_ROUTES } from '@/constants/routes';
@@ -255,6 +256,10 @@ describe('LibrarySurface', () => {
 
   beforeEach(() => {
     window.localStorage.clear();
+    // Grid is the shipped default view mode; most tests below exercise the
+    // list renderer, so seed the persisted preference explicitly instead of
+    // depending on the default.
+    window.localStorage.setItem(LIBRARY_VIEW_MODE_STORAGE_KEY, 'list');
     navigationMock.searchParams = new URLSearchParams();
     audioMock.playbackState = { ...audioMock.basePlaybackState };
     audioMock.toggleTrack.mockClear();
@@ -384,17 +389,20 @@ describe('LibrarySurface', () => {
     );
   });
 
-  it('defaults to list view on first load', () => {
+  it('defaults to grid view on first load', () => {
+    window.localStorage.removeItem(LIBRARY_VIEW_MODE_STORAGE_KEY);
     renderLibrary([buildAsset()]);
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getByText('Apr 28')).toHaveAttribute('title', 'Apr 28, 2026');
+    expect(screen.queryByRole('table')).toBeNull();
     expect(
-      screen.getByTestId('library-release-row-release-1')
+      screen.getByRole('button', { name: /View Take Me Over/u })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /View Take Me Over/u })
-    ).toBeNull();
+      screen.getByTestId('library-grid-density-toggle')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('library-release-status-release-1')
+    ).toBeInTheDocument();
   });
 
   it('shows the card-size toggle in grid view and persists density preference', () => {
@@ -1086,7 +1094,7 @@ describe('LibrarySurface', () => {
       }),
     ]);
 
-    // Defaults to list (header hidden, release rows present).
+    // Starts in list view (seeded preference; header hidden, release rows present).
     expect(
       screen.getByTestId('library-release-row-release-1')
     ).toBeInTheDocument();

--- a/apps/web/tests/unit/library/library-grid-preferences.test.ts
+++ b/apps/web/tests/unit/library/library-grid-preferences.test.ts
@@ -75,9 +75,9 @@ describe('library view mode preferences', () => {
     vi.unstubAllGlobals();
   });
 
-  it('defaults to list view when no preference is stored', () => {
+  it('defaults to grid view when no preference is stored', () => {
     expect(readLibraryViewMode()).toBe(DEFAULT_LIBRARY_VIEW_MODE);
-    expect(readLibraryViewMode()).toBe('list');
+    expect(readLibraryViewMode()).toBe('grid');
   });
 
   it('persists and reads grid, list, and table view modes', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4845 -->

## Summary

JOV-4845 (PR 1 of 2 under JOV-3481) asked for a Grid/List view-mode scaffold with a persisted toggle on the Library page. On current `main` that scaffold is already shipped and verified:

- Typed view-mode model `LibraryViewMode = 'grid' | 'list' | 'table'` (`library-data.ts`) — a third mode needs no refactor.
- Persisted toggle via the repo's existing client-persistence pattern (`useLibraryViewMode` in `library-grid-preferences.ts`, localStorage key `jovie:library-view-mode`), same style as grid-density and saved-view prefs.
- Artwork-forward `AssetGrid`/`AssetCard` tiles with always-reserved status pills (release + approval), recreated in shared layers — no `app/exp/*` imports, no new feature flag.
- Smart Filters with live counts and asset-type tabs operate in every mode (they live on surface state, not the renderer).

The one acceptance criterion not yet true on `main`: **Grid is the default**. This PR flips `DEFAULT_LIBRARY_VIEW_MODE` from `'list'` to `'grid'`. Users with a stored preference are untouched (persisted choice always wins); only first-load/no-preference renders change.

Note on scope: the ticket says not to expose a Table option in this PR, but the shipped surface on `main` already exposes the Table mode (merged earlier under the JOV-3481 train). Removing shipped functionality would be a regression, so this PR leaves it in place — flagged here for reviewer awareness.

## Changes

- `apps/web/app/app/(shell)/library/library-grid-preferences.ts`: `DEFAULT_LIBRARY_VIEW_MODE: 'list' → 'grid'`.
- `apps/web/tests/unit/library/LibrarySurface.test.tsx`: seed the `list` preference in the shared `beforeEach` (most tests exercise the list renderer; this makes the dependency explicit instead of relying on the old default); rewrite the first-load test to assert the grid default (grid card + density toggle + status pill present, no table).
- `apps/web/tests/unit/library/library-grid-preferences.test.ts`: default-preference assertion updated to `grid`.

## Test plan / results

- `pnpm --filter web exec vitest run tests/unit/library` — **24 files, 153 tests, all pass** (includes `LibrarySurface.test.tsx` 40 tests: toggle switching, persistence across modes, grid cards, smart filters, tabs).
- `pnpm biome check --write` on touched files — clean, no fixes.
- `pnpm --filter @jovie/web run typecheck` — clean.
- Pre-push `git diff --check origin/main...HEAD` — clean.

## Screenshots

UI-visible change (first-load default view). Screenshot capture unavailable in this headless environment; behavior is covered by the component tests above. Grid mode itself is unchanged from the shipped implementation — only the initial mode for users without a stored preference changes.

Fixes JOV-4845
https://linear.app/jovie/issue/JOV-4845/jov-3481a-library-gridlist-view-mode-scaffold-with-persisted-toggle
