### PR TITLE
fix(profile): keep drawer open across background data churn (JOV-4848)

### DIFF
--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -273,6 +273,7 @@ export function ProfileCompactTemplate({
   const compactShellRef = useRef<HTMLDivElement | null>(null);
   const drawerOpenRef = useRef(initialDrawerView !== null);
   const drawerViewRef = useRef<DrawerView>(initialDrawerView ?? 'menu');
+  const lastSyncedModeRef = useRef<ProfileMode | null>(null);
   const lastPrimaryModeRef = useRef<ProfileMode>('profile');
   const initialLocationModeAlignedRef = useRef(false);
   const suppressNextHistorySyncRef = useRef(true);
@@ -557,8 +558,23 @@ export function ProfileCompactTemplate({
   }, [requestedMode]);
 
   useEffect(() => {
+    // Drawer open/close sync is keyed to the requested *mode* (stable visitor
+    // intent), not to data. `resolveInitialView` also depends on data-derived
+    // capabilities (hasContacts/hasTip/hasReleases), so a background refetch
+    // that transiently empties data re-runs this effect. Without the
+    // mode-change gate that churn would close an open drawer (and the
+    // resolving refetch would re-open it / yank the view back) — the
+    // intermittent open/close bug from JOV-4848. When only data changed, an
+    // already-open drawer must be left untouched; render-time fallbacks own
+    // missing data (same pattern as the JOV-2150 no-flicker fix).
+    const modeChanged = lastSyncedModeRef.current !== requestedMode;
+    lastSyncedModeRef.current = requestedMode;
+
     const resolved = resolveInitialView(requestedMode);
     if (resolved) {
+      if (!modeChanged && drawerOpenRef.current) {
+        return;
+      }
       clearCloseResetTimer();
       drawerViewRef.current = resolved;
       setDrawerView(resolved);
@@ -576,6 +592,10 @@ export function ProfileCompactTemplate({
       drawerOpenRef.current &&
       drawerViewRef.current === 'menu'
     ) {
+      return;
+    }
+
+    if (!modeChanged && drawerOpenRef.current) {
       return;
     }
 

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -279,6 +279,7 @@ describe('ProfileCompactTemplate', () => {
         readonly view: string;
         readonly presentation?: string;
         readonly onOpenChange?: (open: boolean) => void;
+        readonly onViewChange?: (view: string) => void;
       }) => (
         <div
           data-testid='mock-profile-unified-drawer'
@@ -292,6 +293,13 @@ describe('ProfileCompactTemplate', () => {
             onClick={() => props.onOpenChange?.(false)}
           >
             Close drawer
+          </button>
+          <button
+            type='button'
+            data-testid='mock-profile-unified-drawer-menu'
+            onClick={() => props.onViewChange?.('menu')}
+          >
+            Open menu
           </button>
         </div>
       )
@@ -1448,6 +1456,84 @@ describe('ProfileCompactTemplate', () => {
     });
 
     restoreViewport();
+  });
+
+  describe('drawer view stability under data churn (JOV-4848)', () => {
+    // Regression: the drawer open/close sync effect used to re-run whenever a
+    // data-derived capability (hasContacts/hasTip/hasReleases) flipped, so a
+    // background refetch that transiently emptied `contacts` closed the drawer
+    // and the resolving refetch re-opened it — an intermittent close/reopen
+    // cycle visible to the user. Drawer open state must be keyed to the
+    // requested mode (stable intent), never to data object identity or
+    // transient loading states.
+
+    function renderContactDrawer(contacts: PublicContact[]) {
+      return (
+        <ProfileCompactTemplate
+          mode='contact'
+          artist={mockArtist}
+          socialLinks={[]}
+          contacts={contacts}
+        />
+      );
+    }
+
+    function drawerOpenHistory(): boolean[] {
+      return mockProfileUnifiedDrawer.mock.calls.map(
+        call => (call[0] as { readonly open: boolean }).open
+      );
+    }
+
+    it('keeps the drawer open across a refetch that transiently empties data', async () => {
+      const { rerender } = render(renderContactDrawer(mockContacts));
+
+      const drawer = () => screen.getByTestId('mock-profile-unified-drawer');
+      await waitFor(() => {
+        expect(drawer()).toHaveAttribute('data-open', 'true');
+        expect(drawer()).toHaveAttribute('data-view', 'contact');
+      });
+
+      // Background refetch transiently returns empty data (loading state).
+      rerender(renderContactDrawer([]));
+
+      // Refetch resolves with new object identities for the same entity.
+      rerender(renderContactDrawer(mockContacts.map(c => ({ ...c }))));
+
+      await waitFor(() => {
+        expect(drawer()).toHaveAttribute('data-open', 'true');
+        expect(drawer()).toHaveAttribute('data-view', 'contact');
+      });
+
+      // No render may have observed a closed drawer — no close/reopen cycle.
+      const history = drawerOpenHistory();
+      expect(history.length).toBeGreaterThan(0);
+      expect(history).not.toContain(false);
+    });
+
+    it('does not yank the in-drawer view back to the mode view when data churns', async () => {
+      const { rerender } = render(renderContactDrawer(mockContacts));
+
+      const drawer = () => screen.getByTestId('mock-profile-unified-drawer');
+      await waitFor(() => {
+        expect(drawer()).toHaveAttribute('data-view', 'contact');
+      });
+
+      // Visitor navigates inside the drawer to the root menu (a view with no
+      // associated profile mode).
+      fireEvent.click(screen.getByTestId('mock-profile-unified-drawer-menu'));
+      await waitFor(() => {
+        expect(drawer()).toHaveAttribute('data-view', 'menu');
+      });
+
+      // Data churn: refetch empties contacts, then resolves with fresh objects.
+      rerender(renderContactDrawer([]));
+      rerender(renderContactDrawer(mockContacts.map(c => ({ ...c }))));
+
+      // The drawer stays open and the visitor's chosen view is preserved.
+      expect(drawer()).toHaveAttribute('data-open', 'true');
+      expect(drawer()).toHaveAttribute('data-view', 'menu');
+      expect(drawerOpenHistory()).not.toContain(false);
+    });
   });
 
   describe('hydration-safe profile mode sync', () => {


### PR DESCRIPTION
## Summary

Fixes the intermittent profile drawer open/close from JOV-2148 (PR B: view stability under data churn).

**Root cause:** In `ProfileCompactTemplate`, the drawer open/close sync effect depended on `resolveInitialView`, which is derived from data-driven capabilities (`hasContacts`, `hasTip`, `hasReleases`). A background refetch that transiently emptied `contacts`/`socialLinks`/`releases` flipped a capability → the effect re-ran, resolved `null`, and closed the open drawer; when the refetch resolved, the drawer re-opened (and the visitor's in-drawer view, e.g. the root menu, was yanked back to the mode's view).

**Fix:** Drawer open/close sync is now gated on requested-*mode* changes (stable visitor intent), never on data object identity or transient loading states. When only data churned, an already-open drawer is left untouched; missing data is owned by render-time fallbacks — the same pattern as the JOV-2150 no-flicker fix in `ProfileUnifiedDrawer`.

Smallest correct change: 20 added lines in one component + regression tests.

## Test plan

- New regression tests in `apps/web/tests/unit/profile/profile-compact-template.test.tsx` (`drawer view stability under data churn (JOV-4848)`):
  - mount the drawer open (`mode='contact'`), simulate a refetch that transiently returns empty contacts and then resolves with **new object identities**, assert the drawer never observes `open=false` (no close/reopen cycle) and stays on the contact view;
  - visitor navigates to the in-drawer root menu, data churns → drawer stays open and the menu view is preserved.
- Verified both tests **fail on `origin/main`** (close/reopen cycle + view yank reproduced) and **pass with the fix**.
- `pnpm --filter web exec vitest run tests/unit/profile` — 83 files / 669 tests pass (incl. existing JOV-2150 drawer stability + releases suites).
- `pnpm --filter @jovie/web run typecheck` — clean. `pnpm biome check` — clean. Pre-commit gates (eslint, a11y, lint-staged typecheck) — clean.

## Screenshots

Logic-only change (state-sync gating); no visual diff. The churn scenario is timing-dependent, so the regression is captured by the unit tests above rather than a static screenshot.

Fixes JOV-4848
https://linear.app/jovie/issue/JOV-4848/jov-2148b-profile-drawer-view-stability-under-data-churn
