### PR TITLE
fix(shipper): pass --always-approve to grok CLI so headless runs ship PRs

### DIFF
--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -837,6 +837,7 @@ export function buildAgentCommand(
         String(route.maxTurns),
         '--permission-mode',
         config.grokPermissionMode,
+        '--always-approve',
         '--no-alt-screen',
       ],
     };

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -702,6 +702,7 @@ describe('codex issue shipper prompt', () => {
       '50',
       '--permission-mode',
       'auto',
+      '--always-approve',
       '--no-alt-screen',
     ]);
     expect(command.args).not.toContain('--sandbox');


### PR DESCRIPTION
## Problem
Grok 4.5 CLI works headless for smokes, but the issue-shipper's `buildAgentCommand` never passes `--always-approve`. With `--permission-mode auto`, headless Grok asks/refuses to apply edits → 0 PRs shipped from 100s of 'successful' runs.

## Fix
Add `--always-approve` to the grok CLI args in `buildAgentCommand`. Keep the configured session model (`grok-4.5`) unchanged. The deterministic finisher then commits/pushes/PRs the produced worktree diff.

## Test
Focused `codex-issue-shipper.test.mjs` grok test updated to assert `--always-approve`; 77/77 pass. Biome lint clean. (Pre-existing unrelated tsc errors in the test file unchanged.)