### PR TITLE
fix(ci): make production public-profile alias perf gate warning-only

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1112,6 +1112,14 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    # Warning-only on production alias (JOV-4854 / #15586): cold-cache single-sample
+    # noise must not fail Production Verified. Measurement is retained; the staged
+    # immutable public-profile budget gate in promote-production stays hard.
+    # Re-evaluate when: public-profile usable-alias-result-max p95 stays ≤1500ms for
+    # 14 consecutive Production Controller runs without cold-cache single-sample
+    # false-reds — then restore hard-fail if product stability allows.
+    outputs:
+      performance_status: ${{ steps.alias-perf.outputs.performance_status }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1120,19 +1128,28 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - uses: ./.github/actions/setup-playwright
       - name: Gate canonical public-profile aliases on usable results
+        id: alias-perf
         working-directory: apps/web
         env:
           CI: 'true'
-        run: >-
-          pnpm exec tsx scripts/performance-budgets-guard.ts
-          --base-url https://jov.ie
-          --runs 5
-          --route-id public-profile-listen
-          --route-id public-profile-music
-          --route-id public-profile-subscribe
-          --route-id public-profile-tip
-          --route-id public-profile-tour
-          --route-id public-profile-releases
+        run: |
+          set -euo pipefail
+          # Keep measuring post-promote alias budgets, but treat budget misses as
+          # warnings so a single cold-cache sample cannot red Production Verified.
+          if ! pnpm exec tsx scripts/performance-budgets-guard.ts \
+            --base-url https://jov.ie \
+            --runs 5 \
+            --route-id public-profile-listen \
+            --route-id public-profile-music \
+            --route-id public-profile-subscribe \
+            --route-id public-profile-tip \
+            --route-id public-profile-tour \
+            --route-id public-profile-releases; then
+            echo "::warning::Production public-profile alias usable-result budgets failed on jov.ie (JOV-4854: warning-only until p95 ≤1500ms for 14 consecutive Production Controller runs)."
+            echo "performance_status=warn" >> "$GITHUB_OUTPUT"
+          else
+            echo "performance_status=passed" >> "$GITHUB_OUTPUT"
+          fi
 
   sentry-error-gate:
     name: Sentry Error Gate (production)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Production public-profile alias perf gate is warning-only (#15586 / JOV-4854):** post-promote `jov.ie` usable-result budgets still measure and emit `::warning::` / `performance_status=warn` on cold-cache noise, but no longer fail Production Verified; the immutable staged public-profile budget gate remains hard.
 - [internal] **Desktop releases now fail closed on publication proof (JOV-4545):** production creates an exact-commit private draft first, verifies all five updater assets and checksums, and writes the release marker only after an independent published-asset check.
 - **Calendar keeps a usable seven-column month grid (JOV-4819):** the authenticated desktop calendar and its loading state now own explicit responsive grid geometry, preventing production builds from collapsing the month into a single narrow day column.
 - [internal] **Unused flag asset dependency removed:** `flag-icons` no longer installs 552 unused package files after the country selector moved its two live flags to owned local SVGs.

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1743,7 +1743,7 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     expect(verifyStep).toContain('EXPECTED_PRODUCTION_DEPLOYMENT_ID');
   });
 
-  it('makes canonical public-profile alias usable results release-gating', () => {
+  it('measures production public-profile alias budgets as warning-only (staged remains hard)', () => {
     const workflow = readFileSync(productionReleaseWorkflowPath, 'utf8');
     const aliasGate = getJobBlock(
       workflow,
@@ -1755,14 +1755,39 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     expect(aliasGate).toContain('setup-playwright');
     expect(aliasGate).toContain('--base-url https://jov.ie');
     expect(aliasGate).toContain('--runs 5');
+    // Post-promote production alias budgets must not fail the job on miss.
+    expect(aliasGate).toContain('id: alias-perf');
+    expect(aliasGate).toContain(
+      'if ! pnpm exec tsx scripts/performance-budgets-guard.ts'
+    );
+    expect(aliasGate).toContain(
+      'echo "performance_status=warn" >> "$GITHUB_OUTPUT"'
+    );
+    expect(aliasGate).toContain(
+      'echo "performance_status=passed" >> "$GITHUB_OUTPUT"'
+    );
+    expect(aliasGate).toContain('::warning::');
+    expect(aliasGate).toContain(
+      'performance_status: ${{ steps.alias-perf.outputs.performance_status }}'
+    );
+    expect(aliasGate).not.toContain('fail_performance_gate');
+    expect(aliasGate).not.toContain('continue-on-error: true');
+    expect(aliasGate).not.toMatch(
+      /if ! pnpm exec tsx scripts\/performance-budgets-guard\.ts[\s\S]*?exit 1/
+    );
     const promoteJob = getJobBlock(workflow, 'promote-production');
     const stagedPerformanceGate = getStepBlock(
       promoteJob,
       'Prove canonical navigation budgets on exact staged build'
     );
     expect(stagedPerformanceGate).toContain('--base-url "$deployment_url"');
+    // Immutable staged public-profile gate stays hard-fail.
     expect(stagedPerformanceGate).toContain(
       'Public-profile alias usable-result contract failed on the immutable staged deployment.'
+    );
+    expect(stagedPerformanceGate).toContain('fail_performance_gate');
+    expect(stagedPerformanceGate).toMatch(
+      /public-profile-releases \|\| \\\s*\n\s*fail_performance_gate/
     );
     for (const routeId of [
       'public-profile-listen',
@@ -1774,6 +1799,7 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     ]) {
       expect(aliasGate).toContain(`--route-id ${routeId}`);
     }
+    // Downstream still requires job successful completion (exit 0), not a perf pass.
     expect(releaseResult).toContain('production-public-profile-alias-gate,');
     expect(releaseResult).toContain(
       'production-public-profile-alias-gate:${{ needs.production-public-profile-alias-gate.result }}'

--- a/apps/web/tests/unit/lib/ai/sdk.gateway.test.ts
+++ b/apps/web/tests/unit/lib/ai/sdk.gateway.test.ts
@@ -64,6 +64,8 @@ describe('lib/ai/sdk gateway routing', () => {
     process.env.HELICONE_GATEWAY_BASE_URL =
       'https://helicone-proxy.example.workers.dev/v1/ai';
     delete process.env.HELICONE_API_KEY;
+    // Ambient Doppler/dev AI_GATEWAY_API_KEY must not leak into this case.
+    delete process.env.AI_GATEWAY_API_KEY;
 
     const { gateway } = await import('@/lib/ai/sdk');
     gateway('openai/gpt-4o-mini');


### PR DESCRIPTION
## Summary
- Convert post-promote `production-public-profile-alias-gate` to **warning-only** so cold-cache single-sample budget misses on `jov.ie` no longer fail Production Verified.
- Keep measuring all six `public-profile-*` routes (`--runs 5`) and emit `::warning::` + `performance_status=warn|passed`.
- Leave the immutable **staged** public-profile `fail_performance_gate` hard (pre-promote).
- `release-result` still requires the alias-gate job to **complete successfully** (setup/infra failures still block); it does not require a performance pass.
- Unblock pre-push by isolating `sdk.gateway.test.ts` from ambient `AI_GATEWAY_API_KEY`.

Fixes #15586
<!-- linear-issue-id:JOV-4854 -->

## Why
Production Controller run(s) on 2026-08-06 went red on `FAIL usable-alias-result-max: 1667.7ms / 1500.0ms` for a single cold-cache sample on `/dualipa/listen` while promote/canary/alias/migrate all succeeded and production already tracked main. Policy: a slow product is preferable to a broken or undeployed product.

## What changed
| Surface | Behavior |
|---|---|
| Post-promote alias gate (`https://jov.ie`) | Warning-only on budget miss |
| Staged immutable public-profile budgets | Still hard-fail via `fail_performance_gate` |
| Sentry / OAuth / promote / rollback | Unchanged |
| 1500ms baseline | Unchanged |

## Verification
```text
pnpm --filter web exec vitest run tests/unit/ci/deploy-workflow.test.ts
# Test Files  1 passed (1)
# Tests  98 passed (98)

pnpm --filter web exec vitest run tests/unit/lib/ai/sdk.gateway.test.ts
# Tests  3 passed (3)

coderabbit review --agent -c AGENTS.md -t uncommitted
# findings: 2 minor (addressed: JOV-4854 re-eval comment + stronger shell assertions)

pre-push (husky): unit shards + ci:harness:check green; branch pushed
```

### Subagent reviews
| Agent | Verdict |
|---|---|
| testing | PASS (98/98 deploy-workflow; contract adequate) |
| security | PASS (no auth/oauth/sentry/domain weakening; staged hard gate retained) |
| review | Approve (warning-only scoped correctly) |

## Cost Impact
- None. Same measurement command; only exit severity softened on the post-promote alias job.

## Risk
- Post-promote alias budget regressions become warnings (intentional). Availability still covered by staged hard public-profile gate, public-profile smoke, alias ownership verify, Sentry, and OAuth.
- Re-evaluate when: public-profile usable-alias-result-max p95 stays ≤1500ms for 14 consecutive Production Controller runs without cold-cache false-reds.

## Proof of done (post-merge)
Next Production Controller run should show the alias gate as `::warning::` / `performance_status=warn` on budget miss (not FAIL) and Production Verified SUCCESS when production alias == main HEAD.

<!-- agent-run-artifact
issue: 15586
linear: JOV-4854
branch: codex/gh-15586-fix-ci-convert-production-public-profile-alias-p-2026-08-07T03-16-55-485z
head_sha: 4946807d877ae27dab479ecd131571bcf7a5e3de
verification:
  deploy-workflow.test.ts: pass (98/98)
  sdk.gateway.test.ts: pass (3/3)
  coderabbit: reviewed (2 minor addressed)
  testing_subagent: pass
  security_subagent: pass
  review_subagent: approve
  pre-push: pass
-->