### PR TITLE
fix(web): clean Spotify arbitrary-hex and legacy motion tokens (JOV-4873)

### DIFF
--- a/apps/web/app/(dynamic)/playlists/[slug]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/[slug]/page.tsx
@@ -297,8 +297,7 @@ export default async function PlaylistPage({
             >
               <SocialIcon
                 platform='spotify'
-                // eslint-disable-next-line @jovie/no-hardcoded-theme-colors -- Spotify brand green on playlist CTA
-                className='h-5 w-5 text-[#1DB954]'
+                className='h-5 w-5 text-brand-spotify'
                 aria-hidden
               />
               Open in Spotify
@@ -341,8 +340,7 @@ export default async function PlaylistPage({
                       href={`https://open.spotify.com/track/${track.spotifyTrackId}`}
                       target='_blank'
                       rel='noopener noreferrer'
-                      // eslint-disable-next-line @jovie/no-hardcoded-theme-colors -- Spotify brand green on track play affordance
-                      className='flex-shrink-0 p-2 text-white/20 hover:text-[#1DB954]'
+                      className='flex-shrink-0 p-2 text-white/20 hover:text-brand-spotify'
                       aria-label={`Play ${track.trackName} on Spotify`}
                     >
                       <span className='sr-only'>

--- a/apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts
+++ b/apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts
@@ -30,7 +30,7 @@ const BASE_CLASSES = [
   'border-(--pill-border) hover:border-(--pill-border-hover)',
   'bg-(--linear-app-content-surface) hover:bg-(--pill-bg-hover)',
   'text-secondary-token hover:text-primary-token',
-  'transition-[background-color,border-color,color,grid-template-columns,max-width,opacity,padding,margin] duration-180 ease-out',
+  'transition-[background-color,border-color,color,grid-template-columns,max-width,opacity,padding,margin] duration-subtle ease-out',
 ] as const;
 
 /**

--- a/apps/web/components/organisms/footer-module/config.ts
+++ b/apps/web/components/organisms/footer-module/config.ts
@@ -68,7 +68,7 @@ export function getVariantConfigs(
 export const FOOTER_LINK_CLASS_NAME = cn(
   'inline-flex h-7 items-center',
   'text-app leading-[19.5px] font-normal tracking-tight',
-  'transition-colors duration-100',
+  'transition-colors duration-fast',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interactive focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
 );
 

--- a/apps/web/components/organisms/sidebar/menu.stories.tsx
+++ b/apps/web/components/organisms/sidebar/menu.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { SidebarProvider } from './context';
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from './menu';
+
+const meta = {
+  title: 'Organisms/Sidebar/menu',
+  component: SidebarMenuButton,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <SidebarProvider>
+        <div className='w-56 p-4'>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <Story />
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </div>
+      </SidebarProvider>
+    ),
+  ],
+} satisfies Meta<typeof SidebarMenuButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Overview',
+  },
+};
+
+export const Active: Story = {
+  args: {
+    children: 'Library',
+    isActive: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Earnings',
+    disabled: true,
+  },
+};

--- a/apps/web/components/organisms/sidebar/menu.test.tsx
+++ b/apps/web/components/organisms/sidebar/menu.test.tsx
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./context', () => ({
+  useSidebar: () => ({
+    state: 'open',
+    open: true,
+    setOpen: vi.fn(),
+    openMobile: false,
+    setOpenMobile: vi.fn(),
+    isMobile: false,
+    toggleSidebar: vi.fn(),
+  }),
+}));
+
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSubButton,
+} from './menu';
+
+describe('sidebar menu', () => {
+  it('renders menu rows inside a list', () => {
+    render(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton>Overview</SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+    expect(screen.getByText('Overview')).toBeTruthy();
+  });
+
+  it('marks the active button and keeps tokenized motion classes', () => {
+    render(<SidebarMenuButton isActive>Library</SidebarMenuButton>);
+    const button = screen.getByText('Library').closest('button');
+    expect(button?.getAttribute('data-active')).toBe('true');
+    const className = button?.className ?? '';
+    expect(className).toContain('duration-fast');
+    expect(className).toContain('ease-interactive');
+  });
+
+  it('renders a sub button with nav font weight', () => {
+    render(<SidebarMenuSubButton href='/app'>Releases</SidebarMenuSubButton>);
+    const link = screen.getByText('Releases').closest('a');
+    expect(link?.className).toContain('duration-normal');
+  });
+});
+
+describe('sidebar menu motion tokens (JOV-4873)', () => {
+  it('uses intent motion tokens only — no raw numeric durations', () => {
+    const source = readFileSync(path.join(__dirname, 'menu.tsx'), 'utf8');
+    expect(source).not.toMatch(/\bduration-\d/);
+    // Icon color snaps instantly: a 0ms transition is equivalent to no
+    // transition, so no duration-0 escape hatch may come back.
+    expect(source).not.toContain('duration-0');
+  });
+});

--- a/apps/web/components/organisms/sidebar/menu.tsx
+++ b/apps/web/components/organisms/sidebar/menu.tsx
@@ -61,8 +61,9 @@ const sidebarMenuButtonVariants = cva(
     'group-data-[collapsible=icon]:[&>span:last-child]:opacity-0 group-data-[collapsible=icon]:[&>span:not(.sr-only)]:hidden',
     // Icon styling — 14px to match Linear's nav icon size
     '[&>[data-sidebar-icon]]:flex [&>[data-sidebar-icon]]:size-3.5 [&>[data-sidebar-icon]]:shrink-0 [&>[data-sidebar-icon]]:items-center [&>[data-sidebar-icon]]:justify-center',
-    '[&>svg]:size-3.5 [&>svg]:shrink-0 [&>svg]:text-sidebar-item-icon [&>svg]:transition-colors [&>svg]:duration-0 [&>svg]:ease-interactive',
-    '[&_[data-sidebar-icon]_svg]:text-sidebar-item-icon [&_[data-sidebar-icon]_svg]:transition-colors [&_[data-sidebar-icon]_svg]:duration-0 [&_[data-sidebar-icon]_svg]:ease-interactive',
+    // Icon color snaps instantly with the row (no transition — Linear: instant for icon colors)
+    '[&>svg]:size-3.5 [&>svg]:shrink-0 [&>svg]:text-sidebar-item-icon',
+    '[&_[data-sidebar-icon]_svg]:text-sidebar-item-icon',
     'hover:[&>svg]:text-sidebar-item-foreground',
     'hover:[&_[data-sidebar-icon]_svg]:text-sidebar-item-foreground',
     'data-[active=true]:[&>svg]:text-sidebar-item-foreground',

--- a/apps/web/tests/unit/app/public-playlists-cta-style-guard.test.ts
+++ b/apps/web/tests/unit/app/public-playlists-cta-style-guard.test.ts
@@ -11,6 +11,6 @@ describe('public playlist CTA style guard', () => {
     expect(source).toContain(
       'text-black dark:text-white transition-colors hover:bg-white dark:bg-surface-1/90'
     );
-    expect(source).toContain("className='h-5 w-5 text-[#1DB954]'");
+    expect(source).toContain("className='h-5 w-5 text-brand-spotify'");
   });
 });


### PR DESCRIPTION
## Summary

P3 UI-drift cleanup from the JOVIE_UI_DRIFT_AUDIT (2026-08-03) — replaces raw/legacy values with design-system tokens, behavior-preserving.

- **`playlists/[slug]/page.tsx`**: `text-[#1DB954]` ×2 → `text-brand-spotify` (`--color-brand-spotify` token); removed the two `@jovie/no-hardcoded-theme-colors` eslint-disable exceptions that are no longer needed.
- **`components/organisms/sidebar/menu.tsx`**: removed `transition-colors duration-0 ease-interactive` on nav icon svg selectors — a 0ms transition is equivalent to no transition, so icon color still snaps instantly (Linear behavior unchanged), minus the raw numeric duration the audit flagged.
- **`PlatformPill.utils.ts`**: `duration-180` → `duration-subtle` (DS intent token, 150ms; picks up reduced-motion zeroing).
- **`footer-module/config.ts`**: `duration-100` → `duration-fast` (tokenized, same 100ms timing; precedent: JOV-4157 PRs).
- Added colocated `menu.test.tsx` + `menu.stories.tsx` for `sidebar/menu.tsx` (required by the component-ship-gate for any touched component); the test includes a regression assertion that no raw numeric `duration-N` classes return.
- Updated `public-playlists-cta-style-guard.test.ts` for the brand token.

## Test plan

- `pnpm exec vitest run tests/unit/app/public-playlists-cta-style-guard.test.ts tests/unit/app/admin-playlists-surface-guard.test.ts` — 3 passed
- `pnpm exec vitest run components/organisms/sidebar/menu.test.tsx` — 4 passed
- `pnpm exec vitest run tests/unit/components/organisms/sidebar-height-chain.test.tsx tests/unit/components/site/MarketingFooter.test.tsx tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts` — 8 passed
- `pnpm exec eslint` on all touched files — clean
- `pnpm --filter @jovie/web run typecheck` — clean
- `pnpm biome check` on touched files — clean
- `node scripts/component-ship-gate.mjs` — PASS (diff + story quality + ratchet)

## Screenshots

No visual change expected: `text-brand-spotify` resolves to the same Spotify green hue (`--color-brand-spotify`, oklch 68–70% 0.21 145 ≈ #1DB954), `duration-fast` = 100ms identical timing, `duration-subtle` 180→150ms on pill expand (imperceptible), sidebar icon color remains instant. Screenshot capture unavailable in this environment.

Fixes JOV-4873
https://linear.app/jovie/issue/JOV-4873/p3-ui-drift-clean-spotify-arbitrary-hex-and-legacy-motion-tokens