### PR TITLE
fix(web): unify error/recovery UI on one RecoveryState contract (JOV-4868)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -41,6 +41,7 @@ import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { APP_ROUTES } from '@/constants/routes';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
 import { DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 import { useClipboard } from '@/hooks/useClipboard';
 import { env } from '@/lib/env-client';
 import { useNotifications } from '@/lib/hooks/useNotifications';
@@ -306,7 +307,7 @@ function ChatProfileFallback({
                 className='gap-2'
               >
                 <RefreshCw className='h-4 w-4' />
-                Retry
+                {RECOVERY_COPY.retryLabel}
               </Button>
             </>
           )}

--- a/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
+++ b/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
@@ -9,6 +9,7 @@ import { JovieChat } from '@/components/jovie/JovieChat';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 
 function ProfilePageChatFallback() {
   const router = useRouter();
@@ -57,7 +58,7 @@ function ProfilePageChatInner() {
                 ariaLabel='Retry Loading Profile Chat'
                 onClick={() => router.refresh()}
                 icon={<RefreshCw className='h-4 w-4' />}
-                label='Retry'
+                label={RECOVERY_COPY.retryLabel}
               />
             </ContentSurfaceCard>
           </div>

--- a/apps/web/app/app/(shell)/layout.ov-mode.test.tsx
+++ b/apps/web/app/app/(shell)/layout.ov-mode.test.tsx
@@ -210,7 +210,7 @@ describe('AppShellLayout OV mode', () => {
       expect.objectContaining({
         title: 'Dashboard failed to load',
         actions: [
-          expect.objectContaining({ label: 'Retry', variant: 'primary' }),
+          expect.objectContaining({ label: 'Try again', variant: 'primary' }),
           expect.objectContaining({
             label: 'Return To Jovie',
             variant: 'secondary',

--- a/apps/web/app/app/(shell)/layout.tsx
+++ b/apps/web/app/app/(shell)/layout.tsx
@@ -10,6 +10,7 @@ import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
 import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
 import { APP_ROUTES } from '@/constants/routes';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 import {
   APP_SHELL_MODE_HEADER,
   parseTrustedAppShellMode,
@@ -179,7 +180,7 @@ export default async function AppShellLayout({
             description='We could not load your workspace data. Try again, or return to Jovie.'
             actions={[
               {
-                label: 'Retry',
+                label: RECOVERY_COPY.retryLabel,
                 href: APP_ROUTES.DASHBOARD,
                 variant: 'primary',
               },

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SystemBErrorFallback } from '@/components/providers/SystemBErrorFallback';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 import type { ErrorProps } from '@/types/common';
 
 export default function RootError({ error, reset }: ErrorProps) {
@@ -9,7 +10,7 @@ export default function RootError({ error, reset }: ErrorProps) {
       description='An unexpected error occurred.'
       digest={error.digest}
       actions={[
-        { type: 'button', label: 'Try Again', onClick: reset },
+        { type: 'button', label: RECOVERY_COPY.retryLabel, onClick: reset },
         { type: 'link', label: 'Go Home', href: '/', variant: 'secondary' },
       ]}
     />

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -3,6 +3,7 @@
 import './globals.css';
 import { useEffect } from 'react';
 import { SystemBErrorFallback } from '@/components/providers/SystemBErrorFallback';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 
 /**
  * Global error page for Next.js App Router.
@@ -45,7 +46,11 @@ export default function GlobalError({
             description='An unexpected error occurred.'
             digest={error.digest}
             actions={[
-              { type: 'button', label: 'Try Again', onClick: reset },
+              {
+                type: 'button',
+                label: RECOVERY_COPY.retryLabel,
+                onClick: reset,
+              },
               {
                 type: 'link',
                 label: 'Go Home',

--- a/apps/web/components/features/feedback/ErrorBanner.tsx
+++ b/apps/web/components/features/feedback/ErrorBanner.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { toast } from '@/components/feedback';
 import { cn } from '@/lib/utils';
+import { RECOVERY_COPY } from './recovery-contract';
 
 export interface ErrorBannerAction {
   readonly label: string;
@@ -149,7 +150,9 @@ export function ErrorBanner({
               onClick={() => setShowDetails(!showDetails)}
               className='h-auto text-xs text-red-100/70 hover:text-red-100 dark:text-red-200/70 dark:hover:text-red-200 underline decoration-dotted'
             >
-              {showDetails ? 'Hide Error Details' : 'Show Error Details'}
+              {showDetails
+                ? `Hide ${RECOVERY_COPY.detailsLabel}`
+                : `Show ${RECOVERY_COPY.detailsLabel}`}
             </Button>
 
             {showDetails && (

--- a/apps/web/components/features/feedback/ErrorDetails.tsx
+++ b/apps/web/components/features/feedback/ErrorDetails.tsx
@@ -3,6 +3,7 @@
 import { Copy } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from '@/components/feedback';
+import { RECOVERY_COPY } from './recovery-contract';
 
 /**
  * Generate a short reference ID for errors without a Next.js digest.
@@ -94,7 +95,7 @@ export function ErrorDetails({
             type='button'
             onClick={handleCopy}
             className='inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-tertiary-token hover:text-primary-token hover:bg-surface-2 transition-colors duration-normal ease-interactive'
-            aria-label='Copy error details to clipboard'
+            aria-label='Copy Error Details To Clipboard'
           >
             <Copy className='h-3.5 w-3.5' aria-hidden='true' />
             Copy error details
@@ -134,7 +135,7 @@ export function ErrorDetails({
         data-focus-treatment='underline-only'
         className='cursor-pointer list-none text-center text-xs text-quaternary-token transition-colors duration-normal ease-interactive hover:text-tertiary-token'
       >
-        Error Details
+        {RECOVERY_COPY.detailsLabel}
       </summary>
       <div className='pt-3'>{content}</div>
     </details>

--- a/apps/web/components/features/feedback/PageErrorState.test.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.test.tsx
@@ -20,13 +20,15 @@ describe('PageErrorState', () => {
     expect(
       screen.getByRole('heading', { name: 'Unable to Load Dashboard' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
-    const summary = screen.getByText('Error Details');
+    expect(
+      screen.getByRole('button', { name: 'Try again' })
+    ).toBeInTheDocument();
+    const summary = screen.getByText('Error details');
     const details = summary.closest('details');
     expect(document.querySelectorAll('details')).toHaveLength(1);
     expect(details).not.toHaveAttribute('open');
     expect(
-      details?.querySelector('[aria-label="Copy error details to clipboard"]')
+      details?.querySelector('[aria-label="Copy Error Details To Clipboard"]')
     ).not.toBeNull();
     expect(document.querySelector('.lucide-triangle-alert')).toBeNull();
 
@@ -51,7 +53,7 @@ describe('PageErrorState', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
@@ -66,12 +68,12 @@ describe('PageErrorState', () => {
       />
     );
 
-    const details = screen.getByText('Error Details').closest('details');
+    const details = screen.getByText('Error details').closest('details');
     expect(details).not.toHaveAttribute('open');
     expect(screen.getAllByText(longMessage)).toHaveLength(1);
     expect(details).not.toHaveTextContent(longMessage);
     expect(
-      details?.querySelector('[aria-label="Copy error details to clipboard"]')
+      details?.querySelector('[aria-label="Copy Error Details To Clipboard"]')
     ).not.toBeNull();
   });
 
@@ -84,7 +86,7 @@ describe('PageErrorState', () => {
       />
     );
 
-    const details = screen.getByText('Error Details').closest('details');
+    const details = screen.getByText('Error details').closest('details');
     expect(details).toHaveTextContent('Request timed out after 30 seconds.');
   });
 });

--- a/apps/web/components/features/feedback/PageErrorState.tsx
+++ b/apps/web/components/features/feedback/PageErrorState.tsx
@@ -2,12 +2,13 @@
 
 import { Button } from '@jovie/ui';
 import { ErrorDetails } from './ErrorDetails';
+import { RECOVERY_COPY } from './recovery-contract';
 
 interface PageErrorStateProps {
   readonly title?: string;
   readonly message: string;
   readonly error?: Error & { digest?: string };
-  /** Label for the primary action button (default: "Retry") */
+  /** Label for the primary action button (default: "Try again") */
   readonly actionLabel?: string;
   /** Custom handler for the primary action (default: reload page) */
   readonly onRetry?: () => void;
@@ -36,10 +37,10 @@ interface PageErrorStateProps {
  * />
  */
 export function PageErrorState({
-  title = 'Something went wrong',
+  title = RECOVERY_COPY.title,
   message,
   error,
-  actionLabel = 'Retry',
+  actionLabel = RECOVERY_COPY.retryLabel,
   onRetry,
   extraContext,
 }: PageErrorStateProps) {

--- a/apps/web/components/features/feedback/recovery-contract.ts
+++ b/apps/web/components/features/feedback/recovery-contract.ts
@@ -1,0 +1,22 @@
+/**
+ * RecoveryState contract — the single source of truth for error/recovery UI.
+ *
+ * Every error presenter (SystemBErrorFallback, PublicPageErrorFallback,
+ * PageErrorState, ErrorBanner, and the chat inline error card) must take its
+ * user-facing recovery copy from this module so the surfaces cannot drift
+ * apart again ('Refresh' vs 'Try Again' vs 'Retry').
+ *
+ * Diagnostic identifiers (Next.js error digest / Error ID) are support-path
+ * data: presenters may only render them behind an opt-in disclosure
+ * (e.g. a <details> toggle), never in the default tree.
+ */
+export const RECOVERY_COPY = {
+  /** Default headline for an unexpected error. */
+  title: 'Something went wrong',
+  /** The one recovery action label. There is a single recovery path. */
+  retryLabel: 'Try again',
+  /** Label for the opt-in support/diagnostics disclosure. */
+  detailsLabel: 'Error details',
+} as const;
+
+export type RecoveryCopy = typeof RECOVERY_COPY;

--- a/apps/web/components/jovie/components/ChatArtifactErrorCard.tsx
+++ b/apps/web/components/jovie/components/ChatArtifactErrorCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@jovie/ui';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 
 interface ChatArtifactErrorCardProps {
   readonly title: string;
@@ -40,7 +41,7 @@ export function ChatArtifactErrorCard({
           onClick={() => submitRetryPrompt(retryPrompt)}
           className='mt-2 h-7 px-2 text-2xs'
         >
-          Retry
+          {RECOVERY_COPY.retryLabel}
         </Button>
       ) : null}
     </output>

--- a/apps/web/components/organisms/DashboardErrorFallback.stories.tsx
+++ b/apps/web/components/organisms/DashboardErrorFallback.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { DashboardErrorFallback } from './DashboardErrorFallback';
+
+const meta: Meta<typeof DashboardErrorFallback> = {
+  title: 'Organisms/DashboardErrorFallback',
+  component: DashboardErrorFallback,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className='flex min-h-screen'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardErrorFallback>;
+
+const error = Object.assign(new Error('The dashboard request timed out.'), {
+  digest: 'dashboard-timeout',
+});
+
+export const DashboardFatalErrorDesktop: Story = {
+  args: {
+    error,
+    resetErrorBoundary: fn(),
+  },
+};
+
+export const DashboardFatalErrorMobile: Story = {
+  args: DashboardFatalErrorDesktop.args,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};

--- a/apps/web/components/organisms/DashboardErrorFallback.test.tsx
+++ b/apps/web/components/organisms/DashboardErrorFallback.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
+import { DashboardErrorFallback } from './DashboardErrorFallback';
+
+describe('DashboardErrorFallback', () => {
+  it('follows the RecoveryState contract: one Try again action, digest behind disclosure', () => {
+    const resetErrorBoundary = vi.fn();
+    const error = Object.assign(new Error('The dashboard request timed out.'), {
+      digest: 'dashboard-timeout',
+    });
+
+    render(
+      <DashboardErrorFallback
+        error={error}
+        resetErrorBoundary={resetErrorBoundary}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Unable to Load Dashboard' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: RECOVERY_COPY.retryLabel })
+    ).toBeInTheDocument();
+
+    // Digest is support-path data: present only inside the opt-in disclosure.
+    const digest = screen.getByText('Error ID: dashboard-timeout');
+    const disclosure = digest.closest('details');
+    expect(disclosure).not.toBeNull();
+    expect(disclosure).not.toHaveAttribute('open');
+  });
+});

--- a/apps/web/components/organisms/DashboardErrorFallback.tsx
+++ b/apps/web/components/organisms/DashboardErrorFallback.tsx
@@ -21,7 +21,6 @@ export function DashboardErrorFallback({
         'An unexpected error occurred while loading your dashboard.'
       }
       error={errorWithDigest}
-      actionLabel='Retry'
       onRetry={resetErrorBoundary}
       extraContext={{ Context: 'Dashboard' }}
     />

--- a/apps/web/components/providers/PublicPageErrorFallback.tsx
+++ b/apps/web/components/providers/PublicPageErrorFallback.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 import { captureErrorInSentry } from '@/lib/errors/capture';
 import { SystemBErrorFallback } from './SystemBErrorFallback';
 
@@ -24,7 +25,9 @@ export function PublicPageErrorFallback({
     <SystemBErrorFallback
       description='Try refreshing the page.'
       digest={error.digest}
-      actions={[{ type: 'button', label: 'Refresh', onClick: onRefresh }]}
+      actions={[
+        { type: 'button', label: RECOVERY_COPY.retryLabel, onClick: onRefresh },
+      ]}
       role='alert'
       ariaLive='assertive'
     />

--- a/apps/web/components/providers/SystemBErrorFallback.tsx
+++ b/apps/web/components/providers/SystemBErrorFallback.tsx
@@ -5,6 +5,7 @@ import {
   JOVIE_ICON_PATH,
   JOVIE_ICON_VIEW_BOX,
 } from '@/components/atoms/jovie-icon-path';
+import { RECOVERY_COPY } from '@/features/feedback/recovery-contract';
 
 type SystemBErrorFallbackAction =
   | {
@@ -23,6 +24,7 @@ type SystemBErrorFallbackAction =
 interface SystemBErrorFallbackProps {
   readonly title?: string;
   readonly description: string;
+  /** Support-path diagnostic. Rendered only behind an opt-in disclosure. */
   readonly digest?: string;
   readonly actions: readonly SystemBErrorFallbackAction[];
   readonly role?: 'alert';
@@ -37,7 +39,7 @@ function rootClassName(className: string | undefined): string {
 }
 
 export function SystemBErrorFallback({
-  title = 'Something Went Wrong',
+  title = RECOVERY_COPY.title,
   description,
   digest,
   actions,
@@ -100,7 +102,14 @@ export function SystemBErrorFallback({
         </div>
 
         {digest ? (
-          <p className='system-b-error-fallback__digest'>Error ID: {digest}</p>
+          <details className='system-b-error-fallback__details'>
+            <summary className='system-b-error-fallback__details-summary'>
+              {RECOVERY_COPY.detailsLabel}
+            </summary>
+            <p className='system-b-error-fallback__digest'>
+              Error ID: {digest}
+            </p>
+          </details>
         ) : null}
       </div>
     </div>

--- a/apps/web/lib/queries/QueryErrorBoundary.tsx
+++ b/apps/web/lib/queries/QueryErrorBoundary.tsx
@@ -30,7 +30,6 @@ function DefaultErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
       title='Something went wrong'
       message={errorWithDigest.message || 'An unexpected error occurred'}
       error={errorWithDigest}
-      actionLabel='Try again'
       onRetry={resetErrorBoundary}
       extraContext={{ Context: 'Query' }}
     />

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2345,8 +2345,24 @@ html:not(.dark) .smart-link-powered-by {
   color: var(--system-b-text-primary);
 }
 
-:where(.system-b-error-fallback__digest) {
+:where(.system-b-error-fallback__details) {
   margin: var(--space-5) 0 0;
+}
+
+:where(.system-b-error-fallback__details-summary) {
+  cursor: pointer;
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  transition: color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-error-fallback__details-summary:hover) {
+  color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-error-fallback__digest) {
+  margin: var(--space-2) 0 0;
   color: var(--color-text-quaternary-token);
   font-size: var(--text-xs);
   line-height: var(--leading-normal);

--- a/apps/web/tests/e2e/yc-demo.spec.ts
+++ b/apps/web/tests/e2e/yc-demo.spec.ts
@@ -541,7 +541,7 @@ async function gotoDemoScene(
         .locator('body')
         .innerText({ timeout: 1_000 })
         .catch(() => '');
-      if (attempt === 2 || !bodyText.includes('Something Went Wrong')) {
+      if (attempt === 2 || !/something went wrong/i.test(bodyText)) {
         throw error;
       }
       console.warn(`[yc-demo] ${url} hit error page; retrying navigation...`);

--- a/apps/web/tests/unit/atoms/TableErrorFallback.test.tsx
+++ b/apps/web/tests/unit/atoms/TableErrorFallback.test.tsx
@@ -56,7 +56,7 @@ describe('TableErrorFallback', () => {
   it('renders a copy details button', () => {
     render(<TableErrorFallback {...defaultProps} />);
     expect(
-      screen.getByRole('button', { name: 'Copy error details to clipboard' })
+      screen.getByRole('button', { name: 'Copy Error Details To Clipboard' })
     ).toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -534,7 +534,7 @@ describe('ChatPageClient', () => {
       'We hit a problem loading your profile. Please retry in a moment.'
     );
     const retryButton = Array.from(container.querySelectorAll('button')).find(
-      button => button.textContent?.trim() === 'Retry'
+      button => button.textContent?.trim() === 'Try again'
     );
     expect(retryButton).toBeDefined();
     expect(mockSentryAddBreadcrumb).toHaveBeenCalled();

--- a/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
+++ b/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
@@ -143,7 +143,7 @@ describe('ProfilePageChat', () => {
     // Should have a retry button
     const retryButton = container.querySelector('button');
     expect(retryButton).not.toBeNull();
-    expect(retryButton?.textContent).toContain('Retry');
+    expect(retryButton?.textContent).toContain('Try again');
   });
 
   it('refreshes the app route instead of reloading the document from the error fallback', () => {

--- a/apps/web/tests/unit/chat/chat-terminal-states.test.tsx
+++ b/apps/web/tests/unit/chat/chat-terminal-states.test.tsx
@@ -89,7 +89,9 @@ describe('chat terminal states', () => {
       expect(
         screen.getByText('Image provider unavailable.')
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Try again' })
+      ).toBeInTheDocument();
     });
 
     it('renders a failed pitch artifact card with retry', () => {
@@ -113,7 +115,9 @@ describe('chat terminal states', () => {
       ).toBeInTheDocument();
       expect(screen.getByText('Pitch Generation Failed')).toBeInTheDocument();
       expect(screen.getByText('Pitch model timed out.')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Try again' })
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/web/tests/unit/providers/system-b-error-fallback.test.tsx
+++ b/apps/web/tests/unit/providers/system-b-error-fallback.test.tsx
@@ -34,20 +34,19 @@ describe('SystemBErrorFallback', () => {
         description='An unexpected error occurred.'
         digest='digest-1'
         actions={[
-          { type: 'button', label: 'Try Again', onClick: reset },
+          { type: 'button', label: 'Try again', onClick: reset },
           { type: 'link', label: 'Go Home', href: '/', variant: 'secondary' },
         ]}
       />
     );
 
     expect(
-      screen.getByRole('heading', { name: 'Something Went Wrong' })
+      screen.getByRole('heading', { name: 'Something went wrong' })
     ).toBeInTheDocument();
     expect(
       screen.getByText('An unexpected error occurred.')
     ).toBeInTheDocument();
-    expect(screen.getByText('Error ID: digest-1')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Try Again' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Try again' })).toHaveAttribute(
       'data-variant',
       'primary'
     );
@@ -55,6 +54,22 @@ describe('SystemBErrorFallback', () => {
       'href',
       '/'
     );
+  });
+
+  it('keeps the error digest behind an opt-in support disclosure', () => {
+    render(
+      <SystemBErrorFallback
+        description='An unexpected error occurred.'
+        digest='digest-1'
+        actions={[{ type: 'button', label: 'Try again', onClick: () => {} }]}
+      />
+    );
+
+    const disclosure = screen.getByText('Error details').closest('details');
+    expect(disclosure).not.toBeNull();
+    expect(disclosure).not.toHaveAttribute('open');
+    const digest = screen.getByText('Error ID: digest-1');
+    expect(disclosure).toContainElement(digest);
   });
 
   it('keeps the shared primitive free of local visual token drift', async () => {

--- a/apps/web/tests/unit/public-page-error-fallback.test.tsx
+++ b/apps/web/tests/unit/public-page-error-fallback.test.tsx
@@ -52,19 +52,26 @@ describe('PublicPageErrorFallback', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Something Went Wrong',
+        name: 'Something went wrong',
       })
     ).toBeInTheDocument();
     expect(screen.getByText('Try refreshing the page.')).toBeInTheDocument();
-    expect(screen.getByText('Error ID: abc123')).toBeInTheDocument();
+    // Digest stays out of the default tree: it lives behind the opt-in
+    // support disclosure.
+    const digest = screen.getByText('Error ID: abc123');
+    const disclosure = digest.closest('details');
+    expect(disclosure).not.toBeNull();
+    expect(disclosure).not.toHaveAttribute('open');
     expect(screen.getByRole('alert')).toHaveClass(
       'dark',
       'system-b-error-fallback'
     );
     expect(screen.getAllByRole('button')).toHaveLength(1);
-    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Try again' })
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
 
     expect(refreshMock).toHaveBeenCalledTimes(1);
   });

--- a/docs/design-system/state-matrix.md
+++ b/docs/design-system/state-matrix.md
@@ -150,4 +150,5 @@ These states apply across families and were previously undocumented.
 2. Disabled controls must set **both** `disabled` / `aria-disabled` and the disabled-visual tokens — never rely on opacity alone.
 3. Loading skeletons are `aria-hidden` placeholders; parent wrappers (`LoadingSkeleton`, async blocks) own `aria-busy`.
 4. Inline offline is for **in-context** recovery; full-page offline/error uses `EmptyState` or `PageErrorState`.
-5. When adding a new state, update this matrix **and** add a Storybook story before shipping.
+5. Error/recovery presenters (`SystemBErrorFallback`, `PublicPageErrorFallback`, `PageErrorState`, `ErrorBanner`, chat inline error cards) take copy from the RecoveryState contract (`apps/web/components/features/feedback/recovery-contract.ts`) — one `Try again` recovery action; error digests render only behind an opt-in details disclosure, never in the default tree.
+6. When adding a new state, update this matrix **and** add a Storybook story before shipping.


### PR DESCRIPTION
## Summary

P1 UI-drift fix from `docs/audits/JOVIE_UI_DRIFT_AUDIT_2026-08-03.md`: error/recovery surfaces had drifted apart — inconsistent retry copy ('Refresh' / 'Try Again' / 'Retry') and the Next.js error digest shown to users by default.

- Adds `apps/web/components/features/feedback/recovery-contract.ts` — the single `RecoveryState` copy contract (`title`, `retryLabel`, `detailsLabel`) that all presenters now consume.
- Unifies recovery copy across the four live presenters: `SystemBErrorFallback`, `PublicPageErrorFallback`, `PageErrorState`, `ErrorBanner`, plus the chat inline error card (`ChatArtifactErrorCard`) and chat surfaces.
- Digest / Error ID is removed from the default tree: `SystemBErrorFallback` now renders it only behind an opt-in `<details>` support-path disclosure (consistent with the existing `ErrorDetails` pattern). Styles added in `design-system.css`.
- `docs/design-system/state-matrix.md` updated to document the contract.

## Test plan

- `pnpm --filter web exec vitest run` on all touched test files (9 files): **62/62 passed** — including updated `system-b-error-fallback`, `public-page-error-fallback`, `PageErrorState`, chat terminal-state tests, and new `DashboardErrorFallback` tests/stories asserting the digest is hidden by default and revealed via the disclosure.
- `pnpm --filter @jovie/web run typecheck` — clean.
- `pnpm biome check` on all 26 touched files — clean.
- `git diff --check origin/main...HEAD` — clean.
- Pre-push gate (ci:harness validate + docs check) — passed on push.

## Screenshots

Not captured in this headless environment; behavior change is: retry buttons now read "Try again" everywhere, and "Error ID: <digest>" is collapsed behind an "Error details" disclosure instead of being visible by default.

Fixes JOV-4868
https://linear.app/jovie/issue/JOV-4868/p1-ui-drift-unify-errorrecovery-ui-to-one-contract-remove-digest-from