### PR TITLE
feat(merch): converge chat tools on one canonical quality-gated pipeline (JOV-4743)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -139,10 +139,8 @@ import {
 import { formatLyricsForAppleMusic } from '@/lib/lyrics/format-lyrics-for-apple-music';
 import { formatMerchMoney } from '@/lib/merch/pricing';
 import {
-  createMerchGeneration,
   optimizeMerchCards,
   reorderMerchCards,
-  selectMerchDesign,
   showArtistPayouts,
   showMerchSales,
   updateMerchCardDetails,
@@ -1201,82 +1199,10 @@ function createGenerateAlbumArtTool(params: {
   });
 }
 
-function _createMerchGenerationTool(params: {
-  readonly profileId: string | null;
-  readonly clerkUserId: string;
-  readonly command: 'create_merch' | 'preview_merch_options';
-  readonly conversationId?: string | null;
-  readonly turnId?: string | null;
-}) {
-  return tool({
-    description:
-      'Generate exactly three premium merch design options for the current artist. Use for make merch, create a tee, create a hoodie, or make something that would sell.',
-    inputSchema: chatToolSchema({
-      prompt: z.string().max(500).optional(),
-      itemType: z.string().max(80).optional(),
-      makeLive: z.boolean().optional(),
-    }),
-    execute: async ({ prompt, itemType }) => {
-      if (!params.profileId) {
-        return { success: false as const, error: 'Profile ID required' };
-      }
-
-      const merchPrompt = [prompt, itemType ? `Item type: ${itemType}` : null]
-        .filter(Boolean)
-        .join('\n')
-        .trim();
-
-      const result = await createMerchGeneration({
-        profileId: params.profileId,
-        clerkUserId: params.clerkUserId,
-        prompt: merchPrompt || 'Make premium merch for this artist.',
-        command: params.command,
-        conversationId: params.conversationId ?? null,
-        turnId: params.turnId ?? null,
-      });
-
-      return {
-        ...result,
-        nextStep: 'Pick 1, 2, or 3. You can also tell me what to change.',
-      };
-    },
-  });
-}
-
-function _createSelectMerchDesignTool(params: {
-  readonly profileId: string | null;
-  readonly clerkUserId: string;
-}) {
-  return tool({
-    description:
-      'Select a merch option from a previous generation and create a Jovie merch card. Publish only when the artist asks to make it live.',
-    inputSchema: z
-      .object({
-        generationId: z.string().uuid(),
-        optionNumber: z.number().int().min(1).max(3).optional(),
-        optionId: z.string().uuid().optional(),
-        makeLive: z.boolean().optional(),
-      })
-      .refine(data => data.optionNumber !== undefined || data.optionId, {
-        message: 'Provide either optionNumber or optionId.',
-        path: ['optionNumber'],
-      }),
-    execute: async ({ generationId, optionNumber, optionId, makeLive }) => {
-      if (!params.profileId) {
-        return { success: false as const, error: 'Profile ID required' };
-      }
-
-      return selectMerchDesign({
-        generationId,
-        clerkUserId: params.clerkUserId,
-        optionId,
-        optionNumber,
-        publish: makeLive === true,
-      });
-    },
-  });
-}
-
+// JOV-4743: the legacy `_createMerchGenerationTool` / `_createSelectMerchDesignTool`
+// factories were removed — chat merch generation converges on the canonical
+// tools in `@/lib/chat/tools/merch-tools` (createMerchGenerateTool &
+// createMerchPreviewTool → generateMerchDesigns).
 function createMerchStatusTool(params: {
   readonly action: 'publish' | 'pause' | 'unpause' | 'archive';
   readonly profileId: string | null;

--- a/apps/web/lib/chat/tools/merch-tools.integration.test.ts
+++ b/apps/web/lib/chat/tools/merch-tools.integration.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * JOV-4743 integration test: the `createMerch` and `previewMerchOptions` chat
+ * tools must enter the SAME canonical, quality-gated generation pipeline
+ * (`generateMerchDesigns`) and produce the SAME option contract — including
+ * the versioned contract stamp and the truthful-mockup lifecycle state — and
+ * neither tool may bypass the verified-source / no-person gate.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  generateMerchDesigns: vi.fn(),
+  proposeMerchAction: vi.fn(),
+  getMerchSourceCandidates: vi.fn(),
+  isExplicitUserProvidedSource: vi.fn(),
+  requiresAssetPreservingRender: vi.fn(),
+}));
+
+vi.mock('@/lib/merch/design-generation', () => ({
+  generateMerchDesigns: hoisted.generateMerchDesigns,
+}));
+
+vi.mock('@/lib/chat/tools/merch-propose', () => ({
+  proposeMerchAction: hoisted.proposeMerchAction,
+}));
+
+vi.mock('@/lib/merch/source-candidates', () => ({
+  getMerchSourceCandidates: hoisted.getMerchSourceCandidates,
+  isExplicitUserProvidedSource: hoisted.isExplicitUserProvidedSource,
+  requiresAssetPreservingRender: hoisted.requiresAssetPreservingRender,
+}));
+
+import { createMerchGenerateTool, createMerchPreviewTool } from './merch-tools';
+
+const PROFILE_ID = 'profile-1';
+const CLERK_USER_ID = 'user_1';
+
+const VERIFIED_SOURCE = {
+  sourceType: 'song_title' as const,
+  sourceText: 'Midnight Run',
+  provenanceTitle: 'Midnight Run',
+  rightsStatus: 'owned' as const,
+};
+
+const CANONICAL_RESULT = {
+  success: true as const,
+  generationId: '11111111-1111-1111-1111-111111111111',
+  prompt: 'stadium tee graphic\nItem type: premium tee',
+  contractVersion: 'merch-generation/v1',
+  nextStep: 'Pick one and I’ll put it on products.',
+  designs: [
+    {
+      id: 'option-1',
+      option_number: 1,
+      design_name: 'Midnight Run Signal Field',
+      concept: 'Signal Field direction: stadium tee graphic',
+      status: 'ready' as const,
+      mockup_status: 'pending_mockup' as const,
+      preview_url:
+        'https://blob.vercel-storage.com/merch/generated/profile-1/gen/option-1.png',
+      slots: {
+        artist_name: 'Test Artist',
+        short_text: 'Midnight Run',
+        source_label: 'song title: Midnight Run',
+        source_type: 'song_title' as const,
+      },
+      recommended: true,
+    },
+  ],
+};
+
+function makeTools() {
+  const params = {
+    profileId: PROFILE_ID,
+    clerkUserId: CLERK_USER_ID,
+    conversationId: 'conv-1',
+    turnId: 'turn-1',
+  };
+  return {
+    createMerch: createMerchGenerateTool(params),
+    previewMerchOptions: createMerchPreviewTool(params),
+  };
+}
+
+describe('merch chat tools converge on the canonical pipeline (JOV-4743)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.generateMerchDesigns.mockResolvedValue(CANONICAL_RESULT);
+    hoisted.requiresAssetPreservingRender.mockReturnValue(false);
+    hoisted.isExplicitUserProvidedSource.mockReturnValue(true);
+    hoisted.getMerchSourceCandidates.mockResolvedValue([]);
+  });
+
+  it('both tools invoke the same canonical generator with the same gate inputs', async () => {
+    const { createMerch, previewMerchOptions } = makeTools();
+    const input = {
+      prompt: 'stadium tee graphic',
+      itemType: 'premium tee',
+      source: VERIFIED_SOURCE,
+    };
+
+    const createResult = await createMerch.execute!(
+      { ...input, makeLive: false },
+      {} as never
+    );
+    const previewResult = await previewMerchOptions.execute!(
+      input,
+      {} as never
+    );
+
+    // Same canonical gate invoked once per tool, with identical inputs.
+    expect(hoisted.generateMerchDesigns).toHaveBeenCalledTimes(2);
+    const [createCall, previewCall] = hoisted.generateMerchDesigns.mock.calls;
+    expect(createCall[0]).toEqual(previewCall[0]);
+    expect(createCall[0]).toMatchObject({
+      profileId: PROFILE_ID,
+      clerkUserId: CLERK_USER_ID,
+      source: VERIFIED_SOURCE,
+      conversationId: 'conv-1',
+      turnId: 'turn-1',
+    });
+
+    // Same option contract from both entry points: versioned contract stamp,
+    // pending_mockup lifecycle state, identical design payload keys.
+    expect(createResult).toEqual(previewResult);
+    for (const result of [createResult, previewResult]) {
+      expect(result).toMatchObject({
+        success: true,
+        contractVersion: 'merch-generation/v1',
+      });
+      const designs = (result as typeof CANONICAL_RESULT).designs;
+      expect(designs).toHaveLength(1);
+      expect(designs[0]).toMatchObject({
+        status: 'ready',
+        mockup_status: 'pending_mockup',
+      });
+    }
+  });
+
+  it('neither tool can bypass the verified-source gate', async () => {
+    hoisted.isExplicitUserProvidedSource.mockReturnValue(false);
+    // Catalog candidates exist but none match the requested source.
+    hoisted.getMerchSourceCandidates.mockResolvedValue([
+      {
+        ...VERIFIED_SOURCE,
+        sourceText: 'Other Song',
+        merchScore: 1,
+        whyItWorks: 'confirmed catalog title',
+      },
+    ]);
+
+    const { createMerch, previewMerchOptions } = makeTools();
+    const input = { prompt: 'bootleg design', source: VERIFIED_SOURCE };
+
+    const createResult = await createMerch.execute!(
+      { ...input, makeLive: true },
+      {} as never
+    );
+    const previewResult = await previewMerchOptions.execute!(
+      input,
+      {} as never
+    );
+
+    expect(createResult).toEqual(previewResult);
+    expect(createResult).toMatchObject({
+      success: false,
+      error: expect.stringContaining('not a confirmed title'),
+    });
+    // The gate stopped both tools before any generation happened.
+    expect(hoisted.generateMerchDesigns).not.toHaveBeenCalled();
+  });
+
+  it('neither tool can force an asset-preserving Library asset through prompt generation', async () => {
+    hoisted.requiresAssetPreservingRender.mockReturnValue(true);
+
+    const assetSource = {
+      sourceType: 'library_asset' as const,
+      sourceText: 'Logo',
+      provenanceTitle: 'Logo',
+      rightsStatus: 'owned' as const,
+      assetId: '22222222-2222-2222-2222-222222222222',
+    };
+    const { createMerch, previewMerchOptions } = makeTools();
+
+    const createResult = await createMerch.execute!(
+      { prompt: 'recreate my logo', source: assetSource },
+      {} as never
+    );
+    const previewResult = await previewMerchOptions.execute!(
+      { prompt: 'recreate my logo', source: assetSource },
+      {} as never
+    );
+
+    expect(createResult).toEqual(previewResult);
+    expect(createResult).toMatchObject({
+      success: false,
+      error: expect.stringContaining('asset-preserving render path'),
+    });
+    expect(hoisted.generateMerchDesigns).not.toHaveBeenCalled();
+  });
+
+  it('both tools require a verified source before any model call', async () => {
+    const { createMerch, previewMerchOptions } = makeTools();
+
+    const createResult = await createMerch.execute!(
+      { prompt: 'surprise me' },
+      {} as never
+    );
+    const previewResult = await previewMerchOptions.execute!(
+      { prompt: 'surprise me' },
+      {} as never
+    );
+
+    expect(createResult).toEqual(previewResult);
+    expect(createResult).toMatchObject({
+      success: true,
+      state: 'source_selection_required',
+    });
+    expect(hoisted.generateMerchDesigns).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/chat/tools/merch-tools.ts
+++ b/apps/web/lib/chat/tools/merch-tools.ts
@@ -7,13 +7,15 @@ import 'server-only';
  * artist chat. They wrap the merch generator service and return structured
  * payloads the chat UI renders as merch cards.
  *
- * Implementation strategy:
- * - generateMerchOptions: takes a design concept, calls the merch generator
- *   service, and returns merch generation options for the UI
- * - previewMerchOptions: same as generate but with preview semantics
+ * Implementation strategy (JOV-4743):
+ * - createMerch and previewMerchOptions share one executor that calls the
+ *   canonical, quality-gated generator (`generateMerchDesigns`, see
+ *   `@/lib/merch/generation-contract`) — there is no per-tool divergence.
  * - selectMerchOption: picks a design option and creates a merch card
  *
- * @see @/lib/services/merch/merch-generator.ts - Core generation logic
+ * @see @/lib/merch/design-generation.ts - Canonical generation pipeline
+ * @see @/lib/merch/generation-contract.ts - Versioned contract + receipt
+ * @see @/lib/services/merch/merch-generator.ts - Legacy compatibility adapters
  * @see @/lib/chat/tool-schemas.ts - Tool schema definitions
  * @see onboarding-tool-impls.ts - Similar pattern for onboarding tools
  */
@@ -127,6 +129,69 @@ export function createMerchSourceTool(params: {
 }
 
 /**
+ * Shared executor for both generation chat tools (JOV-4743).
+ *
+ * `createMerch` and `previewMerchOptions` differ only in the fallback prompt
+ * goal; everything else — the versioned prompt contract, the verified-source /
+ * no-person gate, and the canonical `generateMerchDesigns` pipeline with its
+ * quality evidence and publish blockers — is this single code path, so neither
+ * tool can drift or bypass the gate.
+ */
+async function executeCanonicalMerchGeneration(
+  params: {
+    readonly profileId: string | null;
+    readonly clerkUserId: string;
+    readonly conversationId?: string | null;
+    readonly turnId?: string | null;
+    readonly fallbackPrompt: string;
+  },
+  input: {
+    readonly prompt?: string;
+    readonly itemType?: string;
+    readonly source?: MerchSource;
+  }
+) {
+  if (!params.profileId) {
+    return { success: false as const, error: 'Profile ID required' };
+  }
+
+  const generationPrompt = buildMerchGenerationPrompt(
+    input.prompt,
+    input.itemType,
+    params.fallbackPrompt
+  );
+  const sourceResolution = await resolveVerifiedSource({
+    profileId: params.profileId,
+    prompt: generationPrompt.prompt,
+    source: input.source,
+  });
+  if ('error' in sourceResolution) {
+    return { success: false as const, error: sourceResolution.error };
+  }
+  if ('sourceSelection' in sourceResolution) {
+    return sourceResolution.sourceSelection;
+  }
+
+  const result = await generateMerchDesigns({
+    profileId: params.profileId,
+    clerkUserId: params.clerkUserId,
+    prompt: generationPrompt.prompt,
+    source: sourceResolution.source,
+    conversationId: params.conversationId ?? null,
+    turnId: params.turnId ?? null,
+  });
+  return {
+    ...result,
+    ...(generationPrompt.usedDefaultItemType
+      ? {
+          productTypeNotice:
+            'Started with a premium tee. You can switch the product after choosing a design.',
+        }
+      : {}),
+  };
+}
+
+/**
  * Creates the generate merch options chat tool.
  * Attached to the authenticated chat toolset when the artist has
  * merch creation access.
@@ -140,46 +205,14 @@ export function createMerchGenerateTool(params: {
   return tool({
     description: TOOL_SCHEMAS.createMerch.description,
     inputSchema: TOOL_SCHEMAS.createMerch.inputSchema,
-    execute: async ({ prompt, itemType, makeLive: _makeLive, source }) => {
-      if (!params.profileId) {
-        return { success: false as const, error: 'Profile ID required' };
-      }
-
-      const generationPrompt = buildMerchGenerationPrompt(
-        prompt,
-        itemType,
-        'Premium illustrated merch for this artist.'
-      );
-      const sourceResolution = await resolveVerifiedSource({
-        profileId: params.profileId,
-        prompt: generationPrompt.prompt,
-        source,
-      });
-      if ('error' in sourceResolution) {
-        return { success: false as const, error: sourceResolution.error };
-      }
-      if ('sourceSelection' in sourceResolution) {
-        return sourceResolution.sourceSelection;
-      }
-
-      const result = await generateMerchDesigns({
-        profileId: params.profileId,
-        clerkUserId: params.clerkUserId,
-        prompt: generationPrompt.prompt,
-        source: sourceResolution.source,
-        conversationId: params.conversationId ?? null,
-        turnId: params.turnId ?? null,
-      });
-      return {
-        ...result,
-        ...(generationPrompt.usedDefaultItemType
-          ? {
-              productTypeNotice:
-                'Started with a premium tee. You can switch the product after choosing a design.',
-            }
-          : {}),
-      };
-    },
+    execute: async ({ prompt, itemType, makeLive: _makeLive, source }) =>
+      executeCanonicalMerchGeneration(
+        {
+          ...params,
+          fallbackPrompt: 'Premium illustrated merch for this artist.',
+        },
+        { prompt, itemType, source }
+      ),
   });
 }
 
@@ -196,46 +229,14 @@ export function createMerchPreviewTool(params: {
   return tool({
     description: TOOL_SCHEMAS.previewMerchOptions.description,
     inputSchema: TOOL_SCHEMAS.previewMerchOptions.inputSchema,
-    execute: async ({ prompt, itemType, source }) => {
-      if (!params.profileId) {
-        return { success: false as const, error: 'Profile ID required' };
-      }
-
-      const generationPrompt = buildMerchGenerationPrompt(
-        prompt,
-        itemType,
-        'Premium illustrated merch concepts for this artist.'
-      );
-      const sourceResolution = await resolveVerifiedSource({
-        profileId: params.profileId,
-        prompt: generationPrompt.prompt,
-        source,
-      });
-      if ('error' in sourceResolution) {
-        return { success: false as const, error: sourceResolution.error };
-      }
-      if ('sourceSelection' in sourceResolution) {
-        return sourceResolution.sourceSelection;
-      }
-
-      const result = await generateMerchDesigns({
-        profileId: params.profileId,
-        clerkUserId: params.clerkUserId,
-        prompt: generationPrompt.prompt,
-        source: sourceResolution.source,
-        conversationId: params.conversationId ?? null,
-        turnId: params.turnId ?? null,
-      });
-      return {
-        ...result,
-        ...(generationPrompt.usedDefaultItemType
-          ? {
-              productTypeNotice:
-                'Started with a premium tee. You can switch the product after choosing a design.',
-            }
-          : {}),
-      };
-    },
+    execute: async ({ prompt, itemType, source }) =>
+      executeCanonicalMerchGeneration(
+        {
+          ...params,
+          fallbackPrompt: 'Premium illustrated merch concepts for this artist.',
+        },
+        { prompt, itemType, source }
+      ),
   });
 }
 

--- a/apps/web/lib/merch/design-generation.ts
+++ b/apps/web/lib/merch/design-generation.ts
@@ -1,7 +1,13 @@
 import 'server-only';
 
 /**
- * Phase-A merch design generation.
+ * Phase-A merch design generation — THE canonical generation pipeline for
+ * chat-driven merch (JOV-4743, see `@/lib/merch/generation-contract`).
+ *
+ * Every chat tool entry point (`createMerch`, `previewMerchOptions`) must call
+ * `generateMerchDesigns` so the versioned prompt/content contract (verified
+ * source + no-person rules), the qualityReview evidence payload, and the
+ * publish blockers apply identically everywhere.
  *
  * Generates N illustrated, transparent (alpha) print graphics for the artist via
  * the multi-model graphic engine, persists each as a merchDesignOption bound to
@@ -31,8 +37,13 @@ import { env } from '@/lib/env-server';
 import { logger } from '@/lib/utils/logger';
 import { resolveMerchCatalogSelection } from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
+import {
+  MERCH_CANONICAL_PIPELINE_ID,
+  MERCH_GENERATION_CONTRACT_VERSION,
+  type MerchGenerationReceipt,
+} from './generation-contract';
 import { generatePrintGraphic } from './graphic-engine';
-import { attachMockupsToDesignOption, generateProductMockups } from './mockups';
+import { scheduleMerchMockupEnrichment } from './mockup-enrichment';
 import {
   buildMerchPricingSnapshot,
   calculateRecommendedSalePriceCents,
@@ -392,43 +403,57 @@ async function getRecentSelectedStrategyLabels(
 }
 
 /**
- * Fire-and-forget: render the fulfillment-accurate Printful mockup for each
- * design (the alpha graphic on the real default product) and attach it. The
- * selected card then prefers the truthful Printful photo over the alpha preview
- * (selectPreferredMockupUrl). Non-blocking and best-effort — a Printful outage
- * leaves the alpha art in place. Pop-color / multi-product curation is a
- * follow-up; this ships the truthful default-product mockup.
+ * Logs the batch-level production receipt: canonical path, contract version,
+ * per-option terminal mockup disposition, and final batch disposition.
  */
-function attachPrintfulMockupsAsync(
-  designs: readonly {
+function logMerchGenerationReceipt(receipt: MerchGenerationReceipt): void {
+  logger.info('[merch-generation] production receipt', { ...receipt });
+}
+
+/**
+ * Schedules durable, observable Printful mockup enrichment for the generated
+ * designs (JOV-4743). Each option stays `pending_mockup` until the truthful
+ * product mockup is attached (`mockup_ready`) or the retry budget/timeout is
+ * exhausted (`mockup_failed`, which blocks publish). Replaces the previous
+ * untracked fire-and-forget `Promise.allSettled` path.
+ */
+function schedulePrintfulMockupEnrichment(params: {
+  readonly generationId: string;
+  readonly profileId: string;
+  readonly startedAt: number;
+  readonly requestedDesignCount: number;
+  readonly designs: readonly {
     readonly optionId: string;
     readonly printFileUrl: string;
-  }[]
-): void {
-  void Promise.allSettled(
-    designs.map(async ({ optionId, printFileUrl }) => {
-      try {
-        const { results } = await generateProductMockups({
-          printFileUrl,
-          catalogProductId: MERCH_DEFAULT_PRINTFUL_PRODUCT.catalogProductId,
-          catalogVariantIds: Object.values(
-            MERCH_DEFAULT_PRINTFUL_PRODUCT.variantMap
-          ),
-          placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
-          technique: MERCH_DEFAULT_PRINTFUL_PRODUCT.technique,
-          productTypes: [MERCH_DEFAULT_PRINTFUL_PRODUCT.productType],
-        });
-        const mockupUrls = results.flatMap(r => r.mockupUrls);
-        if (mockupUrls.length > 0) {
-          await attachMockupsToDesignOption(optionId, mockupUrls);
-        }
-      } catch (error) {
-        logger.warn('[merch-designs] printful mockup attach failed', {
-          optionId,
-          err: error instanceof Error ? error.message : String(error),
-        });
-      }
-    })
+  }[];
+}): void {
+  scheduleMerchMockupEnrichment(
+    params.designs.map(({ optionId, printFileUrl }) => ({
+      optionId,
+      request: {
+        printFileUrl,
+        catalogProductId: MERCH_DEFAULT_PRINTFUL_PRODUCT.catalogProductId,
+        catalogVariantIds: Object.values(
+          MERCH_DEFAULT_PRINTFUL_PRODUCT.variantMap
+        ),
+        placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
+        technique: MERCH_DEFAULT_PRINTFUL_PRODUCT.technique,
+        productTypes: [MERCH_DEFAULT_PRINTFUL_PRODUCT.productType],
+      },
+    })),
+    outcomes => {
+      logMerchGenerationReceipt({
+        pipeline: MERCH_CANONICAL_PIPELINE_ID,
+        contractVersion: MERCH_GENERATION_CONTRACT_VERSION,
+        generationId: params.generationId,
+        profileId: params.profileId,
+        requestedDesignCount: params.requestedDesignCount,
+        readyDesignCount: params.designs.length,
+        mockups: outcomes,
+        disposition: 'ready',
+        durationMs: Date.now() - params.startedAt,
+      });
+    }
   );
 }
 
@@ -561,6 +586,11 @@ export async function generateMerchDesigns(params: {
               copyrightRisk: 'low',
               typography: 'generated',
               printFeasible: true,
+              // Canonical-pipeline evidence (JOV-4743): the truthful Printful
+              // mockup is pending until enrichment reaches a terminal state.
+              contractVersion: MERCH_GENERATION_CONTRACT_VERSION,
+              pipeline: MERCH_CANONICAL_PIPELINE_ID,
+              mockupStatus: 'pending_mockup',
             },
             learning: {
               styleLane: 'fashion_graphic_item',
@@ -585,6 +615,11 @@ export async function generateMerchDesigns(params: {
             model_key: graphic.modelKey,
             concept,
             status: 'ready',
+            // The alpha print art is ready; the truthful Printful product
+            // mockup is not — this candidate stays pending_mockup until the
+            // enrichment worker reaches a terminal state. Never presented as
+            // a finished product photo (JOV-4743).
+            mockup_status: 'pending_mockup',
             preview_url: previewUrl,
             slots: {
               artist_name: name,
@@ -632,12 +667,32 @@ export async function generateMerchDesigns(params: {
     readyDesignCount: ready.length,
   });
 
-  // Non-blocking: attach the truthful Printful product mockup to each design.
-  attachPrintfulMockupsAsync(
-    ready.flatMap(d =>
-      d.preview_url ? [{ optionId: d.id, printFileUrl: d.preview_url }] : []
-    )
+  // Durable + observable: attach the truthful Printful product mockup to each
+  // design and log the terminal production receipt when enrichment settles.
+  const enrichmentDesigns = ready.flatMap(d =>
+    d.preview_url ? [{ optionId: d.id, printFileUrl: d.preview_url }] : []
   );
+  if (enrichmentDesigns.length > 0) {
+    schedulePrintfulMockupEnrichment({
+      generationId,
+      profileId: params.profileId,
+      startedAt,
+      requestedDesignCount: count,
+      designs: enrichmentDesigns,
+    });
+  } else {
+    logMerchGenerationReceipt({
+      pipeline: MERCH_CANONICAL_PIPELINE_ID,
+      contractVersion: MERCH_GENERATION_CONTRACT_VERSION,
+      generationId,
+      profileId: params.profileId,
+      requestedDesignCount: count,
+      readyDesignCount: 0,
+      mockups: [],
+      disposition: 'failed',
+      durationMs: Date.now() - startedAt,
+    });
+  }
 
   await db
     .update(merchGenerationBatches)
@@ -651,6 +706,7 @@ export async function generateMerchDesigns(params: {
     success: true,
     generationId,
     prompt: params.prompt,
+    contractVersion: MERCH_GENERATION_CONTRACT_VERSION,
     nextStep: 'Pick one and I’ll put it on products.',
     designs: ready,
   };

--- a/apps/web/lib/merch/generation-contract.ts
+++ b/apps/web/lib/merch/generation-contract.ts
@@ -1,0 +1,82 @@
+import 'server-only';
+
+/**
+ * Canonical merch generation contract (JOV-4743).
+ *
+ * There is exactly one canonical generation pipeline for chat-driven merch:
+ * `generateMerchDesigns` in `@/lib/merch/design-generation`. Every chat tool
+ * (`createMerch`, `previewMerchOptions`) must enter through it so the
+ * versioned prompt/content contract (verified source + no-person rules), the
+ * reviewer/evidence payload (`qualityReview`), and the publish blockers apply
+ * identically at every entry point.
+ *
+ * This module is the single source of truth for:
+ * - the contract version stamped on every generated option,
+ * - the truthful-mockup lifecycle states (`pending_mockup` until the real
+ *   Printful mockup exists, then a terminal `mockup_ready`/`mockup_failed`),
+ * - the production receipt shape logged for every generation batch.
+ */
+
+export const MERCH_GENERATION_CONTRACT_VERSION = 'merch-generation/v1';
+
+export const MERCH_CANONICAL_PIPELINE_ID =
+  'lib/merch/design-generation.generateMerchDesigns';
+
+/**
+ * Truthful-mockup lifecycle for a generated design option. Options start as
+ * `pending_mockup` (only the alpha print art exists) and must reach a terminal
+ * state: `mockup_ready` (real Printful product mockup attached) or
+ * `mockup_failed` (timeout/retry budget exhausted — blocks publish).
+ */
+export type MerchMockupStatus =
+  | 'pending_mockup'
+  | 'mockup_ready'
+  | 'mockup_failed';
+
+export const MERCH_MOCKUP_TERMINAL_STATUSES: readonly MerchMockupStatus[] = [
+  'mockup_ready',
+  'mockup_failed',
+];
+
+/**
+ * User-visible publish blocker for an option whose truthful mockup reached a
+ * terminal failure. Surfaced in sellability reasons and selection results.
+ */
+export const MERCH_MOCKUP_FAILURE_PUBLISH_BLOCKER =
+  'Product mockup failed to render on the real garment; regenerate the design before publishing.';
+
+/**
+ * Reads the persisted mockup lifecycle state from an option's qualityReview
+ * evidence payload. Options generated before this contract (or through the
+ * legacy deterministic path) have no stamp and return null — they keep their
+ * historical behavior (backward compatible).
+ */
+export function readOptionMockupStatus(
+  qualityReview: Record<string, unknown> | null | undefined
+): MerchMockupStatus | null {
+  const value = qualityReview?.mockupStatus;
+  return value === 'pending_mockup' ||
+    value === 'mockup_ready' ||
+    value === 'mockup_failed'
+    ? value
+    : null;
+}
+
+export interface MerchGenerationReceipt {
+  readonly pipeline: typeof MERCH_CANONICAL_PIPELINE_ID;
+  readonly contractVersion: typeof MERCH_GENERATION_CONTRACT_VERSION;
+  readonly generationId: string;
+  readonly profileId: string;
+  readonly requestedDesignCount: number;
+  readonly readyDesignCount: number;
+  /** Per-option terminal mockup disposition (empty when none scheduled). */
+  readonly mockups: readonly {
+    readonly optionId: string;
+    readonly status: MerchMockupStatus;
+    readonly attempts: number;
+    readonly error?: string;
+  }[];
+  /** Final disposition of the batch: ready (options returned) or failed. */
+  readonly disposition: 'ready' | 'failed';
+  readonly durationMs: number;
+}

--- a/apps/web/lib/merch/mockup-enrichment.test.ts
+++ b/apps/web/lib/merch/mockup-enrichment.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * JOV-4743: mockup enrichment must be durable and observable — retry budget,
+ * terminal `mockup_ready` / `mockup_failed` states persisted on the option,
+ * and idempotent skips when a truthful Printful mockup already exists.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  generateProductMockups: vi.fn(),
+  attachMockupsToDesignOption: vi.fn(),
+  selectLimit: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: hoisted.selectLimit })),
+      })),
+    })),
+    update: vi.fn(() => ({ set: hoisted.updateSet })),
+  },
+}));
+
+vi.mock('@/lib/db/schema/merch', () => ({
+  merchDesignOptions: {
+    id: 'id',
+    mockupUrls: 'mockup_urls',
+    qualityReview: 'quality_review',
+  },
+}));
+
+vi.mock('@/lib/merch/mockups', () => ({
+  generateProductMockups: hoisted.generateProductMockups,
+  attachMockupsToDesignOption: hoisted.attachMockupsToDesignOption,
+}));
+
+import {
+  MAX_MOCKUP_ATTEMPTS,
+  runMerchMockupEnrichment,
+} from './mockup-enrichment';
+
+const ITEM = {
+  optionId: 'option-1',
+  request: {
+    printFileUrl:
+      'https://blob.vercel-storage.com/merch/generated/p/g/option-1.png',
+    catalogProductId: 71,
+    catalogVariantIds: [4011],
+    productTypes: ['t-shirt'],
+  },
+} as const;
+
+const PRINTFUL_URL = 'https://files.printful.com/mockups/abc.png';
+
+describe('runMerchMockupEnrichment (JOV-4743)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.selectLimit.mockResolvedValue([{ mockupUrls: [] }]);
+    hoisted.updateSet.mockReturnValue({ where: hoisted.updateWhere });
+    hoisted.updateWhere.mockResolvedValue(undefined);
+    hoisted.attachMockupsToDesignOption.mockResolvedValue(undefined);
+  });
+
+  it('attaches mockups and reaches terminal mockup_ready', async () => {
+    hoisted.generateProductMockups.mockResolvedValue({
+      results: [{ mockupUrls: [PRINTFUL_URL] }],
+      errors: [],
+    });
+
+    const [outcome] = await runMerchMockupEnrichment([ITEM]);
+
+    expect(outcome).toEqual({
+      optionId: 'option-1',
+      status: 'mockup_ready',
+      attempts: 1,
+    });
+    expect(hoisted.attachMockupsToDesignOption).toHaveBeenCalledWith(
+      'option-1',
+      [PRINTFUL_URL]
+    );
+    // Terminal state persisted on the option's qualityReview evidence.
+    expect(hoisted.updateSet).toHaveBeenCalled();
+  });
+
+  it('is idempotent: skips options that already have a truthful Printful mockup', async () => {
+    hoisted.selectLimit.mockResolvedValue([{ mockupUrls: [PRINTFUL_URL] }]);
+
+    const [outcome] = await runMerchMockupEnrichment([ITEM]);
+
+    expect(outcome).toEqual({
+      optionId: 'option-1',
+      status: 'mockup_ready',
+      attempts: 0,
+    });
+    expect(hoisted.generateProductMockups).not.toHaveBeenCalled();
+  });
+
+  it('exhausts the retry budget and persists terminal mockup_failed', async () => {
+    hoisted.generateProductMockups.mockRejectedValue(
+      new Error('Printful unavailable')
+    );
+
+    const [outcome] = await runMerchMockupEnrichment([ITEM]);
+
+    expect(outcome).toMatchObject({
+      optionId: 'option-1',
+      status: 'mockup_failed',
+      attempts: MAX_MOCKUP_ATTEMPTS,
+      error: 'Printful unavailable',
+    });
+    expect(hoisted.generateProductMockups).toHaveBeenCalledTimes(
+      MAX_MOCKUP_ATTEMPTS
+    );
+    expect(hoisted.attachMockupsToDesignOption).not.toHaveBeenCalled();
+    expect(hoisted.updateSet).toHaveBeenCalled();
+  });
+
+  it('treats an empty provider result as a failure and retries', async () => {
+    hoisted.generateProductMockups.mockResolvedValue({
+      results: [],
+      errors: ['Printful is not configured'],
+    });
+
+    const [outcome] = await runMerchMockupEnrichment([ITEM]);
+
+    expect(outcome.status).toBe('mockup_failed');
+    expect(outcome.error).toContain('Printful is not configured');
+    expect(hoisted.generateProductMockups).toHaveBeenCalledTimes(
+      MAX_MOCKUP_ATTEMPTS
+    );
+  });
+});

--- a/apps/web/lib/merch/mockup-enrichment.ts
+++ b/apps/web/lib/merch/mockup-enrichment.ts
@@ -1,0 +1,220 @@
+import 'server-only';
+
+/**
+ * Durable, observable Printful mockup enrichment (JOV-4743).
+ *
+ * Replaces the untracked fire-and-forget `Promise.allSettled` mockup attach.
+ * Guarantees:
+ * - Survives the response: scheduled with Next.js `after()` so serverless
+ *   teardown cannot silently drop the work (falls back to inline execution
+ *   outside a request scope, e.g. tests/scripts).
+ * - Retry budget + timeout: each option gets up to MAX_MOCKUP_ATTEMPTS
+ *   attempts, each bounded by MOCKUP_ATTEMPT_TIMEOUT_MS.
+ * - Idempotency: an option that already has a truthful Printful mockup is
+ *   skipped; URL attachment itself dedupes by URL set membership.
+ * - Terminal receipt: every option reaches a terminal state persisted on its
+ *   qualityReview evidence (`mockup_ready` | `mockup_failed`) and returned to
+ *   the caller for the batch-level production receipt.
+ */
+
+import { sql as drizzleSql, eq } from 'drizzle-orm';
+import { after } from 'next/server';
+import { db } from '@/lib/db';
+import { merchDesignOptions } from '@/lib/db/schema/merch';
+import { logger } from '@/lib/utils/logger';
+import type { MerchMockupStatus } from './generation-contract';
+import { isPrintfulMockupUrl } from './mockup-urls';
+import {
+  attachMockupsToDesignOption,
+  generateProductMockups,
+  type MockupGenerationRequest,
+} from './mockups';
+
+/** Retry budget per option (initial attempt + one retry). */
+export const MAX_MOCKUP_ATTEMPTS = 2;
+/** Hard ceiling per attempt; the Printful poll loop alone can run ~48s. */
+export const MOCKUP_ATTEMPT_TIMEOUT_MS = 90_000;
+
+export interface MerchMockupEnrichmentItem {
+  readonly optionId: string;
+  readonly request: MockupGenerationRequest;
+}
+
+export interface MerchMockupEnrichmentOutcome {
+  readonly optionId: string;
+  readonly status: Extract<MerchMockupStatus, 'mockup_ready' | 'mockup_failed'>;
+  readonly attempts: number;
+  readonly error?: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+/**
+ * Merges the terminal mockup state into the option's qualityReview evidence
+ * without clobbering the rest of the review payload. Best-effort: a
+ * persistence failure is logged, not thrown, so one bad write cannot mask the
+ * terminal outcome.
+ */
+async function persistOptionMockupStatus(
+  optionId: string,
+  status: MerchMockupStatus,
+  error?: string
+): Promise<void> {
+  const patch: Record<string, unknown> = {
+    mockupStatus: status,
+    mockupCompletedAt: new Date().toISOString(),
+    ...(error ? { mockupError: error } : {}),
+  };
+  try {
+    await db
+      .update(merchDesignOptions)
+      .set({
+        qualityReview: drizzleSql`coalesce(${merchDesignOptions.qualityReview}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`,
+        updatedAt: new Date(),
+      })
+      .where(eq(merchDesignOptions.id, optionId));
+  } catch (persistError) {
+    logger.error('[merch-mockups] failed to persist terminal mockup status', {
+      optionId,
+      status,
+      err: errorMessage(persistError),
+    });
+  }
+}
+
+async function enrichOptionMockup(
+  item: MerchMockupEnrichmentItem
+): Promise<MerchMockupEnrichmentOutcome> {
+  // Idempotency: never regenerate a truthful mockup that already exists.
+  try {
+    const [option] = await db
+      .select({ mockupUrls: merchDesignOptions.mockupUrls })
+      .from(merchDesignOptions)
+      .where(eq(merchDesignOptions.id, item.optionId))
+      .limit(1);
+    if (option?.mockupUrls.some(isPrintfulMockupUrl)) {
+      return { optionId: item.optionId, status: 'mockup_ready', attempts: 0 };
+    }
+  } catch (readError) {
+    logger.warn('[merch-mockups] idempotency read failed; continuing', {
+      optionId: item.optionId,
+      err: errorMessage(readError),
+    });
+  }
+
+  let lastError = 'Printful mockup generation returned no mockups.';
+  for (let attempt = 1; attempt <= MAX_MOCKUP_ATTEMPTS; attempt += 1) {
+    try {
+      const { results, errors } = await withTimeout(
+        generateProductMockups(item.request),
+        MOCKUP_ATTEMPT_TIMEOUT_MS,
+        `Printful mockup generation (option ${item.optionId}, attempt ${attempt})`
+      );
+      const mockupUrls = results.flatMap(result => result.mockupUrls);
+      if (mockupUrls.length > 0) {
+        await attachMockupsToDesignOption(item.optionId, mockupUrls);
+        await persistOptionMockupStatus(item.optionId, 'mockup_ready');
+        logger.info('[merch-mockups] Printful mockups attached', {
+          optionId: item.optionId,
+          attempt,
+          mockupCount: mockupUrls.length,
+        });
+        return {
+          optionId: item.optionId,
+          status: 'mockup_ready',
+          attempts: attempt,
+        };
+      }
+      lastError =
+        errors.length > 0
+          ? errors.join('; ')
+          : 'Printful mockup generation returned no mockups.';
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+    logger.warn('[merch-mockups] mockup attempt failed', {
+      optionId: item.optionId,
+      attempt,
+      maxAttempts: MAX_MOCKUP_ATTEMPTS,
+      err: lastError,
+    });
+  }
+
+  // Terminal failure: user-visible state that blocks publish (JOV-4743).
+  await persistOptionMockupStatus(item.optionId, 'mockup_failed', lastError);
+  logger.error('[merch-mockups] mockup enrichment reached terminal failure', {
+    optionId: item.optionId,
+    attempts: MAX_MOCKUP_ATTEMPTS,
+    err: lastError,
+  });
+  return {
+    optionId: item.optionId,
+    status: 'mockup_failed',
+    attempts: MAX_MOCKUP_ATTEMPTS,
+    error: lastError,
+  };
+}
+
+/** Runs enrichment for all items; never throws — every item gets a terminal outcome. */
+export async function runMerchMockupEnrichment(
+  items: readonly MerchMockupEnrichmentItem[]
+): Promise<readonly MerchMockupEnrichmentOutcome[]> {
+  return Promise.all(items.map(enrichOptionMockup));
+}
+
+/**
+ * Schedules enrichment so it outlives the response. Inside a request scope the
+ * work runs via Next.js `after()`; outside one (tests, scripts) it runs inline
+ * so the tracked DB states are still written instead of dropped.
+ */
+export function scheduleMerchMockupEnrichment(
+  items: readonly MerchMockupEnrichmentItem[],
+  onSettled?: (
+    outcomes: readonly MerchMockupEnrichmentOutcome[]
+  ) => void | Promise<void>
+): void {
+  if (items.length === 0) return;
+  const run = async () => {
+    const outcomes = await runMerchMockupEnrichment(items);
+    await onSettled?.(outcomes);
+  };
+  const guarded = () => {
+    run().catch(error => {
+      logger.error('[merch-mockups] enrichment worker crashed', {
+        err: errorMessage(error),
+      });
+    });
+  };
+  try {
+    after(guarded);
+  } catch {
+    // No request scope (unit tests, scripts): execute inline so the work is
+    // still tracked and observable rather than silently dropped.
+    guarded();
+  }
+}

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -40,9 +40,13 @@ import {
   resolveMerchCatalogSelection,
 } from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
+import {
+  MERCH_MOCKUP_FAILURE_PUBLISH_BLOCKER,
+  readOptionMockupStatus,
+} from './generation-contract';
 import { resolveArchivedMerchRestoreStatus } from './merch-lifecycle-policy';
+import { scheduleMerchMockupEnrichment } from './mockup-enrichment';
 import { isPrintfulMockupUrl, selectPreferredMockupUrl } from './mockup-urls';
-import { attachMockupsToDesignOption, generateProductMockups } from './mockups'; // HOT ZONE pipeline (gh-9803)
 import {
   buildMerchPresetPriceQuotes,
   buildMerchPricingSnapshot,
@@ -389,6 +393,10 @@ function getDesignOptionSellability(
   if (option.productionWarnings.length > 0) {
     reasons.push('Unresolved production warnings.');
   }
+  // JOV-4743: a terminal mockup failure is user-visible and blocks publish.
+  if (readOptionMockupStatus(option.qualityReview) === 'mockup_failed') {
+    reasons.push(MERCH_MOCKUP_FAILURE_PUBLISH_BLOCKER);
+  }
   return { sellable: reasons.length === 0, reasons };
 }
 
@@ -545,50 +553,37 @@ function calculateRankScore(
   );
 }
 
+/**
+ * Attaches truthful Printful mockups to options via the shared durable
+ * enrichment runner (JOV-4743) — scheduled with `after()`, retried within a
+ * budget, timed out, and persisted to a terminal `mockup_ready` /
+ * `mockup_failed` state on each option. No untracked fire-and-forget path.
+ */
 function attachPrintfulMockupsAsync(
   options: readonly MerchDesignOption[]
 ): void {
-  void Promise.allSettled(
-    options.map(async option => {
+  scheduleMerchMockupEnrichment(
+    options.flatMap(option => {
       const printFileUrl = option.printFileUrls[0];
       if (!printFileUrl) {
         logger.warn('[merch-pipeline] skipping mockups without print file', {
           optionId: option.id,
         });
-        return;
+        return [];
       }
-
-      try {
-        const { results, errors } = await generateProductMockups({
-          printFileUrl,
-          catalogProductId: option.printfulCatalogProductId,
-          catalogVariantIds: option.printfulCatalogVariantIds,
-          placements: option.placements,
-          technique: option.technique,
-          productTypes: [option.productType],
-        });
-        const mockupUrls = results.flatMap(result => result.mockupUrls);
-        if (mockupUrls.length > 0) {
-          await attachMockupsToDesignOption(option.id, mockupUrls);
-          logger.info('[merch-pipeline] Printful mockups attached', {
-            optionId: option.id,
-            mockupCount: mockupUrls.length,
-          });
-        } else if (errors.length > 0) {
-          logger.warn('[merch-pipeline] Printful mockup generation failed', {
-            optionId: option.id,
-            errors,
-          });
-        }
-      } catch (error) {
-        logger.warn(
-          '[merch-pipeline] mockup step failed (non-fatal for batch)',
-          {
-            optionId: option.id,
-            err: error instanceof Error ? error.message : String(error),
-          }
-        );
-      }
+      return [
+        {
+          optionId: option.id,
+          request: {
+            printFileUrl,
+            catalogProductId: option.printfulCatalogProductId,
+            catalogVariantIds: option.printfulCatalogVariantIds,
+            placements: option.placements,
+            technique: option.technique,
+            productTypes: [option.productType],
+          },
+        },
+      ];
     })
   );
 }
@@ -1118,6 +1113,15 @@ export async function selectMerchDesign(params: {
   }
 
   const cardSellability = getMerchCardSellability(card);
+  // JOV-4743: a terminal mockup failure on the selected option is a
+  // user-visible publish blocker even when the card's own economics pass.
+  const publishBlockers = [...cardSellability.reasons];
+  if (
+    readOptionMockupStatus(selected.qualityReview) === 'mockup_failed' &&
+    !publishBlockers.includes(MERCH_MOCKUP_FAILURE_PUBLISH_BLOCKER)
+  ) {
+    publishBlockers.push(MERCH_MOCKUP_FAILURE_PUBLISH_BLOCKER);
+  }
   const printfulMockupUrl =
     card.mockupUrls.find(isPrintfulMockupUrl) ??
     selected.mockupUrls.find(isPrintfulMockupUrl) ??
@@ -1133,9 +1137,8 @@ export async function selectMerchDesign(params: {
       card.status === 'live'
         ? publicMerchUrl(profile.usernameNormalized, card.id)
         : null,
-    publishBlockedReasons: cardSellability.sellable
-      ? undefined
-      : cardSellability.reasons,
+    publishBlockedReasons:
+      publishBlockers.length > 0 ? publishBlockers : undefined,
     product: {
       productType: card.productType,
       productName:
@@ -1146,7 +1149,7 @@ export async function selectMerchDesign(params: {
       mockupStatus: printfulMockupUrl ? 'ready' : 'pending',
       retailPrice: formatMerchMoney(card.retailPriceCents),
       artistProfit: formatMerchMoney(card.artistPayoutPerUnitEstimateCents),
-      publishEligible: cardSellability.sellable,
+      publishEligible: publishBlockers.length === 0,
     },
   };
 }

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -5,6 +5,7 @@ import type {
   MerchPrintfulSnapshot,
   MerchShippingAddress,
 } from '@/lib/db/schema/merch';
+import type { MerchMockupStatus } from './generation-contract';
 
 export type MerchDesignCommand =
   | 'create_merch'
@@ -137,6 +138,13 @@ export interface MerchDesignPreview {
   readonly model_key?: string;
   readonly concept: string;
   readonly status: 'generating' | 'ready';
+  /**
+   * Truthful-mockup lifecycle (JOV-4743): candidates are `pending_mockup`
+   * until the real Printful product mockup exists (`mockup_ready`) or
+   * enrichment fails terminally (`mockup_failed`, blocks publish). Absent on
+   * pre-contract options.
+   */
+  readonly mockup_status?: MerchMockupStatus;
   /** Transparent (alpha) print-art preview. Present only when status is `ready`. */
   readonly preview_url?: string;
   readonly slots: MerchDesignSlots;
@@ -160,6 +168,12 @@ export interface MerchDesignCarouselResult {
   readonly generationId: string;
   readonly prompt?: string;
   readonly nextStep?: string;
+  /**
+   * Version of the canonical generation contract that produced these options
+   * (`MERCH_GENERATION_CONTRACT_VERSION`). Optional only for pre-contract
+   * fixtures/payloads; the canonical pipeline always sets it.
+   */
+  readonly contractVersion?: string;
   readonly designs: readonly MerchDesignPreview[];
 }
 

--- a/apps/web/lib/services/merch/merch-generator.ts
+++ b/apps/web/lib/services/merch/merch-generator.ts
@@ -1,10 +1,18 @@
 import 'server-only';
 
 /**
- * Merch generator wrappers for chat tool execution.
+ * Merch generator compatibility adapters (JOV-4743).
  *
- * Keeps chat-layer plumbing thin by delegating all generation/selection logic
- * to the canonical merch service.
+ * The canonical, quality-gated generation pipeline for chat-driven merch is
+ * `generateMerchDesigns` in `@/lib/merch/design-generation` (see
+ * `@/lib/merch/generation-contract`). The live chat tools
+ * (`createMerch`, `previewMerchOptions`) call it directly via
+ * `@/lib/chat/tools/merch-tools`.
+ *
+ * `generateMerchFromConcept` / `previewMerchFromConcept` below are explicit
+ * compatibility adapters over the legacy deterministic `createMerchGeneration`
+ * path (still used by release-autopilot and the MCP route). They are covered
+ * by merch-generator.test.ts; do not wire new chat entry points through them.
  */
 
 import {
@@ -81,6 +89,10 @@ export interface ChatMerchGenerationInput {
  *
  * Thin wrapper over createMerchGeneration that enriches prompt text with
  * optional item type hints and routes request metadata.
+ *
+ * @deprecated Compatibility adapter for the legacy deterministic path. New
+ * chat entry points must use the canonical quality-gated pipeline
+ * (`generateMerchDesigns`) instead — see `@/lib/merch/generation-contract`.
  */
 export async function generateMerchFromConcept(
   input: ChatMerchGenerationInput
@@ -108,6 +120,10 @@ export async function generateMerchFromConcept(
  * This currently follows the same persisted generation flow as
  * generateMerchFromConcept, but marks the batch/turn as
  * preview_merch_options for downstream handling.
+ *
+ * @deprecated Compatibility adapter for the legacy deterministic path. New
+ * chat entry points must use the canonical quality-gated pipeline
+ * (`generateMerchDesigns`) instead — see `@/lib/merch/generation-contract`.
  */
 export async function previewMerchFromConcept(
   input: ChatMerchGenerationInput


### PR DESCRIPTION
## Summary

Fixes JOV-4743 — the merch surface had divergent generation paths and an untracked fire-and-forget Printful mockup attach that let the user-visible response arrive before truthful mockup enrichment completed.

- **One canonical generator.** `createMerch` and `previewMerchOptions` now share a single executor (`executeCanonicalMerchGeneration`) that calls the documented canonical pipeline `generateMerchDesigns` (`lib/merch/design-generation.ts`). Neither tool can bypass the verified-source / no-person gate — the gate runs before any model call in the shared path. The dead divergent `_createMerchGenerationTool`/`_createSelectMerchDesignTool` factories in the chat route are removed, and the legacy `merch-generator.ts` wrappers are marked as explicit, tested compatibility adapters.
- **Versioned contract + production receipt.** New `lib/merch/generation-contract.ts` defines `merch-generation/v1`, stamped on every option's `qualityReview` evidence, and a batch-level receipt (pipeline, contract version, per-option mockup disposition, final disposition) logged when enrichment settles.
- **Truthful mockup lifecycle.** Candidates return `mockup_status: 'pending_mockup'` until the real Printful mockup exists; enrichment persists a terminal `mockup_ready` / `mockup_failed` state on each option. Terminal failure surfaces as a publish blocker (`getDesignOptionSellability` + selection result `publishBlockedReasons`).
- **Durable async, no fire-and-forget.** New `lib/merch/mockup-enrichment.ts` runner: scheduled via Next.js `after()` (survives response teardown), retry budget of 2 attempts, 90s per-attempt timeout, idempotent skip when a Printful mockup already exists, terminal receipt. The legacy `service.ts` attach path routes through the same runner.

## Test plan

- New integration test `lib/chat/tools/merch-tools.integration.test.ts`: both chat tools invoke the same canonical generator with identical gate inputs, return the same option contract (contract version + `pending_mockup` state), and neither can bypass the verified-source / asset-preserving gates.
- New `lib/merch/mockup-enrichment.test.ts`: terminal `mockup_ready`/`mockup_failed` states, retry-budget exhaustion, idempotent skip.
- Ran: `vitest run` over `lib/merch`, `lib/chat/tools`, `lib/services/merch`, chat route + carousel tests — **26 files / 162 tests pass**; `tsc` typecheck clean; `biome check` clean; pre-push gate green.

## Backward compatibility

No schema changes. Pre-contract options/cards carry no `mockupStatus` stamp and keep their historical behavior; the carousel DTO only gains optional fields.

## Notes

- Full pre-publish visual QA/quarantine remains JOV-4739's scope; this PR makes terminal mockup failure block auto-publish and surface user-visible reasons at selection time.
- No UI-visible surface changes (chat carousel renders the same fields); screenshots not applicable.

Linear: https://linear.app/jovie/issue/JOV-4743/merch-generation-converge-chat-tools-on-one-canonical-quality-gated