### PR TITLE
chore(design-system): strip retired/dead color tokens, add System B DTCG export

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -27,13 +27,10 @@
   --public-shell-header-offset: var(--linear-header-height);
   --public-shell-bg: var(--color-bg-base);
   --public-shell-text: var(--color-text-primary-token);
-  --public-shell-border: var(--color-border-default);
-  --public-shell-content-max: var(--ds-public-content-max);
   /* Legacy variant names — alias to canonical 1298px until Wave 4 consumer sweep */
   --public-content-max-landing: var(--ds-public-content-max);
   --public-content-max-page: var(--ds-public-content-max);
   /* TODO(DS_FOUNDATION_V1 Wave 4): consider deprecating once consumers migrate to --ds-prose-max */
-  --public-content-max-prose: var(--ds-prose-max);
   --app-shell-content-max-wide: 84rem;
   --app-shell-content-max-reading: 56rem;
   --app-shell-content-max-form: 50rem;
@@ -50,9 +47,6 @@
   --app-dialog-radius: var(--profile-inner-radius);
   --app-shell-sidebar-floating-radius: 14px;
   --page-pad: clamp(16px, 4vw, 32px);
-  --section-gap: clamp(16px, 3vw, 28px);
-  --card-pad: clamp(14px, 3vw, 24px);
-  --avatar-size: clamp(88px, 22vw, 144px);
   --cover-height: clamp(220px, 34svh, 400px);
   --content-max: 720px;
   --profile-bottom-nav-height: calc(
@@ -207,23 +201,17 @@
   /* Neutral foundation hue — Linear March 2026 refresh (shifted from 272→282) */
   --theme-base-chroma: 0.015;
   /* Very low chroma for neutrals */
-  --theme-accent-hue: 282;
   /* Brand accent hue — aligned with base hue per Linear refresh */
-  --theme-accent-chroma: 0.18;
   /* Vibrant accent saturation */
   --theme-contrast: 65;
   /* Contrast level (0-100) */
 
   /* Derived base lightness for light mode */
-  --theme-base-l: 99%;
   /* Near white for light mode */
 }
 
 .profile-viewport {
   --page-pad: clamp(16px, 4vw, 32px);
-  --section-gap: clamp(16px, 3vw, 28px);
-  --card-pad: clamp(14px, 3vw, 24px);
-  --avatar-size: clamp(88px, 22vw, 144px);
   --cover-height: clamp(220px, 34svh, 400px);
   --content-max: 720px;
 }
@@ -505,11 +493,9 @@
 }
 
 :where(.profile-primary-tab-transition[data-direction="-1"]) {
-  --profile-tab-enter-offset: -6px;
 }
 
 :where(.profile-primary-tab-transition[data-direction="1"]) {
-  --profile-tab-enter-offset: 6px;
 }
 
 @keyframes profile-tab-enter {
@@ -761,7 +747,6 @@ html[data-profile-initial-mode]
 
 :root.dark {
   /* Dark mode only changes base lightness */
-  --theme-base-l: 12%;
   /* Deep dark for dark mode */
 }
 
@@ -892,7 +877,6 @@ html[data-profile-initial-mode]
   --color-cell-hover: #f0f0f0;
 
   /* Shadows — Linear's exact values (same hierarchy, lighter in light mode) */
-  --shadow-color: 240 10% 3.9%;
   --shadow-sm: 0px 4px 4px -1px #0000000a, 0px 1px 1px 0px #00000014;
   --shadow-md: 0 3px 8px #0000001a, 0 2px 5px #0000001a, 0 1px 1px #0000001a;
   --shadow-lg:
@@ -954,8 +938,6 @@ html[data-profile-initial-mode]
     transparent 100%
   );
   --profile-drawer-bg: rgb(248, 248, 250);
-  --profile-drawer-shadow:
-    0 -10px 24px rgba(12, 12, 18, 0.06), 0 -24px 56px rgba(12, 12, 18, 0.14);
   --profile-drawer-highlight: linear-gradient(
     180deg,
     rgba(255, 255, 255, 0.48),
@@ -981,10 +963,7 @@ html[data-profile-initial-mode]
   --profile-status-pill-fg: rgba(255, 255, 255, 0.98);
   --profile-rail-dot-active: rgba(12, 12, 15, 0.9);
   --profile-rail-dot-inactive: rgba(12, 12, 15, 0.18);
-  --profile-composer-bg: rgba(255, 255, 255, 0.78);
   --profile-composer-border: rgba(255, 255, 255, 0.8);
-  --profile-composer-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.68), 0 18px 42px rgba(15, 17, 24, 0.12);
   --profile-dock-bg: rgba(247, 247, 249, 0.58);
   --profile-dock-border: rgba(255, 255, 255, 0.72);
   --profile-dock-shadow:
@@ -1245,8 +1224,6 @@ html[data-profile-initial-mode]
     transparent 100%
   );
   --profile-drawer-bg: rgb(14, 16, 20);
-  --profile-drawer-shadow:
-    0 -10px 26px rgba(0, 0, 0, 0.2), 0 -24px 68px rgba(0, 0, 0, 0.38);
   --profile-drawer-highlight: linear-gradient(
     180deg,
     rgba(255, 255, 255, 0.08),
@@ -1272,10 +1249,7 @@ html[data-profile-initial-mode]
   --profile-status-pill-fg: rgba(255, 255, 255, 0.98);
   --profile-rail-dot-active: rgba(255, 255, 255, 0.92);
   --profile-rail-dot-inactive: rgba(255, 255, 255, 0.18);
-  --profile-composer-bg: rgba(255, 255, 255, 0.08);
   --profile-composer-border: rgba(255, 255, 255, 0.1);
-  --profile-composer-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 16px 40px rgba(0, 0, 0, 0.28);
   --profile-dock-bg: rgba(30, 32, 40, 0.52);
   --profile-dock-border: rgba(255, 255, 255, 0.18);
   --profile-dock-shadow:
@@ -1325,8 +1299,6 @@ html[data-profile-initial-mode]
   );
   /* Selection roles */
   --color-bg-selected: var(--noir-ion-selected);
-  --color-bg-selected-strong: var(--noir-ion-selected-strong);
-  --color-border-interactive: var(--noir-ion-border-interactive);
 }
 
 /* Public-profile navigation is one distinct functional glass layer. It floats
@@ -1872,7 +1844,6 @@ html[data-profile-initial-mode]
 
   /* Linear font features (extracted 2026-03-16: --font-settings: "cv01","ss03") */
   --font-features: "cv01", "ss03";
-  --font-optical-sizing: 28;
 
   /* Font weights — Linear uses Inter Variable axis with non-standard stops
      Extracted from Linear CSS vars (2026-02-17):
@@ -2088,7 +2059,6 @@ html[data-profile-initial-mode]
    ============================================ */
 :root {
   --menu-background: 255 255 255;
-  --menu-foreground: 12 12 12;
   --menu-border: 229 231 235;
   --menu-shadow: 0 0 0 / 0.1;
   --menu-item-hover: 245 246 248;
@@ -2099,7 +2069,6 @@ html[data-profile-initial-mode]
   /* Menu tokens aligned to Linear surface hierarchy (2026-02-16)
      Menu bg = surface-0 (rgb 16,17,18) — elevated menus use darker base */
   --menu-background: 16 17 18;
-  --menu-foreground: 244 244 245;
   --menu-border: 255 255 255 / 0.08;
   --menu-shadow: 0 0 0 / 0.35;
   --menu-item-hover: 35 37 42;
@@ -2137,9 +2106,6 @@ html[data-profile-initial-mode]
   );
 
   /* Item states */
-  --liquid-glass-item-hover: oklch(0% 0 0 / 5%);
-  --liquid-glass-item-active: oklch(0% 0 0 / 8%);
-  --liquid-glass-item-selected: oklch(0% 0 0 / 10%);
 
   /* Blur values */
   --liquid-glass-blur: 24px;
@@ -2167,9 +2133,6 @@ html[data-profile-initial-mode]
   );
 
   /* Item states */
-  --liquid-glass-item-hover: oklch(100% 0 0 / 6%);
-  --liquid-glass-item-active: oklch(100% 0 0 / 10%);
-  --liquid-glass-item-selected: oklch(100% 0 0 / 12%);
 }
 
 .profile-intent-page {
@@ -2545,43 +2508,16 @@ html:not(.dark) .smart-link-powered-by {
    Source: home-page-hero handoff bundle (Claude Design 2026-04).
 */
 :root {
-  --geist-blue-bg: #e1f0ff;
   --geist-blue-solid: #0070f3;
-  --geist-blue-fg: #ffffff;
-  --geist-purple-bg: #f4e8ff;
   --geist-purple-solid: #8b5cf6;
-  --geist-purple-fg: #ffffff;
-  --geist-pink-bg: #ffe4f1;
   --geist-pink-solid: #ff0080;
-  --geist-pink-fg: #ffffff;
-  --geist-red-bg: #ffe5e5;
   --geist-red-solid: #e00000;
-  --geist-red-fg: #ffffff;
-  --geist-amber-bg: #fff3d6;
   --geist-amber-solid: #f5a623;
-  --geist-amber-fg: #18181b;
-  --geist-yellow-bg: #fff9c2;
   --geist-yellow-solid: #f7d600;
-  --geist-yellow-fg: #18181b;
-  --geist-green-bg: #d3f9d8;
   --geist-green-solid: #0cce6b;
-  --geist-green-fg: #ffffff;
-  --geist-teal-bg: #ccf5ef;
   --geist-teal-solid: #00bcd4;
-  --geist-teal-fg: #ffffff;
-  --geist-cyan-bg: #d6f3ff;
   --geist-cyan-solid: #22c1fc;
-  --geist-cyan-fg: #18181b;
 
   /* Rotation order — blue, purple, pink, amber, green, teal, red, cyan, yellow.
    * Apple-style hue rotation across feature surfaces. */
-  --geist-rotation-1: var(--geist-blue-solid);
-  --geist-rotation-2: var(--geist-purple-solid);
-  --geist-rotation-3: var(--geist-pink-solid);
-  --geist-rotation-4: var(--geist-amber-solid);
-  --geist-rotation-5: var(--geist-green-solid);
-  --geist-rotation-6: var(--geist-teal-solid);
-  --geist-rotation-7: var(--geist-red-solid);
-  --geist-rotation-8: var(--geist-cyan-solid);
-  --geist-rotation-9: var(--geist-yellow-solid);
 }

--- a/design.tokens.json
+++ b/design.tokens.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://design-tokens.github.io/community-group/format/",
+  "$version": 1,
+  "name": "Jovie System B (Noir Ion)",
+  "$description": "Canonical Jovie design tokens, dark-first. Source of truth: apps/web/styles/design-system.css. Export generated 2026-08-07. Used by importers (e.g. Magic Patterns) instead of scraping raw repo colors.",
+  "color": {
+    "surface.canvas": {
+      "$value": "#030407",
+      "$type": "color"
+    },
+    "surface.shell": {
+      "$value": "#06080d",
+      "$type": "color"
+    },
+    "surface.panel": {
+      "$value": "#0a0d16",
+      "$type": "color"
+    },
+    "surface.card": {
+      "$value": "#0f1420",
+      "$type": "color"
+    },
+    "surface.elevated": {
+      "$value": "#151b2a",
+      "$type": "color"
+    },
+    "surface.floating": {
+      "$value": "#1b2436",
+      "$type": "color"
+    },
+    "surface.bgBase": {
+      "$value": "#030407",
+      "$type": "color"
+    },
+    "surface.bgPage": {
+      "$value": "#030407",
+      "$type": "color"
+    },
+    "surface.surface0": {
+      "$value": "#06080d",
+      "$type": "color"
+    },
+    "surface.surface1": {
+      "$value": "var(--linear-bg-surface-1)",
+      "$type": "color"
+    },
+    "surface.surface2": {
+      "$value": "#151b2a",
+      "$type": "color"
+    },
+    "surface.surface3": {
+      "$value": "#1b2436",
+      "$type": "color"
+    },
+    "text.primary": {
+      "$value": "#f7f8f8",
+      "$type": "color"
+    },
+    "text.secondary": {
+      "$value": "#d0d6e0",
+      "$type": "color"
+    },
+    "text.tertiary": {
+      "$value": "#8a8f98",
+      "$type": "color"
+    },
+    "text.quaternary": {
+      "$value": "#62666d",
+      "$type": "color"
+    },
+    "text.disabled": {
+      "$value": "oklch(40% 0.006 282)",
+      "$type": "color"
+    },
+    "border.subtle": {
+      "$value": "oklch(100% 0 0 / 15%)",
+      "$type": "color"
+    },
+    "border.default": {
+      "$value": "oklch(100% 0 0 / 25%)",
+      "$type": "color"
+    },
+    "border.strong": {
+      "$value": "oklch(100% 0 0 / 40%)",
+      "$type": "color"
+    },
+    "border.focus": {
+      "$value": "#11afff",
+      "$type": "color"
+    },
+    "accent.ion": {
+      "$value": "#11afff",
+      "$type": "color"
+    },
+    "accent.focusRing": {
+      "$value": "rgba(17, 175, 255, 0.72)",
+      "$type": "color"
+    },
+    "accent.selected": {
+      "$value": "rgba(17, 175, 255, 0.1)",
+      "$type": "color"
+    },
+    "accent.ultra": {
+      "$value": "#a982ff",
+      "$type": "color"
+    },
+    "accent.pulse": {
+      "$value": "#ff48d2",
+      "$type": "color"
+    },
+    "accent.aqua": {
+      "$value": "#24f6d2",
+      "$type": "color"
+    },
+    "accent.mint": {
+      "$value": "#39e58c",
+      "$type": "color"
+    },
+    "accent.gold": {
+      "$value": "#ffc857",
+      "$type": "color"
+    },
+    "accent.flare": {
+      "$value": "#ff677d",
+      "$type": "color"
+    },
+    "status.success": {
+      "$value": "#39e58c",
+      "$type": "color"
+    },
+    "status.warning": {
+      "$value": "#ffc857",
+      "$type": "color"
+    },
+    "status.error": {
+      "$value": "#ff677d",
+      "$type": "color"
+    },
+    "feature.analytics": {
+      "$value": "#11afff",
+      "$type": "color"
+    },
+    "feature.conversion": {
+      "$value": "#a982ff",
+      "$type": "color"
+    },
+    "feature.beauty": {
+      "$value": "#ff48d2",
+      "$type": "color"
+    },
+    "feature.links": {
+      "$value": "#24f6d2",
+      "$type": "color"
+    },
+    "feature.speed": {
+      "$value": "#39e58c",
+      "$type": "color"
+    },
+    "feature.pro": {
+      "$value": "#ffc857",
+      "$type": "color"
+    }
+  }
+}

--- a/docs/llms-design-manifest.txt
+++ b/docs/llms-design-manifest.txt
@@ -38,7 +38,7 @@
 - `border-subtle`, `border-default`, `border-strong`
 - `focus-ring-themed` or `focus-visible:*` on interactive elements
 
-## Design Tokens (258 contract tokens; 499 total in CSS)
+## Design Tokens (245 contract tokens; 461 total in CSS)
 
 Contract tokens below are the semantic surface for AI edits. DSP brand colors and extended accent palettes live in `apps/web/styles/design-system.css` only.
 
@@ -79,7 +79,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 - `--color-bg-primary`: lch(98.94% 0.5 282)
 - `--color-bg-secondary`: lch(95.94% 0.5 282)
 - `--color-bg-selected`: var(--noir-ion-selected)
-- `--color-bg-selected-strong`: var(--noir-ion-selected-strong)
 - `--color-bg-surface-0`: #f5f5f5
 - `--color-bg-surface-1`: var(--linear-app-content-surface)
 - `--color-bg-surface-2`: #f2f3f5
@@ -87,7 +86,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 - `--color-bg-tooltip`: #101012
 - `--color-border-default`: oklch(0% 0 0 / 8%)
 - `--color-border-focus`: #7170ff
-- `--color-border-interactive`: var(--noir-ion-border-interactive)
 - `--color-border-strong`: oklch(0% 0 0 / 15%)
 - `--color-border-subtle`: oklch(0% 0 0 / 5%)
 - `--color-btn-primary-bg`: oklch(10% 0 0)
@@ -204,8 +202,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 ### Public Shell
 
 - `--public-shell-bg`: var(--color-bg-base)
-- `--public-shell-border`: var(--color-border-default)
-- `--public-shell-content-max`: var(--ds-public-content-max)
 - `--public-shell-header-offset`: var(--linear-header-height)
 - `--public-shell-text`: var(--color-text-primary-token)
 
@@ -213,18 +209,16 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 
 - `--public-content-max-landing`: var(--ds-public-content-max)
 - `--public-content-max-page`: var(--ds-public-content-max)
-- `--public-content-max-prose`: var(--ds-prose-max)
 
 ### Profile Shell
 
 - `--profile-action-radius`: 14px
-- `--profile-bottom-nav-height`: calc( 3.125rem + max(10px, env(safe-area-inset-bottom)) + 14px )
+- `--profile-bottom-nav-height`: calc( var(--space-12) + var(--space-2-5) + max(10px, env(safe-area-inset-bottom)) + var(--space-2) )
 - `--profile-card-radius`: 22px
 - `--profile-drawer-bg`: rgb(248, 248, 250)
 - `--profile-drawer-highlight`: linear-gradient( 180deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.06) 40%, transparent 100% )
 - `--profile-drawer-radius-desktop`: 20px
 - `--profile-drawer-radius-mobile`: 22px
-- `--profile-drawer-shadow`: 0 -10px 24px rgba(12, 12, 18, 0.06), 0 -24px 56px rgba(12, 12, 18, 0.14)
 - `--profile-inner-radius`: 18px
 - `--profile-notification-icon-size`: 17px
 - `--profile-shell-card-radius`: 24px
@@ -267,7 +261,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 - `--font-display`: var(--font-satoshi, "Satoshi"), -apple-system, "system-ui", sans-serif
 - `--font-features`: "cv01", "ss03"
 - `--font-mono`: "SF Mono", "Fira Code", "Fira Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace
-- `--font-optical-sizing`: 28
 - `--font-sans`: var(--font-inter, "Inter Variable"), "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif
 - `--font-weight-bold`: 680
 - `--font-weight-book`: 450
@@ -302,7 +295,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 - `--shadow-button-inset`: 0px 4px 4px -1px oklch(0% 0 0 / 6%), 0px 1px 1px 0px oklch(0% 0 0 / 12%)
 - `--shadow-card`: oklch(80% 0 283) 0px 0px 0px 1px, oklch(0% 0 0 / 2.2%) 0px 3px 6px -2px, oklch(0% 0 0 / 4.4%) 0px 1px 1px 0px
 - `--shadow-card-elevated`: oklch(0% 0 0 / 2.2%) 0px 3px 6px -2px, oklch(0% 0 0 / 4.4%) 0px 1px 1px 0px
-- `--shadow-color`: 240 10% 3.9%
 - `--shadow-divider`: oklch(86% 0 283) 0px -0.5px 0px 0px inset
 - `--shadow-lg`: 0 4px 40px #00000014, 0 3px 20px #0000001a, 0 2px 6px #00000014, 0 1px 1px #0000000f
 - `--shadow-md`: 0 3px 8px #0000001a, 0 2px 5px #0000001a, 0 1px 1px #0000001a
@@ -312,11 +304,8 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 
 ### Theme Inputs
 
-- `--theme-accent-chroma`: 0.18
-- `--theme-accent-hue`: 282
 - `--theme-base-chroma`: 0.015
 - `--theme-base-hue`: 282
-- `--theme-base-l`: 99%
 - `--theme-contrast`: 65
 
 ### Motion Tokens
@@ -328,7 +317,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 
 ### Other Tokens
 
-- `--card-pad`: clamp(14px, 3vw, 24px)
 - `--content-max`: 720px
 - `--duration-cinematic`: var(--ds-motion-cinematic-duration)
 - `--duration-fast`: 100ms
@@ -347,7 +335,6 @@ Contract tokens below are the semantic surface for AI edits. DSP brand colors an
 - `--ease-spring`: cubic-bezier(0.34, 1.56, 0.64, 1)
 - `--ease-subtle`: var(--ds-motion-subtle-easing)
 - `--page-pad`: clamp(16px, 4vw, 32px)
-- `--section-gap`: clamp(16px, 3vw, 28px)
 
 ## Shared UI Components (36 atom primitives)
 


### PR DESCRIPTION
## Summary
Cleans drifted / non-canonical color tokens from the canonical design source so the system locks onto **System B** and importers (Magic Patterns) stop scraping retired System A drift.

### Removed from `apps/web/styles/design-system.css` (48 dead tokens, 60 def lines)
Verified **zero live references repo-wide** (var(), Tailwind `bg-(--x)` paren syntax, `@theme`, `.tsx/.ts/.css/.mjs`, tests, scripts, apps/ios) before each removal:
- **Full Geist System A palette** — `--geist-*` (27): the legacy Vercel/Geist color set that was the bulk of scraped System A drift. Style guards already ban geist; these were vestigial. (Static `pitch/colors_and_type.css` carries its own self-contained copy, untouched.)
- **Retired liquid-glass frosted-glass** — `--liquid-glass-item-*` (3)
- Legacy utility/UI defaults — `--menu-foreground`, `--shadow-color`, `--font-optical-sizing`
- Dead profile/composer helpers — `--profile-composer-bg/shadow`, `--profile-drawer-shadow`, `--profile-tab-enter-offset`
- Unused public-shell/platform aliases — `--public-shell-border`, `--public-shell-content-max`, `--public-content-max-prose`
- Unused shell geometry — `--avatar-size`, `--card-pad`, `--section-gap`
- Dead theme-gen inputs — `--theme-accent-hue/chroma`, `--theme-base-l` (kept documented `--theme-base-hue/chroma/contrast` trio)
- Dead semantic aliases — `--color-bg-selected-strong`, `--color-border-interactive`

### Kept (conservative — no breaking live UI, no gutting System B)
Every token referenced by live components (`--color-link-visited`, `--state-offline-*`, `--state-permission-*`, `--public-shell-bg/text`), test-asserted tokens (`--color-bg-selected`, all `--noir-ion-*` anchors), and documented System B canon.

### Added
- **`design.tokens.json`** — DTCG export of the 39 canonical **dark-first System B** tokens (Noir Ion surfaces, text scale, borders, focus/selection, 7 status accents Ion/Ultra/Pulse/Aqua/Mint/Gold/Flare, status success/warning/error, feature accents), each resolved to a literal value from `design-system.css`. Clean machine-readable set for importers.
- Regenerated `docs/llms-design-manifest.txt` (drops stale references to removed tokens).

### Sizing
`design-system.css`: 528 → 480 CSS vars; 338 → 322 unique colors.

## Test Plan
- [x] `lint:contrast-ratchet` — clean, no new violations
- [x] `noir-ion-tokens`, `linear-namespace-ratchet`, `singular-system-b-ratchet` — pass (Noir Ion anchors intact)
- [x] System B style guards (chat-composer, entity-rich-chip, profile-liquid-glass-nav), avatar utils — pass
- [x] `biome check` on CSS — clean
- [x] CSS brace balance — 169/169