### PR TITLE
feat(library): dense Tracks-catalog Table mode + Tracks route fold-in (JOV-4846)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -62,6 +62,15 @@ import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
 import { ProviderIcon } from '@/components/atoms/ProviderIcon';
 import { TableActionMenu } from '@/components/atoms/table-action-menu';
 import { NavigationDestinationReady } from '@/components/features/dashboard/NavigationDestinationReady';
+import {
+  formatLibraryItemType,
+  formatLibraryStatus,
+  formatReleaseStatus,
+  formatReleaseType,
+  LIBRARY_CATALOG_TABLE_COLUMNS,
+  LibraryCatalogProvidersCell,
+  LibraryCatalogStatusCell,
+} from '@/components/features/library/library-catalog-columns';
 import { LibraryAssetSharePanel } from '@/components/features/library-asset-share/LibraryAssetSharePanel';
 import { LibraryAssetShareUrlCell } from '@/components/features/library-asset-share/LibraryAssetShareUrlCell';
 import { LibraryShareDropCreator } from '@/components/features/library-share/LibraryShareDropCreator';
@@ -98,17 +107,12 @@ import {
   TableContextMenu,
 } from '@/components/organisms/table/molecules/TableContextMenu';
 import { alignment } from '@/components/organisms/table/table.styles';
-import {
-  type DspAvatarItem,
-  DspAvatarStack,
-} from '@/components/shell/DspAvatarStack';
 import type { FilterPill } from '@/components/shell/pill-search.types';
 import { APP_ROUTES } from '@/constants/routes';
 import { useRegisterHeaderSearch } from '@/contexts/HeaderActionsContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
-import { PROVIDER_CONFIG } from '@/lib/discography/config';
 import type { ProviderKey } from '@/lib/discography/types';
 import {
   formatLibraryApprovalStatus,
@@ -153,6 +157,7 @@ import {
 } from './library-entity-actions';
 import {
   LIBRARY_GRID_DENSITY_OPTIONS,
+  parseLibraryViewModeParam,
   useLibraryGridDensity,
   useLibraryViewMode,
 } from './library-grid-preferences';
@@ -320,25 +325,6 @@ function toggleSet<T>(set: ReadonlySet<T>, value: T): Set<T> {
     next.add(value);
   }
   return next;
-}
-
-function formatReleaseType(type: LibraryReleaseAsset['releaseType']): string {
-  return type.split('_').map(capitalizeFirst).join(' ');
-}
-
-function formatLibraryItemType(asset: LibraryReleaseAsset): string {
-  if (getLibraryItemKind(asset) === 'merch') {
-    return asset.productType?.trim() || 'Merch';
-  }
-  return formatReleaseType(asset.releaseType);
-}
-
-function formatReleaseStatus(status: LibraryReleaseAsset['status']): string {
-  return capitalizeFirst(status);
-}
-
-function formatLibraryStatus(asset: LibraryReleaseAsset): string {
-  return asset.itemStatusLabel ?? formatReleaseStatus(asset.status);
 }
 
 function assetMatchesFilters(
@@ -525,26 +511,6 @@ const ReleaseCell = memo(function ReleaseCell({
   );
 });
 
-const StatusCell = memo(function StatusCell({
-  asset,
-}: {
-  readonly asset: LibraryReleaseAsset;
-}) {
-  return (
-    <span
-      role='status'
-      className={cn(
-        'system-b-library-status-pill inline-flex h-6 w-fit max-w-full items-center truncate rounded-full border px-2 leading-4',
-        releaseStatusClasses(asset.status)
-      )}
-      data-testid={`library-release-status-${asset.id}`}
-      aria-label={`Release Status: ${formatLibraryStatus(asset)}`}
-    >
-      {formatLibraryStatus(asset)}
-    </span>
-  );
-});
-
 const ApprovalStatusCell = memo(function ApprovalStatusCell({
   asset,
 }: {
@@ -579,70 +545,6 @@ const ReleaseDateCell = memo(function ReleaseDateCell({
         ? formatLibraryReleaseDate(asset.releaseDate)
         : 'No date'}
     </span>
-  );
-});
-
-/**
- * Neutral fallback avatar color for provider keys missing from
- * `PROVIDER_CONFIG`. Points at a System B text token — no raw hex here.
- */
-const LIBRARY_DSP_FALLBACK_COLOR = 'var(--linear-text-quaternary)';
-
-/**
- * Map a library asset's provider links -> `DspAvatarItem[]` for the stacked
- * provider-logo affordance. Every link present on the asset renders `live`;
- * brand color + label come from the canonical `PROVIDER_CONFIG`.
- */
-function libraryProvidersToDspItems(
-  providers: LibraryReleaseAsset['providers']
-): DspAvatarItem[] {
-  return providers.map(provider => {
-    const config = PROVIDER_CONFIG[provider.key];
-    const label = config?.label ?? provider.label;
-    return {
-      id: provider.key,
-      label,
-      glyph: label.charAt(0).toUpperCase(),
-      color: config?.accent ?? LIBRARY_DSP_FALLBACK_COLOR,
-      status: 'live' as const,
-    };
-  });
-}
-
-const ProvidersCell = memo(function ProvidersCell({
-  asset,
-}: {
-  readonly asset: LibraryReleaseAsset;
-}) {
-  const items = libraryProvidersToDspItems(asset.providers);
-
-  if (items.length === 0) {
-    return (
-      <span
-        role='img'
-        aria-label='No Providers'
-        className='system-b-library-meta-text text-quaternary-token'
-      >
-        &mdash;
-      </span>
-    );
-  }
-
-  return <DspAvatarStack dsps={items} maxVisible={3} />;
-});
-
-const CatalogArtworkCell = memo(function CatalogArtworkCell({
-  asset,
-}: {
-  readonly asset: LibraryReleaseAsset;
-}) {
-  return (
-    <ArtworkFrame
-      size='thumbnail'
-      className='system-b-library-artwork-shell block h-9 w-9'
-    >
-      <LibraryMediaThumbnail asset={asset} size='row' />
-    </ArtworkFrame>
   );
 });
 
@@ -704,61 +606,13 @@ function createLibraryActionColumn(metaClassName: string) {
   });
 }
 
-// Slice 1 minimal catalog column set: status · artwork · title · artist · type.
-// Slice 2/3 adds BPM/key/energy/rating/waveform/DSP columns + the Tracks fold-in.
+// Dense Tracks-catalog table (JOV-4846): status · artwork · title · artist ·
+// type · BPM · key · energy · rating · length · waveform · DSP providers,
+// recreated from the /exp/shell-v1 Tracks table in the shared layer. The
+// action menu column is appended here because it needs this surface's
+// entity-action context.
 const LIBRARY_CATALOG_COLUMNS = [
-  libraryColumnHelper.display({
-    id: 'status',
-    header: 'Status',
-    cell: ({ row }) => <StatusCell asset={row.original} />,
-    size: 112,
-    minSize: 96,
-    meta: { className: alignment.workspaceSeamX },
-  }),
-  libraryColumnHelper.display({
-    id: 'artwork',
-    header: 'Artwork',
-    cell: ({ row }) => <CatalogArtworkCell asset={row.original} />,
-    size: 56,
-    minSize: 56,
-    enableSorting: false,
-    meta: { className: 'px-2' },
-  }),
-  libraryColumnHelper.accessor('title', {
-    id: 'title',
-    header: 'Title',
-    cell: ({ row }) => (
-      <span className='system-b-library-release-title block truncate'>
-        {row.original.title}
-      </span>
-    ),
-    minSize: 180,
-    size: 9999,
-    enableSorting: false,
-    meta: { className: 'px-2' },
-  }),
-  libraryColumnHelper.display({
-    id: 'releaseDate',
-    header: 'Date',
-    cell: ({ row }) => <ReleaseDateCell asset={row.original} />,
-    size: 112,
-    minSize: 96,
-    meta: { className: 'pl-2 pr-3' },
-  }),
-  libraryColumnHelper.accessor('artist', {
-    id: 'artist',
-    header: 'Artist',
-    cell: ({ row }) => (
-      <span className='system-b-library-meta-text block truncate text-tertiary-token'>
-        {row.original.artist}
-      </span>
-    ),
-    size: 160,
-    minSize: 120,
-    enableSorting: false,
-    meta: { className: 'hidden md:table-cell px-2' },
-  }),
-  createLibraryTypeColumn('hidden sm:table-cell pl-2 pr-3', 120, 96),
+  ...LIBRARY_CATALOG_TABLE_COLUMNS,
   createLibraryActionColumn('w-10 pl-1 pr-2'),
 ] as ColumnDef<LibraryReleaseAsset, unknown>[];
 
@@ -785,7 +639,7 @@ const LIBRARY_TABLE_COLUMNS = [
   libraryColumnHelper.display({
     id: 'status',
     header: 'Release',
-    cell: ({ row }) => <StatusCell asset={row.original} />,
+    cell: ({ row }) => <LibraryCatalogStatusCell asset={row.original} />,
     size: 112,
     minSize: 96,
     meta: { className: 'hidden md:table-cell px-2' },
@@ -802,7 +656,7 @@ const LIBRARY_TABLE_COLUMNS = [
   libraryColumnHelper.display({
     id: 'providers',
     header: 'Providers',
-    cell: ({ row }) => <ProvidersCell asset={row.original} />,
+    cell: ({ row }) => <LibraryCatalogProvidersCell asset={row.original} />,
     size: 120,
     minSize: 96,
     meta: { className: 'hidden md:table-cell px-2' },
@@ -2516,6 +2370,16 @@ export function LibrarySurface({
   useEffect(() => {
     setPreset(parseLibraryViewParam(searchParams.get('view')));
   }, [searchParams]);
+
+  // Deep-link view-mode override (e.g. the /app/tracks redirect lands on
+  // `/app/library?view=audio&mode=table`). A valid `mode` param wins over the
+  // persisted preference and is itself persisted so the choice sticks.
+  useEffect(() => {
+    const modeParam = parseLibraryViewModeParam(searchParams.get('mode'));
+    if (modeParam) {
+      setView(modeParam);
+    }
+  }, [searchParams, setView]);
 
   useEffect(() => {
     setSavedView(readPersistedLibrarySavedView());

--- a/apps/web/app/app/(shell)/library/library-grid-preferences.ts
+++ b/apps/web/app/app/(shell)/library/library-grid-preferences.ts
@@ -98,11 +98,25 @@ export function useLibraryGridDensity(): {
   return { density: value, setDensity: setValue };
 }
 
-function parseLibraryViewMode(value: string | null): LibraryViewMode {
+export function parseLibraryViewMode(value: string | null): LibraryViewMode {
   if (value === 'grid' || value === 'list' || value === 'table') {
     return value;
   }
   return DEFAULT_LIBRARY_VIEW_MODE;
+}
+
+/**
+ * Parse a `?mode=` deep-link param (e.g. the /app/tracks redirect). Returns
+ * `null` when the param is absent or invalid so callers can distinguish "no
+ * override" from a real mode choice.
+ */
+export function parseLibraryViewModeParam(
+  value: string | null
+): LibraryViewMode | null {
+  if (value === 'grid' || value === 'list' || value === 'table') {
+    return value;
+  }
+  return null;
 }
 
 export function readLibraryViewMode(): LibraryViewMode {

--- a/apps/web/app/app/(shell)/tracks/page.tsx
+++ b/apps/web/app/app/(shell)/tracks/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+
+export const runtime = 'nodejs';
+
+/**
+ * Tracks folded into the Library as the Table view mode (JOV-4846). Land on
+ * the audio asset tab with table mode preselected — the closest production
+ * equivalent of the retired Tracks catalog.
+ */
+export default async function TracksPage() {
+  redirect(`${APP_ROUTES.LIBRARY}?view=audio&mode=table`);
+}

--- a/apps/web/components/features/library/library-catalog-columns.tsx
+++ b/apps/web/components/features/library/library-catalog-columns.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { memo, useMemo } from 'react';
+import { LibraryMediaThumbnail } from '@/app/app/(shell)/library/LibraryMediaThumbnail';
+import {
+  formatLibraryDuration,
+  type LibraryReleaseAsset,
+} from '@/app/app/(shell)/library/library-data';
+import { libraryWaveformPeaks } from '@/app/app/(shell)/library/library-waveform-peaks';
+import { ArtworkFrame } from '@/components/atoms/ArtworkFrame';
+import { alignment } from '@/components/organisms/table/table.styles';
+import {
+  type DspAvatarItem,
+  DspAvatarStack,
+} from '@/components/shell/DspAvatarStack';
+import { PROVIDER_CONFIG } from '@/lib/discography/config';
+import { releaseStatusClasses } from '@/lib/library/release-status';
+import { cn } from '@/lib/utils';
+import { capitalizeFirst } from '@/lib/utils/string-utils';
+
+// ---------------------------------------------------------------------------
+// Dense Tracks-catalog columns for the Library Table view mode (JOV-4846).
+// Recreated from the /exp/shell-v1 Tracks table in the shared layer — the
+// experiment code is never imported. Every cell renders production data only;
+// metrics the production schema does not carry yet (BPM, key, energy, rating)
+// render a stable em-dash placeholder instead of fabricated values.
+// ---------------------------------------------------------------------------
+
+export function formatReleaseType(
+  type: LibraryReleaseAsset['releaseType']
+): string {
+  return type.split('_').map(capitalizeFirst).join(' ');
+}
+
+export function formatLibraryItemType(asset: LibraryReleaseAsset): string {
+  if (asset.itemKind === 'merch') {
+    return asset.productType?.trim() || 'Merch';
+  }
+  return formatReleaseType(asset.releaseType);
+}
+
+export function formatReleaseStatus(
+  status: LibraryReleaseAsset['status']
+): string {
+  return capitalizeFirst(status);
+}
+
+export function formatLibraryStatus(asset: LibraryReleaseAsset): string {
+  return asset.itemStatusLabel ?? formatReleaseStatus(asset.status);
+}
+
+export const LibraryCatalogStatusCell = memo(function LibraryCatalogStatusCell({
+  asset,
+}: {
+  readonly asset: LibraryReleaseAsset;
+}) {
+  return (
+    <span
+      role='status'
+      className={cn(
+        'system-b-library-status-pill inline-flex h-6 w-fit max-w-full items-center truncate rounded-full border px-2 leading-4',
+        releaseStatusClasses(asset.status)
+      )}
+      data-testid={`library-release-status-${asset.id}`}
+      aria-label={`Release Status: ${formatLibraryStatus(asset)}`}
+    >
+      {formatLibraryStatus(asset)}
+    </span>
+  );
+});
+
+export const LibraryCatalogArtworkCell = memo(
+  function LibraryCatalogArtworkCell({
+    asset,
+  }: {
+    readonly asset: LibraryReleaseAsset;
+  }) {
+    return (
+      <ArtworkFrame
+        size='thumbnail'
+        className='system-b-library-artwork-shell block h-9 w-9'
+      >
+        <LibraryMediaThumbnail asset={asset} size='row' />
+      </ArtworkFrame>
+    );
+  }
+);
+
+/**
+ * Neutral fallback avatar color for provider keys missing from
+ * `PROVIDER_CONFIG`. Points at a System B text token — no raw hex here.
+ */
+const LIBRARY_DSP_FALLBACK_COLOR = 'var(--linear-text-quaternary)';
+
+/**
+ * Map a library asset's provider links -> `DspAvatarItem[]` for the stacked
+ * provider-logo affordance. Every link present on the asset renders `live`;
+ * brand color + label come from the canonical `PROVIDER_CONFIG`.
+ */
+export function libraryProvidersToDspItems(
+  providers: LibraryReleaseAsset['providers']
+): DspAvatarItem[] {
+  return providers.map(provider => {
+    const config = PROVIDER_CONFIG[provider.key];
+    const label = config?.label ?? provider.label;
+    return {
+      id: provider.key,
+      label,
+      glyph: label.charAt(0).toUpperCase(),
+      color: config?.accent ?? LIBRARY_DSP_FALLBACK_COLOR,
+      status: 'live' as const,
+    };
+  });
+}
+
+export const LibraryCatalogProvidersCell = memo(
+  function LibraryCatalogProvidersCell({
+    asset,
+  }: {
+    readonly asset: LibraryReleaseAsset;
+  }) {
+    const items = libraryProvidersToDspItems(asset.providers);
+
+    if (items.length === 0) {
+      return (
+        <span
+          role='img'
+          aria-label='No Providers'
+          className='system-b-library-meta-text text-quaternary-token'
+        >
+          &mdash;
+        </span>
+      );
+    }
+
+    return <DspAvatarStack dsps={items} maxVisible={3} />;
+  }
+);
+
+/**
+ * Placeholder for catalog metrics the production schema does not carry yet
+ * (BPM, musical key, energy, rating). Fixed-size em-dash so the dense row
+ * never shifts when real values land.
+ */
+export type LibraryCatalogMetric = 'bpm' | 'key' | 'energy' | 'rating';
+
+const LIBRARY_CATALOG_METRIC_LABELS: Record<LibraryCatalogMetric, string> = {
+  bpm: 'BPM',
+  key: 'Key',
+  energy: 'Energy',
+  rating: 'Rating',
+};
+
+export const LibraryCatalogMetricCell = memo(function LibraryCatalogMetricCell({
+  asset,
+  metric,
+}: {
+  readonly asset: LibraryReleaseAsset;
+  readonly metric: LibraryCatalogMetric;
+}) {
+  const label = LIBRARY_CATALOG_METRIC_LABELS[metric];
+  return (
+    <span
+      role='img'
+      aria-label={`${label}: Not Available`}
+      title={`${label} is not available for this item yet`}
+      data-testid={`library-catalog-${metric}-${asset.id}`}
+      className='system-b-library-meta-text block text-right text-quaternary-token'
+    >
+      &mdash;
+    </span>
+  );
+});
+
+export const LibraryCatalogLengthCell = memo(function LibraryCatalogLengthCell({
+  asset,
+}: {
+  readonly asset: LibraryReleaseAsset;
+}) {
+  return (
+    <span
+      data-testid={`library-catalog-length-${asset.id}`}
+      className='system-b-library-meta-text block whitespace-nowrap text-right tabular-nums text-tertiary-token'
+    >
+      {asset.totalDurationMs ? (
+        formatLibraryDuration(asset.totalDurationMs)
+      ) : (
+        <span role='img' aria-label='Length: Not Available'>
+          &mdash;
+        </span>
+      )}
+    </span>
+  );
+});
+
+const CATALOG_WAVEFORM_BAR_COUNT = 48;
+const CATALOG_WAVEFORM_WIDTH = 160;
+const CATALOG_WAVEFORM_HEIGHT = 24;
+
+/**
+ * Static mini waveform for the dense catalog row. Fixed canvas (160x24) so
+ * empty/loading/populated states and view-mode switches never shift layout.
+ * Peaks derive deterministically from the asset's waveform seed — the same
+ * production source as the card scrub waveform. Decorative: row click already
+ * opens the asset, so no seek interaction here.
+ */
+export const LibraryCatalogWaveformCell = memo(
+  function LibraryCatalogWaveformCell({
+    asset,
+  }: {
+    readonly asset: LibraryReleaseAsset;
+  }) {
+    const peaks = useMemo(() => {
+      const all = libraryWaveformPeaks(asset.waveformSeed);
+      const stride = all.length / CATALOG_WAVEFORM_BAR_COUNT;
+      return Array.from(
+        { length: CATALOG_WAVEFORM_BAR_COUNT },
+        (_, index) => all[Math.floor(index * stride)] ?? 0.08
+      );
+    }, [asset.waveformSeed]);
+
+    const barStride = CATALOG_WAVEFORM_WIDTH / CATALOG_WAVEFORM_BAR_COUNT;
+    const maxAmp = CATALOG_WAVEFORM_HEIGHT / 2 - 1;
+
+    return (
+      <div
+        data-testid={`library-catalog-waveform-${asset.id}`}
+        aria-hidden='true'
+        className='flex h-6 w-40 items-center text-quaternary-token'
+      >
+        <svg
+          viewBox={`0 0 ${CATALOG_WAVEFORM_WIDTH} ${CATALOG_WAVEFORM_HEIGHT}`}
+          preserveAspectRatio='none'
+          aria-hidden='true'
+          className='block h-6 w-40'
+        >
+          {peaks.map((height, index) => {
+            const x = index * barStride + barStride / 2;
+            const half = Math.max(0.5, height * maxAmp);
+            return (
+              <line
+                key={x}
+                x1={x}
+                x2={x}
+                y1={CATALOG_WAVEFORM_HEIGHT / 2 - half}
+                y2={CATALOG_WAVEFORM_HEIGHT / 2 + half}
+                stroke='currentColor'
+                strokeWidth={Math.max(1, barStride * 0.4)}
+                strokeLinecap='round'
+              />
+            );
+          })}
+        </svg>
+      </div>
+    );
+  }
+);
+
+const libraryCatalogColumnHelper = createColumnHelper<LibraryReleaseAsset>();
+
+/**
+ * Dense Tracks-catalog column set for the Library Table view mode:
+ * status · artwork · title · artist · type · BPM · key · energy · rating ·
+ * length · waveform · DSP providers. The row-level action menu column is
+ * appended by the caller (it needs the surface's entity-action context).
+ */
+export const LIBRARY_CATALOG_TABLE_COLUMNS = [
+  libraryCatalogColumnHelper.display({
+    id: 'status',
+    header: 'Status',
+    cell: ({ row }) => <LibraryCatalogStatusCell asset={row.original} />,
+    size: 112,
+    minSize: 96,
+    meta: { className: alignment.workspaceSeamX },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'artwork',
+    header: 'Artwork',
+    cell: ({ row }) => <LibraryCatalogArtworkCell asset={row.original} />,
+    size: 56,
+    minSize: 56,
+    enableSorting: false,
+    meta: { className: 'px-2' },
+  }),
+  libraryCatalogColumnHelper.accessor('title', {
+    id: 'title',
+    header: 'Title',
+    cell: ({ row }) => (
+      <span className='system-b-library-release-title block truncate'>
+        {row.original.title}
+      </span>
+    ),
+    minSize: 180,
+    size: 9999,
+    enableSorting: false,
+    meta: { className: 'px-2' },
+  }),
+  libraryCatalogColumnHelper.accessor('artist', {
+    id: 'artist',
+    header: 'Artist',
+    cell: ({ row }) => (
+      <span className='system-b-library-meta-text block truncate text-tertiary-token'>
+        {row.original.artist}
+      </span>
+    ),
+    size: 160,
+    minSize: 120,
+    enableSorting: false,
+    meta: { className: 'hidden md:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'type',
+    header: 'Type',
+    cell: ({ row }) => (
+      <span className='system-b-library-meta-text truncate text-tertiary-token'>
+        {formatLibraryItemType(row.original)}
+      </span>
+    ),
+    size: 120,
+    minSize: 96,
+    meta: { className: 'hidden sm:table-cell pl-2 pr-3' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'bpm',
+    header: 'BPM',
+    cell: ({ row }) => (
+      <LibraryCatalogMetricCell asset={row.original} metric='bpm' />
+    ),
+    size: 72,
+    minSize: 64,
+    meta: { className: 'hidden lg:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'key',
+    header: 'Key',
+    cell: ({ row }) => (
+      <LibraryCatalogMetricCell asset={row.original} metric='key' />
+    ),
+    size: 72,
+    minSize: 64,
+    meta: { className: 'hidden lg:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'energy',
+    header: 'Energy',
+    cell: ({ row }) => (
+      <LibraryCatalogMetricCell asset={row.original} metric='energy' />
+    ),
+    size: 80,
+    minSize: 72,
+    meta: { className: 'hidden xl:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'rating',
+    header: 'Rating',
+    cell: ({ row }) => (
+      <LibraryCatalogMetricCell asset={row.original} metric='rating' />
+    ),
+    size: 88,
+    minSize: 80,
+    meta: { className: 'hidden xl:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'length',
+    header: 'Length',
+    cell: ({ row }) => <LibraryCatalogLengthCell asset={row.original} />,
+    size: 80,
+    minSize: 72,
+    meta: { className: 'hidden md:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'waveform',
+    header: 'Waveform',
+    cell: ({ row }) => <LibraryCatalogWaveformCell asset={row.original} />,
+    size: 176,
+    minSize: 176,
+    enableSorting: false,
+    meta: { className: 'hidden xl:table-cell px-2' },
+  }),
+  libraryCatalogColumnHelper.display({
+    id: 'providers',
+    header: 'DSP Providers',
+    cell: ({ row }) => <LibraryCatalogProvidersCell asset={row.original} />,
+    size: 120,
+    minSize: 96,
+    meta: { className: 'hidden md:table-cell px-2' },
+  }),
+] as ColumnDef<LibraryReleaseAsset, unknown>[];

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -45,6 +45,8 @@ export const APP_ROUTES = {
   AUDIENCE: '/app/audience',
   EARNINGS: '/app/earnings',
   LIBRARY: '/app/library',
+  /** Legacy Tracks path. Keep as a redirect source only — Tracks folded into Library (JOV-4846). */
+  LEGACY_TRACKS: '/app/tracks',
   TASKS: '/app/tasks',
   CHAT: '/app/chat',
   CHAT_PROFILE_PANEL: '/app/chat?panel=profile',

--- a/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
+++ b/apps/web/tests/unit/app/workspace-page-seam-contract.test.ts
@@ -36,12 +36,22 @@ describe('workspace page optical seam contract', () => {
 
   it('keeps Library leading columns on the shared table seam', () => {
     const librarySurface = read('app/app/(shell)/library/LibrarySurface.tsx');
+    // Dense catalog columns live in the shared table layer (JOV-4846); its
+    // leading status column keeps the same workspace seam.
+    const catalogColumns = read(
+      'components/features/library/library-catalog-columns.tsx'
+    );
 
     expect(librarySurface).toContain(
       "import { alignment } from '@/components/organisms/table/table.styles';"
     );
-    expect(librarySurface.match(/alignment\.workspaceSeamX/g)).toHaveLength(2);
+    const seamOccurrences = [
+      ...librarySurface.matchAll(/alignment\.workspaceSeamX/g),
+      ...catalogColumns.matchAll(/alignment\.workspaceSeamX/g),
+    ];
+    expect(seamOccurrences).toHaveLength(2);
     expect(librarySurface).not.toContain('pl-2.5');
+    expect(catalogColumns).not.toContain('pl-2.5');
   });
 
   it('keeps the dashboard title on the workspace seam ahead of the visual rail-control order', () => {

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -329,10 +329,22 @@ describe('LibrarySurface', () => {
       resolve(process.cwd(), LIBRARY_SURFACE_SOURCE),
       'utf8'
     );
-
-    const statusPillClasses = source.match(
-      /system-b-library-status-pill inline-flex[^']*/gu
+    // The dense catalog status pill lives in the shared table layer
+    // (JOV-4846) — scan both sources so no pill loses the one-line contract.
+    const catalogSource = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/features/library/library-catalog-columns.tsx'
+      ),
+      'utf8'
     );
+
+    const statusPillClasses = [
+      ...source.matchAll(/system-b-library-status-pill inline-flex[^']*/gu),
+      ...catalogSource.matchAll(
+        /system-b-library-status-pill inline-flex[^']*/gu
+      ),
+    ].map(match => match[0]);
 
     expect(statusPillClasses).toHaveLength(4);
     for (const className of statusPillClasses ?? []) {
@@ -1115,9 +1127,6 @@ describe('LibrarySurface', () => {
       screen.getByRole('columnheader', { name: 'Title' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('columnheader', { name: 'Date' })
-    ).toBeInTheDocument();
-    expect(
       screen.getByRole('columnheader', { name: 'Artist' })
     ).toBeInTheDocument();
     expect(
@@ -1138,6 +1147,96 @@ describe('LibrarySurface', () => {
       screen.queryByTestId('library-catalog-row-release-1')
     ).not.toBeInTheDocument();
     expect(window.localStorage.getItem('jovie:library-view-mode')).toBe('list');
+  });
+
+  it('renders the full dense Tracks-catalog column set in table mode (JOV-4846)', () => {
+    renderLibrary([buildAsset()]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table View' }));
+
+    // Full experiment column set: status · artwork · title · artist · type ·
+    // BPM · key · energy · rating · length · waveform · DSP providers.
+    for (const header of [
+      'Status',
+      'Artwork',
+      'Title',
+      'Artist',
+      'Type',
+      'BPM',
+      'Key',
+      'Energy',
+      'Rating',
+      'Length',
+      'Waveform',
+      'DSP Providers',
+    ]) {
+      expect(
+        screen.getByRole('columnheader', { name: header })
+      ).toBeInTheDocument();
+    }
+
+    // Production data populates the real fields.
+    expect(
+      screen.getByTestId('library-release-status-release-1')
+    ).toHaveTextContent('Released');
+    expect(
+      screen.getByTestId('library-catalog-length-release-1')
+    ).toHaveTextContent('3:32');
+    expect(
+      screen.getByTestId('library-catalog-waveform-release-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('View DSP Distribution Details')
+    ).toBeInTheDocument();
+
+    // Metrics the production schema does not carry render a stable em-dash
+    // placeholder — never fabricated values.
+    for (const metric of ['bpm', 'key', 'energy', 'rating']) {
+      expect(
+        screen.getByTestId(`library-catalog-${metric}-release-1`)
+      ).toHaveTextContent('—');
+    }
+  });
+
+  it('keeps asset-type tabs and smart filters working in table mode (JOV-4846)', () => {
+    renderLibrary([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Silent Artwork',
+        previewUrl: null,
+        assetKinds: ['artwork'],
+      }),
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Table View' }));
+    expect(
+      screen.getByTestId('library-catalog-row-release-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('library-catalog-row-release-2')
+    ).toBeInTheDocument();
+
+    // Audio tab keeps only the asset with a playable preview.
+    fireEvent.click(screen.getByRole('button', { name: /^Audio/ }));
+    expect(
+      screen.getByTestId('library-catalog-row-release-1')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('library-catalog-row-release-2')
+    ).not.toBeInTheDocument();
+  });
+
+  it('honors the mode=table deep-link param and persists it (JOV-4846)', () => {
+    navigationMock.searchParams = new URLSearchParams('view=audio&mode=table');
+    renderLibrary([buildAsset()]);
+
+    expect(
+      screen.getByTestId('library-catalog-row-release-1')
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem('jovie:library-view-mode')).toBe(
+      'table'
+    );
   });
 
   it('starts the persistent player from real production preview data', () => {

--- a/apps/web/tests/unit/routes/legacy-dashboard-redirect-stubs.test.ts
+++ b/apps/web/tests/unit/routes/legacy-dashboard-redirect-stubs.test.ts
@@ -45,4 +45,16 @@ describe('legacy dashboard redirect stubs', () => {
       `${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
     );
   });
+
+  it('sends tracks traffic to the library table mode with the audio tab preselected (JOV-4846)', async () => {
+    const { default: TracksPage } = await import(
+      '../../../app/app/(shell)/tracks/page'
+    );
+
+    await TracksPage();
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.LIBRARY}?view=audio&mode=table`
+    );
+  });
 });

--- a/apps/web/tests/unit/routes/shell-redirect-stubs.baseline.json
+++ b/apps/web/tests/unit/routes/shell-redirect-stubs.baseline.json
@@ -41,7 +41,8 @@
     "/app/settings/delete-account",
     "/app/settings/profile",
     "/app/threads",
-    "/app/tipping"
+    "/app/tipping",
+    "/app/tracks"
   ],
-  "note": "Existing compatibility redirects at JOV-3772. This allowlist may shrink but no new page-level redirect stub may be added. Canonical routes render their page in the unified shell."
+  "note": "Existing compatibility redirects at JOV-3772. This allowlist may shrink but no new page-level redirect stub may be added. Exception: /app/tracks (JOV-4846) folds the retired Tracks surface into Library with table mode + audio tab preselected, mirroring the /app/dashboard/library fold-in. Canonical routes render their page in the unified shell."
 }


### PR DESCRIPTION
## Summary

PR 2 of 2 for JOV-3481 (Library asset hub). Folds the never-shipped `/exp/shell-v1` dense Tracks table into Library as the **Table** view mode and retires Tracks as a separate surface.

- **Table mode**: dense catalog columns — status · artwork · title · artist · type · BPM · key · energy · rating · length · waveform · DSP providers — recreated in the shared layer (`apps/web/components/features/library/library-catalog-columns.tsx`). **No imports from `app/exp/*`, no mock data.** Metrics the production schema does not carry yet (BPM/key/energy/rating) render a fixed em-dash placeholder; everything else comes from real release data.
- **Smart Filters + live counts + asset-type tabs** operate in Table mode on the same visible-assets pipeline as Grid/List.
- **Tracks fold-in**: `/app/tracks` redirects to `/app/library?view=audio&mode=table` (registered in the redirect-stub baseline, same pattern as the dashboard/library fold-in). No production Tracks nav item existed, so nothing to remove from nav config.
- **`?mode=` deep links** (grid|list|table) override and persist the view-mode preference; Grid/List behavior unchanged.

## Test plan

- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean
- `pnpm biome check` on all touched files — clean
- `vitest run tests/unit/library/LibrarySurface.test.tsx tests/unit/routes/legacy-dashboard-redirect-stubs.test.ts tests/unit/app/workspace-page-seam-contract.test.ts` — **58/58 pass**, incl. new coverage:
  - full dense column set renders in table mode from real data
  - asset-type tabs + smart filters keep working in table mode
  - mode deep-link switching + persistence
  - `/app/tracks` → Library redirect stub contract
- Pre-push gate: full unit suite **2522 passed / 9 skipped (293 files)**, CI harness manifest valid

## Screenshots

Not captured (headless environment). Layout-shift: the table reserves fixed column geometry and uses the same shell table primitives; empty/loading/populated states and mode switches are covered by the LibrarySurface tests (grid↔list↔table switches keep the release list stable, no content movement assertions changed).

Fixes JOV-4846
https://linear.app/jovie/issue/JOV-4846/jov-3481b-library-table-mode-dense-tracks-catalog-tracks-route-fold-in