### PR TITLE
fix(web): consolidate page-shell defaults to one content contract (JOV-4867)

### DIFF
--- a/apps/web/app/app/(shell)/admin/ingest/AdminIngestPageClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ingest/AdminIngestPageClient.tsx
@@ -149,7 +149,7 @@ export function AdminIngestContent({ history }: AdminIngestPageClientProps) {
 
 export function AdminIngestPageClient(props: AdminIngestPageClientProps) {
   return (
-    <PageShell>
+    <PageShell frame='none' contentPadding='none'>
       <PageContent>
         <AdminIngestContent {...props} />
       </PageContent>

--- a/apps/web/app/app/(shell)/admin/loading.tsx
+++ b/apps/web/app/app/(shell)/admin/loading.tsx
@@ -6,7 +6,7 @@ import { AdminHealthDashboardSkeleton } from './_components/AdminHealthDashboard
  */
 export default function AdminLoading() {
   return (
-    <PageShell>
+    <PageShell frame='none' contentPadding='none'>
       <PageContent>
         <div className='flex h-full flex-col gap-4'>
           <AdminHealthDashboardSkeleton />

--- a/apps/web/app/app/(shell)/admin/screenshots/loading.tsx
+++ b/apps/web/app/app/(shell)/admin/screenshots/loading.tsx
@@ -12,7 +12,7 @@ const SKELETON_KEYS = Array.from({ length: 8 }, (_, i) => `ss-loading-${i}`);
  */
 export default function ScreenshotsLoading() {
   return (
-    <PageShell>
+    <PageShell frame='none' contentPadding='none'>
       <PageHeader title='Screenshots' description='Loading screenshots...' />
       <PageContent>
         <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>

--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -433,6 +433,7 @@ export function CalendarPageClient() {
   return (
     <PageShell
       data-testid='calendar-workspace'
+      frame='none'
       contentPadding='none'
       toolbar={
         <PageToolbar

--- a/apps/web/app/app/(shell)/calendar/CalendarRouteSkeleton.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarRouteSkeleton.tsx
@@ -62,6 +62,7 @@ export function CalendarRouteSkeleton() {
       aria-busy='true'
       aria-label='Loading Calendar'
       aria-live='polite'
+      frame='none'
       contentPadding='none'
       toolbar={
         <PageToolbar

--- a/apps/web/app/app/(shell)/dashboard/release-plan/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/release-plan/page.tsx
@@ -34,6 +34,7 @@ export default function ReleasePlanPage() {
   return (
     <PageShell
       aria-label='Release Plan'
+      frame='none'
       contentPadding='default'
       className='h-full'
       data-testid='release-plan-shell'
@@ -54,7 +55,7 @@ export default function ReleasePlanPage() {
                 onClick={() => setPlan(generateDemoPlan())}
                 size='sm'
               >
-                Generate plan
+                Generate Plan
               </Button>
             }
             subtitleClassName='whitespace-normal'

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -198,7 +198,9 @@ export default function PromoDownloadsPage() {
 
   return (
     <PageShell
-      aria-label='Promo downloads'
+      frame='none'
+      contentPadding='none'
+      aria-label='Promo Downloads'
       data-testid='release-downloads-shell'
     >
       <PageContent>
@@ -213,7 +215,7 @@ export default function PromoDownloadsPage() {
               <button
                 type='button'
                 aria-disabled={uploading || undefined}
-                aria-label='Drop or choose a promo download audio file'
+                aria-label='Drop Or Choose A Promo Download Audio File'
                 onClick={() => {
                   if (!uploading) {
                     fileInputRef.current?.click();
@@ -267,7 +269,7 @@ export default function PromoDownloadsPage() {
               onChange={handleFileSelect}
               disabled={uploading}
               className='sr-only'
-              aria-label='Upload promo download audio file'
+              aria-label='Upload Promo Download Audio File'
             />
             <output
               className='block min-h-9 border-t border-transparent px-3 py-2.5 text-xs sm:px-4'

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -860,7 +860,11 @@ export function ProfilesWorkspace({
 
   if (!data) {
     return (
-      <PageShell data-testid='profiles-workspace'>
+      <PageShell
+        frame='none'
+        contentPadding='none'
+        data-testid='profiles-workspace'
+      >
         <EmptyState
           icon={<UserRound className='h-5 w-5' aria-hidden />}
           heading='No Artist Profile Selected'
@@ -878,6 +882,8 @@ export function ProfilesWorkspace({
 
   return (
     <PageShell
+      frame='none'
+      contentPadding='none'
       data-testid='profiles-workspace'
       surfaceMode='table'
       toolbar={

--- a/apps/web/app/app/(shell)/tour-dates/TourDatesPageClient.tsx
+++ b/apps/web/app/app/(shell)/tour-dates/TourDatesPageClient.tsx
@@ -21,6 +21,8 @@ export function TourDatesPageClient({
   return (
     <ChatEntityPanelProvider resetKey={profileId}>
       <PageShell
+        frame='none'
+        contentPadding='none'
         surfaceMode='table'
         data-testid='tour-dates-page'
         contentClassName='min-h-0'

--- a/apps/web/components/features/admin/layout/AdminPage.tsx
+++ b/apps/web/components/features/admin/layout/AdminPage.tsx
@@ -76,7 +76,7 @@ export function AdminPage<
   const showMetaHeader = Boolean(description || actions);
 
   return (
-    <PageShell>
+    <PageShell frame='none' contentPadding='none'>
       <PageContent noPadding>
         <div
           className={cn(

--- a/apps/web/components/features/dashboard/dashboard-pay/DashboardPay.tsx
+++ b/apps/web/components/features/dashboard/dashboard-pay/DashboardPay.tsx
@@ -409,6 +409,7 @@ export function DashboardPay() {
     <>
       <h1 className='sr-only'>Earnings Dashboard</h1>
       <PageShell
+        frame='none'
         maxWidth='wide'
         contentPadding='compact'
         data-testid='dashboard-earnings-workspace'

--- a/apps/web/components/features/dashboard/insights/InsightsPanel.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsPanel.tsx
@@ -208,7 +208,12 @@ export function InsightsPanelView({
   );
 
   return (
-    <PageShell toolbar={toolbar} data-testid={testId}>
+    <PageShell
+      frame='none'
+      contentPadding='none'
+      toolbar={toolbar}
+      data-testid={testId}
+    >
       <div className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden'>
         <div className='flex flex-col gap-4 px-3 py-2.5 sm:px-4 sm:py-3.5'>
           <AppSegmentControl

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
@@ -23,6 +23,8 @@ const AUDIENCE_LOADING_COLUMNS = buildAudienceMemberColumns('members');
 export function AudienceTableLoadingShell() {
   return (
     <PageShell
+      frame='none'
+      contentPadding='none'
       aria-busy='true'
       aria-label='Loading Audience'
       data-testid='dashboard-audience-loading'

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -847,6 +847,8 @@ export const DashboardAudienceTableUnified = memo(
         <AudienceTableStableProvider value={stableContextValue}>
           <AudienceTableVolatileProvider value={volatileContextValue}>
             <PageShell
+              frame='none'
+              contentPadding='none'
               className='overflow-hidden'
               data-testid={testId}
               surfaceMode='table'

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceView.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceView.tsx
@@ -82,7 +82,10 @@ export function DspPresenceView({
   // Shell integration: drawer toggle + right panel width
   const { setTableMeta } = useTableMeta();
   const itemsRef = useRef(data.items);
-  itemsRef.current = data.items;
+
+  useEffect(() => {
+    itemsRef.current = data.items;
+  }, [data.items]);
 
   useEffect(() => {
     const toggle = () => {
@@ -140,7 +143,12 @@ export function DspPresenceView({
 
   if (data.items.length === 0) {
     return (
-      <PageShell toolbar={toolbar} data-testid='dsp-presence-workspace'>
+      <PageShell
+        frame='none'
+        contentPadding='none'
+        toolbar={toolbar}
+        data-testid='dsp-presence-workspace'
+      >
         <div
           className='flex h-full min-h-0 flex-1 items-center justify-center p-8'
           data-testid='dsp-presence-content-panel'
@@ -166,7 +174,12 @@ export function DspPresenceView({
   }
 
   return (
-    <PageShell toolbar={toolbar} data-testid='dsp-presence-workspace'>
+    <PageShell
+      frame='none'
+      contentPadding='none'
+      toolbar={toolbar}
+      data-testid='dsp-presence-workspace'
+    >
       <div
         className='flex min-h-0 flex-1 overflow-hidden'
         data-testid='dsp-presence-content-panel'

--- a/apps/web/components/features/dashboard/organisms/jovie-work-feed/JovieWorkPanel.tsx
+++ b/apps/web/components/features/dashboard/organisms/jovie-work-feed/JovieWorkPanel.tsx
@@ -10,7 +10,7 @@ export function JovieWorkPanel() {
   const profileId = selectedProfile?.id;
 
   return (
-    <PageShell data-testid='jovie-work-page'>
+    <PageShell frame='none' contentPadding='none' data-testid='jovie-work-page'>
       <div className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden'>
         <div className='flex flex-col gap-4 px-3 py-2.5 sm:px-4 sm:py-3.5'>
           <div className='space-y-1'>

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -22,12 +22,12 @@ import { instantiateReleaseTasks } from '@/app/app/(shell)/dashboard/releases/ta
 import { toast } from '@/components/feedback';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
 import { DrawerLoadingSkeleton } from '@/components/molecules/drawer';
-import { useTableMeta } from '@/components/organisms/AuthShellWrapper';
 import { DialogLoadingSkeleton } from '@/components/organisms/DialogLoadingSkeleton';
 import { PageShell } from '@/components/organisms/PageShell';
 import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
 import { APP_ROUTES } from '@/constants/routes';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
+import { useTableMeta } from '@/contexts/TableMetaContext';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { openChatWithPrompt } from '@/lib/chat/open-chat-with-prompt';
 import type { ReleaseViewModel } from '@/lib/discography/types';
@@ -536,7 +536,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
   );
 
   // Empty selection for subheader export (simplified - no bulk selection)
-  const selectedIds = useRef(new Set<string>()).current;
+  const [selectedIds] = useState(() => new Set<string>());
 
   const handleArtistConnected = useCallback(
     (newReleases: ReleaseViewModel[], newArtistName: string) => {
@@ -760,7 +760,10 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
 
   // Use ref to avoid infinite loop - rows array reference changes each render
   const rowsRef = useRef(rows);
-  rowsRef.current = rows;
+
+  useEffect(() => {
+    rowsRef.current = rows;
+  }, [rows]);
 
   useEffect(() => {
     // Toggle function: close if open, open first release if closed
@@ -1028,7 +1031,12 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
           onMatchStatusChange={handleMatchStatusChange}
         />
         {showEmptyState && (
-          <PageShell className='mt-2.5' data-testid='release-table-shell'>
+          <PageShell
+            frame='none'
+            contentPadding='none'
+            className='mt-2.5'
+            data-testid='release-table-shell'
+          >
             <Suspense fallback={null}>
               <ReleasesEmptyState
                 onConnectSpotify={() => setSpotifySearchOpen(true)}
@@ -1049,6 +1057,8 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
         {showReleasesTable && (
           <QueryErrorBoundary>
             <PageShell
+              frame='none'
+              contentPadding='none'
               className='mt-2.5'
               data-testid='release-table-shell'
               toolbar={

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrixNotices.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrixNotices.tsx
@@ -173,7 +173,12 @@ export function ConnectedReleaseEmptyState({
     : 'Sync from Spotify to start generating smart links.';
 
   return (
-    <PageShell className='mt-2.5' data-testid='release-table-shell'>
+    <PageShell
+      frame='none'
+      contentPadding='none'
+      className='mt-2.5'
+      data-testid='release-table-shell'
+    >
       <DrawerSurfaceCard
         variant='card'
         className='flex min-h-53 flex-col items-center justify-center px-5 py-9 text-center'

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -2134,6 +2134,8 @@ export function TasksPageClient() {
         }
       />
       <PageShell
+        frame='none'
+        contentPadding='none'
         className='absolute inset-0 overflow-hidden'
         surfaceClassName='p-0'
         data-testid='tasks-workspace'

--- a/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
@@ -69,7 +69,11 @@ function TasksUpgradeContent({
 
 export function TasksWorkspaceUpgradeInterstitial() {
   return (
-    <PageShell data-testid='tasks-upgrade-interstitial'>
+    <PageShell
+      frame='none'
+      contentPadding='none'
+      data-testid='tasks-upgrade-interstitial'
+    >
       <NavigationDestinationReady destination='tasks' />
       <section className='flex min-h-0 flex-1 items-center justify-center px-6 py-6'>
         <TasksUpgradeContent

--- a/apps/web/components/features/dashboard/youtube/RevivalQueuePanel.tsx
+++ b/apps/web/components/features/dashboard/youtube/RevivalQueuePanel.tsx
@@ -293,7 +293,12 @@ export function RevivalQueuePanel({
   );
 
   return (
-    <PageShell toolbar={toolbar} data-testid={testId}>
+    <PageShell
+      frame='none'
+      contentPadding='none'
+      toolbar={toolbar}
+      data-testid={testId}
+    >
       <div className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden'>
         <div className='flex flex-col gap-6 px-3 py-2.5 sm:px-4 sm:py-3.5'>
           <ChannelIntelligencePanel

--- a/apps/web/components/features/demo/SettingsDemoHarness.tsx
+++ b/apps/web/components/features/demo/SettingsDemoHarness.tsx
@@ -59,7 +59,12 @@ export function SettingsDemoHarness({
     );
   } else if (shell === 'page') {
     content = (
-      <PageShell maxWidth='wide' contentPadding='compact' data-testid={testId}>
+      <PageShell
+        frame='none'
+        maxWidth='wide'
+        contentPadding='compact'
+        data-testid={testId}
+      >
         {children}
       </PageShell>
     );

--- a/apps/web/components/organisms/PageShell.stories.tsx
+++ b/apps/web/components/organisms/PageShell.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { PageContent, PageHeader, PageShell } from './PageShell';
+
+const meta: Meta<typeof PageShell> = {
+  title: 'Organisms/PageShell',
+  component: PageShell,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    children: (
+      <>
+        <PageHeader title='Releases' description='Manage your catalog' />
+        <PageContent>
+          <div>Page content</div>
+        </PageContent>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Canonical default — identical geometry to AppShellContentPanel (JOV-4867). */
+export const Default: Story = {};
+
+/** Legacy unframed/unpadded look via explicit props on the adapter. */
+export const Unframed: Story = {
+  args: {
+    frame: 'none',
+    contentPadding: 'none',
+  },
+};
+
+/** Table surface with page-owned scroll (settings route pattern). */
+export const TableSurfacePageScroll: Story = {
+  args: {
+    surfaceMode: 'table',
+    scroll: 'page',
+    maxWidth: 'wide',
+  },
+};

--- a/apps/web/components/organisms/PageShell.tsx
+++ b/apps/web/components/organisms/PageShell.tsx
@@ -19,23 +19,15 @@ export interface PageShellProps
 }
 
 /**
- * PageShell - Standardized page container with rounded corners
+ * PageShell — compatibility adapter over {@link AppShellContentPanel}.
  *
- * Provides consistent layout structure across all dashboard and admin pages:
- * - Rounded corners (8px radius)
- * - Proper background surface
- * - Full height with overflow handling
- * - Optional outer padding
- *
- * Usage Pattern:
- * ```tsx
- * <PageShell>
- *   <PageHeader title="Page Title" />
- *   <div className="flex-1 min-h-0 overflow-auto">
- *     {content}
- *   </div>
- * </PageShell>
- * ```
+ * JOV-4867 (UI drift P1): the authenticated app has ONE content contract —
+ * `AppShellContentPanel`. `PageShell` no longer defines its own defaults; it
+ * forwards every prop so both names resolve to the same geometry
+ * (`frame='content-container'`, `contentPadding='default'`, `scroll='panel'`,
+ * `maxWidth='full'`, `surfaceMode='default'`). Callers that need the legacy
+ * unframed/unpadded look pass `frame='none'` / `contentPadding='none'`
+ * explicitly. Prefer `AppShellContentPanel` in new code.
  *
  * @example
  * ```tsx
@@ -46,44 +38,15 @@ export interface PageShellProps
  *         title="My Page"
  *         action={<Button>Action</Button>}
  *       />
- *       <div className="flex-1 min-h-0 p-6">
- *         Page content here
- *       </div>
+ *       <PageContent>Page content here</PageContent>
  *     </PageShell>
  *   );
  * }
  * ```
  */
-export function PageShell({
-  children,
-  toolbar,
-  maxWidth = 'full',
-  frame = 'none',
-  contentPadding = 'none',
-  surfaceMode = 'default',
-  scroll = 'panel',
-  className,
-  surfaceClassName,
-  contentClassName,
-  'data-testid': testId,
-  ...sectionProps
-}: PageShellProps) {
+export function PageShell({ children, ...panelProps }: PageShellProps) {
   return (
-    <AppShellContentPanel
-      toolbar={toolbar}
-      maxWidth={maxWidth}
-      frame={frame}
-      contentPadding={contentPadding}
-      surfaceMode={surfaceMode}
-      scroll={scroll}
-      className={className}
-      surfaceClassName={surfaceClassName}
-      contentClassName={contentClassName}
-      data-testid={testId}
-      {...sectionProps}
-    >
-      {children}
-    </AppShellContentPanel>
+    <AppShellContentPanel {...panelProps}>{children}</AppShellContentPanel>
   );
 }
 

--- a/apps/web/components/shell/TasksRouteSkeleton.tsx
+++ b/apps/web/components/shell/TasksRouteSkeleton.tsx
@@ -5,6 +5,8 @@ import { PageToolbar } from '@/components/organisms/table';
 export function TasksRouteSkeleton() {
   return (
     <PageShell
+      frame='none'
+      contentPadding='none'
       aria-label='Loading Tasks'
       aria-busy='true'
       aria-live='polite'

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -138,7 +138,11 @@ describe('surface elevation guardrails', () => {
     );
 
     expect(pageShell).toContain('AppShellContentPanel');
-    expect(pageShell).toContain("frame = 'none'");
+    // JOV-4867: PageShell is a pure compatibility adapter — it must not
+    // re-declare divergent defaults (the old `frame = 'none'` drift). The
+    // single authenticated content contract lives in AppShellContentPanel.
+    expect(pageShell).not.toContain("frame = 'none'");
+    expect(pageShell).not.toContain("contentPadding = 'none'");
     expect(dashboardPanel).toContain("frame = 'content-container'");
     expect(dashboardPanel).toContain("'none'");
     expect(settingsLayout).toContain('PageShell');

--- a/apps/web/tests/unit/dashboard/DspPresenceView.test.tsx
+++ b/apps/web/tests/unit/dashboard/DspPresenceView.test.tsx
@@ -67,10 +67,14 @@ vi.mock('@/components/organisms/PageShell', () => ({
   PageShell: ({
     children,
     toolbar,
+    frame: _frame,
+    contentPadding: _contentPadding,
     ...props
   }: {
     children: ReactNode;
     toolbar: ReactNode;
+    frame?: string;
+    contentPadding?: string;
   }) => (
     <div {...props}>
       <div data-testid='presence-toolbar'>{toolbar}</div>

--- a/apps/web/tests/unit/shell/page-shell-content-contract.test.tsx
+++ b/apps/web/tests/unit/shell/page-shell-content-contract.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AppShellContentPanel } from '@/components/organisms/AppShellContentPanel';
+import { PageShell } from '@/components/organisms/PageShell';
+
+/**
+ * JOV-4867 — P1 UI drift: one authenticated content contract.
+ *
+ * `AppShellContentPanel` is the single content contract for authenticated
+ * routes. `PageShell` is a compatibility adapter that must render byte-for-byte
+ * identical geometry. These tests pin layout, scroll, and focus geometry so
+ * the two abstractions cannot drift apart again.
+ */
+describe('PageShell → AppShellContentPanel content contract (JOV-4867)', () => {
+  it('renders identical geometry to AppShellContentPanel when no props are given', () => {
+    const adapter = render(
+      <PageShell data-testid='adapter-panel'>
+        <div>Contract content</div>
+      </PageShell>
+    );
+    const canonical = render(
+      <AppShellContentPanel data-testid='adapter-panel'>
+        <div>Contract content</div>
+      </AppShellContentPanel>
+    );
+
+    expect(adapter.container.innerHTML).toEqual(canonical.container.innerHTML);
+  });
+
+  it('renders identical geometry for the legacy unframed/unpadded look when props are explicit', () => {
+    const adapter = render(
+      <PageShell frame='none' contentPadding='none' maxWidth='wide'>
+        <div>Legacy content</div>
+      </PageShell>
+    );
+    const canonical = render(
+      <AppShellContentPanel frame='none' contentPadding='none' maxWidth='wide'>
+        <div>Legacy content</div>
+      </AppShellContentPanel>
+    );
+
+    expect(adapter.container.innerHTML).toEqual(canonical.container.innerHTML);
+  });
+});
+
+describe('content contract layout geometry (JOV-4867)', () => {
+  it('keeps an unbroken min-h-0/flex-1 chain from the section to the content', () => {
+    render(
+      <AppShellContentPanel data-testid='geometry-panel'>
+        <div>Content</div>
+      </AppShellContentPanel>
+    );
+
+    const section = screen.getByTestId('geometry-panel');
+    expect(section).toHaveClass('flex', 'min-h-0', 'min-w-0', 'flex-1');
+
+    // Every wrapper between the section and the leaf content participates in
+    // the height chain — no wrapper may collapse the column or shift layout.
+    let node = section.firstElementChild as HTMLElement | null;
+    const chain: HTMLElement[] = [];
+    while (node && node.firstElementChild) {
+      chain.push(node);
+      node = node.firstElementChild as HTMLElement | null;
+    }
+    expect(chain.length).toBeGreaterThanOrEqual(3);
+    for (const wrapper of chain) {
+      expect(wrapper).toHaveClass('min-h-0');
+    }
+  });
+
+  it('reserves toolbar space without shifting the content column', () => {
+    const { container } = render(
+      <AppShellContentPanel toolbar={<div>Toolbar</div>}>
+        <div>Content</div>
+      </AppShellContentPanel>
+    );
+
+    const toolbarSlot = screen.getByText('Toolbar').parentElement;
+    expect(toolbarSlot).toHaveClass('shrink-0');
+    // Toolbar precedes content in DOM order so tab order matches visual order.
+    const html = container.innerHTML;
+    expect(html.indexOf('Toolbar')).toBeLessThan(html.indexOf('Content'));
+  });
+});
+
+describe('content contract scroll geometry (JOV-4867)', () => {
+  it('keeps panel scroll constrained by default (routes scroll inside the clip)', () => {
+    render(
+      <AppShellContentPanel data-testid='scroll-panel'>
+        <div>Content</div>
+      </AppShellContentPanel>
+    );
+
+    const section = screen.getByTestId('scroll-panel');
+    expect(section).toHaveClass('min-h-0', 'overflow-hidden');
+    expect(section).not.toHaveClass('overflow-y-auto');
+  });
+
+  it('lets the page own vertical scroll only in scroll="page" mode (settings routes)', () => {
+    render(
+      <AppShellContentPanel scroll='page' data-testid='scroll-panel'>
+        <div>Content</div>
+      </AppShellContentPanel>
+    );
+
+    const section = screen.getByTestId('scroll-panel');
+    expect(section).toHaveClass(
+      'min-h-0',
+      'overflow-y-auto',
+      'overflow-x-hidden',
+      'overscroll-contain'
+    );
+  });
+});
+
+describe('content contract focus geometry (JOV-4867)', () => {
+  it('does not steal focus: the shell section is not focusable and adds no tab stop', () => {
+    render(
+      <AppShellContentPanel toolbar={<button type='button'>Action</button>}>
+        <button type='button'>Content action</button>
+      </AppShellContentPanel>
+    );
+
+    const section = screen.getByText('Content action').closest('section');
+    expect(section).not.toBeNull();
+    expect(section).not.toHaveAttribute('tabindex');
+  });
+
+  it('keeps focus order matching visual order: toolbar controls come first', () => {
+    const { container } = render(
+      <AppShellContentPanel toolbar={<button type='button'>Action</button>}>
+        <button type='button'>Content action</button>
+      </AppShellContentPanel>
+    );
+
+    const tabStops = container.querySelectorAll('button');
+    expect(tabStops[0]).toHaveTextContent('Action');
+    expect(tabStops[1]).toHaveTextContent('Content action');
+  });
+});

--- a/docs/design-system/app-shell-route-scaffold-matrix.md
+++ b/docs/design-system/app-shell-route-scaffold-matrix.md
@@ -1,0 +1,59 @@
+# App Shell Route-to-Scaffold Matrix
+
+System of record for which scaffold each authenticated route renders through.
+Source ticket: JOV-4867 (P1 UI drift — `docs/audits/JOVIE_UI_DRIFT_AUDIT_2026-08-03.md`).
+
+## Layer contract
+
+| Layer | Component | Role |
+| --- | --- | --- |
+| Frame | `apps/web/components/organisms/AppShellFrame.tsx` | Auth primitive. Owns sidebar mount, main plane, right rail, audio tray, mobile bottom surface. Mounted once by `AuthShell` for the whole `app/app/(shell)` group. |
+| Content | `apps/web/components/organisms/AppShellContentPanel.tsx` | **The single authenticated content contract.** Owns max-width, frame (`content-container` default), content padding (`default`), surface mode, and scroll ownership (`panel` default). |
+| Adapter | `apps/web/components/organisms/PageShell.tsx` | Compatibility adapter only. Forwards every prop to `AppShellContentPanel` with **no divergent defaults** (JOV-4867). Prefer `AppShellContentPanel` in new code. |
+
+Before JOV-4867, `PageShell` silently overrode the contract with
+`frame='none'` / `contentPadding='none'` defaults, so two routes that looked
+identical in source rendered different geometry depending on which name they
+imported. Defaults now live in exactly one place: `AppShellContentPanel`.
+Callers that need the unframed/unpadded look pass those props explicitly.
+
+## Route → scaffold matrix (primary authenticated routes)
+
+Routes mount inside `AppShellFrame` via `app/app/(shell)/layout.tsx` → `AuthShell`. The content column then renders one of:
+
+| Route | Content scaffold | `frame` | `contentPadding` | `scroll` | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `/app/dashboard` (chat) | `ChatWorkspaceSurface` → PageShell | `none` | `none` | `panel` | Full-bleed chat plane; ambient gradient owned by frame. |
+| `/app/chats` (`/app/threads`) | `ThreadsPageClient` → PageShell | `content-container` | `none` | `panel` | |
+| `/app/library` | `LibrarySurface` → PageShell | `content-container` | `none` | `panel` | `surfaceMode='table'`. |
+| `/app/calendar` | `CalendarPageClient` → PageShell | `none` | `none` | `panel` | Toolbar slot for month nav. |
+| `/app/tasks` | `TasksPageClient` → PageShell | `none` | `none` | `panel` | Absolute-inset workspace. |
+| `/app/insights` | `InsightsPanel` → PageShell | `none` | `none` | `panel` | |
+| `/app/presence` | `DspPresenceView` → PageShell | `none` | `none` | `panel` | |
+| `/app/audience` | `DashboardAudienceTableUnified` → PageShell | `none` | `none` | `panel` | `surfaceMode='table'`. |
+| `/app/releases` | `ReleaseProviderMatrix` → PageShell | `none` | `none` | `panel` | |
+| `/app/releases/[id]/tasks` | `ReleaseTaskPage` → PageShell | `content-container` | `none` | `panel` | |
+| `/app/tour-dates` | `TourDatesPageClient` → PageShell | `none` | `none` | `panel` | `surfaceMode='table'`. |
+| `/app/profiles` | `ProfilesWorkspace` → PageShell | `none` | `none` | `panel` | `surfaceMode='table'` when populated. |
+| `/app/earnings` | `DashboardPay` → PageShell | `none` | `compact` | `panel` | `maxWidth='wide'`. |
+| `/app/dashboard/release-plan` | route page → PageShell | `none` | `default` | `panel` | |
+| `/app/settings/*` | `settings/layout.tsx` → PageShell | `none` | `none` | `page` | Page-level scroll owner; `maxWidth='wide'`. |
+| `/app/admin/*` | `AdminPage` → PageShell | `none` | `none` | `panel` | |
+| `/app/admin/ingest` | `AdminIngestPageClient` → PageShell | `none` | `none` | `panel` | |
+| demo surfaces | `DemoShowcaseSurface` et al. → AppShellContentPanel | per call | per call | per call | Demo surfaces use the canonical panel directly. |
+
+## Geometry invariants (test-pinned)
+
+Pinned by `apps/web/tests/unit/shell/page-shell-content-contract.test.tsx`
+and `apps/web/tests/unit/components/organisms/AppShellContentPanel.test.tsx`:
+
+- **Layout:** unbroken `min-h-0` / `flex-1` chain from the panel `<section>` to
+  the content leaf; toolbar slot is `shrink-0` so it never shifts the column.
+- **Scroll:** default `scroll='panel'` keeps the section at `overflow-hidden`
+  (routes scroll inside the shell clip so the right rail stays fixed);
+  `scroll='page'` (settings) moves `overflow-y-auto` onto the section.
+- **Focus:** the shell section takes no `tabindex`; toolbar controls precede
+  content in DOM order so tab order matches visual order.
+- **Adapter parity:** `PageShell` renders byte-identical markup to
+  `AppShellContentPanel` for the same props, with or without explicit
+  `frame`/`contentPadding`.

--- a/docs/design-system/component-inventory.md
+++ b/docs/design-system/component-inventory.md
@@ -63,3 +63,4 @@ This inventory records the current canonical component owners, known duplicates,
 
 - `apps/web/components/site/Container.tsx` is legacy for public surfaces and should remain only for storybook or internal-only cases until fully retired.
 - `apps/web/components/organisms/footer-module/Footer.tsx` is a public-profile/footer family, not the canonical public marketing/legal footer.
+- Authenticated shell geometry: `AppShellContentPanel` is the single content contract; `PageShell` is a no-defaults compatibility adapter (JOV-4867). Route-by-route mapping lives in [`app-shell-route-scaffold-matrix.md`](app-shell-route-scaffold-matrix.md).


### PR DESCRIPTION
<!-- linear-issue-id:067a06a8-b6f9-4f1d-8150-f2c049699df5 -->

## Summary

P1 UI-drift consolidation (source: `docs/audits/JOVIE_UI_DRIFT_AUDIT_2026-08-03.md`). The authenticated app had two page-shell abstractions with silently different defaults: `AppShellContentPanel` (`frame='content-container'`, `contentPadding='default'`) and `PageShell` (`frame='none'`, `contentPadding='none'`) — two routes that looked identical in source rendered different geometry depending on which name they imported.

- **`PageShell` is now a pure compatibility adapter** over `AppShellContentPanel` — the single authenticated content contract. It forwards every prop and declares no defaults of its own.
- **Behavior-preserving:** every call site that relied on the old implicit defaults (24 usages across dashboard/admin/settings/calendar/profiles/tasks/insights/presence/audience/earnings/release surfaces) now passes `frame` / `contentPadding` explicitly. Rendered geometry is unchanged.
- **Route-to-scaffold matrix** added at `docs/design-system/app-shell-route-scaffold-matrix.md` (frame → content panel → adapter layers, per-route scaffold/geometry table, test-pinned invariants), linked from `component-inventory.md`.
- **Geometry tests** added at `apps/web/tests/unit/shell/page-shell-content-contract.test.tsx`: adapter byte-parity with the canonical panel, unbroken `min-h-0`/`flex-1` layout chain, panel-vs-page scroll ownership, and focus geometry (no shell tab stop, toolbar precedes content in tab order).
- `surface-elevation-guardrails` now pins the normalized contract (PageShell must not re-declare divergent defaults) instead of pinning the drift.
- Added `PageShell.stories.tsx` (component-ship-gate requirement for touched components).
- Ratchet-fixed pre-existing eslint debt in touched files (required by the staged-eslint gate): label Title-Case fixes, `refs-during-render` moved into `useEffect`/`useState`, and one `import/no-cycle` resolved by importing `useTableMeta` from `@/contexts/TableMetaContext` directly instead of the `AuthShellWrapper` re-export.

## Test plan

- `biome check --write` on all touched files — clean
- `eslint` (lint-staged config) on all touched files — exit 0
- `vitest run` — 193 tests across 19 files, all pass, including:
  - new `page-shell-content-contract.test.tsx` (8 tests)
  - `AppShellContentPanel.test.tsx`, `surface-elevation-guardrails.test.ts`, `settings-shell-normalization.test.ts`, `TasksPageClient.test.tsx` (58), `DspPresenceView.test.tsx`, `ReleaseProviderMatrix.test.tsx`, `release-downloads-shell.test.ts`, `shell-variant-parity.test.tsx`, and other shell/route guards
- `typecheck` (`@jovie/web`) — exit 0 (run twice, incl. after ratchet fixes)
- Pre-push gates: component-ship-gate PASS, secret scans clean

## Screenshots

No visual change intended — this is a geometry-preserving consolidation; all visual deltas are pinned to explicit props at call sites. Screenshot capture not available in this environment; parity is asserted by DOM-geometry tests instead.

Fixes JOV-4867
https://linear.app/jovie/issue/JOV-4867/p1-ui-drift-consolidate-live-page-shell-abstractions-to-one
