### PR TITLE
fix(tasks): preserve board loading geometry

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskBoard.test.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskBoardResult, TaskStatus } from '@/lib/tasks/types';
+import { getTaskBoardGridTemplate, TaskBoard } from './TaskBoard';
+
+const visibleStatuses: TaskStatus[] = ['backlog', 'todo', 'in_progress'];
+const emptyBoard: TaskBoardResult = {
+  columns: [],
+  totalCount: 0,
+};
+
+const boardProps = {
+  board: emptyBoard,
+  visibleStatuses,
+  artistName: 'Tim White',
+  selectedTaskId: null,
+  onOpenTask: vi.fn(),
+  onCreateTask: vi.fn(),
+  onMoveTask: vi.fn(),
+  getTaskContextMenuItems: vi.fn(() => []),
+};
+
+describe('TaskBoard geometry', () => {
+  it('keeps loading and loaded states on the same column grid', () => {
+    const { getByTestId, rerender } = render(
+      <TaskBoard {...boardProps} isLoading />
+    );
+    const loadingBoard = getByTestId('tasks-board-skeleton');
+    const loadingTemplate = loadingBoard.style.gridTemplateColumns;
+
+    expect(loadingBoard.children).toHaveLength(visibleStatuses.length);
+
+    rerender(<TaskBoard {...boardProps} isLoading={false} />);
+
+    expect(getByTestId('tasks-board').style.gridTemplateColumns).toBe(
+      loadingTemplate
+    );
+  });
+
+  it.each([
+    0, 1, 3, 4,
+  ])('uses the same responsive grid contract for %s visible columns', columnCount => {
+    const expectedColumnCount = Math.max(columnCount, 1);
+
+    expect(getTaskBoardGridTemplate(columnCount)).toBe(
+      `repeat(${expectedColumnCount}, minmax(0, 1fr))`
+    );
+  });
+});

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -156,8 +156,10 @@ export function TaskBoard({
     }
   };
 
+  const columnCount = Math.max(columns.length, 1);
+
   if (isLoading) {
-    return <TaskBoardSkeleton />;
+    return <TaskBoardSkeleton columnCount={columnCount} />;
   }
 
   return (
@@ -172,7 +174,7 @@ export function TaskBoard({
         className='grid h-full min-h-0 min-w-0 gap-3 overflow-hidden px-3 pb-3 pt-1.5'
         data-testid='tasks-board'
         style={{
-          gridTemplateColumns: `repeat(${Math.max(columns.length, 1)}, minmax(0, 1fr))`,
+          gridTemplateColumns: getTaskBoardGridTemplate(columnCount),
         }}
       >
         {columns.map(column => (
@@ -479,15 +481,29 @@ const TaskBoardCard = memo(function TaskBoardCard({
   );
 });
 
-function TaskBoardSkeleton() {
+export function getTaskBoardGridTemplate(columnCount: number): string {
+  return `repeat(${Math.max(columnCount, 1)}, minmax(0, 1fr))`;
+}
+
+function TaskBoardSkeleton({
+  columnCount,
+}: Readonly<{
+  columnCount: number;
+}>) {
+  const skeletonColumnKeys = Array.from(
+    { length: Math.max(columnCount, 1) },
+    (_, index) => `skeleton-column-${index}`
+  );
+
   return (
     <div
-      className='grid h-full min-h-0 min-w-full gap-3 overflow-hidden px-3 pb-3 pt-1.5'
-      style={{ gridTemplateColumns: 'repeat(4, minmax(17.5rem, 1fr))' }}
+      className='grid h-full min-h-0 min-w-0 gap-3 overflow-hidden px-3 pb-3 pt-1.5'
+      data-testid='tasks-board-skeleton'
+      style={{ gridTemplateColumns: getTaskBoardGridTemplate(columnCount) }}
     >
-      {[0, 1, 2, 3].map(column => (
+      {skeletonColumnKeys.map(columnKey => (
         <div
-          key={column}
+          key={columnKey}
           className='flex h-full min-h-0 w-full min-w-0 flex-col rounded-xl border border-subtle bg-surface-0'
         >
           <div className='h-10 border-b border-subtle px-3 py-3'>


### PR DESCRIPTION
## Summary
- keep TaskBoard loading skeleton columns aligned with the visible board columns
- remove the fixed four-column/min-width loading layout that could overflow or shift the board
- add a regression contract for loading/loaded grid geometry

## Verification
- `pnpm --filter @jovie/web exec vitest run components/features/dashboard/tasks/TaskBoard.test.tsx --config=vitest.config.mts --maxWorkers 1` (5 passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/components/features/dashboard/tasks/TaskBoard.tsx apps/web/components/features/dashboard/tasks/TaskBoard.test.tsx`
- `git diff --check`

Rendered browser proof is not claimed in this source-only slice; the regression is covered at component level.