### PR TITLE
fix(profile): fail-safe platform-name label when handle and URL are both missing (JOV-4847)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileLinkList.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileLinkList.tsx
@@ -19,7 +19,11 @@ import { PROVIDER_LABELS } from '@/features/dashboard/atoms/DspProviderIcon';
 import type { LinkSection } from '@/features/dashboard/organisms/links/utils/link-categorization';
 import { getPlatformCategory } from '@/features/dashboard/organisms/links/utils/platform-category';
 import { cn } from '@/lib/utils';
-import { dedupeLinks, extractHandleFromUrl } from '@/lib/utils/social-platform';
+import {
+  dedupeLinks,
+  extractHandleFromUrl,
+  getSocialDisplayName,
+} from '@/lib/utils/social-platform';
 
 export type CategoryOption = LinkSection | 'all';
 
@@ -100,6 +104,15 @@ interface LinkItemProps {
 function LinkItem({ link, onRemove }: LinkItemProps) {
   const handle = extractHandleFromUrl(link.url);
 
+  // Fail-safe label: derive from the handle first, then the URL's hostname.
+  // The bare platform display name is the LAST resort, used only when no
+  // handle or URL exists at all — it must never masquerade as a handle.
+  const label = handle
+    ? `@${handle}`
+    : link.url?.trim()
+      ? formatDisplayHost(link.url)
+      : getSocialDisplayName(link.platform);
+
   const trailingContent =
     link.platform === 'website' && link.verificationStatus === 'verified' ? (
       <span className='ml-0.5 inline-flex align-middle'>
@@ -114,7 +127,7 @@ function LinkItem({ link, onRemove }: LinkItemProps) {
   return (
     <SidebarLinkRow
       icon={<SocialIcon platform={link.platform} className='h-4 w-4' />}
-      label={handle ? `@${handle}` : formatDisplayHost(link.url)}
+      label={label}
       url={link.url}
       deepLinkPlatform={link.platform}
       isVisible={link.isVisible}

--- a/apps/web/lib/utils/social-platform.ts
+++ b/apps/web/lib/utils/social-platform.ts
@@ -230,6 +230,36 @@ function dedupeKey(platform: string, urlRaw: string): string {
 }
 
 /**
+ * Human-readable display names for known social platforms.
+ *
+ * Used ONLY as a last-resort row label when a link has neither an
+ * extractable handle nor a usable URL — never as a substitute for a real
+ * handle (a bare platform name masquerading as a handle was the original
+ * "YouTube YouTube YouTube" bug, JOV-2149 / JOV-4847).
+ */
+const PLATFORM_DISPLAY_NAMES: Record<string, string> = {
+  instagram: 'Instagram',
+  tiktok: 'TikTok',
+  youtube: 'YouTube',
+  x: 'X',
+  linktree: 'Linktree',
+  threads: 'Threads',
+  facebook: 'Facebook',
+  twitch: 'Twitch',
+  snapchat: 'Snapchat',
+};
+
+/**
+ * Display name for a platform id, used only when no handle/URL exists.
+ * Falls back to the platform id (or 'Link' for blank input) so the label
+ * is never empty.
+ */
+export function getSocialDisplayName(platform: string): string {
+  const id = platform.trim().toLowerCase();
+  return PLATFORM_DISPLAY_NAMES[id] ?? (id || 'Link');
+}
+
+/**
  * Deduplicate a list of links by `(platform, normalized-url)`.
  *
  * - Preserves the first occurrence of each unique key (input order stable).

--- a/apps/web/tests/unit/lib/social-platform.property.test.ts
+++ b/apps/web/tests/unit/lib/social-platform.property.test.ts
@@ -8,7 +8,11 @@
  */
 import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
-import { dedupeLinks, extractHandleFromUrl } from '@/lib/utils/social-platform';
+import {
+  dedupeLinks,
+  extractHandleFromUrl,
+  getSocialDisplayName,
+} from '@/lib/utils/social-platform';
 
 const platformArb = fc.constantFrom(
   'youtube',
@@ -147,6 +151,26 @@ describe('dedupeLinks (property)', () => {
       },
     ];
     expect(dedupeLinks(links)).toHaveLength(1);
+  });
+});
+
+describe('getSocialDisplayName', () => {
+  it('returns the display name for known platforms regardless of casing', () => {
+    expect(getSocialDisplayName('youtube')).toBe('YouTube');
+    expect(getSocialDisplayName('YouTube')).toBe('YouTube');
+    expect(getSocialDisplayName(' instagram ')).toBe('Instagram');
+  });
+
+  it('falls back to the platform id for unknown platforms', () => {
+    expect(getSocialDisplayName('myspace')).toBe('myspace');
+  });
+
+  it('never returns an empty string for arbitrary input', () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), raw => {
+        expect(getSocialDisplayName(raw).length).toBeGreaterThan(0);
+      })
+    );
   });
 });
 

--- a/apps/web/tests/unit/profile/profile-links-dedupe.test.tsx
+++ b/apps/web/tests/unit/profile/profile-links-dedupe.test.tsx
@@ -153,6 +153,35 @@ describe('ProfileLinkList — render-layer dedupe and label fallback', () => {
     expectNoBrokenStrings(container);
   });
 
+  it('falls back to the platform display name only when both handle and URL are missing', async () => {
+    // Last-resort case: no handle extractable AND no usable URL. The row must
+    // still render a human-readable label (the platform display name) rather
+    // than an empty string.
+    const links: PreviewPanelLink[] = [
+      makeLink({ id: '1', platform: 'youtube', url: '' }),
+    ];
+
+    const { container } = render(
+      <ProfileLinkList links={links} selectedCategory='social' />
+    );
+
+    expect(screen.getByText('YouTube')).toBeDefined();
+    expectNoBrokenStrings(container);
+  });
+
+  it('collapses duplicate rows that both lack handle and URL into one row', async () => {
+    const links: PreviewPanelLink[] = [
+      makeLink({ id: '1', platform: 'youtube', url: '' }),
+      makeLink({ id: '2', platform: 'youtube', url: '  ' }),
+    ];
+
+    render(<ProfileLinkList links={links} selectedCategory='social' />);
+
+    const rows = screen.getAllByTestId(/^sidebar-link-row-/);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('YouTube');
+  });
+
   it('renders multiple platforms with no duplicates after a noisy fixture (regression)', async () => {
     // Recreates the production screenshot exactly: Instagram + TikTok +
     // YouTube × 3 (two dupes + one malformed handle-less URL).


### PR DESCRIPTION
## Summary

Child of JOV-2148 (PR A, code-only). Fixes the profile Social tab rendering duplicate/bare-labeled rows (the "@timwhite, @timwhite, YouTube" screenshot bug).

- **Dedupe by canonical identity:** rows are deduped at the render layer via `dedupeLinks` (`apps/web/lib/utils/social-platform.ts`) — normalized `(platform, url)` key collapses casing, `www.`, and trailing-slash variants while keeping distinct query strings and genuinely distinct channels.
- **Fail-safe handle label:** `LinkItem` label chain in `ProfileLinkList.tsx` is now handle (`@x`) → URL hostname (`formatDisplayHost`) → `getSocialDisplayName(platform)` **only** when no handle/URL exists at all. A bare platform name can no longer masquerade as a handle, and a row with neither handle nor URL no longer renders an empty label.
- **No migration/schema change** — enforcement is code-only, per the ticket's hard constraint.

## Test plan

Regression tests (unit + property-style, matching repo setup):
- exact duplicates collapse to one row (`collapses three identical YouTube rows into one row`)
- same handle with different casing/URL forms (`trailing slash + casing variants`, query-string casing)
- missing handle with URL present → hostname label, never bare platform name
- missing both → platform display name as last resort; duplicate handle-less rows still collapse
- noisy-fixture regression recreating the production screenshot

Results:
- `pnpm --filter web exec vitest run tests/unit/profile/profile-links-dedupe.test.tsx tests/unit/lib/social-platform.property.test.ts` → **20/20 passed**
- `pnpm biome check` (4 touched files) → clean
- `pnpm --filter @jovie/web run typecheck` → clean
- `git diff --check origin/main...HEAD` → clean; diff is +99/-3 across 4 files
- Pre-push gate (CI harness validation) → passed

## Screenshots

UI-visible change but no runtime screenshot captured in this environment; behavior is asserted by the render-layer tests above (label text + row counts via `sidebar-link-row-*` testids).

Fixes JOV-4847
https://linear.app/jovie/issue/JOV-4847