### PR TITLE
feat(marketing): add newsletter-signup recipe stub (JOV-4067)

### DIFF
--- a/apps/web/data/marketing/composition.ts
+++ b/apps/web/data/marketing/composition.ts
@@ -140,6 +140,7 @@ export const MarketingCompositionSchema = z.object({
     'waitlist',
     'seo',
     'blog-landing',
+    'newsletter-signup',
   ] as const),
   sections: z.array(MarketingCompositionSectionSchema),
   primaryCtaLabel: z.string(),
@@ -265,7 +266,18 @@ const RECIPE_DECISION_TABLE: readonly {
     recipeId: 'homepage',
     reason: 'traffic=home or general+category',
   },
-  // 11. SEO — informational intent OR catch-all (fan audience falls here per J1 —
+  // 11. Newsletter signup — subscribe conversion (JOV-4067, adversarial C1).
+  //     blog-index+subscribe is claimed by blog-landing (row 6); artist/agency/
+  //     enterprise-buyer audiences are claimed by their rows above; intent-specific
+  //     rows (compare/price/launch/feature) and homepage keep precedence. Before
+  //     this row, subscribe with intent≠blog-index fell to seo.
+  {
+    when: b => b.desiredConversion === 'subscribe',
+    recipeId: 'newsletter-signup',
+    reason:
+      'conversion=subscribe (non-blog-index intent → standalone newsletter signup, not seo)',
+  },
+  // 12. SEO — informational intent OR catch-all (fan audience falls here per J1 —
   //     fan is a documented audience with no recipe yet; served by seo until fan-lp exists)
   {
     when: b => b.intent === 'informational' || b.targetAudience === 'fan',
@@ -634,7 +646,8 @@ function matchesVariant(
       return (
         brief.targetAudience === 'general' ||
         recipeId === 'waitlist' ||
-        recipeId === 'blog-landing'
+        recipeId === 'blog-landing' ||
+        recipeId === 'newsletter-signup'
       );
     }
     return false;
@@ -926,7 +939,7 @@ export function resolveComposition(input: unknown): MarketingComposition {
       } else if (sectionId === 'cta') {
         ctaPosition = 'primary'; // final CTA section is the closing primary
       } else if (sectionId === 'capture') {
-        ctaPosition = 'primary'; // capture is a conversion section (waitlist/blog-landing)
+        ctaPosition = 'primary'; // capture is a conversion section (waitlist/blog-landing/newsletter-signup)
       }
       return {
         sectionId,
@@ -994,4 +1007,4 @@ function pickDegradationRung(
 
 // Import the spec version from the barrel (avoids a circular import via index.ts)
 // We re-declare it here as the source of truth; index.ts re-exports.
-export const MARKETING_SPEC_VERSION = '1.0.0';
+export const MARKETING_SPEC_VERSION = '1.1.0';

--- a/apps/web/data/marketing/recipes.ts
+++ b/apps/web/data/marketing/recipes.ts
@@ -12,6 +12,7 @@
  *             feedback (humanOptIn manifest field per DX2), then promotes to proven.
  *
  * Charter's 11 recipes are all kept (T1 resolution: keep all 11, two-tier).
+ * Post-charter stubs per ARCHITECTURE.md §15: newsletter-signup (JOV-4067).
  */
 
 import type { MarketingAudience, MarketingSectionId } from './sections';
@@ -27,7 +28,8 @@ export type RecipeId =
   | 'launch'
   | 'waitlist'
   | 'seo'
-  | 'blog-landing';
+  | 'blog-landing'
+  | 'newsletter-signup';
 
 export const MARKETING_RECIPE_IDS: readonly RecipeId[] = [
   'homepage',
@@ -41,6 +43,7 @@ export const MARKETING_RECIPE_IDS: readonly RecipeId[] = [
   'waitlist',
   'seo',
   'blog-landing',
+  'newsletter-signup',
 ] as const;
 
 export type RecipeStatus = 'proven' | 'stub';
@@ -1035,6 +1038,66 @@ export const MARKETING_RECIPES: readonly MarketingRecipe[] = [
     neverUse: [
       'With <3 blog posts (zero-proof analog for content — omit the section means no blog)',
       'With capture as the primary conversion (blog-landing primary = read posts; capture = secondary newsletter signup)',
+    ],
+  },
+
+  // ── newsletter-signup (stub — JOV-4067, adversarial C1) ────────────────────
+  {
+    id: 'newsletter-signup',
+    label: 'Newsletter Signup',
+    status: 'stub',
+    audience: 'general',
+    // Stub: order + arc only; first implementation goes through taste feedback then promotes (Design F10).
+    // Standalone newsletter signup page — NOT early-access waitlist (that is the
+    // waitlist recipe, conversion=request-access). Before this recipe existed,
+    // conversion=subscribe with intent≠blog-index fell to seo (adversarial C1).
+    sectionOrder: ['hero', 'capture', 'faq', 'cta'],
+    arc: [
+      {
+        beat: 'promise',
+        feeling: 'what the newsletter gives me',
+        section: 'hero',
+      },
+      {
+        beat: 'subscribe',
+        feeling: 'one email, no commitment',
+        section: 'capture',
+      },
+      {
+        beat: 'objection',
+        feeling: 'frequency/unsubscribe questions answered',
+        section: 'faq',
+      },
+      { beat: 'action', feeling: 'subscribe now', section: 'cta' },
+    ],
+    hierarchy: {
+      oneBigIdea: 'Subscribe to the Jovie newsletter — one email worth opening',
+      seeFirst: 'hero',
+      second: 'capture',
+      third: 'faq',
+      emphasisBudget: {
+        maxDisplayScaleMoments: 1,
+        maxFullBleedBreaks: 1,
+        maxHeroWeightProofElements: 1,
+      },
+      aboveTheFoldContract: {
+        desktop: ['hero', 'capture'], // capture form visible without scroll
+        mobile: ['hero', 'capture'],
+      },
+    },
+    ctaCadence: {
+      strategy: 'sparse',
+      primaryLabel: 'Subscribe',
+      cadence: 'hero-only', // capture IS the conversion — no competing CTA
+    },
+    minContent: ['hero.headline', 'capture.inputSlot'],
+    maxContent: { maxSections: 5 },
+    chooseWhen:
+      'conversion=subscribe AND intent≠blog-index (standalone newsletter signup — blog-index+subscribe stays on blog-landing where capture is secondary)',
+    neverUse: [
+      'For early-access waitlist (use waitlist recipe — request-access conversion, different promise)',
+      'With multiple competing CTAs (capture is the conversion — one input, one submit)',
+      'Without interaction states on capture (Design F2: submitting/success/error/already-subscribed)',
     ],
   },
 ] as const;

--- a/apps/web/data/marketing/sections.ts
+++ b/apps/web/data/marketing/sections.ts
@@ -1510,7 +1510,7 @@ export const MARKETING_SECTIONS: readonly MarketingSection[] = [
         media: 'none',
         alignment: 'centered',
         chooseWhen:
-          'audience=general OR recipe=waitlist OR recipe=blog-landing (newsletter signup)',
+          'audience=general OR recipe=waitlist OR recipe=blog-landing OR recipe=newsletter-signup (newsletter signup)',
         status: 'unproven',
       },
     ],

--- a/apps/web/tests/unit/marketing/recipe-manifest.test.ts
+++ b/apps/web/tests/unit/marketing/recipe-manifest.test.ts
@@ -764,6 +764,35 @@ describe('marketing decision engine determinism (golden fixtures)', () => {
       },
       expectedRecipeId: 'blog-landing',
     },
+    // JOV-4067 (adversarial C1): subscribe conversion with intent≠blog-index →
+    // newsletter-signup (previously fell to seo)
+    {
+      name: 'general + subscribe + informational → newsletter-signup (NOT seo — C1)',
+      brief: {
+        targetAudience: 'general',
+        desiredConversion: 'subscribe',
+        intent: 'informational',
+      },
+      expectedRecipeId: 'newsletter-signup',
+    },
+    {
+      name: 'fan + subscribe → newsletter-signup (subscribe row precedes fan→seo fallthrough)',
+      brief: {
+        targetAudience: 'fan',
+        desiredConversion: 'subscribe',
+        intent: 'informational',
+      },
+      expectedRecipeId: 'newsletter-signup',
+    },
+    {
+      name: 'label + subscribe + category → newsletter-signup (no audience/intent row claims it)',
+      brief: {
+        targetAudience: 'label',
+        desiredConversion: 'subscribe',
+        intent: 'category',
+      },
+      expectedRecipeId: 'newsletter-signup',
+    },
     {
       name: 'general + feature → feature',
       brief: {

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/AGENT_GUIDE.md
 -->
 # Marketing Agent Guide
@@ -11,7 +11,7 @@ doc-freshness: docs/marketing/AGENT_GUIDE.md
 > `COMPOSITION_RULES.md`) are optional commentary. Copy generation follows the
 > typed contract below.
 
-spec-version: 1.0.0 · registry: `apps/web/data/marketing/index.ts`.
+spec-version: 1.1.0 · registry: `apps/web/data/marketing/index.ts`.
 
 ## The 4-step procedure
 

--- a/docs/marketing/ARCHITECTURE.md
+++ b/docs/marketing/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/ARCHITECTURE.md
 -->
 # Marketing Architecture
@@ -11,7 +11,7 @@ doc-freshness: docs/marketing/ARCHITECTURE.md
 > strategy. Agents: start at [`AGENT_GUIDE.md`](./AGENT_GUIDE.md) — it is the
 > sole entrypoint (≤400 lines). This file is reference.
 
-spec-version: 1.0.0 · registry: `apps/web/data/marketing/index.ts` ·
+spec-version: 1.1.0 · registry: `apps/web/data/marketing/index.ts` ·
 charter: `.context/marketing-architecture/GOAL.md` (amended, sole authority) ·
 reviews: CEO + Eng + Design + DX (all CLEAR, final gate A, 2026-07-06).
 
@@ -35,7 +35,7 @@ The contract for consumer agents:
 GOAL.md (charter) ──▶ research digests ──▶ typed registry (apps/web/data/marketing/)
                                                   │ owns ALL normative rules
                                                   │ - sections.ts: taxonomy + variants + chooseWhen + lifecycle
-                                                  │ - recipes.ts:  11 recipes + arc + ctaCadence + hierarchy
+                                                  │ - recipes.ts:  12 recipes + arc + ctaCadence + hierarchy
                                                   │ - composition.ts: resolveComposition(brief) → tuple (Zod)
                                                   │ - routeManifest.ts: route ⇔ recipeId | exempt
                                                   │
@@ -139,8 +139,9 @@ The load-bearing laws:
 
 ## 7. Recipe system
 
-11 recipes, two-tier (Design F10): proven (shipped reference route) vs stub
-(order + arc only; first implementation promotes).
+12 recipes, two-tier (Design F10): proven (shipped reference route) vs stub
+(order + arc only; first implementation promotes). Charter's 11 plus the
+`newsletter-signup` stub added per §15 (JOV-4067).
 
 | id | status | reference | audience |
 |---|---|---|---|
@@ -155,6 +156,7 @@ The load-bearing laws:
 | `waitlist` | stub | — | general |
 | `agency-lp` | stub | — | agency |
 | `enterprise` | stub | — | enterprise-buyer |
+| `newsletter-signup` | stub | — | general |
 
 Full per-recipe definitions (section order, arc, hierarchy, ctaCadence,
 substitutions, fallbacks, min/max content): see
@@ -176,7 +178,7 @@ Algorithm:
 4. Zero-proof filter: drop proof/trust sections without verified data.
 5. Ordering legality: drop sections whose `illegalAfter`/`requiresPrior` are violated.
 6. Variant selection: per section, walk variants; first match wins; no-match → `defaultVariant`.
-7. CTA position assignment: hero=primary, cta section=primary (terminal), capture=primary (waitlist/blog-landing).
+7. CTA position assignment: hero=primary, cta section=primary (terminal), capture=primary (waitlist/blog-landing/newsletter-signup).
 8. Trace: record every step for the AGENT_GUIDE worked example + failure messages.
 
 The output tuple (`MarketingComposition`) has an owned Zod schema (DX11):

--- a/docs/marketing/COMPOSITION_RULES.md
+++ b/docs/marketing/COMPOSITION_RULES.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/COMPOSITION_RULES.md
 -->
 # Marketing Composition Rules

--- a/docs/marketing/DESIGN_GAPS.md
+++ b/docs/marketing/DESIGN_GAPS.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/DESIGN_GAPS.md
 -->
 # Missing-section governance

--- a/docs/marketing/MODEL_USAGE.md
+++ b/docs/marketing/MODEL_USAGE.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/MODEL_USAGE.md
 -->
 # Model usage ledger

--- a/docs/marketing/RECIPE_CATALOG.md
+++ b/docs/marketing/RECIPE_CATALOG.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/RECIPE_CATALOG.md
 -->
 # Marketing Recipe Catalog
@@ -10,9 +10,10 @@ doc-freshness: docs/marketing/RECIPE_CATALOG.md
 > Anchors `#recipe-{id}` are parity-asserted against the registry by the
 > manifest gate.
 
-11 recipes, two-tier (Design F10): `proven` (shipped reference route) vs `stub`
+12 recipes, two-tier (Design F10): `proven` (shipped reference route) vs `stub`
 (order + arc only; first implementation goes through human taste feedback
-then promotes). CI refuses `proven` without a reference route.
+then promotes). CI refuses `proven` without a reference route. (Charter's 11 +
+`newsletter-signup` stub per JOV-4067 / ARCHITECTURE.md §15.)
 
 ## #recipe-homepage (proven)
 
@@ -215,3 +216,24 @@ section means no blog).
 **Never:** with <3 blog posts (zero-proof analog for content); with capture as
 the primary conversion (blog-landing primary = read posts; capture = secondary
 newsletter signup).
+
+## #recipe-newsletter-signup (stub)
+
+**No reference route** (JOV-4067, adversarial C1). **Audience:** general.
+**Sections (4):** hero → capture → faq → cta.
+
+**Arc:** promise → subscribe → objection → action.
+
+**CTA cadence:** sparse, "Subscribe", hero-only (capture IS the conversion —
+no competing CTA).
+
+**Decision tree:** `conversion=subscribe AND intent≠blog-index` (standalone
+newsletter signup — blog-index+subscribe stays on blog-landing where capture
+is secondary; artist/agency/enterprise-buyer audiences keep their recipes).
+Before this recipe, subscribe with intent≠blog-index fell to seo. First
+implementation goes through taste feedback then promotes to proven.
+
+**Never:** for early-access waitlist (use waitlist — request-access conversion,
+different promise); with multiple competing CTAs (capture is the conversion —
+one input, one submit); without interaction states on capture (Design F2:
+submitting/success/error/already-subscribed).

--- a/docs/marketing/SECTION_CATALOG.md
+++ b/docs/marketing/SECTION_CATALOG.md
@@ -1,5 +1,5 @@
 <!--
-spec-version: 1.0.0
+spec-version: 1.1.0
 doc-freshness: docs/marketing/SECTION_CATALOG.md
 -->
 # Marketing Section Catalog
@@ -173,7 +173,8 @@ screenshot or icon; pure text = use `feature-grid` icon-list variant.
 ### #section-capture
 
 **Purpose:** Fan-capture as a PRODUCT DEMO, not just an email form. Phone-framed
-capture demo for artist recipes; email-only for waitlist/blog-landing.
+capture demo for artist recipes; email-only for waitlist/blog-landing/
+newsletter-signup.
 
 **Rationale:** Jovie delta (prior-art §3). Capture is a product demo showing
 the value of capture, with interaction states (submitting/success/error/


### PR DESCRIPTION
## Summary

Per `docs/marketing/ARCHITECTURE.md` §15, a standalone newsletter signup page (blog newsletter subscription, not the early-access waitlist) had no recipe — `desiredConversion=subscribe` with intent≠blog-index fell through to `seo`. This adds the `newsletter-signup` stub recipe (adversarial C1).

- New `newsletter-signup` recipe (status: `stub`) in `apps/web/data/marketing/recipes.ts`: section order `hero → capture → faq → cta`, arc promise → subscribe → objection → action, sparse CTA cadence (capture IS the conversion — no competing CTA), emphasis budget + above-the-fold contract.
- Composition routing: `subscribe` + intent≠blog-index now resolves to `newsletter-signup` instead of `seo` (`apps/web/data/marketing/composition.ts`); blog-index+subscribe stays on `blog-landing` where capture is secondary.
- `sections.ts` + recipe-manifest tests extended for the new recipe id.
- Marketing docs updated: `ARCHITECTURE.md`, `RECIPE_CATALOG.md`, `AGENT_GUIDE.md`, `COMPOSITION_RULES.md`, `DESIGN_GAPS.md`, `MODEL_USAGE.md`, `SECTION_CATALOG.md`.

## Test plan

- `pnpm --filter web exec vitest run tests/unit/marketing/recipe-manifest.test.ts` — 40/40 passed (includes new newsletter-signup manifest assertions)
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean
- `pnpm biome check` on all touched source/test files — clean
- `git diff --check origin/main...HEAD` — clean

## Screenshots

No rendered UI change — this is a data-level recipe stub; first visual implementation goes through taste feedback before promotion to proven (per Design F10).

Fixes JOV-4067 — https://linear.app/jovie/issue/JOV-4067/marketing-newsletter-signup-recipe-stub