### PR TITLE
fix(desktop): align System-B token contract with web app-shell canon (JOV-4803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [Unreleased]
+- [internal] **Desktop System-B token contract aligns with web app-shell canon (JOV-4803):** the desktop tokens contract test now reads Noir Ion dark-mode anchors from `design-system.css` and the authenticated app-shell frame overrides from `system-b-app.css` instead of removed `--linear-*` tokens; no DMG publish in this PR.
 - [internal] **Production public-profile alias perf gate is warning-only (#15586 / JOV-4854):** post-promote `jov.ie` usable-result budgets still measure and emit `::warning::` / `performance_status=warn` on cold-cache noise, but no longer fail Production Verified; the immutable staged public-profile budget gate remains hard.
 - [internal] **Desktop releases now fail closed on publication proof (JOV-4545):** production creates an exact-commit private draft first, verifies all five updater assets and checksums, and writes the release marker only after an independent published-asset check.
 - **Calendar keeps a usable seven-column month grid (JOV-4819):** the authenticated desktop calendar and its loading state now own explicit responsive grid geometry, preventing production builds from collapsing the month into a single narrow day column.

--- a/apps/desktop/scripts/system-b-tokens.test.ts
+++ b/apps/desktop/scripts/system-b-tokens.test.ts
@@ -14,6 +14,10 @@ const designSystemCss = readFileSync(
   join(webRoot, 'styles', 'design-system.css'),
   'utf8'
 );
+const systemBAppCss = readFileSync(
+  join(webRoot, 'styles', 'system-b-app.css'),
+  'utf8'
+);
 
 // Desktop tokens strip whitespace inside rgba(); normalize before comparing.
 function normalize(value: string): string {
@@ -22,36 +26,47 @@ function normalize(value: string): string {
 
 function readCssVar(name: string, fromCss: string): string {
   const match = fromCss.match(new RegExp(`${name}:\\s*([^;]+);`));
-  if (!match) throw new Error(`${name} not found in design-system.css`);
+  if (!match) throw new Error(`${name} not found in web canon CSS`);
   return match[1].trim();
 }
 
-// System-B dark-mode source of truth: the `.dark` block in design-system.css
-// (the desktop app is always dark). These assertions guard against token
-// drift between the web design system and the desktop tokens module.
-describe('SYSTEM_B_DESKTOP_TOKENS stays aligned with web design-system.css', () => {
-  test('borderSubtle matches --linear-border-subtle', () => {
+// System-B dark-mode source of truth (per DESIGN.md "App Colors — Dark
+// Mode"): the Noir Ion anchors in design-system.css plus the authenticated
+// app-shell frame overrides in system-b-app.css (`[data-app-shell-frame]`,
+// JOV-4648 Noir Ion D). The desktop shell is always dark and mirrors the
+// app-shell frame, so desktop tokens are contracted against those values.
+// These assertions guard against token drift between the web design system
+// and the desktop tokens module.
+const appShellFrameBlock = (() => {
+  const match = systemBAppCss.match(
+    /\[data-app-shell-frame="true"\]\s*\{([^}]*)\}/s
+  );
+  if (!match) {
+    throw new Error(
+      '[data-app-shell-frame="true"] block not found in system-b-app.css'
+    );
+  }
+  return match[1];
+})();
+
+describe('SYSTEM_B_DESKTOP_TOKENS stays aligned with web System-B canon', () => {
+  test('borderSubtle matches the app-shell frame --color-border-subtle', () => {
     expect(normalize(SYSTEM_B_DESKTOP_TOKENS.borderSubtle)).toBe(
-      normalize(readCssVar('--linear-border-subtle', designSystemCss))
+      normalize(readCssVar('--color-border-subtle', appShellFrameBlock))
     );
   });
 
-  test('textSecondary matches --linear-text-secondary', () => {
+  test('textSecondary matches the Noir Ion --noir-ion-text-secondary', () => {
+    // The app-shell frame does not override text color; it inherits the dark
+    // Noir Ion anchor (DESIGN.md: Text secondary #D7DCE8).
     expect(normalize(SYSTEM_B_DESKTOP_TOKENS.textSecondary)).toBe(
-      normalize(readCssVar('--linear-text-secondary', designSystemCss))
+      normalize(readCssVar('--noir-ion-text-secondary', designSystemCss))
     );
   });
 
-  test('shadowPopover matches the dark-mode --shadow-popover', () => {
-    // --shadow-popover is defined twice (light default + dark override);
-    // the desktop shell is dark, so compare against the last (dark) value.
-    const matches = [
-      ...designSystemCss.matchAll(/--shadow-popover:\s*([^;]+);/gs),
-    ];
-    expect(matches.length).toBeGreaterThan(1);
-    const darkValue = matches[matches.length - 1][1].trim();
+  test('shadowPopover matches the app-shell frame --shadow-popover', () => {
     expect(normalize(SYSTEM_B_DESKTOP_TOKENS.shadowPopover)).toBe(
-      normalize(darkValue)
+      normalize(readCssVar('--shadow-popover', appShellFrameBlock))
     );
   });
 });

--- a/apps/desktop/src/system-b-tokens.ts
+++ b/apps/desktop/src/system-b-tokens.ts
@@ -6,8 +6,8 @@ export const SYSTEM_B_DESKTOP_TOKENS = {
   radiusPill: '999px',
   radiusShell: '16px',
   shadowPopover:
-    '0 0 0 1px rgba(255,255,255,0.12), 0 10px 28px rgba(0,0,0,0.45)',
+    '0 0 0 1px rgba(255,255,255,0.12), 0 12px 32px rgba(0,0,0,0.52)',
   surfaceColor: '#101216',
   textPrimary: '#f7f8f8',
-  textSecondary: '#d0d6e0',
+  textSecondary: '#d7dce8',
 } as const;


### PR DESCRIPTION
## Summary

Fixes JOV-4803 — the desktop System-B token contract test
(`apps/desktop/scripts/system-b-tokens.test.ts`) drifted from web canon:

- It referenced `--linear-border-subtle` and `--linear-text-secondary`, which
  no longer exist in `apps/web/styles/design-system.css` after the Noir Ion
  migration (test throws "not found").
- It contracted `shadowPopover` against the legacy `.dark` block value
  (`0 10px 28px rgba(0,0,0,0.45)`) instead of the authenticated app-shell
  frame the desktop shell actually mirrors.

**Canon decision (per DESIGN.md, System B dark = Noir Ion):** the canonical
surface is the `[data-app-shell-frame="true"]` overlay in
`apps/web/styles/system-b-app.css` (JOV-4648 Noir Ion D) plus the
`--noir-ion-*` anchors in `design-system.css`. Web canon wins; desktop was
drifted.

Changes:

- `apps/desktop/src/system-b-tokens.ts`
  - `shadowPopover`: `0 10px 28px rgba(0,0,0,0.45)` → `0 12px 32px rgba(0,0,0,0.52)` (matches app-shell frame `--shadow-popover`, the ticket's expected value)
  - `textSecondary`: `#d0d6e0` → `#d7dce8` (matches `--noir-ion-text-secondary`)
- `apps/desktop/scripts/system-b-tokens.test.ts`
  - `borderSubtle` / `shadowPopover` now read from the app-shell frame block
    in `system-b-app.css`; `textSecondary` reads `--noir-ion-text-secondary`
  - Hard errors when the canon block/variable is missing — contract not
    weakened (still exact, whitespace-normalized equality against web source)

## Test plan

- `pnpm --filter @jovie/desktop test` — **full suite green** (67 passing
  assertions, 0 failures), including `system-b-tokens.test.ts` 3/3.
  - Note: on a fresh checkout the suite needs the gitignored
    `apps/desktop/src/env.generated.ts`; generate with
    `node apps/desktop/scripts/write-env.mjs` (pre-existing requirement of
    `desktop-shell-contract.test.mjs`, unrelated to this change).
- `pnpm biome check apps/desktop/scripts/system-b-tokens.test.ts apps/desktop/src/system-b-tokens.ts` — clean.
- `git diff --check origin/main...HEAD` — clean.

## UI notes

Token-only change. `textSecondary` also feeds the desktop shell
loading/error screen (`apps/desktop/src/main.ts`); the `#d0d6e0` → `#d7dce8`
shift is a subtle canon-aligned brightening with no layout impact.
`shadowPopover` is currently contract-only on desktop. Screenshot capture not
applicable (no desktop UI harness in this environment).

Fixes JOV-4803
https://linear.app/jovie/issue/JOV-4803/align-desktop-shadowpopover-token-contract-with-web-canon