### PR TITLE
refactor(web): convert raw buttons on primary routes to canonical Button (JOV-4870)

### DIFF
--- a/apps/web/app/app/(shell)/admin/features/AdminFeaturesTable.tsx
+++ b/apps/web/app/app/(shell)/admin/features/AdminFeaturesTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import * as Switch from '@radix-ui/react-switch';
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { RotateCcw } from 'lucide-react';
@@ -102,8 +103,10 @@ function FlagEnvCell({
           />
         </Switch.Root>
         {/* Reserve the reset slot in every cell so toggling never shifts layout. */}
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='icon'
           onClick={onClear}
           disabled={pending || !overridden}
           title={overridden ? 'Reset to default' : undefined}
@@ -116,12 +119,12 @@ function FlagEnvCell({
               : 'flag-reset-slot'
           }
           data-overridden={overridden ? 'true' : 'false'}
-          className={`shrink-0 text-quaternary-token transition-opacity hover:text-secondary-token ${
+          className={`h-auto w-auto shrink-0 p-0 text-quaternary-token transition-opacity hover:text-secondary-token ${
             overridden ? 'opacity-100' : 'pointer-events-none opacity-0'
           }`}
         >
           <RotateCcw size={11} aria-hidden />
-        </button>
+        </Button>
       </div>
       <span
         className='whitespace-nowrap text-2xs leading-none text-secondary-token'
@@ -161,8 +164,10 @@ function FlagNameCell({
       <span className='block truncate font-medium text-primary-token'>
         {name}
       </span>
-      <button
+      <Button
         type='button'
+        variant='link'
+        size='sm'
         onClick={handleCopyKey}
         title='Copy flag key'
         aria-label={`Copy flag key ${flagKey}`}
@@ -170,7 +175,7 @@ function FlagNameCell({
         className='block max-w-full cursor-pointer truncate font-mono text-xs text-tertiary-token transition-colors hover:text-secondary-token'
       >
         {flagKey}
-      </button>
+      </Button>
       <span className='line-clamp-2 block text-xs leading-snug text-secondary-token'>
         {description}
       </span>

--- a/apps/web/app/app/(shell)/admin/investors/TokenCopyButton.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/TokenCopyButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { Check, Copy, Eye, EyeOff } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -37,8 +38,10 @@ export function TokenCopyButton({ token }: Readonly<TokenCopyButtonProps>) {
       >
         {visibleToken}
       </code>
-      <button
+      <Button
         type='button'
+        variant='ghost'
+        size='icon'
         onClick={() => setIsRevealed(value => !value)}
         className='inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-tertiary-token transition-[color,opacity] hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
         aria-label={
@@ -51,9 +54,11 @@ export function TokenCopyButton({ token }: Readonly<TokenCopyButtonProps>) {
         ) : (
           <Eye className='h-3 w-3' aria-hidden='true' />
         )}
-      </button>
-      <button
+      </Button>
+      <Button
         type='button'
+        variant='ghost'
+        size='icon'
         onClick={copyToken}
         className='inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-tertiary-token transition-[color,opacity] hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
         aria-label='Copy Full Investor Token'
@@ -67,7 +72,7 @@ export function TokenCopyButton({ token }: Readonly<TokenCopyButtonProps>) {
         ) : (
           <Copy className='h-3 w-3' aria-hidden='true' />
         )}
-      </button>
+      </Button>
     </span>
   );
 }

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -302,13 +303,15 @@ function DeploymentActionsMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='icon'
           aria-label='Deployment Actions'
           className='flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-tertiary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:bg-surface-1 focus-visible:outline-none'
         >
           <MoreHorizontal className='h-3.5 w-3.5' aria-hidden='true' />
-        </button>
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end' sideOffset={6}>
         {run.url ? (
@@ -486,23 +489,27 @@ function AiOpsItemRow({
       <div className='flex shrink-0 items-center gap-1.5 text-right text-2xs text-tertiary-token'>
         <p>{formatDeploymentTime(item.updatedAt)}</p>
         {isDismissed && onUndismiss ? (
-          <button
+          <Button
             type='button'
+            variant='ghost'
+            size='sm'
             onClick={onUndismiss}
             aria-label='Restore Item'
             className='rounded px-1 py-0.5 text-2xs text-tertiary-token hover:text-primary-token'
           >
             Undo
-          </button>
+          </Button>
         ) : onDismiss ? (
-          <button
+          <Button
             type='button'
+            variant='ghost'
+            size='icon'
             onClick={onDismiss}
             aria-label='Dismiss Item'
             className='rounded p-0.5 text-tertiary-token hover:text-primary-token'
           >
             <X className='h-3.5 w-3.5' aria-hidden='true' />
-          </button>
+          </Button>
         ) : null}
       </div>
     </ShellListRowFrame>
@@ -617,8 +624,10 @@ function HermesDispatchControls({
         </select>
       </div>
       <div className='flex flex-wrap gap-2'>
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='sm'
           onClick={() => void dispatchWorker(false)}
           disabled={isDispatching}
           className='inline-flex min-h-10 items-center gap-2 rounded-lg border border-(--linear-btn-primary-border) bg-btn-primary px-3 text-app font-semibold text-btn-primary-foreground shadow-button-inset transition-colors hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:cursor-not-allowed disabled:opacity-60'
@@ -628,16 +637,18 @@ function HermesDispatchControls({
           ) : (
             <Rocket className='h-4 w-4' aria-hidden='true' />
           )}
-          Dispatch worker
-        </button>
-        <button
+          Dispatch Worker
+        </Button>
+        <Button
           type='button'
+          variant='ghost'
+          size='sm'
           onClick={() => void dispatchWorker(true)}
           disabled={isDispatching}
           className='inline-flex min-h-10 items-center gap-2 rounded-lg border border-subtle bg-surface-0 px-3 text-app font-semibold text-primary-token disabled:cursor-not-allowed disabled:opacity-60'
         >
-          Dry run
-        </button>
+          Dry Run
+        </Button>
       </div>
       {message ? (
         <p className='text-app leading-5 text-secondary-token'>{message}</p>

--- a/apps/web/app/app/(shell)/admin/ops/HudMetricSourceTrust.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudMetricSourceTrust.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { ExternalLink, RefreshCw } from 'lucide-react';
 import { formatSourceFreshness, isSourceStale } from '@/lib/hud/source-trust';
 import type { HudMetricSourceTrust as HudMetricSourceTrustType } from '@/types/hud';
@@ -57,15 +58,17 @@ export function HudMetricSourceTrust({
         </p>
         <div className='flex shrink-0 items-center gap-2'>
           {onRetry && source.state === 'unavailable' ? (
-            <button
+            <Button
               type='button'
+              variant='link'
+              size='sm'
               onClick={onRetry}
               className='inline-flex items-center gap-1 text-2xs font-medium text-secondary-token transition-colors hover:text-primary-token'
               data-testid={`hud-source-retry-${source.key}`}
             >
               <RefreshCw className='h-3 w-3' aria-hidden='true' />
               Retry
-            </button>
+            </Button>
           ) : null}
           {source.dashboardUrl ? (
             <a

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -473,7 +473,9 @@ const ReleaseCell = memo(function ReleaseCell({
       >
         <LibraryMediaThumbnail asset={asset} size='row' />
         {hasPreview ? (
-          <button
+          <Button
+            variant='ghost'
+            size='icon'
             type='button'
             onClick={event => onTogglePreview(asset, event)}
             onKeyDown={event => event.stopPropagation()}
@@ -496,7 +498,7 @@ const ReleaseCell = memo(function ReleaseCell({
             ) : (
               <PlayCircle className='h-3.5 w-3.5' strokeWidth={2.25} />
             )}
-          </button>
+          </Button>
         ) : null}
       </ArtworkFrame>
       <span className='min-w-0'>
@@ -1510,7 +1512,9 @@ const AssetCard = memo(function AssetCard({
         </button>
       </Button>
       {hasPreview ? (
-        <button
+        <Button
+          variant='ghost'
+          size='icon'
           type='button'
           onClick={event => onTogglePreview(asset, event)}
           aria-label={
@@ -1536,7 +1540,7 @@ const AssetCard = memo(function AssetCard({
           <span className='sr-only'>
             {isPreviewPlaying ? 'Pause Preview' : 'Play Preview'}
           </span>
-        </button>
+        </Button>
       ) : null}
     </article>
   );
@@ -1719,7 +1723,9 @@ function NoResults({ onReset }: { readonly onReset: () => void }) {
       description='No library items match the selected view or filters.'
       className='min-h-75'
       action={
-        <button
+        <Button
+          variant='ghost'
+          size='sm'
           type='button'
           onClick={onReset}
           className={cn(
@@ -1728,7 +1734,7 @@ function NoResults({ onReset }: { readonly onReset: () => void }) {
           )}
         >
           Reset View
-        </button>
+        </Button>
       }
     />
   );
@@ -1779,7 +1785,9 @@ function PreviewActionButton({
   const label = isPreviewPlaying ? 'Pause Preview' : 'Play Preview';
 
   return (
-    <button
+    <Button
+      variant='ghost'
+      size='sm'
       type='button'
       onClick={event => onTogglePreview(asset, event)}
       aria-label={`${label} for ${asset.title}`}
@@ -1799,7 +1807,7 @@ function PreviewActionButton({
         <PlayCircle className='h-3 w-3' strokeWidth={2.25} />
       )}
       {compact ? <span className='sr-only'>{label}</span> : label}
-    </button>
+    </Button>
   );
 }
 

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge } from '@jovie/ui';
+import { Badge, Button } from '@jovie/ui';
 import {
   Calendar,
   Check,
@@ -96,7 +96,9 @@ function EditableBio({
 
   if (!editing) {
     return (
-      <button
+      <Button
+        variant='ghost'
+        size='sm'
         type='button'
         aria-label='Edit Bio'
         onClick={() => {
@@ -112,7 +114,7 @@ function EditableBio({
         ) : (
           <p className='text-app text-tertiary-token'>Click to add a bio...</p>
         )}
-      </button>
+      </Button>
     );
   }
 
@@ -154,7 +156,9 @@ function LocationField({
           onSelect={onChange}
           placeholder={`Change ${addLabel.toLowerCase()}`}
           trigger={
-            <button
+            <Button
+              variant='ghost'
+              size='sm'
               type='button'
               className='flex items-center gap-2 rounded-lg px-1.5 py-1 text-xs text-secondary-token transition-colors hover:bg-surface-0 hover:text-primary-token'
             >
@@ -163,7 +167,7 @@ function LocationField({
                 aria-hidden='true'
               />
               <span className='capitalize'>{label(value)}</span>
-            </button>
+            </Button>
           }
         />
       );
@@ -183,13 +187,15 @@ function LocationField({
         onSelect={onChange}
         placeholder={`Add your ${addLabel.toLowerCase()}`}
         trigger={
-          <button
+          <Button
+            variant='ghost'
+            size='sm'
             type='button'
             className='flex items-center gap-2 rounded-lg px-1.5 py-1 text-xs text-tertiary-token transition-colors hover:bg-surface-0 hover:text-secondary-token'
           >
             <Icon className='h-3.5 w-3.5 shrink-0' aria-hidden='true' />
             <span>Add your {addLabel.toLowerCase()}</span>
-          </button>
+          </Button>
         }
       />
     );
@@ -325,27 +331,31 @@ function PressPhotosSection({
       {/* First-import banner */}
       {draftPhotos.length > 0 && !bannerDismissed && (
         <div className='relative rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 px-3 py-2'>
-          <button
+          <Button
+            variant='ghost'
+            size='icon'
             type='button'
             onClick={() => setBannerDismissed(true)}
             className='absolute top-1.5 right-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full text-tertiary-token hover:text-default'
             aria-label='Dismiss'
           >
             <X className='h-3 w-3' />
-          </button>
+          </Button>
           <p className='pr-5 text-2xs text-secondary-token'>
             We found {draftPhotos.length} photo
             {draftPhotos.length > 1 ? 's' : ''} from your streaming profiles.
             Approve the ones you want on your public profile.
           </p>
           {draftPhotos.length >= 2 && onApprove && (
-            <button
+            <Button
+              variant='link'
+              size='sm'
               type='button'
               onClick={handleApproveAll}
               className='mt-1.5 text-2xs font-medium text-accent hover:underline'
             >
-              Approve all
-            </button>
+              Approve All
+            </Button>
           )}
         </div>
       )}
@@ -381,7 +391,9 @@ function PressPhotosSection({
                 </span>
                 {/* Delete button */}
                 {onDelete && (
-                  <button
+                  <Button
+                    variant='ghost'
+                    size='icon'
                     type='button'
                     onClick={() => handleDelete(photo.id)}
                     disabled={deletingPhotoId === photo.id}
@@ -393,11 +405,13 @@ function PressPhotosSection({
                     ) : (
                       <X className='h-3 w-3' />
                     )}
-                  </button>
+                  </Button>
                 )}
                 {/* Approve button */}
                 {onApprove && (
-                  <button
+                  <Button
+                    variant='ghost'
+                    size='sm'
                     type='button'
                     onClick={() => handleApprove(photo.id)}
                     disabled={approvingPhotoId === photo.id}
@@ -412,7 +426,7 @@ function PressPhotosSection({
                         Approve
                       </>
                     )}
-                  </button>
+                  </Button>
                 )}
               </div>
             ))}
@@ -443,7 +457,9 @@ function PressPhotosSection({
                   {photo.status}
                 </span>
                 {onDelete && (
-                  <button
+                  <Button
+                    variant='ghost'
+                    size='icon'
                     type='button'
                     onClick={() => handleDelete(photo.id)}
                     disabled={deletingPhotoId === photo.id}
@@ -455,7 +471,7 @@ function PressPhotosSection({
                     ) : (
                       <X className='h-3 w-3' />
                     )}
-                  </button>
+                  </Button>
                 )}
               </div>
             ))}
@@ -484,7 +500,9 @@ function PressPhotosSection({
                   className='object-cover'
                 />
                 {onDelete && (
-                  <button
+                  <Button
+                    variant='ghost'
+                    size='icon'
                     type='button'
                     onClick={() => handleDelete(photo.id)}
                     disabled={deletingPhotoId === photo.id}
@@ -496,7 +514,7 @@ function PressPhotosSection({
                     ) : (
                       <X className='h-3.5 w-3.5' />
                     )}
-                  </button>
+                  </Button>
                 )}
               </div>
             ))}
@@ -672,16 +690,18 @@ export function ProfileAboutTab({
                 >
                   {genre}
                   {onGenresChange && (
-                    <button
+                    <Button
+                      variant='ghost'
+                      size='icon'
                       type='button'
                       onClick={() =>
                         onGenresChange(genres.filter(g => g !== genre))
                       }
-                      className='ml-0.5 hover:text-primary-token transition-colors'
+                      className='ml-0.5 h-auto w-auto p-0 hover:text-primary-token transition-colors'
                       aria-label={`Remove ${genre}`}
                     >
                       <X className='h-3 w-3' />
-                    </button>
+                    </Button>
                   )}
                 </Badge>
               ))}
@@ -690,13 +710,15 @@ export function ProfileAboutTab({
                   selected={genres}
                   onChange={onGenresChange}
                   trigger={
-                    <button
+                    <Button
+                      variant='ghost'
+                      size='sm'
                       type='button'
                       className='inline-flex items-center gap-0.5 rounded-full border border-dashed border-subtle px-2.5 py-0.5 text-2xs font-medium text-tertiary-token transition-colors hover:border-secondary-token hover:text-secondary-token'
                     >
                       <Plus className='h-3 w-3' />
                       Add
-                    </button>
+                    </Button>
                   }
                 />
               )}
@@ -707,13 +729,15 @@ export function ProfileAboutTab({
               selected={[]}
               onChange={onGenresChange}
               trigger={
-                <button
+                <Button
+                  variant='ghost'
+                  size='sm'
                   type='button'
                   className='flex items-center gap-1.5 text-xs text-tertiary-token transition-colors hover:text-secondary-token'
                 >
                   <Plus className='h-3.5 w-3.5' />
                   <span>Add genres</span>
-                </button>
+                </Button>
               }
             />
           )}

--- a/apps/web/tests/unit/design-system/raw-button.baseline.json
+++ b/apps/web/tests/unit/design-system/raw-button.baseline.json
@@ -1,4 +1,4 @@
 {
-  "count": 625,
-  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down \u2014 lower this when a PR converts raw buttons to the canonical Button. 713\u2192637 on 2026-07-20 (#11783 partial): admin/dev/shell/molecules/feedback/waitlist hot-zone wave converted safe raw buttons to @jovie/ui Button."
+  "count": 590,
+  "note": "Raw <button> tags in apps/web/{components,app}. Ratchet only goes down — lower this when a PR converts raw buttons to the canonical Button. 713→637 on 2026-07-20 (#11783 partial): admin/dev/shell/molecules/feedback/waitlist hot-zone wave converted safe raw buttons to @jovie/ui Button. 625→590 (JOV-4870): LibrarySurface, ProfileAboutTab, and admin HUD/features/investors surfaces converted; 5 layout-critical holdouts remain (multi-child flex/grid distribution incompatible with Button's internal content span) plus FounderConversionHud (1) blocked by pre-existing lint debt in that file."
 }


### PR DESCRIPTION
## Summary

Eliminates P2 UI drift ([JOV-4870](https://linear.app/jovie/issue/JOV-4870/p2-ui-drift-convert-raw-buttons-on-primary-routes-library-profile)) by converting mounted primary-route raw `<button>` holdouts to the canonical `@jovie/ui` `Button`:

- **LibrarySurface** (`/app/library`): 4 converted — row/card preview toggles, NoResults reset, PreviewActionButton
- **ProfileAboutTab** (profile contact sidebar): 12 converted — bio edit trigger, location pickers, genre add/remove, press-photo approve/delete, banner dismiss, approve-all
- **Admin surfaces**: 10 converted — HUD ops dashboard (5), HUD metric source trust (1), features table (2), investor token copy (2)

**Ratchet:** `raw-button.baseline.json` lowered **625 → 590** (measured via the ratchet's own counting logic).

### Holdouts (deliberate)
- 5 layout-critical buttons stay raw: their multi-child layouts rely on parent flex/grid distribution (`justify-between`, `flex-1`, column stacks) that the canonical Button's internal content span would break.
- `FounderConversionHud` (1) excluded: the file has 7 **pre-existing** ESLint errors on `main` (server-only imports, label casing) that fail the staged-file gate for any commit touching it — verified identical failures against `origin/main`. Follow-up filed: **JOV-4877**.

### Behavior notes
- All props, handlers, aria attributes, testids, and classNames preserved verbatim; `className` merges last so original styling wins conflicts.
- Two icon-only buttons got explicit `h-auto w-auto p-0` to prevent the canonical icon-size default from shifting layout (genre-remove badge, flag-reset slot) — no-layout-shift rule.
- Label casing normalized where `@jovie/canonical-ui-label-casing` requires it for canonical Buttons: "Dispatch worker"→"Dispatch Worker", "Dry run"→"Dry Run", "Approve all"→"Approve All".

## Test plan

- `pnpm exec biome check` on all touched files — clean
- `eslint` on all touched files — clean (0 errors)
- `pnpm --filter @jovie/web run typecheck` — pass
- `vitest run tests/unit/design-system/raw-button-ratchet.test.ts` — pass (590 ≤ 590)
- `vitest run tests/unit/library` — 24 files / 156 tests pass
- `vitest run ProfileAboutTab + ProfileContactSidebar tests` — 29 tests pass
- `vitest run` admin HUD/features/investor suites — 30 tests pass
- Pre-push gate: **293 test files / 2525 tests passed**, CI harness validation pass

## Screenshots

No screenshot capture available in this environment. Changes are element-swap refactors with preserved classNames; visual delta is limited to canonical focus-ring/disabled treatments and the three Title Case label changes above.

Fixes JOV-4870