### PR TITLE
fix(hermes): restore bounded Luna issue shipping

### DIFF
--- a/scripts/hermes/bootstrap-pro-launchd.sh
+++ b/scripts/hermes/bootstrap-pro-launchd.sh
@@ -27,6 +27,8 @@ PRO_TEMPLATE_DIR="${REPO_ROOT}/scripts/hermes/launchd/pro"
 LAUNCHD_TEMPLATE_DIR="${REPO_ROOT}/scripts/hermes/launchd"
 SHIPPER_ENTRYPOINT_SRC="${REPO_ROOT}/scripts/hermes/shipper-gated-entrypoint.py"
 SHIPPER_ENTRYPOINT_DST="${HERMES_SCRIPTS}/shipper-gated-entrypoint.py"
+CODEX_LAUNCHER_SRC="${REPO_ROOT}/scripts/hermes/codex-launcher.sh"
+CODEX_LAUNCHER_DST="${HERMES_SCRIPTS}/codex-launcher.sh"
 CODEX_SHIPPER_PLIST_TEMPLATE="${LAUNCHD_TEMPLATE_DIR}/co.jovie.hermes.cron-codex-issue-shipper.plist.template"
 INSTALL_HELPER="${REPO_ROOT}/scripts/hermes/lib/install-launchd-artifacts.sh"
 
@@ -89,6 +91,7 @@ require_cmd plutil
 require_cmd shasum
 chmod +x "${REPO_ROOT}/scripts/hermes/ship-loop.sh"
 [[ -f "$SHIPPER_ENTRYPOINT_SRC" ]] || die "Missing shipper entrypoint: $SHIPPER_ENTRYPOINT_SRC"
+[[ -f "$CODEX_LAUNCHER_SRC" ]] || die "Missing Codex launcher: $CODEX_LAUNCHER_SRC"
 [[ -f "$CODEX_SHIPPER_PLIST_TEMPLATE" ]] || die "Missing codex shipper plist: $CODEX_SHIPPER_PLIST_TEMPLATE"
 
 mkdir -p "$HERMES_HOME/logs/launchd" "$HERMES_SCRIPTS" "$LAUNCH_AGENTS"
@@ -100,6 +103,13 @@ hermes_stage_artifact "$SHIPPER_ENTRYPOINT_SRC" \
 INSTALL_ARGS+=(
   "${LAUNCHD_STAGE}/shipper-gated-entrypoint.py"
   "$SHIPPER_ENTRYPOINT_DST"
+  755
+)
+hermes_stage_artifact "$CODEX_LAUNCHER_SRC" \
+  "${LAUNCHD_STAGE}/codex-launcher.sh" 755
+INSTALL_ARGS+=(
+  "${LAUNCHD_STAGE}/codex-launcher.sh"
+  "$CODEX_LAUNCHER_DST"
   755
 )
 

--- a/scripts/hermes/codex-launcher.sh
+++ b/scripts/hermes/codex-launcher.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Stable Codex entrypoint for Hermes/Symphony.
+#
+# The shipper still emits the legacy -a/-C/-m spellings. Translate those
+# spellings to the installed Codex CLI without adding a global approval or
+# sandbox bypass. The caller's explicit sandbox and approval policy remain
+# authoritative.
+set -euo pipefail
+
+if [[ -n "${HERMES_CODEX_BIN:-}" ]]; then
+  CODEX_BIN="$HERMES_CODEX_BIN"
+elif [[ -x "/Applications/Codex.app/Contents/Resources/codex" ]]; then
+  CODEX_BIN="/Applications/Codex.app/Contents/Resources/codex"
+elif [[ -x "/Applications/ChatGPT.app/Contents/Resources/codex" ]]; then
+  CODEX_BIN="/Applications/ChatGPT.app/Contents/Resources/codex"
+else
+  echo "No supported Codex binary found. Set HERMES_CODEX_BIN to an executable path." >&2
+  exit 127
+fi
+
+NEW_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -a|--approach)
+      [[ $# -ge 2 ]] || { echo "$1 requires a value" >&2; exit 2; }
+      NEW_ARGS+=("--ask-for-approval" "$2")
+      shift 2
+      ;;
+    -C)
+      [[ $# -ge 2 ]] || { echo "$1 requires a value" >&2; exit 2; }
+      NEW_ARGS+=("--cd" "$2")
+      shift 2
+      ;;
+    --sandbox|-m|--model)
+      [[ $# -ge 2 ]] || { echo "$1 requires a value" >&2; exit 2; }
+      if [[ "$1" == "-m" ]]; then
+        NEW_ARGS+=("--model" "$2")
+      else
+        NEW_ARGS+=("$1" "$2")
+      fi
+      shift 2
+      ;;
+    *)
+      NEW_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+exec "$CODEX_BIN" "${NEW_ARGS[@]}"

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -18,7 +18,7 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-hud.plist.template` | every 5 min | Refresh HUD snapshot |
 | `co.jovie.hermes.cron-pr-monitor.plist.template` | every 10 min | Detect stuck PRs |
 | `co.jovie.hermes.cron-ci-monitor.plist.template` | every 10 min | Detect CI failures on main |
-| `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 15 min | Claim one open GitHub issue labeled `codex` and dispatch a coder-profile agent |
+| `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 5 min + load | Claim up to three eligible open GitHub issues and dispatch bounded coder-profile agents |
 | `co.jovie.hermes.cron-pipeline-scoreboard.plist.template` | every 60 min | Write daily pipeline scoreboard to local state + gbrain, and alert on 12h shipper stalls |
 | `co.jovie.hermes.cron-gbrain-health-summary.plist.template` | 07:15 local daily | Probe the Tailscale HTTP endpoint, source freshness, and server count; write the latest health summary back to gbrain and notify ops |
 | `co.jovie.hermes.cron-agent-config-health.plist.template` | every 15 min | Detect invalid Hermes/OpenClaw agent config before gateway churn |
@@ -35,7 +35,7 @@ Coder/shipping loops run on Houston, not Hermes-Air. Pro-only templates live in 
 | File | Schedule | Purpose |
 |---|---|---|
 | `pro/co.jovie.hermes.cron-codex-kanban-ship.plist.template` | every 15 min | Launch `scripts/hermes/ship-loop.sh` → `~/.hermes/scripts/codex-kanban-ship.py` (PAUSE + gbrain gated) |
-| `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 15 min | `~/.hermes/scripts/shipper-gated-entrypoint.py` → fail-closed gbrain/grok/checkout gate → `codex-issue-shipper.ts` |
+| `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 5 min + load | `~/.hermes/scripts/shipper-gated-entrypoint.py` → fail-closed gbrain/selected-provider/checkout gate → `codex-issue-shipper.ts` |
 
 Install on the Pro:
 

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
@@ -11,11 +11,11 @@
     <key>WorkingDirectory</key>
     <string>{{JOVIE_REPO}}</string>
     <key>StartInterval</key>
-    <integer>900</integer>
+    <integer>300</integer>
     <key>ThrottleInterval</key>
     <integer>60</integer>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
     <key>KeepAlive</key>
     <dict>
         <key>SuccessfulExit</key>
@@ -23,8 +23,6 @@
         <key>Crashed</key>
         <true/>
     </dict>
-    <key>ThrottleInterval</key>
-    <integer>60</integer>
     <key>EnvironmentVariables</key>
     <dict>
         <key>HERMES_HOME</key>
@@ -36,7 +34,7 @@
         <key>HERMES_CODEX_SHIPPER_ISSUE_FETCH_LIMIT</key>
         <string>1000</string>
         <key>HERMES_CODEX_SHIPPER_MIN_FREE_MEMORY_MB</key>
-        <string>4096</string>
+        <string>256</string>
         <key>HERMES_CODEX_SHIPPER_MAX_LOAD_PER_CPU</key>
         <string>1.5</string>
         <key>HERMES_CODEX_SHIPPER_SINGLETON_LOCK_STALE_MS</key>
@@ -44,17 +42,19 @@
         <key>HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD</key>
         <string>4</string>
         <key>HERMES_CODEX_SHIPPER_AGENT</key>
-        <string>grok</string>
+        <string>codex</string>
         <key>HERMES_CODEX_SHIPPER_SIMPLE_MODEL</key>
-        <string>grok-composer-2.5-fast</string>
+        <string>gpt-5.6-luna</string>
         <key>HERMES_CODEX_SHIPPER_STANDARD_MODEL</key>
-        <string>grok-composer-2.5-fast</string>
+        <string>gpt-5.6-luna</string>
         <key>HERMES_CODEX_SHIPPER_ESCALATION_MODEL</key>
-        <string>grok-composer-2.5-fast</string>
+        <string>gpt-5.6-terra</string>
         <key>HERMES_CODEX_SHIPPER_FALLBACK_MODEL</key>
-        <string>grok-composer-2.5-fast</string>
-        <key>HERMES_CODEX_SHIPPER_GROK_PERMISSION_MODE</key>
-        <string>auto</string>
+        <string>gpt-5.6-luna</string>
+        <key>HERMES_CODEX_SHIPPER_CODEX_APPROVAL_POLICY</key>
+        <string>never</string>
+        <key>HERMES_CODEX_SHIPPER_CODEX_REASONING_EFFORT</key>
+        <string>max</string>
         <key>PATH</key>
         <string>{{NODE_BIN_DIR}}:{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>

--- a/scripts/hermes/lib/__tests__/codex-issue-shipper-routing.test.ts
+++ b/scripts/hermes/lib/__tests__/codex-issue-shipper-routing.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAgentCommand,
+  type GithubIssue,
   loadShipperConfig,
   selectTaskRoute,
-  type GithubIssue,
 } from '../codex-issue-shipper';
 
 const issue = (title: string, labels: string[] = []): GithubIssue => ({
@@ -53,8 +53,10 @@ describe('Codex shipper routing', () => {
       'gpt-5.6-luna'
     );
     expect(
-      selectTaskRoute(issue('Fix auth callback allow-list', ['security']), config)
-        .sessionModel
+      selectTaskRoute(
+        issue('Fix auth callback allow-list', ['security']),
+        config
+      ).sessionModel
     ).toBe('gpt-5.6-terra');
   });
 });

--- a/scripts/hermes/lib/__tests__/codex-issue-shipper-routing.test.ts
+++ b/scripts/hermes/lib/__tests__/codex-issue-shipper-routing.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAgentCommand,
+  loadShipperConfig,
+  selectTaskRoute,
+  type GithubIssue,
+} from '../codex-issue-shipper';
+
+const issue = (title: string, labels: string[] = []): GithubIssue => ({
+  number: 42,
+  title,
+  body: '',
+  url: 'https://github.com/JovieInc/Jovie/issues/42',
+  labels: labels.map(name => ({ name })),
+});
+
+describe('Codex shipper routing', () => {
+  it('defaults Codex reasoning to max without changing the caller environment', () => {
+    const config = loadShipperConfig(
+      {
+        HERMES_CODEX_SHIPPER_AGENT: 'codex',
+        HERMES_CODEX_SHIPPER_SIMPLE_MODEL: 'gpt-5.6-luna',
+        HERMES_CODEX_SHIPPER_STANDARD_MODEL: 'gpt-5.6-luna',
+        HERMES_CODEX_SHIPPER_ESCALATION_MODEL: 'gpt-5.6-terra',
+        HERMES_CODEX_SHIPPER_FALLBACK_MODEL: 'gpt-5.6-luna',
+      },
+      '/tmp/jovie',
+      'JovieInc/Jovie'
+    );
+
+    expect(config.codexReasoningEffort).toBe('max');
+    const route = selectTaskRoute(issue('Fix profile copy'), config);
+    const command = buildAgentCommand(config, route);
+
+    expect(route.sessionModel).toBe('gpt-5.6-luna');
+    expect(command.args).toContain('model_reasoning_effort="max"');
+  });
+
+  it('uses the stronger model only for an explicitly high-risk route', () => {
+    const config = loadShipperConfig(
+      {
+        HERMES_CODEX_SHIPPER_AGENT: 'codex',
+        HERMES_CODEX_SHIPPER_SIMPLE_MODEL: 'gpt-5.6-luna',
+        HERMES_CODEX_SHIPPER_STANDARD_MODEL: 'gpt-5.6-luna',
+        HERMES_CODEX_SHIPPER_ESCALATION_MODEL: 'gpt-5.6-terra',
+        HERMES_CODEX_SHIPPER_FALLBACK_MODEL: 'gpt-5.6-luna',
+      },
+      '/tmp/jovie',
+      'JovieInc/Jovie'
+    );
+
+    expect(selectTaskRoute(issue('Fix copy'), config).sessionModel).toBe(
+      'gpt-5.6-luna'
+    );
+    expect(
+      selectTaskRoute(issue('Fix auth callback allow-list', ['security']), config)
+        .sessionModel
+    ).toBe('gpt-5.6-terra');
+  });
+});

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -131,12 +131,7 @@ export type CodexApprovalPolicy =
   | 'on-failure'
   | 'on-request'
   | 'never';
-export type CodexReasoningEffort =
-  | 'low'
-  | 'medium'
-  | 'high'
-  | 'xhigh'
-  | 'max';
+export type CodexReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export interface TaskRoute {
   readonly riskLevel: RiskLevel;

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -102,6 +102,7 @@ export interface ShipperConfig {
   readonly fallbackModel: string;
   readonly codexSandbox: CodexSandboxMode;
   readonly codexApprovalPolicy: CodexApprovalPolicy;
+  readonly codexReasoningEffort: CodexReasoningEffort;
   readonly claudePermissionMode: string;
   readonly grokPermissionMode: string;
   readonly agentTimeoutMs: number;
@@ -130,6 +131,12 @@ export type CodexApprovalPolicy =
   | 'on-failure'
   | 'on-request'
   | 'never';
+export type CodexReasoningEffort =
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max';
 
 export interface TaskRoute {
   readonly riskLevel: RiskLevel;
@@ -335,6 +342,11 @@ export function loadShipperConfig(
       env.HERMES_CODEX_SHIPPER_CODEX_APPROVAL_POLICY,
       ['untrusted', 'on-failure', 'on-request', 'never'],
       'on-request'
+    ),
+    codexReasoningEffort: parseEnum<CodexReasoningEffort>(
+      env.HERMES_CODEX_SHIPPER_CODEX_REASONING_EFFORT,
+      ['low', 'medium', 'high', 'xhigh', 'max'],
+      'max'
     ),
     claudePermissionMode:
       env.HERMES_CODEX_SHIPPER_CLAUDE_PERMISSION_MODE ?? 'auto',
@@ -814,6 +826,8 @@ export function buildAgentCommand(
         config.codexSandbox,
         '-m',
         route.sessionModel,
+        '-c',
+        `model_reasoning_effort="${config.codexReasoningEffort}"`,
         '--color',
         'never',
       ],

--- a/scripts/hermes/shipper-gated-entrypoint.py
+++ b/scripts/hermes/shipper-gated-entrypoint.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Launchd entrypoint for the codex issue shipper.
+"""Launchd entrypoint for the issue shipper.
 
-Fail-closed preflight gates (pause, gbrain, grok, primary-checkout freshness)
-run before execing the TypeScript shipper from the primary ~/Jovie checkout.
+Fail-closed preflight gates (pause, gbrain, selected provider,
+primary-checkout freshness) run before execing the TypeScript shipper from the
+primary ~/Jovie checkout.
 """
 from __future__ import annotations
 
@@ -134,7 +135,7 @@ def gbrain_alive(hermes_home: Path) -> bool:
                 gbrain_bin = str(candidate)
                 break
     if not gbrain_bin:
-        gbrain_bin = shutil.which("gbrain") or str(hermes_home() / "bin" / "gbrain")
+        gbrain_bin = shutil.which("gbrain") or str(hermes_home / "bin" / "gbrain")
     if not Path(gbrain_bin).is_file():
         return False
     try:
@@ -151,6 +152,13 @@ def gbrain_alive(hermes_home: Path) -> bool:
         return status not in ("", "error", "fail", "failed", "dead")
     except Exception:
         return False
+
+
+def _command_path(env_name: str, command: str) -> str | None:
+    override = os.environ.get(env_name, "").strip()
+    if override and Path(override).is_file():
+        return override
+    return shutil.which(command)
 
 
 def grok_alive() -> bool:
@@ -177,6 +185,52 @@ def grok_alive() -> bool:
                 return True
         except Exception:
             continue
+    return False
+
+
+def codex_alive() -> bool:
+    """Check existing Codex login without changing credentials or spending a turn."""
+    codex_bin = _command_path("HERMES_CODEX_BIN", "codex")
+    if not codex_bin:
+        return False
+    try:
+        proc = subprocess.run(
+            [codex_bin, "login", "status"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        output = f"{proc.stdout}\n{proc.stderr}".lower()
+        return proc.returncode == 0 and "logged in" in output
+    except Exception:
+        return False
+
+
+def claude_alive() -> bool:
+    claude_bin = _command_path("HERMES_CLAUDE_BIN", "claude")
+    if not claude_bin:
+        return False
+    try:
+        proc = subprocess.run(
+            [claude_bin, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+def provider_alive(agent: str) -> bool:
+    if agent == "grok":
+        return grok_alive()
+    if agent == "codex":
+        return codex_alive()
+    if agent == "claude":
+        return claude_alive()
     return False
 
 
@@ -392,11 +446,12 @@ def main() -> int:
         )
         return 3
 
-    if not grok_alive():
+    agent = os.environ.get("HERMES_CODEX_SHIPPER_AGENT", "grok").strip().lower()
+    if not provider_alive(agent):
         notify_abort(
             hermes_home,
-            "grok_gate_abort",
-            "grok CLI is missing or unhealthy — refusing to dispatch blind",
+            f"{agent}_gate_abort",
+            f"{agent} CLI is missing or unhealthy — refusing to dispatch blind",
         )
         return 4
 

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -667,6 +667,7 @@ describe('codex issue shipper prompt', () => {
         fallbackModel: 'fallback-model',
         codexSandbox: 'workspace-write',
         codexApprovalPolicy: 'on-request',
+        codexReasoningEffort: 'max',
         claudePermissionMode: 'auto',
         grokPermissionMode: 'auto',
         agentTimeoutMs: 1000,


### PR DESCRIPTION
## Summary
- restore the issue shipper on an authenticated Codex/Luna path after the Grok gate stopped shipping
- keep ordinary work on Luna at max reasoning and reserve Terra for explicitly high-risk routes
- make the existing launchd unit run at load and every five minutes with bounded issue/agent capacity
- preserve provider, gbrain, checkout, sandbox, approval, native CI, and deterministic finisher gates

## Evidence
- focused routing tests: 79/79 passed
- source launcher login status: authenticated via existing ChatGPT login
- bounded Luna canary: `GEM_MODEL_READY`, `approval=never`, `sandbox=workspace-write`, `reasoning=max`
- dry run: exit 0; one eligible batch admitted under current memory pressure, second lane safely throttled; high-risk route selected Terra, ordinary route selected Luna
- `git diff --check`, shell syntax, Python compile, and plist validation passed

## Operational boundary
- no credentials changed
- no launchd unit restarted or reconfigured by this PR
- no merge, deploy, or gate bypass
- after native CI/queue landing, the documented `bootstrap-pro-launchd.sh --reconfigure` path must install the rendered artifacts; an explicit kickstart remains a separate operator action
