### PR TITLE
UI: chat start screen — clean invite-to-act empty state, keep brand ambience (JOV-4878)

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils';
 import { deriveChatRailContextTargets } from './chat-context-rail';
 import { resolveChatEmptyStateAffordance } from './chat-empty-state-contract';
 import { ChatDropZoneOverlay } from './components/ChatDropZoneOverlay';
+import { ChatEmptyStateWelcome } from './components/ChatEmptyStateComposerRegion';
 import { ChatEmptyStateOpportunityCards } from './components/ChatEmptyStateOpportunityCards';
 import { ChatPinnedOpportunityHeader } from './components/ChatPinnedOpportunityHeader';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
@@ -517,11 +518,12 @@ export function JovieChat({
   const showThreadView =
     conversationExists || conversationInProgress || pinnedOpportunity !== null;
   const showBottomComposer = showThreadView;
+  const composerHasIntent =
+    composerPickerOpen || Boolean(input.trim()) || chipTray.chips.length > 0;
   const emptyStateAffordance = resolveChatEmptyStateAffordance({
     conversationExists,
     conversationInProgress,
-    composerHasIntent:
-      composerPickerOpen || Boolean(input.trim()) || chipTray.chips.length > 0,
+    composerHasIntent,
     opportunityCardCount: showEmptyOpportunityCards
       ? pendingOpportunityCards.length
       : 0,
@@ -530,6 +532,14 @@ export function JovieChat({
   });
   const showEmptyActionCards = emptyStateAffordance === 'starter-actions';
   const showEmptyPromptRail = emptyStateAffordance === 'suggestion-pills';
+  // Clean start screen (JOV-4878): when the stage is otherwise bare, fill the
+  // scroll region above the docked composer with the centered welcome (ambient
+  // brand logo + invitation). Hidden while the composer has intent so the
+  // composer owns attention; geometry never shifts (composer stays docked).
+  const showEmptyWelcome =
+    !composerHasIntent &&
+    (emptyStateAffordance === 'none' ||
+      emptyStateAffordance === 'suggestion-pills');
   const shouldReservePickerClearance = showBottomComposer && composerPickerOpen;
   const messageViewportPaddingBottom = shouldReservePickerClearance
     ? CHAT_PICKER_THREAD_CLEARANCE
@@ -741,6 +751,9 @@ export function JovieChat({
                 <ChatEmptyStateComposerRegion
                   greetingName={displayName ?? username ?? null}
                   stableDocked
+                  showDockedWelcome={
+                    showEmptyWelcome && emptyStateAffordance === 'none'
+                  }
                   above={
                     showEmptyOpportunityCards ? (
                       <ChatEmptyStateOpportunityCards
@@ -760,9 +773,16 @@ export function JovieChat({
                       </div>
                     ) : showEmptyPromptRail ? (
                       <div
-                        className='mx-auto flex min-h-full w-full max-w-[46rem] items-end pb-3'
+                        className='mx-auto flex min-h-full w-full max-w-[46rem] flex-col items-center pb-3'
                         data-testid='chat-empty-state-soft-suggestions-slot'
                       >
+                        <div className='flex min-h-0 flex-1 flex-col items-center justify-center py-2 text-center'>
+                          {showEmptyWelcome ? (
+                            <ChatEmptyStateWelcome
+                              greetingName={displayName ?? username ?? null}
+                            />
+                          ) : null}
+                        </div>
                         <SuggestedPrompts
                           onSelect={handleSuggestedPrompt}
                           isFirstSession={isFirstSession}

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
@@ -16,19 +16,19 @@ describe('ChatEmptyStateComposerRegion', () => {
     expect(logo.getAttribute('aria-hidden')).toBe('true');
   });
 
-  it('greets by display name when provided', () => {
+  it('invites action by first name when provided', () => {
     render(
-      <ChatEmptyStateComposerRegion greetingName='Tim'>
+      <ChatEmptyStateComposerRegion greetingName='Tim White'>
         <div data-testid='composer-child' />
       </ChatEmptyStateComposerRegion>
     );
 
     expect(screen.getByTestId('chat-empty-state-greeting').textContent).toBe(
-      'Hi, Tim'
+      "What's next, Tim?"
     );
   });
 
-  it('falls back to a generic greeting without a display name', () => {
+  it('falls back to a generic invitation without a display name', () => {
     render(
       <ChatEmptyStateComposerRegion greetingName='  '>
         <div data-testid='composer-child' />
@@ -36,7 +36,7 @@ describe('ChatEmptyStateComposerRegion', () => {
     );
 
     expect(screen.getByTestId('chat-empty-state-greeting').textContent).toBe(
-      'Hi there'
+      "What's next?"
     );
   });
 
@@ -120,5 +120,45 @@ describe('ChatEmptyStateComposerRegion', () => {
       screen.getByTestId('chat-empty-state-composer-region')
     ).toHaveAttribute('data-layout', 'docked');
     expect(screen.getByTestId('chat-empty-state-above-scroll')).toBeTruthy();
+  });
+
+  it('fills the docked scroll region with the centered welcome when invited', () => {
+    render(
+      <ChatEmptyStateComposerRegion stableDocked showDockedWelcome>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    const region = screen.getByTestId('chat-empty-state-composer-region');
+    expect(region).toHaveAttribute('data-layout', 'docked');
+    // Composer keeps its bottom-dock geometry — welcome never shifts it.
+    expect(
+      screen.getByTestId('chat-empty-state-centered-composer')
+    ).toHaveAttribute('data-dock', 'bottom');
+
+    const aboveScroll = screen.getByTestId('chat-empty-state-above-scroll');
+    expect(aboveScroll.className).not.toContain('absolute');
+    const welcome = screen.getByTestId('chat-empty-state-welcome');
+    expect(welcome.className).toContain('items-center');
+    expect(screen.getByTestId('chat-empty-state-logo')).toBeTruthy();
+    expect(screen.getByTestId('chat-empty-state-greeting').textContent).toBe(
+      "What's next?"
+    );
+  });
+
+  it('keeps the docked scroll region blank when the welcome is suppressed', () => {
+    render(
+      <ChatEmptyStateComposerRegion
+        stableDocked
+        showDockedWelcome
+        hideWelcomeHeader
+      >
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    expect(screen.queryByTestId('chat-empty-state-welcome')).toBeNull();
+    expect(screen.queryByTestId('chat-empty-state-logo')).toBeNull();
+    expect(screen.queryByTestId('chat-empty-state-greeting')).toBeNull();
   });
 });

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -7,14 +7,60 @@ import { CHAT_CONTENT_SHELL_CLASSNAME } from '../chat-layout';
 
 const AMBIENT_LOGO_OPACITY = 0.18;
 
+function resolveInvitationCopy(greetingName?: string | null): string {
+  const trimmedName = greetingName?.trim();
+  if (!trimmedName) return "What's next?";
+  const firstName = trimmedName.split(/\s+/)[0];
+  return `What's next, ${firstName}?`;
+}
+
+/**
+ * Ambient brand logo + action-forward invitation copy. Centered, low-noise,
+ * and layout-stable: it only ever renders inside reserved space (the centered
+ * welcome stack or the docked layout's scroll region), never between the
+ * composer and the viewport edge, so it cannot move the composer.
+ */
+export function ChatEmptyStateWelcome({
+  greetingName,
+}: {
+  readonly greetingName?: string | null;
+}) {
+  return (
+    <>
+      <div
+        aria-hidden='true'
+        className='relative z-10 mb-4'
+        style={{ opacity: AMBIENT_LOGO_OPACITY }}
+        data-testid='chat-empty-state-logo'
+      >
+        <BrandLogo
+          size={56}
+          className='text-primary-token'
+          aria-hidden={true}
+        />
+      </div>
+      <h2
+        className='relative z-10 text-2xl font-semibold text-primary-token'
+        data-testid='chat-empty-state-greeting'
+      >
+        {resolveInvitationCopy(greetingName)}
+      </h2>
+    </>
+  );
+}
+
 /**
  * Empty-chat scaffold.
  *
- * - Welcome (no `above`): logo + greeting + composer centered in the viewport.
+ * - Welcome (no `above`): logo + invitation + composer centered in the viewport.
  * - Task/scaffold (`above`): cards scroll in the upper region; the composer
  *   (and any quick-action rail passed as children) docks to the bottom of the
  *   usable area so the first card is never clipped by mid-viewport absolute
  *   positioning and chips stay reachable without overlapping the dock.
+ * - Docked welcome (`showDockedWelcome`, no `above`): the logo + invitation
+ *   render centered inside the scroll region while the composer keeps its
+ *   bottom-docked geometry, so transient affordances can come and go without
+ *   moving the composer.
  */
 export function ChatEmptyStateComposerRegion({
   above,
@@ -22,6 +68,7 @@ export function ChatEmptyStateComposerRegion({
   greetingName,
   hideWelcomeHeader = false,
   stableDocked = false,
+  showDockedWelcome = false,
 }: {
   readonly above?: ReactNode;
   readonly children: ReactNode;
@@ -29,9 +76,12 @@ export function ChatEmptyStateComposerRegion({
   readonly hideWelcomeHeader?: boolean;
   /** Keep composer geometry docked when transient empty-state affordances hide. */
   readonly stableDocked?: boolean;
+  /**
+   * In the docked layout with no `above` content, fill the scroll region with
+   * the centered welcome (ambient logo + invitation) instead of blank space.
+   */
+  readonly showDockedWelcome?: boolean;
 }) {
-  const trimmedName = greetingName?.trim();
-  const greeting = trimmedName ? `Hi, ${trimmedName}` : 'Hi there';
   const showWelcomeHeader = !above && !hideWelcomeHeader;
 
   if (above || stableDocked) {
@@ -46,7 +96,17 @@ export function ChatEmptyStateComposerRegion({
           className='min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pb-3'
           data-testid='chat-empty-state-above-scroll'
         >
-          {above ?? <div className='h-full' aria-hidden='true' />}
+          {above ??
+            (showDockedWelcome && !hideWelcomeHeader ? (
+              <div
+                className='flex min-h-full flex-col items-center justify-center text-center'
+                data-testid='chat-empty-state-welcome'
+              >
+                <ChatEmptyStateWelcome greetingName={greetingName} />
+              </div>
+            ) : (
+              <div className='h-full' aria-hidden='true' />
+            ))}
         </div>
         {/* Bottom-docked composer + quick-action chips (passed as children) */}
         <div
@@ -67,29 +127,10 @@ export function ChatEmptyStateComposerRegion({
       data-layout='centered'
     >
       {showWelcomeHeader ? (
-        <div
-          aria-hidden='true'
-          className='relative z-10 mb-4'
-          style={{ opacity: AMBIENT_LOGO_OPACITY }}
-          data-testid='chat-empty-state-logo'
-        >
-          <BrandLogo
-            size={56}
-            className='text-primary-token'
-            aria-hidden={true}
-          />
-        </div>
-      ) : null}
-      {showWelcomeHeader ? (
-        <h2
-          className='relative z-10 mb-6 text-2xl font-semibold text-primary-token'
-          data-testid='chat-empty-state-greeting'
-        >
-          {greeting}
-        </h2>
+        <ChatEmptyStateWelcome greetingName={greetingName} />
       ) : null}
       <div
-        className='relative z-10 w-full'
+        className={`relative z-10 w-full${showWelcomeHeader ? ' mt-6' : ''}`}
         data-testid='chat-empty-state-centered-composer'
       >
         {children}

--- a/apps/web/components/jovie/components/index.ts
+++ b/apps/web/components/jovie/components/index.ts
@@ -1,6 +1,9 @@
 export { ChatAvatarUploadCard } from './ChatAvatarUploadCard';
 export { ChatDropZoneOverlay } from './ChatDropZoneOverlay';
-export { ChatEmptyStateComposerRegion } from './ChatEmptyStateComposerRegion';
+export {
+  ChatEmptyStateComposerRegion,
+  ChatEmptyStateWelcome,
+} from './ChatEmptyStateComposerRegion';
 export { ChatEmptyStateOpportunityCards } from './ChatEmptyStateOpportunityCards';
 export { ChatFileChips } from './ChatFileChips';
 export { ChatInput } from './ChatInput';

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -179,7 +179,7 @@ describe('JovieChat empty state', () => {
     mockChatState.chipTray.chips = [];
   });
 
-  it('renders a stable docked composer without filler prompts when no skill is featured', () => {
+  it('renders a stable docked composer with the centered welcome when no skill is featured', () => {
     const { container, getByTestId, queryByTestId, queryByText } =
       renderWithQueryClient(<JovieChat profileId='profile-1' />);
 
@@ -192,10 +192,15 @@ describe('JovieChat empty state', () => {
     expect(emptyViewport.className).toContain('flex-1');
     expect(emptyViewport).toHaveAttribute('data-empty-affordance', 'none');
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
-    expect(queryByTestId('chat-empty-state-logo')).toBeNull();
-    expect(queryByTestId('chat-empty-state-greeting')).toBeNull();
+    // Clean start screen (JOV-4878): ambient brand logo + action-forward
+    // invitation centered above the docked composer.
+    expect(getByTestId('chat-empty-state-welcome')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-logo')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-greeting').textContent).toBe(
+      "What's next?"
+    );
     expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
-    // No action cards and no featured skills: the composer stands alone.
+    // No action cards and no featured skills: welcome + docked composer only.
     expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
     expect(queryByTestId('chat-composer-dock')).toBeNull();
     expect(queryByTestId('chat-empty-state-soft-suggestions-slot')).toBeNull();
@@ -388,6 +393,10 @@ describe('JovieChat empty state', () => {
     expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
     expect(queryByTestId('chat-composer-dock')).toBeNull();
     expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
+    // Typing gives the composer full focus: welcome + logo hide too.
+    expect(queryByTestId('chat-empty-state-welcome')).toBeNull();
+    expect(queryByTestId('chat-empty-state-logo')).toBeNull();
+    expect(queryByTestId('chat-empty-state-greeting')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(queryByText('Connect Your Music Catalog')).toBeNull();
     expect(queryByTestId('suggested-prompts-rail')).toBeNull();
@@ -410,6 +419,8 @@ describe('JovieChat empty state', () => {
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(queryByTestId('chat-empty-state-soft-suggestions-slot')).toBeNull();
     expect(queryByTestId('suggested-prompts-rail')).toBeNull();
+    expect(queryByTestId('chat-empty-state-welcome')).toBeNull();
+    expect(queryByTestId('chat-empty-state-greeting')).toBeNull();
   });
 
   it('does not render first-session welcome copy in the empty state', () => {
@@ -491,9 +502,11 @@ describe('JovieChat empty state', () => {
 
     expect(getByTestId('chat-empty-state-opportunity-cards')).toBeTruthy();
     expect(getByText('Detroit listeners up 340%')).toBeTruthy();
-    // Pills stay hidden when opportunities are present.
+    // Pills and the welcome stay hidden when opportunities own the stage.
     expect(queryByTestId('suggested-prompts-rail')).toBeNull();
     expect(queryByTestId('chat-empty-state-soft-suggestions-slot')).toBeNull();
+    expect(queryByTestId('chat-empty-state-welcome')).toBeNull();
+    expect(queryByTestId('chat-empty-state-logo')).toBeNull();
   });
 
   it('enters pinned-card mode when an opportunity card is tapped', () => {


### PR DESCRIPTION
## Summary

Simplifies the `/app/chat` empty (start) screen toward the ChatGPT-style reference while keeping Jovie's brand ambience, per Tim's directive on JOV-4878.

- **Action-forward invitation copy** replaces the bare greeting: "What's next, <first name>?" (fallback: "What's next?").
- **Brand background preserved:** the ambient `BrandLogo` (0.18 opacity) and the shell-owned ambient gradient wash are untouched — the logo now also shows in the previously blank docked empty state.
- **Composer stays the hero:** bottom-docked composer geometry is unchanged, with the mic (dictation) and attach input-mode affordances visible as before.
- **Zero layout shift:** the welcome (logo + invitation) renders inside the existing reserved scroll region of `ChatEmptyStateComposerRegion` (`stableDocked` contract intact). It appears when the stage is bare or above the suggestion-pill rail, and hides while the composer has intent (typing / chips / slash picker) so the composer owns attention.

### Implementation

- Extracted `ChatEmptyStateWelcome` (ambient logo + invitation) from `ChatEmptyStateComposerRegion`; new optional `showDockedWelcome` prop fills the docked layout's empty scroll region.
- `JovieChat` wires `showEmptyWelcome = !composerHasIntent && (affordance === 'none' || 'suggestion-pills')`; pill rail keeps its bottom anchor via the flex-1 welcome slot.
- No backend, auth, route, or data-model changes. No new dialogs.

## Test plan

- `vitest run ChatEmptyStateComposerRegion.test.tsx JovieChat.empty-state.test.tsx` → **21/21 pass** (updated to the new invitation copy; added docked-welcome + suppression coverage)
- Related suites: opportunity cards, empty-state contract, OnboardingChat intro/turnstile, JovieChat audio-review → **26/26 pass**
- `pnpm --filter @jovie/web run typecheck` → pass; `biome check` clean; pre-commit eslint (`--max-warnings=0`) + `a11y:check:staged` + secret scans → pass
- `git diff --check origin/main...HEAD` → clean

## Screenshots

Screenshot capture was not available in this environment (no seeded local session). Expected visual: centered ambient Jovie logo + "What's next, <name>?" headline in the upper region, suggestion pills above the docked hero composer; on short viewports the upper region scrolls while the composer stays docked. Desktop/mobile use the same layout contract (responsive padding already in the region).

## Gate

Design/taste approval (Tim) before merge, per ticket.

Fixes JOV-4878 — https://linear.app/jovie/issue/JOV-4878