### PR TITLE
fix: enrich Sentry autofix incident context

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -127,7 +127,7 @@ jobs:
             2. Diagnose one root cause and state a narrow objective. Do not treat the title as proof.
             3. Select one minimal, non-overlapping fix plan and define its regression proof.
             4. Implement only that fix and add or update the regression test.
-            5. Run `pnpm biome check . --write` and `pnpm turbo typecheck --filter=@jovie/web`; run the focused regression test and fix any failures.
+            5. Run the repository formatter, the Jovie web typecheck, and the focused regression test; fix any failures before continuing.
             6. If simplify_bounded=true, run a small simplification pass on touched files only:
                - remove dead imports/locals
                - flatten obvious nested conditionals

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: sentry-autofix-${{ github.event.client_payload.issue_id }}
+  group: sentry-autofix-${{ github.event.client_payload.dedupe_key || github.event.client_payload.issue_id }}
   cancel-in-progress: false
 
 jobs:
@@ -32,9 +32,9 @@ jobs:
         id: dedup
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          ISSUE_ID: ${{ github.event.client_payload.issue_id }}
+          DEDUPE_KEY: ${{ github.event.client_payload.dedupe_key || github.event.client_payload.issue_id }}
         run: |
-          BRANCH="sentry-fix/${ISSUE_ID}"
+          BRANCH="sentry-fix/${DEDUPE_KEY}"
           if git ls-remote --heads "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH" | grep -q "$BRANCH"; then
             echo "Branch $BRANCH already exists — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -52,9 +52,9 @@ jobs:
       - name: Create fix branch
         if: steps.dedup.outputs.skip != 'true'
         env:
-          ISSUE_ID: ${{ github.event.client_payload.issue_id }}
+          DEDUPE_KEY: ${{ github.event.client_payload.dedupe_key || github.event.client_payload.issue_id }}
         run: |
-          git checkout -b "sentry-fix/${ISSUE_ID}"
+          git checkout -b "sentry-fix/${DEDUPE_KEY}"
 
       - name: Setup Node.js and pnpm
         if: steps.dedup.outputs.skip != 'true'
@@ -100,6 +100,17 @@ jobs:
             **Culprit:** ${{ github.event.client_payload.culprit }}
             **Message:** ${{ github.event.client_payload.message }}
             **Sentry URL:** ${{ github.event.client_payload.url }}
+            **Root-cause fingerprint:** ${{ github.event.client_payload.context.root_cause_fingerprint }}
+            **Environment:** ${{ github.event.client_payload.context.environment }}
+            **Release:** ${{ github.event.client_payload.context.release }}
+            **Project:** ${{ github.event.client_payload.context.project }}
+            **Route / transaction:** ${{ github.event.client_payload.context.route }}
+            **Level:** ${{ github.event.client_payload.context.level }}
+            **Event ID:** ${{ github.event.client_payload.context.event_id }}
+            **First seen:** ${{ github.event.client_payload.context.first_seen }}
+            **Last seen:** ${{ github.event.client_payload.context.last_seen }}
+            **Event count:** ${{ github.event.client_payload.context.event_count }}
+            **Affected users:** ${{ github.event.client_payload.context.user_count }}
 
             **Automation Contract:**
             - verify_required: ${{ steps.contract.outputs.verify_required }}
@@ -111,19 +122,20 @@ jobs:
             ${{ github.event.client_payload.stacktrace }}
             ```
 
-            Instructions:
-            1. Investigate the error using the culprit file and stack trace
-            2. Fix the root cause of the bug
-            3. Run `pnpm biome check . --write` to auto-fix formatting
-            4. Run `pnpm turbo typecheck --filter=@jovie/web` to verify types pass
-            5. If validation fails, fix the issues and re-run
+            Work in these gated stages. Do not advance when the prior stage lacks evidence:
+            1. Inventory the supplied release, environment, route, recurrence, and stack evidence. If customer impact or the current release is ambiguous, make no code change and report the missing evidence.
+            2. Diagnose one root cause and state a narrow objective. Do not treat the title as proof.
+            3. Select one minimal, non-overlapping fix plan and define its regression proof.
+            4. Implement only that fix and add or update the regression test.
+            5. Run `pnpm biome check . --write` and `pnpm turbo typecheck --filter=@jovie/web`; run the focused regression test and fix any failures.
             6. If simplify_bounded=true, run a small simplification pass on touched files only:
                - remove dead imports/locals
                - flatten obvious nested conditionals
                - improve unclear local variable names
                - do not change behavior/API contracts
                - skip sensitive paths (.github/, drizzle/migrations/, auth/billing/security-critical)
-            7. Use model_tier as guidance for depth/cost profile:
+            7. Record the source-blind verification result and leave production resolution pending until post-deploy recurrence evidence is available.
+            8. Use model_tier as guidance for depth/cost profile:
                - premium: thorough and comprehensive
                - economy: concise and targeted
 
@@ -139,11 +151,18 @@ jobs:
         id: create-pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEDUPE_KEY: ${{ github.event.client_payload.dedupe_key || github.event.client_payload.issue_id }}
           ISSUE_ID: ${{ github.event.client_payload.issue_id }}
           ERROR_TITLE: ${{ github.event.client_payload.title }}
           SENTRY_URL: ${{ github.event.client_payload.url }}
+          SENTRY_ENVIRONMENT: ${{ github.event.client_payload.context.environment }}
+          SENTRY_RELEASE: ${{ github.event.client_payload.context.release }}
+          SENTRY_ROUTE: ${{ github.event.client_payload.context.route }}
+          SENTRY_FINGERPRINT: ${{ github.event.client_payload.context.root_cause_fingerprint }}
+          SENTRY_LAST_SEEN: ${{ github.event.client_payload.context.last_seen }}
+          SENTRY_EVENT_COUNT: ${{ github.event.client_payload.context.event_count }}
         run: |
-          BRANCH="sentry-fix/${ISSUE_ID}"
+          BRANCH="sentry-fix/${DEDUPE_KEY}"
 
           # Check if there are changes to commit (tracked + untracked)
           if git diff --quiet && git diff --staged --quiet && [ -z "$(git status --porcelain)" ]; then
@@ -186,11 +205,19 @@ jobs:
           - **Error:** ${ERROR_TITLE}
           - **Sentry:** ${SENTRY_URL}
           - **Issue ID:** ${ISSUE_ID}
+          - **Root-cause fingerprint:** ${SENTRY_FINGERPRINT}
+          - **Environment:** ${SENTRY_ENVIRONMENT}
+          - **Release:** ${SENTRY_RELEASE}
+          - **Route:** ${SENTRY_ROUTE}
+          - **Last seen:** ${SENTRY_LAST_SEEN}
+          - **Event count:** ${SENTRY_EVENT_COUNT}
 
           ## Test plan
 
           - [ ] CI passes (Biome + TypeScript + tests)
           - [ ] Error no longer reproduces in production after deploy
+
+          This PR does not close the incident. Resolution requires post-deploy recurrence evidence for the affected release and environment.
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code) via Sentry Autofix
           EOF
@@ -211,9 +238,9 @@ jobs:
         if: failure() && steps.dedup.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          ISSUE_ID: ${{ github.event.client_payload.issue_id }}
+          DEDUPE_KEY: ${{ github.event.client_payload.dedupe_key || github.event.client_payload.issue_id }}
         run: |
-          BRANCH="sentry-fix/${ISSUE_ID}"
+          BRANCH="sentry-fix/${DEDUPE_KEY}"
 
           # Check if branch was pushed
           if ! git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then

--- a/apps/web/app/api/webhooks/sentry/route.ts
+++ b/apps/web/app/api/webhooks/sentry/route.ts
@@ -11,7 +11,7 @@
  * Sentry alert → this endpoint → GitHub repository_dispatch → sentry-autofix.yml
  */
 
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { env } from '@/lib/env';
@@ -29,12 +29,55 @@ export const runtime = 'nodejs';
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 const DEDUPE_TTL_SECONDS = 60;
 const DISPATCH_TIMEOUT_MS = 10000;
+const MAX_CONTEXT_LENGTH = 256;
 
 /** Stack frame from Sentry payload */
 interface SentryFrame {
   filename?: string;
   function?: string;
   lineno?: number;
+}
+
+interface RootCauseContext {
+  project: string;
+  environment: string;
+  title: string;
+  culprit: string;
+  frames?: SentryFrame[];
+}
+
+function boundedString(value: unknown, maxLength = MAX_CONTEXT_LENGTH): string {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+
+  return String(value).trim().slice(0, maxLength);
+}
+
+function normalizeSignaturePart(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function buildRootCauseKey({
+  project,
+  environment,
+  title,
+  culprit,
+  frames,
+}: RootCauseContext): string {
+  const topFrame = frames?.[frames.length - 1];
+  const signature = [
+    project || 'unknown-project',
+    environment || 'unknown-environment',
+    title,
+    culprit,
+    boundedString(topFrame?.filename, 512),
+    boundedString(topFrame?.function, 256),
+  ]
+    .map(normalizeSignaturePart)
+    .join('|');
+
+  return `root-${createHash('sha256').update(signature).digest('hex').slice(0, 20)}`;
 }
 
 /**
@@ -74,7 +117,7 @@ export async function POST(request: NextRequest) {
   }
 
   let dedupeAcquired = false;
-  let issueIdForDedupe: string | null = null;
+  let dedupeKeyForClear: string | null = null;
 
   try {
     const body = await request.text();
@@ -111,13 +154,49 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const issueId = String(issue.id);
-    issueIdForDedupe = issueId;
+    const issueId = boundedString(issue.id, 64);
+    const event = payload.data?.event || payload.event || {};
+    const title = boundedString(issue.title) || 'Unknown error';
+    const culprit = boundedString(issue.culprit);
+    const message = boundedString(issue.metadata?.value || issue.message, 1000);
+    const url =
+      boundedString(issue.permalink, 1000) ||
+      `https://sentry.io/issues/${issueId}/`;
 
-    // Dedupe: acquire cross-instance lock before dispatch
+    // Extract stack trace from first exception if available.
+    const frames: SentryFrame[] | undefined =
+      issue.metadata?.stacktrace?.frames ||
+      issue.platform_context?.stacktrace?.frames ||
+      event.exception?.values?.[0]?.stacktrace?.frames;
+    const project = boundedString(
+      issue.project?.slug || payload.data?.project?.slug || payload.project
+    );
+    const environment = boundedString(
+      event.environment || issue.environment,
+      64
+    );
+    const release = boundedString(event.release || issue.release, 128);
+    const route = boundedString(event.transaction || culprit);
+    const level = boundedString(event.level || issue.level, 32);
+    const eventId = boundedString(event.event_id || event.id, 64);
+    const firstSeen = boundedString(issue.firstSeen, 64);
+    const lastSeen = boundedString(issue.lastSeen, 64);
+    const eventCount = boundedString(issue.count, 32);
+    const userCount = boundedString(issue.userCount, 32);
+    const dedupeKey = buildRootCauseKey({
+      project,
+      environment,
+      title,
+      culprit,
+      frames,
+    });
+    dedupeKeyForClear = dedupeKey;
+
+    // Dedupe equivalent reports by a bounded, non-PII root signature. The
+    // issue ID is still forwarded for direct Sentry linkage.
     const dedupeResult = await acquireRecentDispatch(
       'sentry',
-      issueId,
+      dedupeKey,
       DEDUPE_TTL_SECONDS
     );
     dedupeAcquired = dedupeResult.acquired;
@@ -137,17 +216,13 @@ export async function POST(request: NextRequest) {
     if (!dedupeAcquired) {
       logger.info('[Sentry Webhook] Duplicate dispatch suppressed', {
         issueId,
+        dedupeKey,
       });
       return NextResponse.json(
         { received: true, deduplicated: true },
         { headers: NO_STORE_HEADERS }
       );
     }
-
-    const title = issue.title || 'Unknown error';
-    const culprit = issue.culprit || '';
-    const message = issue.metadata?.value || issue.message || '';
-    const url = issue.permalink || `https://sentry.io/issues/${issueId}/`;
 
     if (isTransientInfraHttpIssue({ title, culprit })) {
       logger.info(
@@ -160,16 +235,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Extract stack trace from first exception if available
-    const frames: SentryFrame[] | undefined =
-      issue.metadata?.stacktrace?.frames ||
-      payload.data?.issue?.platform_context?.stacktrace?.frames;
     const stacktrace = frames
       ? frames
           .slice(-10)
           .map(
             (f: SentryFrame) =>
-              `  ${f.filename || '?'}:${f.lineno || '?'} in ${f.function || '?'}`
+              `  ${boundedString(f.filename, 512) || '?'}:${boundedString(f.lineno, 16) || '?'} in ${boundedString(f.function, 256) || '?'}`
           )
           .join('\n')
       : '';
@@ -192,11 +263,25 @@ export async function POST(request: NextRequest) {
           event_type: 'sentry-issue',
           client_payload: {
             issue_id: issueId,
+            dedupe_key: dedupeKey,
             title,
             culprit,
             message,
             url,
             stacktrace,
+            context: {
+              root_cause_fingerprint: dedupeKey,
+              environment,
+              release,
+              project,
+              route,
+              level,
+              event_id: eventId,
+              first_seen: firstSeen,
+              last_seen: lastSeen,
+              event_count: eventCount,
+              user_count: userCount,
+            },
           },
         }),
         timeoutMs: DISPATCH_TIMEOUT_MS,
@@ -210,7 +295,7 @@ export async function POST(request: NextRequest) {
         status: dispatchResponse.status,
         error: errorText,
       });
-      await clearRecentDispatch('sentry', issueId);
+      await clearRecentDispatch('sentry', dedupeKey);
       return NextResponse.json(
         { error: 'Dispatch failed' },
         { status: 502, headers: NO_STORE_HEADERS }
@@ -219,6 +304,7 @@ export async function POST(request: NextRequest) {
 
     logger.info('[Sentry Webhook] Dispatched autofix', {
       issueId,
+      dedupeKey,
       title,
       culprit,
     });
@@ -228,8 +314,8 @@ export async function POST(request: NextRequest) {
       { headers: NO_STORE_HEADERS }
     );
   } catch (error) {
-    if (dedupeAcquired && issueIdForDedupe) {
-      await clearRecentDispatch('sentry', issueIdForDedupe);
+    if (dedupeAcquired && dedupeKeyForClear) {
+      await clearRecentDispatch('sentry', dedupeKeyForClear);
     }
 
     if (error instanceof ServerFetchTimeoutError) {

--- a/apps/web/tests/unit/api/webhooks/sentry.test.ts
+++ b/apps/web/tests/unit/api/webhooks/sentry.test.ts
@@ -206,7 +206,10 @@ describe('POST /api/webhooks/sentry', () => {
 
     expect(response.status).toBe(502);
     expect(data).toEqual({ error: 'Dispatch timed out' });
-    expect(mockClearRecentDispatch).toHaveBeenCalledWith('sentry', '42');
+    expect(mockClearRecentDispatch).toHaveBeenCalledWith(
+      'sentry',
+      expect.stringMatching(/^root-[a-f0-9]{20}$/)
+    );
     expect(mockCaptureCriticalError).toHaveBeenCalledWith(
       'Sentry webhook dispatch timed out',
       expect.any(ServerFetchTimeoutError),
@@ -257,5 +260,96 @@ describe('POST /api/webhooks/sentry', () => {
       })
     );
     expect(mockServerFetch.mock.calls[0]?.[1]).not.toHaveProperty('retry');
+  });
+
+  it('enriches dispatches and deduplicates equivalent reports by root signature', async () => {
+    mockAcquireRecentDispatch.mockResolvedValue({
+      acquired: true,
+      reason: 'acquired',
+    });
+    mockServerFetch.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const { POST } = await import('@/app/api/webhooks/sentry/route');
+    const makePayload = (issueId: string, environment: string) => ({
+      data: {
+        issue: {
+          id: issueId,
+          title: 'Database statement timed out',
+          culprit: 'POST /api/artist',
+          level: 'error',
+          firstSeen: '2026-08-07T18:00:00Z',
+          lastSeen: '2026-08-07T19:00:00Z',
+          count: '14',
+          userCount: 3,
+          project: { slug: 'jovie-web' },
+          metadata: {
+            value: 'canceling statement due to statement timeout',
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'apps/web/app/api/artist/route.ts',
+                  function: 'POST',
+                  lineno: 88,
+                },
+              ],
+            },
+          },
+        },
+        event: {
+          event_id: `event-${issueId}`,
+          environment,
+          release: 'jovie@f863c92',
+          transaction: 'POST /api/artist',
+        },
+      },
+    });
+
+    for (const [issueId, environment] of [
+      ['101', 'production'],
+      ['202', 'production'],
+      ['303', 'development'],
+    ]) {
+      const body = JSON.stringify(makePayload(issueId, environment));
+      const response = await POST(
+        new Request('https://example.com/api/webhooks/sentry', {
+          method: 'POST',
+          headers: { 'sentry-hook-signature': sign(body) },
+          body,
+        }) as never
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const dedupeKeys = mockAcquireRecentDispatch.mock.calls.map(
+      ([source, key]) => {
+        expect(source).toBe('sentry');
+        return key;
+      }
+    );
+    expect(dedupeKeys[0]).toMatch(/^root-[a-f0-9]{20}$/);
+    expect(dedupeKeys[1]).toBe(dedupeKeys[0]);
+    expect(dedupeKeys[2]).not.toBe(dedupeKeys[0]);
+
+    const firstDispatch = JSON.parse(
+      String(mockServerFetch.mock.calls[0]?.[1]?.body)
+    );
+    expect(Object.keys(firstDispatch.client_payload)).toHaveLength(8);
+    expect(firstDispatch.client_payload).toMatchObject({
+      issue_id: '101',
+      dedupe_key: dedupeKeys[0],
+      context: {
+        root_cause_fingerprint: dedupeKeys[0],
+        environment: 'production',
+        release: 'jovie@f863c92',
+        project: 'jovie-web',
+        route: 'POST /api/artist',
+        level: 'error',
+        event_id: 'event-101',
+        first_seen: '2026-08-07T18:00:00Z',
+        last_seen: '2026-08-07T19:00:00Z',
+        event_count: '14',
+        user_count: '3',
+      },
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "ds:offscale": "node scripts/ds-offscale-report.mjs",
     "ds:llms-manifest": "node scripts/generate-llms-design-manifest.mjs",
     "ds:llms-manifest:check": "node scripts/generate-llms-design-manifest.mjs --check",
-    "ci:control:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/ci-duration-ratchet.test.mjs lib/__tests__/ci-branching-guard.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/ci-metrics-compute.test.mjs lib/__tests__/auto-ready-agent-drafts.test.mjs lib/__tests__/eval-main-health-action.test.mjs lib/__tests__/pr-check-failures.test.mjs lib/__tests__/pr-conflict-handler.test.mjs lib/__tests__/ci-fast-workflow-contract.test.mjs lib/__tests__/merge-group-workflow-contract.test.mjs lib/__tests__/lockfile-specifier-preflight.test.mjs",
+    "ci:control:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__/ci-harness.test.mjs lib/__tests__/ci-duration-ratchet.test.mjs lib/__tests__/ci-branching-guard.test.mjs lib/__tests__/merge-queue-guard.test.mjs lib/__tests__/ci-metrics-compute.test.mjs lib/__tests__/auto-ready-agent-drafts.test.mjs lib/__tests__/eval-main-health-action.test.mjs lib/__tests__/pr-check-failures.test.mjs lib/__tests__/pr-conflict-handler.test.mjs lib/__tests__/ci-fast-workflow-contract.test.mjs lib/__tests__/merge-group-workflow-contract.test.mjs lib/__tests__/lockfile-specifier-preflight.test.mjs lib/__tests__/sentry-autofix-workflow-contract.test.mjs",
     "gate-ladder:validate": "node scripts/gate-ladder/validate.mjs",
     "gate-ladder:list": "node scripts/gate-ladder/run.mjs --list",
     "gate-ladder:test": "node --test scripts/gate-ladder/gate-ladder.test.mjs",

--- a/scripts/lib/__tests__/sentry-autofix-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/sentry-autofix-workflow-contract.test.mjs
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const WORKFLOW = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/sentry-autofix.yml'),
+  'utf8'
+);
+
+describe('Sentry autofix workflow contract', () => {
+  it('deduplicates automation by root signature with issue ID fallback', () => {
+    const keyExpression =
+      '${{ github.event.client_payload.dedupe_key || github.event.client_payload.issue_id }}';
+
+    expect(WORKFLOW).toContain(`group: sentry-autofix-${keyExpression}`);
+    expect(WORKFLOW).toContain(`DEDUPE_KEY: ${keyExpression}`);
+    expect(WORKFLOW).toContain('BRANCH="sentry-fix/${DEDUPE_KEY}"');
+  });
+
+  it('carries release, environment, route, and recurrence evidence into repair', () => {
+    for (const field of [
+      'root_cause_fingerprint',
+      'environment',
+      'release',
+      'project',
+      'route',
+      'level',
+      'event_id',
+      'first_seen',
+      'last_seen',
+      'event_count',
+      'user_count',
+    ]) {
+      expect(WORKFLOW, `missing client payload field ${field}`).toContain(
+        `github.event.client_payload.context.${field}`
+      );
+    }
+  });
+
+  it('requires staged diagnosis and post-deploy recurrence proof', () => {
+    expect(WORKFLOW).toContain(
+      'Work in these gated stages. Do not advance when the prior stage lacks evidence'
+    );
+    expect(WORKFLOW).toContain(
+      'If customer impact or the current release is ambiguous, make no code change'
+    );
+    expect(WORKFLOW).toContain(
+      'This PR does not close the incident. Resolution requires post-deploy recurrence evidence'
+    );
+    expect(WORKFLOW).not.toMatch(/close[sd]?\s+(the\s+)?(Sentry\s+)?issue/i);
+  });
+});


### PR DESCRIPTION
## Summary

- deduplicate equivalent Sentry reports by a bounded root-cause signature while separating environments
- carry release, route, project, severity, and recurrence context into the autofix workflow
- require staged diagnosis and post-deploy recurrence proof; a PR does not resolve the incident

## Verification

- webhook unit tests: 6/6
- Sentry workflow contract: 3/3
- CI control suite: 231/231
- Jovie web typecheck
- Biome, actionlint, and diff checks

## Resolution gate

Do not close the originating incident from this PR alone. Resolution requires required CI, merge/deploy proof, and a post-deploy recurrence check for the affected release and environment.