### PR TITLE
refactor(web): compose homepage layout from PublicPageShell (JOV-4872)

### DIFF
--- a/apps/web/app/(home)/layout.tsx
+++ b/apps/web/app/(home)/layout.tsx
@@ -1,9 +1,7 @@
 import './home.css';
 import '../../components/marketing/MarketingSnapRail.css';
-import { SkipToContent } from '@/components/atoms/SkipToContent';
 import { HomeScrollWatcher } from '@/components/homepage/HomeScrollWatcher';
-import { MarketingFooter } from '@/components/site/MarketingFooter';
-import { MarketingHeader } from '@/components/site/MarketingHeader';
+import { PublicPageShell } from '@/components/site/PublicPageShell';
 
 export const revalidate = false;
 
@@ -12,27 +10,27 @@ export default function HomeLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // The homepage composes the shared PublicPageShell as an intentional
+  // variant: homepage header chrome (icon logo, no center nav), minimal
+  // footer, and no fixed-header main offset.
   // Dual min-h-svh is intentional (Lovable-style hero shell): the outer
   // container is at least viewport height, AND main holds the hero at full
   // viewport height on its own. Header sits in flow above, footer below the
   // fold. Scrolling reveals the footer; the hero is the first paint.
   return (
-    <div className='home-viewport dark flex min-h-svh flex-col overflow-x-clip bg-base text-primary-token'>
-      <SkipToContent />
+    <PublicPageShell
+      className='home-viewport dark min-h-svh overflow-x-clip bg-base text-primary-token'
+      footerClassName='system-b-mounted-home-footer'
+      footerVariant='minimal'
+      headerVariant='homepage'
+      logoSize='sm'
+      logoVariant='icon'
+      mainClassName='min-h-svh'
+      mainOffset={false}
+      showHomepageCenterNav={false}
+    >
       <HomeScrollWatcher />
-      <MarketingHeader
-        logoSize='sm'
-        logoVariant='icon'
-        showHomepageCenterNav={false}
-        variant='homepage'
-      />
-      <main id='main-content' className='flex min-h-svh flex-1 flex-col'>
-        {children}
-      </main>
-      <MarketingFooter
-        variant='minimal'
-        className='system-b-mounted-home-footer'
-      />
-    </div>
+      {children}
+    </PublicPageShell>
   );
 }

--- a/apps/web/components/site/PublicPageShell.test.tsx
+++ b/apps/web/components/site/PublicPageShell.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PublicPageShell } from './PublicPageShell';
+
+vi.mock('next/navigation', async importOriginal => {
+  const actual = await importOriginal<typeof import('next/navigation')>();
+  return {
+    ...actual,
+    usePathname: () => '/',
+  };
+});
+
+describe('PublicPageShell', () => {
+  it('renders children inside main#main-content with the header offset by default', () => {
+    render(
+      <PublicPageShell>
+        <p>route content</p>
+      </PublicPageShell>
+    );
+
+    const main = document.getElementById('main-content');
+    expect(main).toBeInTheDocument();
+    expect(main).toHaveTextContent('route content');
+    expect(main?.className).toContain('pt-(--public-shell-header-offset)');
+  });
+
+  it('omits the fixed-header offset when mainOffset is false', () => {
+    render(<PublicPageShell mainOffset={false}>hero</PublicPageShell>);
+
+    const main = document.getElementById('main-content');
+    expect(main?.className).not.toContain('pt-(--public-shell-header-offset)');
+  });
+
+  it('passes footer variant and className through to MarketingFooter', () => {
+    render(
+      <PublicPageShell
+        footerClassName='system-b-mounted-home-footer'
+        footerVariant='minimal'
+      >
+        body
+      </PublicPageShell>
+    );
+
+    const footer = screen.getByTestId('marketing-footer');
+    expect(footer.className).toContain('system-b-mounted-home-footer');
+  });
+
+  it('renders the skip-to-content link by default and can disable it', () => {
+    const { unmount } = render(<PublicPageShell>body</PublicPageShell>);
+    expect(
+      screen.getByRole('link', { name: 'Skip to content' })
+    ).toBeInTheDocument();
+    unmount();
+
+    render(<PublicPageShell skipToContent={false}>body</PublicPageShell>);
+    expect(
+      screen.queryByRole('link', { name: 'Skip to content' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/site/PublicPageShell.tsx
+++ b/apps/web/components/site/PublicPageShell.tsx
@@ -1,3 +1,4 @@
+import type { LogoVariant } from '@/components/atoms/Logo';
 import { SkipToContent } from '@/components/atoms/SkipToContent';
 import { cn } from '@/lib/utils';
 import { MarketingFooter } from './MarketingFooter';
@@ -11,20 +12,34 @@ import { PUBLIC_SHELL_MAIN_OFFSET_CLASS } from './public-shell.constants';
 export interface PublicPageShellProps {
   readonly children: React.ReactNode;
   readonly className?: string;
+  readonly footerClassName?: string;
+  readonly footerVariant?: 'auto' | 'expanded' | 'minimal';
   readonly headerVariant?: MarketingHeaderVariant;
   readonly logoSize?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  readonly logoVariant?: LogoVariant;
   readonly mainClassName?: string;
+  /**
+   * Apply the fixed-header top offset to <main>. The homepage hero owns its
+   * own spacing, so the (home) layout opts out.
+   */
+  readonly mainOffset?: boolean;
   readonly navLinks?: readonly MarketingHeaderNavLink[];
+  readonly showHomepageCenterNav?: boolean;
   readonly skipToContent?: boolean;
 }
 
 export function PublicPageShell({
   children,
   className,
+  footerClassName,
+  footerVariant,
   headerVariant = 'landing',
   logoSize = 'xs',
+  logoVariant,
   mainClassName,
+  mainOffset = true,
   navLinks,
+  showHomepageCenterNav,
   skipToContent = true,
 }: Readonly<PublicPageShellProps>) {
   return (
@@ -32,20 +47,22 @@ export function PublicPageShell({
       {skipToContent ? <SkipToContent /> : null}
       <MarketingHeader
         logoSize={logoSize}
+        logoVariant={logoVariant}
         navLinks={navLinks}
+        showHomepageCenterNav={showHomepageCenterNav}
         variant={headerVariant}
       />
       <main
         id='main-content'
         className={cn(
           'flex flex-1 flex-col',
-          PUBLIC_SHELL_MAIN_OFFSET_CLASS,
+          mainOffset ? PUBLIC_SHELL_MAIN_OFFSET_CLASS : undefined,
           mainClassName
         )}
       >
         {children}
       </main>
-      <MarketingFooter />
+      <MarketingFooter className={footerClassName} variant={footerVariant} />
     </div>
   );
 }

--- a/apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts
@@ -24,9 +24,11 @@ describe('mounted homepage footer CTA System B source contract', () => {
       'components/marketing/homepage-v2/HomepageV2Ctas.tsx'
     );
 
-    expect(layoutSource).toContain('<MarketingFooter');
-    expect(layoutSource).toContain("variant='minimal'");
-    expect(layoutSource).toContain("className='system-b-mounted-home-footer'");
+    expect(layoutSource).toContain('<PublicPageShell');
+    expect(layoutSource).toContain("footerVariant='minimal'");
+    expect(layoutSource).toContain(
+      "footerClassName='system-b-mounted-home-footer'"
+    );
     expect(finalCtaSource).toMatch(
       /(?=.*system-b-mounted-home-footer-cta(?!-))(?=.*system-b-mounted-home-footer-cta-container)(?=.*system-b-mounted-home-footer-cta-copy)(?=.*system-b-mounted-home-footer-cta-heading)(?=.*system-b-mounted-home-footer-cta-action)/s
     );


### PR DESCRIPTION
## Summary

Normalizes the homepage vs marketing shell composition seam (UI drift audit P2 finding, JOV-4872):

- `apps/web/app/(home)/layout.tsx` now composes the shared `PublicPageShell` instead of duplicating the header/footer composition inline — the same shell `(marketing)/layout.tsx` already uses.
- `apps/web/components/site/PublicPageShell.tsx` gains minimal pass-through props (`logoVariant`, `showHomepageCenterNav`, `footerVariant`, `footerClassName`, `mainOffset` opt-out) so the homepage keeps its **intentional variant** behavior pixel-identical:
  - header `variant='homepage'`, `logoSize='sm'`, `logoVariant='icon'`, no center nav
  - footer `variant='minimal'` with `system-b-mounted-home-footer` class
  - dual `min-h-svh` hero shell, no fixed-header main offset (the homepage hero owns its spacing)
- Defaults on all new props preserve previous behavior for every existing `PublicPageShell` consumer (`(marketing)`, `(dynamic)`, `p/[token]`, `drop/[token]`, `a/[handle]`, `[username]` pages).
- `HomeScrollWatcher` stays in the home layout (homepage-only concern; renders `null`).

The redundant inline wrapper in the home layout is removed; the mounted-footer style-guard anchors were updated to the composed prop names (`footerVariant='minimal'`, `footerClassName='system-b-mounted-home-footer'`) — same guard, same pinned values.

## Test plan

- `pnpm biome check --write` on the 3 touched files — clean
- `pnpm --filter @jovie/web run typecheck` — pass (exit 0)
- `vitest run` targeted, 8 files / 37 tests pass:
  - `tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts`
  - `tests/unit/home/mounted-home-pricing-system-b-style-guard.test.ts`
  - `tests/unit/marketing/legal-system-b-style-guard.test.ts`
  - `tests/unit/marketing/homepage-v2-system-b-style-guard.test.ts`
  - `tests/unit/marketing/storybook-catalog-coverage.test.ts`
  - `tests/unit/components/site/MarketingFooter.test.tsx`
  - `tests/unit/components/site/NotFoundPageContent.test.tsx`
  - `tests/unit/app/globals-ui-feel-style-guard.test.ts`
- Pre-commit gates (secret scans, eslint, a11y staged, lint-staged typecheck) all green

## Screenshots

Not captured in the unattended headless environment. The change is structural composition only: every header/footer/layout prop value previously inlined in `(home)/layout.tsx` is passed through unchanged, and `PublicPageShell` defaults are untouched for other routes, so rendered DOM/classes are identical by construction (twMerge resolves `min-h-svh` over the shell's `min-h-screen`).

Fixes JOV-4872
https://linear.app/jovie/issue/JOV-4872/p2-ui-drift-normalize-homepage-vs-marketing-shell-composition-seam
