### PR TITLE
feat(web): OV chat surface with admin-gated chatMode routing (JOV-4810)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -66,6 +66,7 @@ import {
   extractLastUserImageUrl,
   extractLastUserText,
 } from '@/lib/chat/message-text';
+import { canUseOvChatMode, parseChatMode } from '@/lib/chat/ov-mode';
 import { sanitizeAssistantResponse } from '@/lib/chat/prompt-disclosure-guard';
 import {
   updateOwnedReleaseGeneratedPitches,
@@ -667,12 +668,15 @@ function buildChatTurnMetadata(input: {
   readonly toolStepCapExhausted?: boolean;
   /** Resolved model id that produced the turn (feedback attribution). */
   readonly model?: string;
+  /** OV operator chat mode tag (JOV-4810); omitted for customer turns. */
+  readonly chatMode?: 'ov' | null;
 }) {
   return {
     conversationId: input.conversationId,
     turnId: input.turnId,
     requestId: input.requestId,
     ...(input.model ? { model: input.model } : {}),
+    ...(input.chatMode ? { chatMode: input.chatMode } : {}),
     ...(input.toolStepCapExhausted
       ? { toolStepCapExhausted: true as const }
       : {}),
@@ -2476,6 +2480,23 @@ export async function POST(req: Request) {
   const { body, uiMessages } = parsedRequest;
   const { profileId, conversationId } = body;
 
+  // OV chat mode (JOV-4810): only the literal 'ov' is valid, and it is an
+  // internal-tool surface — fail closed for non-admins before any turn work.
+  const chatModeResult = parseChatMode(body.chatMode);
+  if (!chatModeResult.ok) {
+    return NextResponse.json(
+      { error: 'Invalid chatMode', requestId },
+      { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } }
+    );
+  }
+  const chatMode = chatModeResult.chatMode;
+  if (chatMode === 'ov' && !(await canUseOvChatMode(userId))) {
+    return NextResponse.json(
+      { error: 'Admin role required for OV chat mode', requestId },
+      { status: 403, headers: { ...corsHeaders, 'x-request-id': requestId } }
+    );
+  }
+
   // Validate that either profileId or artistContext is provided
   if (
     !toNullableString(profileId) &&
@@ -3027,6 +3048,7 @@ export async function POST(req: Request) {
               turnId: reservedTurn.turnId,
               requestId,
               model: turn.selectedModel,
+              chatMode,
               toolStepCapExhausted: turn.turnSignals.toolStepCapExhausted,
             })
           : undefined,

--- a/apps/web/app/app/(shell)/admin/chat/OvChatClient.tsx
+++ b/apps/web/app/app/(shell)/admin/chat/OvChatClient.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
+import { JovieChat } from '@/components/jovie/JovieChat';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+
+/**
+ * Operator (OV) chat surface (JOV-4810). Deliberately much simpler than the
+ * customer ChatPageClient: no preview panels, no onboarding welcome-chat
+ * bootstrap, no header actions, and no conversation-route navigation — the
+ * URL stays on /app/ov/chat while JovieChat tracks the active conversation
+ * internally. Voice dictation and playback interruption ship inside the
+ * JovieChat composer (ChatInput), so no extra wiring is needed here.
+ */
+export function OvChatClient() {
+  const { selectedProfile, creatorProfiles } = useDashboardData();
+  const activeProfile = selectedProfile ?? creatorProfiles[0] ?? null;
+
+  if (!activeProfile) {
+    return (
+      <ChatWorkspaceSurface>
+        <div className='flex h-full items-center justify-center p-6'>
+          <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
+            <p className='text-sm font-medium text-secondary-token'>
+              OV chat needs an artist profile
+            </p>
+            <p className='text-sm text-tertiary-token'>
+              The signed-in account has no artist profile. Operator chat runs on
+              an artist profile, so add one to this account to use it.
+            </p>
+          </ContentSurfaceCard>
+        </div>
+      </ChatWorkspaceSurface>
+    );
+  }
+
+  return (
+    <ChatWorkspaceSurface>
+      <JovieChat
+        profileId={activeProfile.id}
+        displayName={activeProfile.displayName ?? undefined}
+        avatarUrl={activeProfile.avatarUrl}
+        username={activeProfile.username ?? undefined}
+        chatMode='ov'
+      />
+    </ChatWorkspaceSurface>
+  );
+}

--- a/apps/web/app/app/(shell)/admin/chat/page.tsx
+++ b/apps/web/app/app/(shell)/admin/chat/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import { requireCurrentAdminPageAccess } from '@/lib/admin/page-access';
+import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
+import { OvChatClient } from './OvChatClient';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const metadata: Metadata = {
+  title: 'Chat',
+  description: 'Operator chat surface on the signed-in artist profile.',
+  robots: NOINDEX_ROBOTS,
+};
+
+/**
+ * /app/ov/chat — operator chat surface (JOV-4810).
+ *
+ * Admin auth is enforced by `apps/web/app/app/(shell)/admin/layout.tsx`; the
+ * page-level guard below is authoritative even when Next renders the
+ * surrounding layouts in parallel. Turns are tagged `chatMode: 'ov'` and the
+ * /api/chat route re-verifies the admin role per request.
+ */
+export default async function AdminChatPage() {
+  await requireCurrentAdminPageAccess();
+
+  return <OvChatClient />;
+}

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -78,6 +78,7 @@ export function JovieChat({
   username,
   isFirstSession = false,
   isProfileComplete = false,
+  chatMode,
   actionCards,
   ambientOwnedByShell = false,
 }: JovieChatProps) {
@@ -128,6 +129,7 @@ export function JovieChat({
     onConversationCreate,
     username,
     pinnedOpportunity,
+    chatMode,
   });
 
   const visibleActionCards = useMemo(() => {

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -77,6 +77,11 @@ interface UseJovieChatOptions {
     readonly primaryActionLabel?: string;
     readonly signalType?: string;
   } | null;
+  /**
+   * Operator (OV) chat mode (JOV-4810). When 'ov', every turn body includes
+   * `chatMode: 'ov'`; the server gates that mode on an admin role.
+   */
+  readonly chatMode?: 'ov';
 }
 
 /** Fast interval (ms) to poll for auto-generated title after first message. */
@@ -276,6 +281,7 @@ export function useJovieChat({
   onConversationCreate,
   username,
   pinnedOpportunity = null,
+  chatMode,
 }: UseJovieChatOptions) {
   const router = useRouter();
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -376,7 +382,7 @@ export function useJovieChat({
         onConversationCreate?.(nextConversationId, phase);
       }
     },
-    [activeConversationId, onConversationCreate]
+    [activeConversationId, onConversationCreate, setActiveConversationId]
   );
   const adoptServerConversationIdRef = useRef(adoptServerConversationId);
   useEffect(() => {
@@ -407,6 +413,7 @@ export function useJovieChat({
   // Create transport: prefer profileId for server-side fetching, fall back to artistContext
   const transport = useMemo(
     () =>
+      // eslint-disable-next-line react-hooks/refs -- refs are only read inside the fetch/prepareSendMessagesRequest closures at request time, never during render
       new DefaultChatTransport({
         api: '/api/chat',
         body: {
@@ -415,6 +422,7 @@ export function useJovieChat({
             ? { conversationId: activeConversationId }
             : {}),
           ...(pinnedOpportunity ? { pinnedOpportunity } : {}),
+          ...(chatMode === 'ov' ? { chatMode } : {}),
         },
         prepareSendMessagesRequest: ({ messages, body }) => {
           const staticBody =
@@ -475,6 +483,7 @@ export function useJovieChat({
       artistContext,
       activeConversationId,
       pinnedOpportunity,
+      chatMode,
       dispatchTimelineEvent,
     ]
   );
@@ -1060,7 +1069,7 @@ export function useJovieChat({
       setChatError(null);
       doSubmit(chatError.failedMessage);
     }
-  }, [chatError, doSubmit]);
+  }, [chatError, doSubmit, setChatError]);
 
   const rateLimitedSubmitter = useAsyncRateLimiter(
     async ({

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -60,6 +60,12 @@ export interface JovieChatProps {
   readonly username?: string;
   /** Whether the user is in their first post-onboarding chat session */
   readonly isFirstSession?: boolean;
+  /**
+   * Operator (OV) chat mode (JOV-4810). When set to 'ov', the client tags
+   * each turn with `chatMode: 'ov'` and the server enforces an admin gate.
+   * Omitted = customer (artist) mode, byte-identical to previous behavior.
+   */
+  readonly chatMode?: 'ov';
   /** Whether profile setup is complete, used to suppress setup quick actions. */
   readonly isProfileComplete?: boolean;
   /** Contextual, production-backed actions surfaced in an empty thread */

--- a/apps/web/components/organisms/operator-navigation.ts
+++ b/apps/web/components/organisms/operator-navigation.ts
@@ -10,6 +10,7 @@ import {
   LayoutDashboard,
   type LucideIcon,
   Map,
+  MessageSquare,
   Share2,
   TrendingUp,
   Users,
@@ -24,6 +25,7 @@ import type { NavItem } from '@/features/dashboard/dashboard-nav/types';
 
 const OPERATOR_ICON_BY_ID = {
   overview: LayoutDashboard,
+  chat: MessageSquare,
   ops: Gauge,
   people: Users,
   growth: FolderKanban,

--- a/apps/web/constants/admin-navigation.ts
+++ b/apps/web/constants/admin-navigation.ts
@@ -30,6 +30,7 @@ export type AdminOutreachQueue = (typeof adminOutreachQueues)[number];
 
 export type AdminWorkspaceId =
   | 'overview'
+  | 'chat'
   | 'ops'
   | 'people'
   | 'growth'
@@ -79,6 +80,13 @@ export const ADMIN_NAV_REGISTRY: readonly AdminNavRegistryItem[] = [
     href: APP_ROUTES.ADMIN,
     description:
       'Health dashboard — one signal per area linking to detail screens',
+    section: 'workspaces',
+  },
+  {
+    id: 'chat',
+    label: 'Chat',
+    href: APP_ROUTES.ADMIN_CHAT,
+    description: 'Operator chat surface on the signed-in artist profile',
     section: 'workspaces',
   },
   {

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -84,6 +84,7 @@ export const APP_ROUTES = {
   /** Legacy admin root. Redirect-only; use OV or an ADMIN_* constant. */
   LEGACY_ADMIN: '/app/admin',
   ADMIN: '/app/ov',
+  ADMIN_CHAT: '/app/ov/chat',
   ADMIN_OPS: '/app/ov/ops',
   ADMIN_PEOPLE: '/app/ov/people',
   ADMIN_GROWTH: '/app/ov/growth',

--- a/apps/web/lib/chat/ov-mode.ts
+++ b/apps/web/lib/chat/ov-mode.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { isAdmin } from '@/lib/admin/roles';
+
+/**
+ * Operator (OV) chat mode (JOV-4810). The OV chat surface at /app/ov/chat
+ * tags each turn body with `chatMode: 'ov'`; the chat route validates the
+ * literal and gates the mode on an admin role before running the turn.
+ */
+
+export type ChatMode = 'ov';
+
+export type ChatModeParseResult =
+  | { readonly ok: true; readonly chatMode: ChatMode | null }
+  | { readonly ok: false };
+
+/**
+ * Only the literal 'ov' is meaningful. Absent = customer (artist) mode.
+ * Any other value is a malformed request and must be rejected by the caller.
+ */
+export function parseChatMode(value: unknown): ChatModeParseResult {
+  if (value === undefined || value === null) {
+    return { ok: true, chatMode: null };
+  }
+  if (value === 'ov') {
+    return { ok: true, chatMode: 'ov' };
+  }
+  return { ok: false };
+}
+
+/** OV chat turns are internal-tool only; fail closed for non-admins. */
+export async function canUseOvChatMode(
+  userId: string | null
+): Promise<boolean> {
+  if (!userId) return false;
+  return isAdmin(userId);
+}

--- a/apps/web/lib/chat/request-validation.ts
+++ b/apps/web/lib/chat/request-validation.ts
@@ -29,6 +29,8 @@ export type ChatRequestBody = {
   modelRotationStep?: unknown;
   /** Pinned opportunity card (JOV-3933) — server injects into system prompt. */
   pinnedOpportunity?: unknown;
+  /** OV operator chat mode (JOV-4810) — admin-gated on the server. */
+  chatMode?: unknown;
 };
 
 type MessagePart = { type: string; text?: string };

--- a/apps/web/tests/unit/chat/ov-mode.test.ts
+++ b/apps/web/tests/unit/chat/ov-mode.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { canUseOvChatMode, parseChatMode } from '@/lib/chat/ov-mode';
+
+const { isAdminMock } = vi.hoisted(() => ({
+  isAdminMock: vi.fn<(userId: string) => Promise<boolean>>(),
+}));
+
+vi.mock('@/lib/admin/roles', () => ({
+  isAdmin: isAdminMock,
+}));
+
+describe('parseChatMode', () => {
+  it('treats an omitted chatMode as customer mode', () => {
+    expect(parseChatMode(undefined)).toEqual({ ok: true, chatMode: null });
+    expect(parseChatMode(null)).toEqual({ ok: true, chatMode: null });
+  });
+
+  it("accepts only the literal 'ov'", () => {
+    expect(parseChatMode('ov')).toEqual({ ok: true, chatMode: 'ov' });
+  });
+
+  it('rejects any other value', () => {
+    expect(parseChatMode('admin')).toEqual({ ok: false });
+    expect(parseChatMode('OV')).toEqual({ ok: false });
+    expect(parseChatMode('')).toEqual({ ok: false });
+    expect(parseChatMode(1)).toEqual({ ok: false });
+    expect(parseChatMode({ mode: 'ov' })).toEqual({ ok: false });
+  });
+});
+
+describe('canUseOvChatMode', () => {
+  beforeEach(() => {
+    isAdminMock.mockReset();
+  });
+
+  it('fails closed without a user id', async () => {
+    await expect(canUseOvChatMode(null)).resolves.toBe(false);
+    expect(isAdminMock).not.toHaveBeenCalled();
+  });
+
+  it('denies non-admin users', async () => {
+    isAdminMock.mockResolvedValue(false);
+    await expect(canUseOvChatMode('user_1')).resolves.toBe(false);
+    expect(isAdminMock).toHaveBeenCalledWith('user_1');
+  });
+
+  it('allows admin users', async () => {
+    isAdminMock.mockResolvedValue(true);
+    await expect(canUseOvChatMode('user_1')).resolves.toBe(true);
+    expect(isAdminMock).toHaveBeenCalledWith('user_1');
+  });
+});

--- a/apps/web/tests/unit/chat/useJovieChat.chat-mode.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.chat-mode.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useJovieChat } from '@/components/jovie/hooks/useJovieChat';
+
+const { transportBodies } = vi.hoisted(() => ({
+  transportBodies: [] as Array<Record<string, unknown> | undefined>,
+}));
+
+vi.mock('ai', async importOriginal => {
+  const actual = await importOriginal<typeof import('ai')>();
+  return {
+    ...actual,
+    DefaultChatTransport: vi.fn().mockImplementation(function (
+      this: unknown,
+      options: { body?: Record<string, unknown> }
+    ) {
+      transportBodies.push(options.body);
+      return { kind: 'mock-transport' };
+    }),
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: () => ({
+    messages: [],
+    sendMessage: vi.fn(),
+    status: 'ready',
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}));
+
+vi.mock('@tanstack/react-pacer', () => ({
+  useAsyncRateLimiter: () => ({
+    maybeExecute: vi.fn(),
+    getRemainingInWindow: () => 1,
+    state: { isExecuting: false },
+  }),
+}));
+
+vi.mock('@/lib/queries/useChatConversationQuery', () => ({
+  useChatConversationQuery: () => ({
+    data: undefined,
+    error: null,
+    isError: false,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/lib/queries/useChatMutations', () => ({
+  useAddMessagesMutation: () => ({
+    mutate: vi.fn(),
+  }),
+  useCreateConversationMutation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+describe('useJovieChat chatMode transport body', () => {
+  beforeEach(() => {
+    transportBodies.length = 0;
+  });
+
+  it("includes chatMode: 'ov' in the request body when set", () => {
+    renderHook(() => useJovieChat({ profileId: 'profile_1', chatMode: 'ov' }));
+
+    expect(transportBodies.length).toBeGreaterThan(0);
+    for (const body of transportBodies) {
+      expect(body).toMatchObject({ profileId: 'profile_1', chatMode: 'ov' });
+    }
+  });
+
+  it('omits chatMode from the request body in customer mode', () => {
+    renderHook(() => useJovieChat({ profileId: 'profile_1' }));
+
+    expect(transportBodies.length).toBeGreaterThan(0);
+    for (const body of transportBodies) {
+      expect(body).toMatchObject({ profileId: 'profile_1' });
+      expect(body).not.toHaveProperty('chatMode');
+    }
+  });
+});

--- a/apps/web/tests/unit/components/organisms/OperatorMobileNavigation.test.tsx
+++ b/apps/web/tests/unit/components/organisms/OperatorMobileNavigation.test.tsx
@@ -102,6 +102,9 @@ describe('OperatorMobileNavigation', () => {
     expect(within(menu).getByRole('link', { name: 'Overview' })).toHaveFocus();
 
     await user.tab();
+    expect(within(menu).getByRole('link', { name: 'Chat' })).toHaveFocus();
+
+    await user.tab();
     expect(within(menu).getByRole('link', { name: 'Ops' })).toHaveFocus();
 
     await user.keyboard('{Escape}');


### PR DESCRIPTION
## Summary

Mobile parity slice of the OV cockpit (JOV-4810): the operator shell at `/app/ov` now has the **same chat surface** as customer mode, reachable from the OV mobile navigation, with inputs switched to OV via an explicit, admin-gated `chatMode: 'ov'` tag on every turn.

- **Same chat, OV inputs**: new `/app/ov/chat` page renders the unmodified `JovieChat` component (same composer, same voice dictation/playback interruption rails from the JOV-2926 audio work — no forked UI). `OvChatClient` is deliberately minimal: no preview panels, no onboarding bootstrap; the URL stays on `/app/ov/chat` while the hook tracks the active conversation internally.
- **Input routing (`chatMode`)**: `JovieChat` → `useJovieChat` → `/api/chat` turn bodies now carry `chatMode: 'ov'` when the OV surface is used. The server accepts only the literal `'ov'` (400 otherwise), fail-closed gates it on an admin role (403 for non-admins), and tags turn metadata for attribution. Customer-mode requests are byte-identical to previous behavior.
- **Mobile nav**: Chat added to the OV admin nav registry + operator nav icon map, so it appears in `OperatorMobileNavigation` (mobile) and the sidebar; focus-order test updated.
- **Pre-existing lint unblock**: `useJovieChat.ts` had 3 React Compiler ESLint errors already present on `origin/main` (verified against the unmodified file) that blocked any commit touching it. Fixed by aligning two memo dep arrays with compiler inference (stable setters only — no behavior change) and one justified `react-hooks/refs` disable for refs read only inside request-time closures, matching existing repo precedent.

Out of scope per ticket: Taste Inbox swipe stack parity (lives in `apps/console` as a static sweep report; no web surface exists to mirror — needs its own ticket) and wake phrase (pending opt-in decision, JovieInc/Jovie#620).

## Test plan

- `pnpm --filter web exec vitest run tests/unit/chat/` → **108 files, 916 tests passed** (includes new `ov-mode.test.ts` for `parseChatMode`/`canUseOvChatMode` and `useJovieChat.chat-mode.test.tsx` verifying `chatMode: 'ov'` lands in the request body and is omitted in customer mode)
- `pnpm --filter web exec vitest run tests/unit/components/organisms/OperatorMobileNavigation.test.tsx` → **6/6 passed** (Chat link in mobile nav focus order)
- `pnpm --filter @jovie/web run typecheck` → clean
- `pnpm biome check` on all touched files → clean
- ESLint (pre-commit, `--max-warnings=0`) on staged files → clean
- Repo pre-push gate → passed

## Screenshots

UI-visible change (new `/app/ov/chat` page + Chat entry in OV mobile nav). Screenshot capture unavailable in this environment; the page reuses the production `JovieChat` surface with no new styling, so visual behavior matches the existing chat UI.

Fixes JOV-4810
https://linear.app/jovie/issue/JOV-4810/ov-mobile-same-chat-taste-inbox-on-mobile-inputs-switch-to-ov