### PR TITLE
fix(web): render smart-link provider icons in their own brand colors (JOV-4864)

### DIFF
--- a/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
+++ b/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
@@ -194,6 +194,7 @@ export function SoundsLandingPage({
                   onClick={() => handleProviderClick(provider.key)}
                   label={logoConfig?.name ?? provider.label}
                   iconPath={logoConfig?.iconPath}
+                  iconColor={logoConfig?.color}
                 />
               );
             })}

--- a/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
+++ b/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
@@ -439,6 +439,7 @@ export function ReleaseLandingPage({
                   onClick={() => handleProviderClick(provider.key)}
                   label={logoConfig?.name ?? provider.label}
                   iconPath={logoConfig?.iconPath}
+                  iconColor={logoConfig?.color}
                 />
               );
             })}

--- a/apps/web/components/features/demo/DemoReleasePresaveSurface.tsx
+++ b/apps/web/components/features/demo/DemoReleasePresaveSurface.tsx
@@ -82,28 +82,34 @@ export function DemoReleasePresaveSurface() {
               <SmartLinkProviderButton
                 label='Spotify'
                 iconPath={spotifyConfig?.iconPath}
+                iconColor={spotifyConfig?.color}
               />
               <SmartLinkProviderButton
                 label='Apple Music'
                 iconPath={appleConfig?.iconPath}
+                iconColor={appleConfig?.color}
                 href={THE_DEEP_END_APPLE_URL}
               />
               <SmartLinkProviderButton
                 label='YouTube Music'
                 iconPath={youtubeMusicConfig?.iconPath}
+                iconColor={youtubeMusicConfig?.color}
               />
               <SmartLinkProviderButton
                 label='SoundCloud'
                 iconPath={soundcloudConfig?.iconPath}
+                iconColor={soundcloudConfig?.color}
                 href={THE_DEEP_END_SOUNDCLOUD_URL}
               />
               <SmartLinkProviderButton
                 label='TIDAL'
                 iconPath={tidalConfig?.iconPath}
+                iconColor={tidalConfig?.color}
               />
               <SmartLinkProviderButton
                 label='Amazon Music'
                 iconPath={amazonMusicConfig?.iconPath}
+                iconColor={amazonMusicConfig?.color}
               />
             </div>
 

--- a/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
+++ b/apps/web/components/features/home/AutomaticReleaseSmartlinksSection.tsx
@@ -203,6 +203,10 @@ export function AutomaticReleaseSmartlinksSection() {
                             DSP_LOGO_CONFIG[key as keyof typeof DSP_LOGO_CONFIG]
                               ?.iconPath
                           }
+                          iconColor={
+                            DSP_LOGO_CONFIG[key as keyof typeof DSP_LOGO_CONFIG]
+                              ?.color
+                          }
                           className='bg-surface-1 ring-(--linear-border-subtle) hover:bg-hover'
                         />
                       );

--- a/apps/web/components/features/home/ReleasePhoneContent.tsx
+++ b/apps/web/components/features/home/ReleasePhoneContent.tsx
@@ -61,6 +61,7 @@ export function ReleasePhoneContent({
               key={key}
               label={DSP_LABELS[key] ?? 'Spotify'}
               iconPath={config.iconPath}
+              iconColor={config.color}
               className='bg-surface-1 ring-(--linear-border-subtle) hover:bg-hover'
             />
           );

--- a/apps/web/components/features/home/SeeItInActionCarousel.tsx
+++ b/apps/web/components/features/home/SeeItInActionCarousel.tsx
@@ -155,6 +155,7 @@ function ReleasePopoverContent({
               key={provider}
               label={DSP_LABELS[provider]}
               iconPath={config.iconPath}
+              iconColor={config.color}
               href={`${releaseHref}?dsp=${provider}`}
               className='bg-surface-1 ring-(--linear-border-subtle) hover:bg-hover'
             />

--- a/apps/web/components/features/profile/StaticListenInterface.tsx
+++ b/apps/web/components/features/profile/StaticListenInterface.tsx
@@ -186,6 +186,7 @@ export const StaticListenInterface = React.memo(function StaticListenInterface({
                 }}
                 label={isSelected ? `Opening ${dsp.name}...` : dsp.name}
                 iconPath={logoConfig?.iconPath}
+                iconColor={logoConfig?.color}
                 className={cn(providerButtonClassName, buttonClassName)}
               />
             );

--- a/apps/web/components/features/release/PreSaveActions.tsx
+++ b/apps/web/components/features/release/PreSaveActions.tsx
@@ -95,6 +95,7 @@ export function PreSaveActions({
         <SmartLinkProviderButton
           label='Spotify'
           iconPath={spotifyConfig?.iconPath}
+          iconColor={spotifyConfig?.color}
           href={spotifyHref}
         />
       ) : null}
@@ -107,6 +108,7 @@ export function PreSaveActions({
               : 'Apple Music'
           }
           iconPath={appleConfig?.iconPath}
+          iconColor={appleConfig?.color}
           onClick={handleApplePreAdd}
         />
       ) : null}

--- a/apps/web/components/features/release/SmartLinkProviderButton.tsx
+++ b/apps/web/components/features/release/SmartLinkProviderButton.tsx
@@ -4,6 +4,8 @@ import { cn } from '@/lib/utils';
 interface SmartLinkProviderButtonProps {
   readonly label: string;
   readonly iconPath?: string;
+  /** Brand color for the provider icon. Falls back to muted foreground. */
+  readonly iconColor?: string;
   /** Custom icon element — used instead of iconPath when provided */
   readonly icon?: ReactNode;
   readonly href?: string;
@@ -21,6 +23,7 @@ interface SmartLinkProviderButtonProps {
 export function SmartLinkProviderButton({
   label,
   iconPath,
+  iconColor,
   icon,
   href,
   onClick,
@@ -36,7 +39,11 @@ export function SmartLinkProviderButton({
           <svg
             viewBox='0 0 24 24'
             fill='currentColor'
-            className='h-5 w-5 shrink-0 text-muted-foreground'
+            className={cn(
+              'h-5 w-5 shrink-0',
+              iconColor ? undefined : 'text-muted-foreground'
+            )}
+            style={iconColor ? { color: iconColor } : undefined}
             aria-hidden='true'
           >
             <path d={iconPath} />

--- a/apps/web/tests/unit/release/smart-link-provider-button.test.tsx
+++ b/apps/web/tests/unit/release/smart-link-provider-button.test.tsx
@@ -36,4 +36,25 @@ describe('SmartLinkProviderButton', () => {
     fireEvent.click(link);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('renders the provider icon in its brand color when iconColor is given', () => {
+    render(
+      <SmartLinkProviderButton
+        label='Spotify'
+        iconPath='M12 0v24'
+        iconColor='var(--color-brand-spotify)'
+      />
+    );
+
+    const icon = document.querySelector('svg');
+    expect(icon).toHaveStyle({ color: 'var(--color-brand-spotify)' });
+    expect(icon).not.toHaveClass('text-muted-foreground');
+  });
+
+  it('falls back to muted foreground when iconColor is omitted', () => {
+    render(<SmartLinkProviderButton label='Spotify' iconPath='M12 0v24' />);
+
+    const icon = document.querySelector('svg');
+    expect(icon).toHaveClass('text-muted-foreground');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes JOV-4864 — https://linear.app/jovie/issue/JOV-4864/ui-dock-renders-duplicate-colored-icons

The smart-link "dock" of provider buttons rendered **every** DSP icon with the same hard-coded `text-muted-foreground` — a duplicate color treatment across all icons — even though `DSP_LOGO_CONFIG` / `VIDEO_LOGO_CONFIG` (`apps/web/components/atoms/DspLogo.tsx`) define a canonical brand color per provider. Each provider icon now uses its own brand color; muted foreground remains the fallback when no brand color exists.

## Change

- `SmartLinkProviderButton`: new optional `iconColor` prop applied to the provider icon (inline `color`, replacing the muted class only when provided).
- Passed each provider's brand color at every call site: release landing (`/r/[slug]`), sounds landing, profile listen interface, pre-save actions, and homepage/marketing demo surfaces (`ReleasePhoneContent`, `AutomaticReleaseSmartlinksSection`, `SeeItInActionCarousel`, `DemoReleasePresaveSurface`).
- Added unit tests: brand color applied when `iconColor` given; muted fallback preserved when omitted.

## Test plan

- `pnpm exec vitest run tests/unit/release/` — 16 files, 123 tests, all green (incl. 5 button tests, 2 new).
- `pnpm exec vitest run tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx` — green.
- `pnpm biome check --write <changed files>` — clean.
- `pnpm --filter @jovie/web run typecheck` — clean.
- Commit hooks: biome + eslint + a11y staged + web typecheck gates passed; pre-push gate passed.

## Screenshots

Screenshot capture unavailable in this environment (unattended headless agent). Visual change: DSP icons in the provider button list now render in brand colors (e.g. Spotify green, YouTube red) instead of uniform muted grey. No layout shift — only the icon `color` changes; geometry is untouched.

## Notes

The founder's screenshot (`img_b25c015d27fd.jpg`) was not attached to the Linear issue or the synced GitHub issue, so "dock" was interpreted as the smart-link provider button list — the only surface where every app icon received an identical (duplicated) color despite per-brand colors being defined. An alternate candidate (`DspAvatarStack` popover) was investigated and ruled out: its same-color pairs (YouTube/YouTube Music red, TIDAL/TikTok near-black) are brand-real.