### PR TITLE
perf(profile): index legacy alias slug lookups

### DIFF
--- a/apps/web/drizzle/migrations/0088_discog_tracks_creator_slug_index.sql
+++ b/apps/web/drizzle/migrations/0088_discog_tracks_creator_slug_index.sql
@@ -1,0 +1,5 @@
+-- Speed up collision-safe public alias misses against the legacy track table.
+-- The alias resolver probes by creator and slug; this table is intentionally
+-- non-unique because legacy tracks may reuse a slug across releases.
+CREATE INDEX IF NOT EXISTS "discog_tracks_creator_slug_idx"
+  ON "discog_tracks" ("creator_profile_id", "slug");

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -617,6 +617,13 @@
       "when": 1785600000000,
       "tag": "0087_skill_rollouts",
       "breakpoints": true
+    },
+    {
+      "idx": 88,
+      "version": "7",
+      "when": 1786147200000,
+      "tag": "0088_discog_tracks_creator_slug_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/content.ts
+++ b/apps/web/lib/db/schema/content.ts
@@ -225,6 +225,10 @@ export const discogTracks = pgTable(
     releaseIsrcUnique: uniqueIndex('discog_tracks_release_isrc_unique')
       .on(table.releaseId, table.isrc)
       .where(drizzleSql`isrc IS NOT NULL`),
+    creatorSlugIndex: index('discog_tracks_creator_slug_idx').on(
+      table.creatorProfileId,
+      table.slug
+    ),
     releaseIndex: index('discog_tracks_release_id_idx').on(table.releaseId),
     creatorIndex: index('discog_tracks_creator_profile_id_idx').on(
       table.creatorProfileId


### PR DESCRIPTION
## Why
The exact staged production gate recorded a single cold `/dualipa/music` alias sample at 1619ms while later samples were 630–750ms. The alias resolver performs three parallel content-presence probes; the legacy `discog_tracks` probe filtered by `(creator_profile_id, slug)` without a composite index.

## Change
- Add `discog_tracks_creator_slug_idx` to the Drizzle schema.
- Add idempotent migration `0088_discog_tracks_creator_slug_index.sql`.
- Leave redirect/collision precedence, cache behavior, and the cold navigation budget unchanged.

## Verification
- `profile-mode-alias-content-candidate.test.ts` and `smart-link-metadata.test.ts`: 27/27 passed.
- `drizzle:check`: passed.
- `migration:validate`: passed (89 migrations, journal aligned).
- Biome check and `git diff --check`: passed.

This is a normal-gated product/data-path optimization; it does not claim production deployment or resolution until CI, native merge, and the canonical production controller prove it.