### PR TITLE
feat(pitch): add static PDF download link to investor brief (JOV-4850)

### DIFF
--- a/apps/web/components/features/pitch/InvestorBrief.tsx
+++ b/apps/web/components/features/pitch/InvestorBrief.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@jovie/ui';
-import { ArrowRight, Mail } from 'lucide-react';
+import { ArrowRight, Download, Mail } from 'lucide-react';
 import Link from 'next/link';
 import { Logo } from '@/components/atoms/Logo';
 import { fundraisingRegistry } from '@/lib/investors/fundraising-registry';
 import { PitchEngagement } from './PitchEngagement';
 
 const CONTACT_EMAIL = 't@meetjovie.com';
+const PITCH_DECK_PDF_URL = '/Jovie-Pitch-Deck.pdf';
 
 const statusTone = {
   LIVE: 'text-accent-blue',
@@ -66,6 +67,18 @@ export function InvestorBrief({
           </Button>
           <Button asChild variant='secondary'>
             <a href='#brief'>Read The Brief</a>
+          </Button>
+          <Button asChild variant='secondary'>
+            <a
+              href={PITCH_DECK_PDF_URL}
+              download
+              target='_blank'
+              rel='noopener'
+              aria-label='Download Deck As PDF'
+            >
+              <Download className='size-4' aria-hidden='true' />
+              Download Deck
+            </a>
           </Button>
           <Button asChild variant='ghost'>
             <Link href='/investor-portal/closed-loop-creator'>

--- a/apps/web/tests/e2e/pitch.spec.ts
+++ b/apps/web/tests/e2e/pitch.spec.ts
@@ -26,6 +26,10 @@ test.describe('public investor brief', () => {
       page.getByRole('link', { name: 'Request A Meeting' }).first()
     ).toHaveAttribute('href', /mailto:t@meetjovie\.com/iu);
 
+    await expect(
+      page.getByRole('link', { name: 'Download Deck As PDF' })
+    ).toHaveAttribute('href', '/Jovie-Pitch-Deck.pdf');
+
     const appendix = page.getByTestId('pitch-appendix');
     await expect(appendix).not.toHaveAttribute('open', '');
     await expect(appendix).toContainText('Narrative Boundary');


### PR DESCRIPTION
## Summary

Closes the remaining gap in JOV-4850 (GH#9010): both `/pitch` (public, NOINDEX) and `/investor-portal` (token-gated) render the shared `InvestorBrief`, but neither exposed the static pitch-deck PDF. This adds a **Download Deck** button to the hero CTA group pointing at `/Jovie-Pitch-Deck.pdf` (`download`, `target="_blank"`, `rel="noopener"`, `aria-label="Download Deck As PDF"`), and an e2e assertion that the link is present.

**Scope note (important):** most of the ticket's exact scope already landed on `main` via the investor-brief redesign, and parts are obsolete:
- ✅ Public NOINDEX `/pitch` exists (`apps/web/app/pitch/page.tsx`) — renders `InvestorBrief`, no auth gate
- ✅ `PITCH: '/pitch'` route constant, footer Company → Pitch link, committed `apps/web/public/Jovie-Pitch-Deck.pdf`, e2e spec with PDF HEAD 200
- ⚠️ `DeckViewer` **no longer exists** — the deck-based portal was replaced by `InvestorBrief`; no `globalThis.print()` remains in the investor flow, so the `pdfUrl` prop / print-fallback items are moot. Per the ticket's "implement fresh from current `origin/main`" note, this PR adds the PDF download to the component that actually serves both routes.

## Test plan

- `pnpm biome check --write` on touched files — clean
- `pnpm --filter @jovie/web run typecheck` — clean (also re-run by lint-staged on commit)
- eslint + a11y:check:staged — clean (pre-commit)
- `apps/web/tests/e2e/pitch.spec.ts` — asserts PDF link present with correct href (new), page renders, NOINDEX robots, 7 slides, PDF HEAD 200 (existing). E2E runs in CI; local playwright needs the doppler-wrapped dev server.
- `git diff --check` + diff stat inspected before push

## Screenshots

Not captured locally (headless unattended env); change is a single secondary-variant button ("Download Deck" with download icon) added to the existing hero CTA row on `/pitch` and `/investor-portal`.

Fixes JOV-4850
Linear: https://linear.app/jovie/issue/JOV-4850/gh9010-public-pitch-route-reusing-the-investor-deck-noindex