### PR TITLE
fix(sym): fail closed on cooldown state so kimi fallback cannot mask Codex exhaustion

### DIFF
--- a/scripts/hermes/symphony-codex-exhausted.py
+++ b/scripts/hermes/symphony-codex-exhausted.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 
@@ -108,9 +109,39 @@ def _exact_marker(output: bytes) -> bool:
     return any(line == READY_MARKER for line in output.decode(errors="replace").splitlines())
 
 
-def codex_canary_ready() -> tuple[bool, str]:
+def _read_state() -> dict | None:
     if not _known_account_state():
+        return None
+    try:
+        return json.loads(_state_path().read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def _account_off_cooldown(state: dict, now: int) -> bool:
+    """True when at least one recorded account's cooldown has expired."""
+    for raw in (state.get("cooldowns") or {}).values():
+        try:
+            until = int(raw or 0)
+        except (TypeError, ValueError):
+            continue
+        if until <= now:
+            return True
+    return False
+
+
+def codex_canary_ready() -> tuple[bool, str]:
+    # Primary signal: codex-rotate's cooldown state, which matches the live
+    # provider 429s. The live probe through codex-rotate is NOT trusted for the
+    # exhausted verdict: codex-rotate may answer via its kimi fallback even when
+    # every Codex account is capped, which would report ready and keep Symphony
+    # thrashing instead of launching the Grok sidecar.
+    state = _read_state()
+    if state is None:
         return False, "unknown_state"
+    cooldowns = state.get("cooldowns") or {}
+    if cooldowns and not _account_off_cooldown(state, int(time.time())):
+        return False, "all_accounts_cooldown"
     executable = _rotate_executable()
     if executable is None:
         return False, "executable_missing"

--- a/scripts/hermes/tests/symphony-codex-auth-fallback.test.py
+++ b/scripts/hermes/tests/symphony-codex-auth-fallback.test.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import textwrap
 import threading
+import time
 import unittest
 
 
@@ -219,6 +220,43 @@ class FallbackTests(unittest.TestCase):
         self.assertEqual((result.stdout, result.returncode), ("yes\n", 0))
         self.assertNotIn("token_invalidated", result.stdout + result.stderr)
         self.assertNotIn("SECRET", result.stdout + result.stderr)
+
+    def test_all_accounts_cooldown_is_exhausted_despite_kimi_fallback_probe(self):
+        # Both accounts are capped; codex-rotate's kimi fallback would answer the
+        # live probe with GEM_MODEL_READY anyway. The canary must decide from the
+        # cooldown state alone and never consult the probe for this verdict.
+        future = int(time.time()) + 3600
+        self.state.write_text(json.dumps({
+            "active": None,
+            "cooldowns": {"jovie": future, "meetjovie": future},
+            "last_error": {},
+        }))
+        kimi_canary = self.command("codex-rotate", "echo GEM_MODEL_READY")
+        result = self.run_controller(GEM_CODEX_ROTATE_BIN=kimi_canary)
+        self.assertEqual((result.stdout, result.returncode), ("yes\n", 0))
+
+    def test_kimi_fallback_cannot_mask_cooldown_exhaustion_in_sidecar(self):
+        future = int(time.time()) + 3600
+        self.state.write_text(json.dumps({
+            "active": None,
+            "cooldowns": {"jovie": future, "meetjovie": future},
+            "last_error": {},
+        }))
+        kimi_canary = self.command("codex-rotate", "echo GEM_MODEL_READY")
+        self.command("systemctl", "printf 'systemctl %s\\n' \"$*\" >> \"$GEM_EVENTS\"; [ \"$2\" = is-active ] && exit 1; exit 0")
+        self.command("systemd-run", "printf 'systemd-run %s\\n' \"$*\" >> \"$GEM_EVENTS\"")
+        result = subprocess.run(
+            [self.install_runtime() / "symphony-grok-sidecar"], capture_output=True, text=True,
+            env=self.env(GEM_CODEX_ROTATE_BIN=kimi_canary, GEM_EVENTS=self.events,
+                         LINEAR_API_KEY="linear-secret", LINEAR_API_URL=self.linear_url()),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        events = self.events.read_text().splitlines()
+        self.assertEqual(events[0], "systemctl --user stop symphony-ui-pilot.service symphony-lyb.service")
+        self.assertTrue(any(line.startswith("systemd-run") for line in events), events)
+        self.assertIn("codex_exhausted", result.stderr)
+        self.assertNotIn("codex_not_exhausted", result.stderr)
 
     def test_live_canary_requires_luna_and_exact_marker(self):
         canary = self.command("codex-rotate", "printf '%s\\n' \"$*\" > \"$GEM_EVENTS\"; printf 'GEM_MODEL_READY\\n'")


### PR DESCRIPTION
## What

Fixes the Codex-exhausted canary being fooled by `codex-rotate`'s kimi fallback so the Grok sidecar actually launches when both Codex accounts are capped.

## Problem (confirmed)

`codex_canary_ready()` in `scripts/hermes/symphony-codex-exhausted.py` ran `codex-rotate exec --sandbox read-only` with model `gpt-5.6-luna` and checked stdout == `GEM_MODEL_READY`. `codex-rotate` now has a kimi fallback that answers the canary when Codex is capped. Result: the probe returned "ready", the sidecar logged `codex_not_exhausted symphony_active idle`, and **Grok never launched** even though both Codex accounts (`jovie`, `meetjovie`) were in cooldown until ~Aug 8 10:36/10:51 UTC.

## Fix (minimal)

Make the canary **fail closed and honest** — decide the exhausted verdict from `~/.codex-accounts/state.json` cooldowns (which already match the live provider 429s), not from a codex-rotate probe that the kimi fallback can answer:

- All recorded accounts still in cooldown → `exhausted` immediately (`all_accounts_cooldown`), **without** consulting the probe. The kimi fallback cannot flip this verdict.
- Any account off cooldown (or no cooldown records) → run the existing live probe as verification; probe failure still fails closed to exhausted.
- Unknown/unreadable state → `exhausted` (unchanged fail-closed behavior).
- The kimi fallback is **not** disabled for real shipping — only the canary stops trusting it.

## Tests

Regression tests added to `scripts/hermes/tests/symphony-codex-auth-fallback.test.py`:

- `test_all_accounts_cooldown_is_exhausted_despite_kimi_fallback_probe` — both accounts in future cooldown + a codex-rotate that echoes `GEM_MODEL_READY` (kimi-fallback behavior) → canary reports exhausted.
- `test_kimi_fallback_cannot_mask_cooldown_exhaustion_in_sidecar` — same setup through the installed sidecar → stops Symphony and launches Grok (`codex_exhausted`, no `codex_not_exhausted`).

Verified: `python3 scripts/hermes/tests/symphony-codex-auth-fallback.test.py` → 18 tests OK (16 pre-existing + 2 new).

<!-- linear-issue-id:JOV-4858 -->
