### PR TITLE
refactor(ui): consolidate bespoke icon-button family into one @jovie/ui contract (JOV-4871)

### DIFF
--- a/apps/web/components/atoms/AppIconButton.stories.tsx
+++ b/apps/web/components/atoms/AppIconButton.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { AppIconButton } from './AppIconButton';
+
+const PlaceholderIcon = () => (
+  <svg
+    aria-hidden='true'
+    viewBox='0 0 16 16'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.5'
+    className='h-4 w-4'
+  >
+    <circle cx='8' cy='8' r='6' />
+  </svg>
+);
+
+const meta = {
+  title: 'Atoms/AppIconButton',
+  component: AppIconButton,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    ariaLabel: 'App action',
+    children: <PlaceholderIcon />,
+  },
+} satisfies Meta<typeof AppIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithTooltip: Story = {
+  args: {
+    tooltipLabel: 'App action',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/apps/web/components/atoms/AppIconButton.tsx
+++ b/apps/web/components/atoms/AppIconButton.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { Button, type ButtonProps, TooltipShortcut } from '@jovie/ui';
+import { IconButton, type IconButtonProps, TooltipShortcut } from '@jovie/ui';
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
+// Shared chrome for app-shell text/icon controls. Kept verbatim for the
+// text-control consumers; the icon-only path is the canonical `control`
+// variant on @jovie/ui IconButton (JOV-4871).
 export const APP_CONTROL_BUTTON_CLASS =
   'inline-flex h-app-control-sm items-center justify-center gap-1.5 rounded-pill border border-subtle bg-surface-1 px-app-control-x text-xs font-caption tracking-[-0.012em] text-secondary-token shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-default hover:bg-surface-0 hover:text-primary-token hover:shadow-none focus-visible:border-focus focus-visible:bg-surface-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/16 active:border-default active:bg-surface-1 active:shadow-none disabled:pointer-events-none disabled:opacity-50 disabled:shadow-none';
 
@@ -17,8 +20,8 @@ type AppIconButtonLabelProps =
   | { readonly ariaLabel?: never; readonly 'aria-label': string };
 
 export type AppIconButtonProps = Omit<
-  ButtonProps,
-  'children' | 'size' | 'aria-label'
+  IconButtonProps,
+  'size' | 'variant' | 'aria-label' | 'ariaLabel'
 > &
   AppIconButtonLabelProps & {
     readonly children: React.ReactNode;
@@ -26,6 +29,13 @@ export type AppIconButtonProps = Omit<
     readonly tooltipShortcut?: string;
   };
 
+/**
+ * AppIconButton - compat wrapper over the canonical @jovie/ui IconButton
+ * (JOV-4871): `control` variant at the 28px app-control size, with optional
+ * tooltip. Focus ring and 44px hit target come from the base Button.
+ *
+ * @coverage-via apps/web/tests/unit/components/atoms/AppIconButton.test.tsx
+ */
 export const AppIconButton = React.forwardRef<
   HTMLButtonElement,
   AppIconButtonProps
@@ -36,7 +46,6 @@ export const AppIconButton = React.forwardRef<
     'aria-label': ariaLabelProp,
     tooltipLabel,
     tooltipShortcut,
-    variant = 'ghost',
     className,
     ...props
   },
@@ -45,16 +54,16 @@ export const AppIconButton = React.forwardRef<
   const resolvedAriaLabel = ariaLabel ?? ariaLabelProp;
 
   const button = (
-    <Button
+    <IconButton
       ref={ref}
-      variant={variant}
-      size='icon'
-      className={cn(APP_ICON_BUTTON_CLASS, className)}
+      variant='control'
+      size='sm'
+      className={className}
       aria-label={resolvedAriaLabel}
       {...props}
     >
       {children}
-    </Button>
+    </IconButton>
   );
 
   if (!tooltipLabel) return button;

--- a/apps/web/components/atoms/CircleIconButton.stories.tsx
+++ b/apps/web/components/atoms/CircleIconButton.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { CircleIconButton } from './CircleIconButton';
+
+const PlaceholderIcon = () => (
+  <svg
+    aria-hidden='true'
+    viewBox='0 0 16 16'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.5'
+    className='h-4 w-4'
+  >
+    <circle cx='8' cy='8' r='6' />
+  </svg>
+);
+
+const meta = {
+  title: 'Atoms/CircleIconButton',
+  component: CircleIconButton,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    ariaLabel: 'Circle action',
+    children: <PlaceholderIcon />,
+  },
+} satisfies Meta<typeof CircleIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Surface: Story = {};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+  },
+};
+
+export const Frosted: Story = {
+  args: {
+    variant: 'frosted',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/apps/web/components/atoms/CircleIconButton.tsx
+++ b/apps/web/components/atoms/CircleIconButton.tsx
@@ -1,26 +1,24 @@
 'use client';
 
-import { Button } from '@jovie/ui';
+import {
+  type ButtonProps,
+  IconButton,
+  type IconButtonSize,
+  type IconButtonVariant,
+} from '@jovie/ui';
 import * as React from 'react';
 
-import { cn } from '@/lib/utils';
-
 /**
- * CircleIconButton - Unified circular icon button component
+ * CircleIconButton - compat wrapper over the canonical @jovie/ui IconButton
+ * (JOV-4871). Keeps the legacy prop API; the size/variant contract, focus
+ * ring, reduced-motion, and 44px hit target now live in one place.
  *
- * A shared component for all small circle buttons across profiles and auth screens.
- * Supports full design token usage and light/dark mode theming.
+ * @coverage-via apps/web/tests/unit/atoms/CircleIconButton.test.tsx
  *
  * @example
  * // Surface variant (default) - elevated card style
  * <CircleIconButton ariaLabel="Back" onClick={goBack}>
  *   <ArrowLeft className="h-4 w-4" />
- * </CircleIconButton>
- *
- * @example
- * // Frosted variant - glassmorphic with blur
- * <CircleIconButton variant="frosted" ariaLabel="Menu">
- *   <Menu className="h-4 w-4" />
  * </CircleIconButton>
  *
  * @example
@@ -31,171 +29,54 @@ import { cn } from '@/lib/utils';
  */
 
 export type CircleIconButtonSize = 'xs' | 'sm' | 'md' | 'lg';
-export type CircleIconButtonVariant =
-  | 'surface'
-  | 'frosted'
-  | 'ghost'
-  | 'secondary'
-  | 'outline'
-  | 'pearl'
-  | 'pearlQuiet';
+export type CircleIconButtonVariant = Exclude<
+  IconButtonVariant,
+  'control' | 'inline'
+>;
 
 export interface CircleIconButtonProps
-  extends Omit<
-    React.ComponentProps<typeof Button>,
-    'size' | 'variant' | 'asChild'
-  > {
-  /** Button content (typically an icon) */
-  readonly children: React.ReactNode;
+  extends Omit<ButtonProps, 'size' | 'variant' | 'aria-label'> {
   /** Accessible label for screen readers */
   readonly ariaLabel: string;
   /** Button size - xs/sm/md: 40px, lg: 44px */
   readonly size?: CircleIconButtonSize;
   /** Visual variant */
   readonly variant?: CircleIconButtonVariant;
-  /** Render as child element (for Link, etc.) */
-  readonly asChild?: boolean;
-  /** Additional class names */
-  readonly className?: string;
 }
 
-const sizeStyles: Record<CircleIconButtonSize, string> = {
-  xs: 'h-10 w-10',
-  sm: 'h-10 w-10',
-  md: 'h-10 w-10',
-  lg: 'h-11 w-11',
+// Legacy circle sizes collapse onto the canonical contract: xs/sm/md all
+// rendered 40px, lg rendered 44px.
+const SIZE_MAP: Record<CircleIconButtonSize, IconButtonSize> = {
+  xs: 'lg',
+  sm: 'lg',
+  md: 'lg',
+  lg: 'xl',
 };
-
-const iconSizeStyles: Record<CircleIconButtonSize, string> = {
-  xs: '[&>svg]:h-4 [&>svg]:w-4',
-  sm: '[&>svg]:h-4 [&>svg]:w-4',
-  md: '[&>svg]:h-5 [&>svg]:w-5',
-  lg: '[&>svg]:h-5 [&>svg]:w-5',
-};
-
-const variantStyles: Record<
-  CircleIconButtonVariant,
-  {
-    buttonVariant: React.ComponentProps<typeof Button>['variant'];
-    className: string;
-  }
-> = {
-  // Surface - elevated card style with subtle border
-  surface: {
-    buttonVariant: 'secondary',
-    className: cn(
-      'border border-subtle bg-surface-1 text-primary-token',
-      'shadow-sm',
-      'hover:bg-surface-2 hover:text-primary-token hover:shadow-md'
-    ),
-  },
-  // Frosted - glassmorphic with backdrop blur
-  frosted: {
-    buttonVariant: 'frosted-ghost',
-    className: cn(
-      'border border-subtle bg-[color-mix(in_srgb,var(--linear-bg-surface-1)_84%,transparent)] text-primary-token backdrop-blur-sm',
-      'shadow-sm',
-      'hover:bg-[color-mix(in_srgb,var(--linear-bg-surface-2)_88%,transparent)]'
-    ),
-  },
-  // Ghost - transparent with hover background
-  ghost: {
-    buttonVariant: 'ghost',
-    className: cn(
-      'bg-transparent text-secondary-token',
-      'hover:bg-surface-1 hover:text-primary-token'
-    ),
-  },
-  // Secondary - subtle background without border
-  secondary: {
-    buttonVariant: 'secondary',
-    className: cn(
-      'bg-surface-2 text-secondary-token',
-      'shadow-sm',
-      'hover:bg-surface-3 hover:text-primary-token'
-    ),
-  },
-  // Outline - transparent with visible border
-  outline: {
-    buttonVariant: 'outline',
-    className: cn(
-      'border border-subtle bg-transparent text-tertiary-token',
-      'hover:bg-surface-1 hover:text-primary-token'
-    ),
-  },
-  // Pearl - public profile chrome
-  pearl: {
-    buttonVariant: 'ghost',
-    className: cn(
-      'border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-primary-token backdrop-blur-xl',
-      'shadow-(--profile-pearl-shadow)',
-      'hover:bg-(--profile-pearl-bg-hover) hover:text-primary-token',
-      'active:bg-(--profile-pearl-bg-active)'
-    ),
-  },
-  pearlQuiet: {
-    buttonVariant: 'ghost',
-    className: cn(
-      'border border-transparent bg-transparent text-primary-token/78 backdrop-blur-xl',
-      'shadow-none',
-      'hover:border-(--profile-pearl-border) hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_88%,transparent)] hover:text-primary-token hover:shadow-[0_10px_24px_rgba(10,12,18,0.1)]',
-      'focus-visible:border-(--profile-pearl-border) focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] focus-visible:text-primary-token focus-visible:shadow-[0_10px_24px_rgba(10,12,18,0.12)]',
-      'active:bg-(--profile-pearl-bg-active) active:text-primary-token'
-    ),
-  },
-};
-
-const baseStyles = cn(
-  // Shape and layout
-  'inline-flex items-center justify-center rounded-full',
-  // Transitions
-  'transition-colors duration-subtle ease-out',
-  // Required for soft material treatments on profile chrome
-  'relative isolate overflow-hidden',
-  // Touch optimizations
-  'touch-manipulation select-none',
-  '[-webkit-tap-highlight-color:transparent]',
-  // Cursor
-  'cursor-pointer'
-);
 
 export const CircleIconButton = React.forwardRef<
   HTMLButtonElement,
   CircleIconButtonProps
 >(function CircleIconButton(
   {
-    children,
     ariaLabel,
     size = 'sm',
     variant = 'surface',
-    asChild = false,
-    className,
     type = 'button',
+    asChild,
     ...props
   },
   ref
 ) {
-  const variantConfig = variantStyles[variant];
-
   return (
-    <Button
+    <IconButton
       ref={ref}
       asChild={asChild}
       type={asChild ? undefined : type}
-      variant={variantConfig.buttonVariant}
-      size='icon'
-      className={cn(
-        baseStyles,
-        sizeStyles[size],
-        iconSizeStyles[size],
-        variantConfig.className,
-        className
-      )}
-      aria-label={ariaLabel}
+      variant={variant}
+      size={SIZE_MAP[size]}
+      ariaLabel={ariaLabel}
       {...props}
-    >
-      {children}
-    </Button>
+    />
   );
 });
 

--- a/apps/web/components/atoms/FrostedButton.stories.tsx
+++ b/apps/web/components/atoms/FrostedButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { FrostedButton } from './FrostedButton';
+
+const meta = {
+  title: 'Atoms/FrostedButton',
+  component: FrostedButton,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'Frosted action',
+  },
+} satisfies Meta<typeof FrostedButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Solid: Story = {};
+
+export const Ghost: Story = {
+  args: {
+    tone: 'ghost',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    tone: 'outline',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/apps/web/components/atoms/FrostedButton.tsx
+++ b/apps/web/components/atoms/FrostedButton.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import React from 'react';
 import { cn } from '@/lib/utils';
 
+// @coverage-via apps/web/tests/unit/atoms/FrostedButton.test.tsx
+
 export interface FrostedButtonProps extends Omit<ButtonProps, 'variant'> {
   readonly href?: string;
   readonly external?: boolean;
@@ -30,10 +32,11 @@ export const FrostedButton = React.forwardRef<
     ref
   ) => {
     const variant = toneToVariant[tone];
+    // JOV-4871: no bespoke focus ring — the base Button canonical ring and
+    // reduced-motion policy apply unchanged.
     const frostedClasses = cn(
       'backdrop-blur-md transition-colors duration-subtle ease-out',
       'motion-reduce:transition-none',
-      'focus-visible:ring-offset-2 focus-visible:ring-ring focus-visible:ring-offset-background',
       className
     );
 

--- a/apps/web/components/atoms/HeaderIconButton.stories.tsx
+++ b/apps/web/components/atoms/HeaderIconButton.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { HeaderIconButton } from './HeaderIconButton';
+
+const PlaceholderIcon = () => (
+  <svg
+    aria-hidden='true'
+    viewBox='0 0 16 16'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.5'
+    className='h-4 w-4'
+  >
+    <circle cx='8' cy='8' r='6' />
+  </svg>
+);
+
+const meta = {
+  title: 'Atoms/HeaderIconButton',
+  component: HeaderIconButton,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    ariaLabel: 'Header action',
+    children: <PlaceholderIcon />,
+  },
+} satisfies Meta<typeof HeaderIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Medium: Story = {};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+  },
+};
+
+export const ExtraSmall: Story = {
+  args: {
+    size: 'xs',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/apps/web/components/atoms/HeaderIconButton.tsx
+++ b/apps/web/components/atoms/HeaderIconButton.tsx
@@ -1,19 +1,27 @@
 'use client';
 
-import type { ButtonProps } from '@jovie/ui';
+import { IconButton, type IconButtonProps } from '@jovie/ui';
 import * as React from 'react';
-import { AppIconButton } from '@/components/atoms/AppIconButton';
 
 export type HeaderIconButtonSize = 'xs' | 'sm' | 'md';
 
 export interface HeaderIconButtonProps
-  extends Omit<ButtonProps, 'children' | 'size' | 'variant' | 'aria-label'> {
+  extends Omit<
+    IconButtonProps,
+    'children' | 'size' | 'variant' | 'aria-label' | 'ariaLabel'
+  > {
   readonly children: React.ReactNode;
   readonly ariaLabel: string;
   readonly size?: HeaderIconButtonSize;
-  readonly variant?: ButtonProps['variant'];
 }
 
+/**
+ * HeaderIconButton - compat wrapper over the canonical @jovie/ui IconButton
+ * (JOV-4871): `control` variant at compact header sizes (24/28/32px), with
+ * the base Button 44px hit target preserved.
+ *
+ * @coverage-via apps/web/tests/unit/atoms/HeaderIconButton.test.tsx
+ */
 export const HeaderIconButton = React.forwardRef<
   HTMLButtonElement,
   HeaderIconButtonProps
@@ -21,21 +29,17 @@ export const HeaderIconButton = React.forwardRef<
   { children, ariaLabel, size = 'md', className, ...props },
   ref
 ) {
-  const SIZE_CLASS_MAP: Record<HeaderIconButtonSize, string> = {
-    xs: 'h-6 w-6 rounded-full [&_svg]:h-3 [&_svg]:w-3',
-    sm: 'h-7 w-7 rounded-full [&_svg]:h-3.5 [&_svg]:w-3.5',
-    md: 'h-8 w-8 rounded-full [&_svg]:h-4 [&_svg]:w-4',
-  };
-
   return (
-    <AppIconButton
+    <IconButton
       ref={ref}
-      className={[SIZE_CLASS_MAP[size], className].filter(Boolean).join(' ')}
+      variant='control'
+      size={size}
+      className={className}
       ariaLabel={ariaLabel}
       {...props}
     >
       {children}
-    </AppIconButton>
+    </IconButton>
   );
 });
 

--- a/apps/web/components/atoms/InlineIconButton.stories.tsx
+++ b/apps/web/components/atoms/InlineIconButton.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { InlineIconButton } from './InlineIconButton';
+
+const PlaceholderIcon = () => (
+  <svg
+    aria-hidden='true'
+    viewBox='0 0 16 16'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.5'
+    className='h-4 w-4'
+  >
+    <circle cx='8' cy='8' r='6' />
+  </svg>
+);
+
+const meta = {
+  title: 'Atoms/InlineIconButton',
+  component: InlineIconButton,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Inline action',
+    children: <PlaceholderIcon />,
+  },
+} satisfies Meta<typeof InlineIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Visible: Story = {};
+
+export const FadeOnParentHover: Story = {
+  args: {
+    fadeOnParentHover: true,
+  },
+  render: args => (
+    <div className='group rounded-md border border-subtle p-4'>
+      <InlineIconButton {...args} />
+    </div>
+  ),
+};
+
+export const AsLink: Story = {
+  args: {
+    href: '/',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/apps/web/components/atoms/InlineIconButton.tsx
+++ b/apps/web/components/atoms/InlineIconButton.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { Button } from '@jovie/ui';
+import {
+  ICON_BUTTON_FADE_CLASSNAME,
+  ICON_BUTTON_VISIBLE_CLASSNAME,
+  IconButton,
+} from '@jovie/ui';
 import type {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
@@ -10,17 +14,18 @@ import React from 'react';
 
 import { cn } from '@/lib/utils';
 
-// Shell handoff rotation 22: upgraded base for all drawer/edit affordance
-// icon buttons (used by DrawerEditableTextField triggers + actions) to
-// canonical focus rings + DS subtle motion. Predecessor: rot 21 InlineEditRow.
+// Compat wrapper (JOV-4871): drawer/edit affordance icon buttons now use the
+// canonical `inline` variant on @jovie/ui IconButton. The class constants are
+// re-exported from the shared contract so existing imports keep working.
+//
+// @coverage-via apps/web/tests/unit/atoms/InlineIconButton.test.tsx
 export const INLINE_ICON_BUTTON_BASE_CLASSNAME =
-  'relative h-auto min-h-10 w-auto min-w-10 shrink-0 rounded-full border border-transparent bg-transparent p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow,transform] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) [&_svg]:block';
+  'shrink-0 p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow,transform] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 [&_svg]:block';
 
 export const INLINE_ICON_BUTTON_VISIBLE_CLASSNAME =
-  'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100';
+  ICON_BUTTON_VISIBLE_CLASSNAME;
 
-export const INLINE_ICON_BUTTON_FADE_CLASSNAME =
-  'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100';
+export const INLINE_ICON_BUTTON_FADE_CLASSNAME = ICON_BUTTON_FADE_CLASSNAME;
 
 interface InlineIconButtonSharedProps {
   readonly children: ReactNode;
@@ -45,6 +50,14 @@ export type InlineIconButtonProps =
 export const InlineIconButton = React.memo(function InlineIconButton(
   props: InlineIconButtonProps
 ) {
+  const sharedClassName = (className?: string, fadeOnParentHover = false) =>
+    cn(
+      fadeOnParentHover
+        ? INLINE_ICON_BUTTON_FADE_CLASSNAME
+        : INLINE_ICON_BUTTON_VISIBLE_CLASSNAME,
+      className
+    );
+
   if ('href' in props && typeof props.href === 'string') {
     const {
       children,
@@ -54,20 +67,17 @@ export const InlineIconButton = React.memo(function InlineIconButton(
       ...anchorProps
     } = props;
 
-    const sharedClassName = cn(
-      INLINE_ICON_BUTTON_BASE_CLASSNAME,
-      fadeOnParentHover
-        ? INLINE_ICON_BUTTON_FADE_CLASSNAME
-        : INLINE_ICON_BUTTON_VISIBLE_CLASSNAME,
-      className
-    );
-
     return (
-      <Button asChild variant='ghost' size='icon' className={sharedClassName}>
+      <IconButton
+        variant='inline'
+        size='lg'
+        asChild
+        className={sharedClassName(className, fadeOnParentHover)}
+      >
         <a href={href} {...anchorProps}>
           {children}
         </a>
-      </Button>
+      </IconButton>
     );
   }
 
@@ -79,23 +89,15 @@ export const InlineIconButton = React.memo(function InlineIconButton(
     ...buttonProps
   } = props;
 
-  const sharedClassName = cn(
-    INLINE_ICON_BUTTON_BASE_CLASSNAME,
-    fadeOnParentHover
-      ? INLINE_ICON_BUTTON_FADE_CLASSNAME
-      : INLINE_ICON_BUTTON_VISIBLE_CLASSNAME,
-    className
-  );
-
   return (
-    <Button
+    <IconButton
+      variant='inline'
+      size='lg'
       type={type}
-      variant='ghost'
-      size='icon'
-      className={sharedClassName}
+      className={sharedClassName(className, fadeOnParentHover)}
       {...buttonProps}
     >
       {children}
-    </Button>
+    </IconButton>
   );
 });

--- a/apps/web/components/features/auth/AuthLayout.tsx
+++ b/apps/web/components/features/auth/AuthLayout.tsx
@@ -292,7 +292,7 @@ export function AuthLayout({
         <div className='absolute top-4 right-4 z-50'>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <AppIconButton ariaLabel='Open menu' variant='ghost'>
+              <AppIconButton ariaLabel='Open menu'>
                 <MoreHorizontal />
               </AppIconButton>
             </DropdownMenuTrigger>

--- a/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
@@ -156,6 +156,27 @@ describe('CircleIconButton', () => {
     expect(button).toHaveAttribute('type', 'button');
   });
 
+  it('maps legacy sizes onto the canonical IconButton contract (JOV-4871)', () => {
+    const { unmount } = render(
+      <CircleIconButton ariaLabel='Canonical default'>
+        <svg aria-hidden='true' />
+      </CircleIconButton>
+    );
+    expect(
+      screen.getByRole('button', { name: 'Canonical default' })
+    ).toHaveAttribute('data-size', 'icon-lg');
+    unmount();
+
+    render(
+      <CircleIconButton ariaLabel='Canonical large' size='lg'>
+        <svg aria-hidden='true' />
+      </CircleIconButton>
+    );
+    expect(
+      screen.getByRole('button', { name: 'Canonical large' })
+    ).toHaveAttribute('data-size', 'icon-xl');
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(
       <CircleIconButton ariaLabel='Accessible circle button'>

--- a/apps/web/tests/unit/atoms/FrostedButton.test.tsx
+++ b/apps/web/tests/unit/atoms/FrostedButton.test.tsx
@@ -83,6 +83,17 @@ describe('FrostedButton', () => {
     );
   });
 
+  it('adds no bespoke focus ring overrides (JOV-4871)', () => {
+    // The canonical ring comes from the real @jovie/ui Button (covered by
+    // packages/ui tests); this wrapper must not re-introduce drift.
+    render(<FrostedButton>Focus ring</FrostedButton>);
+    const button = screen.getByRole('button', { name: 'Focus ring' });
+    expect(button.className).not.toContain('focus-visible:ring-ring');
+    expect(button.className).not.toContain(
+      'focus-visible:ring-offset-background'
+    );
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(<FrostedButton>Accessible</FrostedButton>);
     await expectNoA11yViolations(container);

--- a/apps/web/tests/unit/atoms/HeaderIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/HeaderIconButton.test.tsx
@@ -76,6 +76,19 @@ describe('HeaderIconButton', () => {
     expect(ref.current?.getAttribute('aria-label')).toBe('Ref test');
   });
 
+  it('maps header sizes onto the canonical IconButton contract (JOV-4871)', () => {
+    render(
+      <HeaderIconButton ariaLabel='Canonical header' size='sm'>
+        <svg aria-hidden='true' />
+      </HeaderIconButton>
+    );
+
+    const button = screen.getByRole('button', { name: 'Canonical header' });
+    expect(button).toHaveAttribute('data-size', 'icon-sm');
+    // 44px hit target preserved below the 44px container size.
+    expect(button.className).toContain('before:h-11');
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(
       <HeaderIconButton ariaLabel='Accessible button'>

--- a/apps/web/tests/unit/atoms/InlineIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/InlineIconButton.test.tsx
@@ -72,6 +72,18 @@ describe('InlineIconButton', () => {
     expect(handleClick).toHaveBeenCalledOnce();
   });
 
+  it('renders through the canonical inline variant contract (JOV-4871)', () => {
+    render(
+      <InlineIconButton aria-label='Canonical inline'>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    const button = screen.getByRole('button', { name: 'Canonical inline' });
+    expect(button).toHaveAttribute('data-variant', 'ghost');
+    expect(button).toHaveAttribute('data-size', 'icon-lg');
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(
       <InlineIconButton aria-label='Accessible inline icon'>

--- a/apps/web/tests/unit/components/atoms/AppIconButton.test.tsx
+++ b/apps/web/tests/unit/components/atoms/AppIconButton.test.tsx
@@ -4,8 +4,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { AppIconButton } from '@/components/atoms/AppIconButton';
 
 vi.mock('@jovie/ui', () => ({
-  Button: ({ children, ...props }: ComponentProps<'button'>) => (
-    <button type='button' {...props}>
+  IconButton: ({
+    children,
+    variant,
+    size,
+    ...props
+  }: ComponentProps<'button'> & {
+    readonly variant?: string;
+    readonly size?: string;
+  }) => (
+    <button type='button' data-variant={variant} data-size={size} {...props}>
       {children}
     </button>
   ),
@@ -25,7 +33,17 @@ describe('AppIconButton', () => {
     const button = screen.getByRole('button', { name: 'Open details' });
     expect(button).toBeInTheDocument();
     expect(button).toBeEnabled();
-    expect(button.className).toContain('rounded-full');
-    expect(button.className).toContain('shadow-none');
+  });
+
+  it('maps onto the canonical IconButton control variant at the sm size', () => {
+    render(
+      <AppIconButton ariaLabel='Open details'>
+        <span aria-hidden='true'>+</span>
+      </AppIconButton>
+    );
+
+    const button = screen.getByRole('button', { name: 'Open details' });
+    expect(button).toHaveAttribute('data-variant', 'control');
+    expect(button).toHaveAttribute('data-size', 'sm');
   });
 });

--- a/packages/ui/atoms/button-contract.ts
+++ b/packages/ui/atoms/button-contract.ts
@@ -12,7 +12,17 @@ export const BUTTON_VARIANT_NAMES = [
   'link',
 ] as const;
 
-export const BUTTON_SIZE_NAMES = ['sm', 'md', 'lg', 'icon'] as const;
+export const BUTTON_SIZE_NAMES = [
+  'sm',
+  'md',
+  'lg',
+  'icon',
+  'icon-xs',
+  'icon-sm',
+  'icon-md',
+  'icon-lg',
+  'icon-xl',
+] as const;
 
 export type ButtonVariant = (typeof BUTTON_VARIANT_NAMES)[number];
 export type ButtonSize = (typeof BUTTON_SIZE_NAMES)[number];

--- a/packages/ui/atoms/button.test.tsx
+++ b/packages/ui/atoms/button.test.tsx
@@ -91,6 +91,34 @@ describe('Button', () => {
     }
   });
 
+  it('keeps a 44px hit target on every icon size (JOV-4871)', () => {
+    const iconSizes = {
+      icon: 'h-9',
+      'icon-xs': 'h-6',
+      'icon-sm': 'h-7',
+      'icon-md': 'h-8',
+      'icon-lg': 'h-10',
+      'icon-xl': 'h-11',
+    } as const;
+
+    for (const [size, container] of Object.entries(iconSizes) as [
+      keyof typeof iconSizes,
+      string,
+    ][]) {
+      const { unmount } = render(<Button size={size}>Icon {size}</Button>);
+      const btn = screen.getByRole('button', { name: `Icon ${size}` });
+      expect(btn.className).toContain(container);
+      if (size === 'icon-xl') {
+        // 44px container satisfies the hit target by construction.
+        expect(btn.className).not.toContain('before:h-11');
+      } else {
+        expect(btn.className).toContain('before:h-11');
+        expect(btn.className).toContain('before:w-11');
+      }
+      unmount();
+    }
+  });
+
   it('maps deprecated variants to canonical variants with a warning', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -25,11 +25,22 @@ const BUTTON_VARIANT_CLASSES: Record<ButtonVariant, string> = {
   link: 'h-auto border-0 bg-transparent p-0 text-primary underline-offset-4 shadow-none hover:underline',
 };
 
+// 44px minimum hit target for icon buttons below 44px (WCAG 2.5.5 / Apple HIG),
+// rendered as an invisible pseudo-element so layout stays compact.
+const ICON_HIT_TARGET_44 =
+  'before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]';
+
 const BUTTON_SIZE_CLASSES: Record<ButtonSize, string> = {
   sm: 'h-7 px-2.5 text-xs before:absolute before:left-1/2 before:top-1/2 before:h-10 before:min-w-10 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
   md: 'h-9 px-3 text-[13px] before:absolute before:left-1/2 before:top-1/2 before:h-11 before:min-w-11 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
   lg: 'h-11 px-5 text-sm before:absolute before:left-1/2 before:top-1/2 before:h-11 before:min-w-11 before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
-  icon: 'h-9 w-9 px-0 before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[""]',
+  icon: `h-9 w-9 px-0 ${ICON_HIT_TARGET_44}`,
+  'icon-xs': `h-6 w-6 px-0 ${ICON_HIT_TARGET_44}`,
+  'icon-sm': `h-7 w-7 px-0 ${ICON_HIT_TARGET_44}`,
+  'icon-md': `h-8 w-8 px-0 ${ICON_HIT_TARGET_44}`,
+  'icon-lg': `h-10 w-10 px-0 ${ICON_HIT_TARGET_44}`,
+  // 44px container already satisfies the hit target.
+  'icon-xl': 'h-11 w-11 px-0',
 };
 
 const buttonVariants = cva(
@@ -46,7 +57,17 @@ const buttonVariants = cva(
     compoundVariants: [
       {
         variant: 'link',
-        size: ['sm', 'md', 'lg', 'icon'],
+        size: [
+          'sm',
+          'md',
+          'lg',
+          'icon',
+          'icon-xs',
+          'icon-sm',
+          'icon-md',
+          'icon-lg',
+          'icon-xl',
+        ],
         className:
           'h-auto min-h-0 w-auto min-w-0 px-0 py-0 before:hidden disabled:opacity-60',
       },

--- a/packages/ui/atoms/icon-button-contract.ts
+++ b/packages/ui/atoms/icon-button-contract.ts
@@ -1,0 +1,37 @@
+/**
+ * Server-safe canonical IconButton contract (JOV-4871).
+ *
+ * One size/variant registry for every icon-only button in the product.
+ * The client `IconButton` (./icon-button) is the only implementation; the
+ * legacy web atoms (CircleIconButton, AppIconButton, HeaderIconButton,
+ * InlineIconButton, DrawerInlineIconButton) are thin compat wrappers over it.
+ *
+ * Sizes map 1:1 onto the base Button `icon-*` sizes (24/28/32/40/44px
+ * containers). Every size below 44px keeps the Button 44px pseudo-element
+ * hit target; `xl` is 44px by construction. All variants share the base
+ * Button focus ring and `motion-reduce:transition-none`.
+ */
+export const ICON_BUTTON_VARIANT_NAMES = [
+  'surface',
+  'frosted',
+  'ghost',
+  'secondary',
+  'outline',
+  'pearl',
+  'pearlQuiet',
+  'control',
+  'inline',
+] as const;
+
+export const ICON_BUTTON_SIZE_NAMES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+export type IconButtonVariant = (typeof ICON_BUTTON_VARIANT_NAMES)[number];
+export type IconButtonSize = (typeof ICON_BUTTON_SIZE_NAMES)[number];
+
+/** Modifier for inline affordances that stay visible without parent hover. */
+export const ICON_BUTTON_VISIBLE_CLASSNAME =
+  'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100';
+
+/** Modifier for inline affordances revealed on parent hover/focus. */
+export const ICON_BUTTON_FADE_CLASSNAME =
+  'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100';

--- a/packages/ui/atoms/icon-button.stories.tsx
+++ b/packages/ui/atoms/icon-button.stories.tsx
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { IconButton } from './icon-button';
+import {
+  ICON_BUTTON_SIZE_NAMES,
+  ICON_BUTTON_VARIANT_NAMES,
+} from './icon-button-contract';
+
+const PlaceholderIcon = () => (
+  <svg
+    aria-hidden='true'
+    viewBox='0 0 16 16'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.5'
+    className='h-4 w-4'
+  >
+    <circle cx='8' cy='8' r='6' />
+  </svg>
+);
+
+const meta: Meta<typeof IconButton> = {
+  title: 'shadcn/IconButton',
+  component: IconButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Canonical icon-only button (JOV-4871): one size/variant contract for every icon button, built on the base Button so the focus ring, 44px hit target, and reduced-motion behavior are identical everywhere.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: [...ICON_BUTTON_VARIANT_NAMES],
+      description: 'Visual style variant',
+    },
+    size: {
+      control: { type: 'select' },
+      options: [...ICON_BUTTON_SIZE_NAMES],
+      description: 'Container size: xs 24 / sm 28 / md 32 / lg 40 / xl 44px',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disabled state',
+    },
+    asChild: {
+      control: { type: 'boolean' },
+      description: 'Render as child element (Radix Slot)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ghost: Story = {
+  args: {
+    ariaLabel: 'Ghost action',
+    variant: 'ghost',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Surface: Story = {
+  args: {
+    ariaLabel: 'Surface action',
+    variant: 'surface',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Frosted: Story = {
+  args: {
+    ariaLabel: 'Frosted action',
+    variant: 'frosted',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    ariaLabel: 'Secondary action',
+    variant: 'secondary',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    ariaLabel: 'Outline action',
+    variant: 'outline',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Pearl: Story = {
+  args: {
+    ariaLabel: 'Pearl action',
+    variant: 'pearl',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const PearlQuiet: Story = {
+  args: {
+    ariaLabel: 'Quiet pearl action',
+    variant: 'pearlQuiet',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Control: Story = {
+  args: {
+    ariaLabel: 'Control action',
+    variant: 'control',
+    size: 'sm',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const Inline: Story = {
+  args: {
+    ariaLabel: 'Inline action',
+    variant: 'inline',
+    size: 'lg',
+    children: <PlaceholderIcon />,
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className='flex items-center gap-3'>
+      {ICON_BUTTON_SIZE_NAMES.map(size => (
+        <IconButton key={size} ariaLabel={`${size} action`} size={size}>
+          <PlaceholderIcon />
+        </IconButton>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/atoms/icon-button.test.tsx
+++ b/packages/ui/atoms/icon-button.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { IconButton } from './icon-button';
+import {
+  ICON_BUTTON_SIZE_NAMES,
+  ICON_BUTTON_VARIANT_NAMES,
+} from './icon-button-contract';
+
+describe('IconButton', () => {
+  it('renders an accessible icon-only button from the canonical contract', () => {
+    render(
+      <IconButton ariaLabel='Open menu'>
+        <svg aria-hidden='true' />
+      </IconButton>
+    );
+
+    const button = screen.getByRole('button', { name: 'Open menu' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('defaults to the ghost lg contract', () => {
+    render(
+      <IconButton ariaLabel='Default'>
+        <svg aria-hidden='true' />
+      </IconButton>
+    );
+
+    const button = screen.getByRole('button', { name: 'Default' });
+    expect(button).toHaveAttribute('data-size', 'icon-lg');
+    expect(button.className).toContain('h-10');
+    expect(button.className).toContain('w-10');
+  });
+
+  it('maps every contract size onto a base Button icon size', () => {
+    const expectedButtonSize: Record<string, string> = {
+      xs: 'icon-xs',
+      sm: 'icon-sm',
+      md: 'icon-md',
+      lg: 'icon-lg',
+      xl: 'icon-xl',
+    };
+
+    for (const size of ICON_BUTTON_SIZE_NAMES) {
+      const { unmount } = render(
+        <IconButton ariaLabel={`Size ${size}`} size={size}>
+          <svg aria-hidden='true' />
+        </IconButton>
+      );
+      const button = screen.getByRole('button', { name: `Size ${size}` });
+      expect(button).toHaveAttribute('data-size', expectedButtonSize[size]);
+      unmount();
+    }
+  });
+
+  it('keeps the 44px hit target pseudo-element below the xl size', () => {
+    for (const size of ICON_BUTTON_SIZE_NAMES) {
+      const { unmount } = render(
+        <IconButton ariaLabel={`Hit ${size}`} size={size}>
+          <svg aria-hidden='true' />
+        </IconButton>
+      );
+      const button = screen.getByRole('button', { name: `Hit ${size}` });
+      if (size === 'xl') {
+        // 44px container satisfies the hit target by construction.
+        expect(button.className).toContain('h-11');
+      } else {
+        expect(button.className).toContain('before:h-11');
+        expect(button.className).toContain('before:w-11');
+      }
+      unmount();
+    }
+  });
+
+  it('shares one focus ring and reduced-motion policy across all variants', () => {
+    for (const variant of ICON_BUTTON_VARIANT_NAMES) {
+      const { unmount } = render(
+        <IconButton ariaLabel={`${variant} action`} variant={variant}>
+          <svg aria-hidden='true' />
+        </IconButton>
+      );
+      const button = screen.getByRole('button', {
+        name: `${variant} action`,
+      });
+      expect(button.className).toContain(
+        'focus-visible:ring-(--linear-border-focus)/55'
+      );
+      expect(button.className).toContain('motion-reduce:transition-none');
+      expect(button.className).not.toContain('focus-visible:ring-ring');
+      expect(button.className).not.toContain('focus-visible:ring-focus/16');
+      unmount();
+    }
+  });
+
+  it('accepts aria-label as an alternative to ariaLabel', () => {
+    render(
+      <IconButton aria-label='Close'>
+        <svg aria-hidden='true' />
+      </IconButton>
+    );
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+});

--- a/packages/ui/atoms/icon-button.tsx
+++ b/packages/ui/atoms/icon-button.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { cn } from '@jovie/ui/lib/utils';
+import { cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { Button, type ButtonProps, type ButtonVariant } from './button';
+import type { ButtonSize } from './button-contract';
+import {
+  ICON_BUTTON_SIZE_NAMES,
+  ICON_BUTTON_VARIANT_NAMES,
+  type IconButtonSize,
+  type IconButtonVariant,
+} from './icon-button-contract';
+
+/**
+ * Canonical icon-only button (JOV-4871).
+ *
+ * Single size/variant contract for every icon button in the product, built on
+ * the base Button so the focus ring, disabled state, and 44px hit target are
+ * identical everywhere. The legacy web atoms (CircleIconButton,
+ * AppIconButton, HeaderIconButton, InlineIconButton, DrawerInlineIconButton)
+ * are thin compat wrappers over this component.
+ */
+
+const ICON_BUTTON_SIZE_TO_BUTTON_SIZE: Record<IconButtonSize, ButtonSize> = {
+  xs: 'icon-xs',
+  sm: 'icon-sm',
+  md: 'icon-md',
+  lg: 'icon-lg',
+  xl: 'icon-xl',
+};
+
+const ICON_BUTTON_VARIANT_TO_BUTTON_VARIANT: Record<
+  IconButtonVariant,
+  ButtonVariant
+> = {
+  surface: 'secondary',
+  frosted: 'ghost',
+  ghost: 'ghost',
+  secondary: 'secondary',
+  outline: 'secondary',
+  pearl: 'ghost',
+  pearlQuiet: 'ghost',
+  control: 'ghost',
+  inline: 'ghost',
+};
+
+// Shared chrome for the circular surface family (profile chrome, auth back
+// buttons): soft-material layering plus the legacy circular transition.
+const CIRCLE_CHROME_CLASSNAME =
+  'relative isolate overflow-hidden cursor-pointer transition-colors duration-subtle ease-out';
+
+const iconButtonVariants = cva(
+  // Shared base: uniform reduced-motion + touch behavior. Focus ring and
+  // hit target come from the base Button so they cannot drift.
+  'touch-manipulation select-none [-webkit-tap-highlight-color:transparent] motion-reduce:transition-none',
+  {
+    variants: {
+      variant: {
+        // Surface - elevated card style with subtle border
+        surface: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'border border-subtle bg-surface-1 text-primary-token',
+          'shadow-sm',
+          'hover:bg-surface-2 hover:text-primary-token hover:shadow-md'
+        ),
+        // Frosted - glassmorphic with backdrop blur
+        frosted: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'border border-subtle bg-[color-mix(in_srgb,var(--linear-bg-surface-1)_84%,transparent)] text-primary-token backdrop-blur-sm',
+          'shadow-sm',
+          'hover:bg-[color-mix(in_srgb,var(--linear-bg-surface-2)_88%,transparent)]'
+        ),
+        // Ghost - transparent with hover background
+        ghost: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'bg-transparent text-secondary-token',
+          'hover:bg-surface-1 hover:text-primary-token'
+        ),
+        // Secondary - subtle background without border
+        secondary: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'bg-surface-2 text-secondary-token',
+          'shadow-sm',
+          'hover:bg-surface-3 hover:text-primary-token'
+        ),
+        // Outline - transparent with visible border
+        outline: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'border border-subtle bg-transparent text-tertiary-token',
+          'hover:bg-surface-1 hover:text-primary-token'
+        ),
+        // Pearl - public profile chrome
+        pearl: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'border border-(--profile-pearl-border) bg-(--profile-pearl-bg) text-primary-token backdrop-blur-xl',
+          'shadow-(--profile-pearl-shadow)',
+          'hover:bg-(--profile-pearl-bg-hover) hover:text-primary-token',
+          'active:bg-(--profile-pearl-bg-active)'
+        ),
+        pearlQuiet: cn(
+          CIRCLE_CHROME_CLASSNAME,
+          'border border-transparent bg-transparent text-primary-token/78 backdrop-blur-xl',
+          'shadow-none',
+          'hover:border-(--profile-pearl-border) hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_88%,transparent)] hover:text-primary-token hover:shadow-[0_10px_24px_rgba(10,12,18,0.1)]',
+          'focus-visible:border-(--profile-pearl-border) focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] focus-visible:text-primary-token focus-visible:shadow-[0_10px_24px_rgba(10,12,18,0.12)]',
+          'active:bg-(--profile-pearl-bg-active) active:text-primary-token'
+        ),
+        // Control - app shell toolbar chrome (28px control height)
+        control:
+          'shrink-0 border border-subtle bg-surface-1 text-secondary-token shadow-none transition-[background-color,color,border-color,box-shadow] duration-subtle hover:border-default hover:bg-surface-0 hover:text-primary-token hover:shadow-none active:border-default active:bg-surface-1 active:shadow-none',
+        // Inline - transparent drawer/edit affordance
+        inline:
+          'shrink-0 p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow,transform] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:bg-surface-1 [&_svg]:block',
+      },
+      size: {
+        // Glyph sizing is only enforced for the compact control/header
+        // sizes; lg/xl leave glyph size to the caller (legacy circle
+        // behavior).
+        xs: '[&_svg]:h-3 [&_svg]:w-3',
+        sm: '[&_svg]:h-3.5 [&_svg]:w-3.5',
+        md: '[&_svg]:h-4 [&_svg]:w-4',
+        lg: '',
+        xl: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'ghost',
+      size: 'lg',
+    },
+  }
+);
+
+export type IconButtonProps = Omit<ButtonProps, 'size' | 'variant'> & {
+  /** Visual variant from the canonical icon-button contract. */
+  readonly variant?: IconButtonVariant;
+  /** Container size: xs 24 / sm 28 / md 32 / lg 40 / xl 44px. */
+  readonly size?: IconButtonSize;
+  /**
+   * Accessible label (alias of `aria-label`). Icon-only buttons must always
+   * resolve a label; the compat wrappers require one in their own props.
+   */
+  readonly ariaLabel?: string;
+};
+
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton(
+    {
+      children,
+      ariaLabel,
+      'aria-label': ariaLabelProp,
+      variant = 'ghost',
+      size = 'lg',
+      className,
+      ...props
+    },
+    ref
+  ) {
+    return (
+      <Button
+        ref={ref}
+        variant={ICON_BUTTON_VARIANT_TO_BUTTON_VARIANT[variant]}
+        size={ICON_BUTTON_SIZE_TO_BUTTON_SIZE[size]}
+        className={cn(iconButtonVariants({ variant, size }), className)}
+        aria-label={ariaLabel ?? ariaLabelProp}
+        {...props}
+      >
+        {children}
+      </Button>
+    );
+  }
+);
+
+IconButton.displayName = 'IconButton';
+
+export {
+  ICON_BUTTON_SIZE_NAMES,
+  ICON_BUTTON_VARIANT_NAMES,
+  iconButtonVariants,
+};

--- a/packages/ui/atoms/index.ts
+++ b/packages/ui/atoms/index.ts
@@ -28,6 +28,16 @@ export {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from './dropdown-menu';
+export type { IconButtonProps } from './icon-button';
+export { IconButton, iconButtonVariants } from './icon-button';
+export {
+  ICON_BUTTON_FADE_CLASSNAME,
+  ICON_BUTTON_SIZE_NAMES,
+  ICON_BUTTON_VARIANT_NAMES,
+  ICON_BUTTON_VISIBLE_CLASSNAME,
+  type IconButtonSize,
+  type IconButtonVariant,
+} from './icon-button-contract';
 export type { KbdProps } from './kbd';
 export { Kbd } from './kbd';
 export {

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -169,6 +169,17 @@ export {
   FormMessage,
   useFormField,
 } from './atoms/form';
+// IconButton
+export type { IconButtonProps } from './atoms/icon-button';
+export { IconButton, iconButtonVariants } from './atoms/icon-button';
+export {
+  ICON_BUTTON_FADE_CLASSNAME,
+  ICON_BUTTON_SIZE_NAMES,
+  ICON_BUTTON_VARIANT_NAMES,
+  ICON_BUTTON_VISIBLE_CLASSNAME,
+  type IconButtonSize,
+  type IconButtonVariant,
+} from './atoms/icon-button-contract';
 // Inline offline notice
 export type { InlineOfflineNoticeProps } from './atoms/inline-offline';
 export { InlineOfflineNotice } from './atoms/inline-offline';


### PR DESCRIPTION
## Summary

Fixes JOV-4871 (P2 UI drift, per docs/audits UI drift audit 2026-08-03).

The bespoke icon-button family — `InlineIconButton`, `DrawerInlineIconButton`, `AppIconButton`, `CircleIconButton`, `HeaderIconButton`, and `FrostedButton` (live in `ReleaseCreditsDialog`) — each maintained its own size map, variant class strings, and focus-ring overrides. This PR consolidates them onto **one size/variant contract on `@jovie/ui`**:

- **New `IconButton` + `icon-button-contract` in `@jovie/ui`** (`packages/ui/atoms/icon-button.tsx`): variants `surface | frosted | ghost | secondary | outline | pearl | pearlQuiet | control | inline`; sizes `xs/sm/md/lg/xl` = 24/28/32/40/44px containers.
- **`Button` gains `icon-xs`…`icon-xl` sizes**; every size below 44px keeps the 44px pseudo-element hit target (WCAG 2.5.5 / Apple HIG); `icon-xl` is 44px by construction.
- **Identical focus ring + reduced motion**: all variants inherit the canonical base-Button ring (`focus-visible:ring-(--linear-border-focus)/55`); bespoke rings on the control class path and `FrostedButton` removed; shared `motion-reduce:transition-none` base.
- **Web atoms become thin compat wrappers** preserving their existing prop APIs and exported class constants, so no call-site changes were needed (one exception: `AuthLayout` dropped a redundant `variant='ghost'` that matched the default).

### Intent-vs-preserve notes

- Legacy size names map onto the contract without pixel changes: header `xs/sm/md` → 24/28/32px; app control → 28px; circle `xs/sm/md` → 40px, `lg` → 44px; inline → 40px.
- Circle `frosted`/`outline` previously went through deprecated Button variant aliases; they now map directly to the same canonical variants (identical render, no dev warnings).
- Glyph sizing is enforced by the contract at compact sizes (matching live header/control behavior); `lg/xl` leave glyph size to callers (matching legacy circle behavior, whose `[&>svg]` rules were dead under the Button content span).

## Test plan

- `packages/ui`: new `icon-button.test.tsx` (6 tests: contract mapping, 44px hit target per size, identical focus ring + reduced-motion across all variants) + `button.test.tsx` icon-size hit-target test — **27 passed**
- `apps/web` unit: `CircleIconButton` (15), `InlineIconButton` (7), `HeaderIconButton` (9), `AppIconButton` (2), `FrostedButton` (11), `canonical-link-migration` (6), `AuthLayout` (7), `ProfileContactSidebar` (19), `DashboardHeader` (11) — **all passed**
- `@jovie/web` + `@jovie/ui` typecheck — clean; Biome — clean
- Pre-push `component-ship-gate` (stories + tests + coverage ratchet) — **PASS** (new stories added for `IconButton` and the five web atoms)

## Screenshots

Not captured (headless agent environment). Visual output is intended to be pixel-identical: all legacy size values, variant class strings, and hover/active states were preserved verbatim; only the focus ring was unified to the canonical ring and deprecated variant aliases were resolved to their canonical equivalents.

Refs JOV-4871