### PR TITLE
test(cmdk): use stable palette input locator

### DIFF
--- a/apps/web/tests/e2e/cmdk-palette.spec.ts
+++ b/apps/web/tests/e2e/cmdk-palette.spec.ts
@@ -20,8 +20,7 @@ import {
   waitForHydration,
 } from './utils/smoke-test-utils';
 
-const PALETTE_INPUT =
-  'input[placeholder="Jump to a page, skill, release, or chat..."]';
+const PALETTE_INPUT = 'input[aria-label="Command Palette Search"]';
 
 test.describe('Command palette — Cmd+K contract', () => {
   test.beforeAll(() => {


### PR DESCRIPTION
## Summary
- replace the stale Cmd+K placeholder selector with CmdKPalette's stable accessible-name selector

## Validation
- `pnpm biome check --write apps/web/tests/e2e/cmdk-palette.spec.ts`
- `pnpm --filter @jovie/web run test:truth`
- `pnpm --filter @jovie/web run test:bug-to-test` (not applicable: test-only change)
- `pnpm turbo typecheck`
- `pnpm --filter @jovie/web exec vitest run components/organisms/CmdKPalette.test.tsx` (2 passed)
- normal pre-commit and pre-push gates

## E2E receipt
The focused Playwright Cmd+K spec was attempted with the local auth bypass. It could not reach assertions because the seeded Neon test database was unavailable (`fetch failed`), and the shared local server on port 3100 had started without `E2E_USE_TEST_AUTH_BYPASS=1`. A dedicated local server was then started on port 3101 but did not advance beyond startup, so that owned test process was stopped. No product behavior was changed.