### PR TITLE
fix(marketing): give each feature tile a distinct accent (JOV-4865)

### DIFF
--- a/apps/web/data/artistNotificationsFeatures.ts
+++ b/apps/web/data/artistNotificationsFeatures.ts
@@ -44,7 +44,9 @@ export const ARTIST_NOTIFICATIONS_SPEC_TILES: readonly MarketingFeatureTile[] =
       title: 'Capture once',
       body: 'A stream, QR scan, or profile visit can become a fan Jovie can reach again.',
       size: 'small',
-      accent: 'green',
+      // Distinct from the activate-creators tile in the homepage v2 power
+      // grid: each rendered feature's accent must be unique.
+      accent: 'purple',
       kicker: 'Audience capture',
       layoutClassName:
         'xl:col-start-10 xl:row-start-1 xl:col-span-3 xl:row-span-1',

--- a/apps/web/data/artistProfileFeatures.ts
+++ b/apps/web/data/artistProfileFeatures.ts
@@ -12,7 +12,8 @@ export const ARTIST_PROFILE_SPEC_TILES: readonly ArtistProfileFeatureTile[] = [
     title: 'Audience Quality Filtering',
     body: 'Jovie identifies bots, your own team, and test traffic so your fan metrics measure actual fans.',
     size: 'large',
-    accent: 'blue',
+    // Distinct from the analytics tile: each feature's accent must be unique.
+    accent: 'gray',
     layoutClassName:
       'xl:col-start-1 xl:row-start-1 xl:col-span-5 xl:row-span-2',
     visual: 'audience-quality-filter',

--- a/apps/web/tests/unit/marketing/feature-tile-accent-uniqueness.test.ts
+++ b/apps/web/tests/unit/marketing/feature-tile-accent-uniqueness.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { ARTIST_NOTIFICATIONS_SPEC_TILES } from '@/data/artistNotificationsFeatures';
+import { ARTIST_PROFILE_SPEC_TILES } from '@/data/artistProfileFeatures';
+import { HOMEPAGE_V2_POWER_TILES } from '@/data/homepageV2Copy';
+
+/**
+ * JOV-4865: the feature accent drives each tile's title color, so two tiles
+ * sharing an accent render the same value where they should be independent.
+ * Lock uniqueness for every rendered tile set.
+ */
+describe('marketing feature tile accents', () => {
+  const cases = [
+    ['artist profile spec tiles', ARTIST_PROFILE_SPEC_TILES],
+    ['artist notifications spec tiles', ARTIST_NOTIFICATIONS_SPEC_TILES],
+    ['homepage v2 power tiles', HOMEPAGE_V2_POWER_TILES],
+  ] as const;
+
+  it.each(cases)('%s use a distinct accent per tile', (_label, tiles) => {
+    const accents = tiles.map(tile => tile.accent);
+    expect(new Set(accents).size).toBe(accents.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Two rendered marketing feature tile sets had duplicate accent values, so two tiles rendered the same accent (icon/color) value where they should be independent:
  - `ARTIST_PROFILE_SPEC_TILES`: `Audience Quality Filtering` shared `blue` with the analytics tile → changed to `gray`
  - `ARTIST_NOTIFICATIONS_SPEC_TILES`: `Capture once` shared `green` with the activate-creators tile in the homepage v2 power grid → changed to `purple`
- Added `feature-tile-accent-uniqueness.test.ts` locking that every rendered tile set uses a distinct accent per tile.

Data-only change; no layout shift, no component changes.

## Test plan
- `pnpm --filter web exec vitest run tests/unit/marketing/feature-tile-accent-uniqueness.test.ts` → 3/3 passed
- `pnpm biome check` on the 3 touched files → clean
- Pre-push gate: 293 test files, 2525 tests passed
- Screenshot note: data-only accent color change on marketing feature tiles; visual capture unavailable in this environment, change verified via the uniqueness test + data diff.

Fixes JOV-4865
https://linear.app/jovie/issue/JOV-4865/ui-accent-iconcolor-and-feature-analytics-show-same-value