### PR TITLE
feat(web): align Start and public actions (JOV-4882)

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -525,7 +525,6 @@ interface OnboardingMessageRegionProps {
   readonly onAttachAccount: (url: string) => void;
   readonly onNoneOfTheseArtists: () => void;
   readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
-  readonly onSelectStarterSuggestion: (prompt: string) => void;
   readonly profileBuilderState: OnboardingProfileBuilderState;
   readonly shouldDockComposer: boolean;
   readonly entryMode: OnboardingEntryMode;
@@ -546,7 +545,6 @@ function OnboardingMessageRegion({
   onAttachAccount,
   onNoneOfTheseArtists,
   onSelectArtist,
-  onSelectStarterSuggestion,
   profileBuilderState,
   shouldDockComposer,
 }: OnboardingMessageRegionProps) {
@@ -572,14 +570,17 @@ function OnboardingMessageRegion({
 
   if (!hasConversationStarted) {
     return (
-      <ChatEmptyStateComposerRegion hideWelcomeHeader>
-        <OnboardingChatEmptyIntro
-          composer={onboardingComposerSurface}
-          mode={entryMode}
-          onSelectSuggestion={onSelectStarterSuggestion}
-          dimmed={composerPickerOpen}
-          isBusy={isBusy}
-        />
+      <ChatEmptyStateComposerRegion
+        above={
+          <div className='flex min-h-full items-center justify-center'>
+            <OnboardingChatEmptyIntro mode={entryMode} />
+          </div>
+        }
+        hideWelcomeHeader
+      >
+        <div className='w-full' data-testid='onboarding-centered-composer'>
+          {onboardingComposerSurface}
+        </div>
       </ChatEmptyStateComposerRegion>
     );
   }
@@ -1057,7 +1058,7 @@ export function OnboardingChat({
             hasConversationStarted || shouldDockComposer
               ? 'max-w-[44rem]'
               : 'max-w-[52rem]',
-            !shouldDockComposer && 'justify-center'
+            !shouldDockComposer && 'h-full justify-center'
           )}
         >
           {flowStatus}
@@ -1075,7 +1076,6 @@ export function OnboardingChat({
             onAttachAccount={handleAttachAccount}
             onNoneOfTheseArtists={handleNoneOfTheseArtists}
             onSelectArtist={handleArtistSelect}
-            onSelectStarterSuggestion={submitText}
             profileBuilderState={profileBuilderState}
             shouldDockComposer={shouldDockComposer}
           />

--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
@@ -1,24 +1,11 @@
 'use client';
 
-import { Camera, Disc3, Eye, Link2, LoaderCircle, Music } from 'lucide-react';
-import type { ComponentType, ReactNode, SVGProps } from 'react';
+import { LoaderCircle } from 'lucide-react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
-import { getChatPromptPillClass } from '@/components/jovie/components/chat-prompt-styles';
-import type { ChatSuggestion } from '@/components/jovie/types';
 import {
   ONBOARDING_ENTRY_SUPPORT,
   ONBOARDING_ENTRY_TITLE,
-  ONBOARDING_STARTER_SUGGESTIONS,
 } from '@/lib/onboarding/empty-state';
-import { cn } from '@/lib/utils';
-
-const ICON_MAP: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
-  Camera,
-  Disc3,
-  Eye,
-  Link2,
-  Music,
-};
 
 export type OnboardingEntryMode =
   | 'blank'
@@ -27,55 +14,7 @@ export type OnboardingEntryMode =
   | 'spotify_handoff';
 
 interface OnboardingChatEmptyIntroProps {
-  readonly composer: ReactNode;
   readonly mode: OnboardingEntryMode;
-  readonly onSelectSuggestion: (prompt: string) => void;
-  readonly dimmed?: boolean;
-  readonly isBusy?: boolean;
-}
-
-function StarterSuggestionPill({
-  suggestion,
-  onSelect,
-  disabled,
-}: {
-  readonly suggestion: ChatSuggestion;
-  readonly onSelect: (prompt: string) => void;
-  readonly disabled: boolean;
-}) {
-  const IconComponent = ICON_MAP[suggestion.icon];
-
-  return (
-    <button
-      type='button'
-      onClick={() => {
-        if (!disabled) onSelect(suggestion.prompt);
-      }}
-      disabled={disabled}
-      className={cn(
-        'group inline-flex min-h-11 items-center px-1 focus-visible:outline-none focus-visible:[&>span]:ring-2 focus-visible:[&>span]:ring-white/25 active:[&>span]:scale-[0.98] motion-reduce:[&>span]:transform-none',
-        disabled ? 'cursor-not-allowed opacity-55' : 'cursor-pointer'
-      )}
-      aria-label={suggestion.label}
-      aria-disabled={disabled}
-    >
-      <span
-        className={cn(
-          'chat-pill transition-[color,background-color,border-color,box-shadow,transform] duration-fast',
-          getChatPromptPillClass('compact')
-        )}
-      >
-        <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
-          {IconComponent ? (
-            <IconComponent className='h-3.5 w-3.5 shrink-0' />
-          ) : null}
-        </span>
-        <span className='min-w-0 flex-1 truncate leading-none'>
-          {suggestion.label}
-        </span>
-      </span>
-    </button>
-  );
 }
 
 function getEntryCopy(mode: OnboardingEntryMode): {
@@ -107,17 +46,10 @@ function getEntryCopy(mode: OnboardingEntryMode): {
 }
 
 export function OnboardingChatEmptyIntro({
-  composer,
   mode,
-  onSelectSuggestion,
-  dimmed = false,
-  isBusy = false,
 }: OnboardingChatEmptyIntroProps) {
   const copy = getEntryCopy(mode);
   const isBlank = mode === 'blank';
-  const dimClass = dimmed
-    ? 'opacity-0 transition-opacity duration-fast ease-out'
-    : 'opacity-100 transition-opacity duration-fast ease-out';
 
   return (
     <div
@@ -125,46 +57,28 @@ export function OnboardingChatEmptyIntro({
       data-entry-mode={mode}
       data-testid='onboarding-empty-intro'
     >
-      <div
-        aria-hidden='true'
-        className='mb-4 text-primary-token opacity-[0.18]'
-      >
-        <BrandLogo size={56} aria-hidden={true} />
-      </div>
+      {!isBlank ? (
+        <div
+          aria-hidden='true'
+          className='mb-4 text-primary-token opacity-[0.18]'
+        >
+          <BrandLogo size={56} aria-hidden={true} />
+        </div>
+      ) : null}
 
       <div className='mb-6 text-center'>
         <h1 className='text-2xl font-semibold text-primary-token'>
           {copy.title}
         </h1>
-        <p className='mt-2 text-sm leading-6 text-secondary-token'>
-          {copy.support}
-        </p>
+        {!isBlank ? (
+          <p className='mt-2 text-sm leading-6 text-secondary-token'>
+            {copy.support}
+          </p>
+        ) : null}
       </div>
 
-      <div className='w-full' data-testid='onboarding-centered-composer'>
-        {composer}
-      </div>
-
-      <div className='flex min-h-[7.5rem] w-full items-start justify-center pt-3'>
-        {isBlank ? (
-          <div
-            className={cn('flex w-full flex-col items-center', dimClass)}
-            aria-hidden={dimmed}
-            inert={dimmed}
-            data-testid='onboarding-starter-suggestions'
-          >
-            <div className='flex max-w-[40rem] flex-wrap justify-center gap-x-1'>
-              {ONBOARDING_STARTER_SUGGESTIONS.map(suggestion => (
-                <StarterSuggestionPill
-                  key={suggestion.label}
-                  suggestion={suggestion}
-                  onSelect={onSelectSuggestion}
-                  disabled={isBusy}
-                />
-              ))}
-            </div>
-          </div>
-        ) : (
+      {!isBlank ? (
+        <div className='flex min-h-11 items-start justify-center pt-3'>
           <div
             className='inline-flex min-h-11 items-center gap-2 text-xs text-secondary-token'
             role='status'
@@ -176,8 +90,8 @@ export function OnboardingChatEmptyIntro({
             />
             Preparing your first message
           </div>
-        )}
-      </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { Skeleton } from '@jovie/ui';
+import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { AppShellFrame } from '@/components/organisms/AppShellFrame';
-import { MarketingSignInLink } from '@/components/organisms/MarketingSignInLink';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
+import { APP_ROUTES } from '@/constants/routes';
 import { track } from '@/lib/analytics';
 import { publicEnv } from '@/lib/env-public';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
@@ -174,7 +175,12 @@ export function OnboardingShell({
               className='absolute right-3 top-3 z-30 sm:right-4 sm:top-4'
               data-testid='onboarding-sign-in-header'
             >
-              <MarketingSignInLink variant='ghost' />
+              <Link
+                className='btn-linear-login focus-ring-themed shrink-0 whitespace-nowrap'
+                href={APP_ROUTES.SIGNIN}
+              >
+                Sign in
+              </Link>
             </div>
             <OnboardingChat
               intentId={intentId}

--- a/apps/web/components/marketing/ClientFaqAccordion.stories.tsx
+++ b/apps/web/components/marketing/ClientFaqAccordion.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ClientFaqAccordion } from './ClientFaqAccordion';
+
+const meta: Meta<typeof ClientFaqAccordion> = {
+  title: 'Marketing/Sections/ClientFaqAccordion',
+  component: ClientFaqAccordion,
+  parameters: { layout: 'centered' },
+  decorators: [
+    Story => (
+      <div className='w-[min(42rem,calc(100vw-2rem))] bg-base p-6 text-primary-token'>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      {
+        question: 'What does Jovie keep moving?',
+        answer:
+          'Your artist profile, release links, and audience signals stay connected in one focused workspace.',
+      },
+      {
+        question: 'Can I start with an existing profile?',
+        answer:
+          'Yes. Jovie keeps the public surface grounded in real artist data.',
+      },
+    ],
+  },
+};

--- a/apps/web/components/marketing/ClientFaqAccordion.tsx
+++ b/apps/web/components/marketing/ClientFaqAccordion.tsx
@@ -39,7 +39,7 @@ export function ClientFaqAccordion({
               type='button'
               aria-expanded={isOpen}
               aria-controls={panelId}
-              className='faq-accordion__trigger focus-ring-themed flex w-full items-start justify-between gap-6 rounded-md py-5 text-left text-base font-semibold leading-[1.35] tracking-[-0.018em] text-primary-token transition-opacity duration-subtle hover:opacity-90'
+              className='faq-accordion__trigger focus-ring-themed flex w-full items-start justify-between gap-6 rounded-md py-6 text-left text-lg font-semibold leading-snug tracking-[-0.018em] text-primary-token transition-opacity duration-subtle hover:opacity-90'
               onClick={() => {
                 const nextIndex = isOpen ? null : index;
                 setOpenIndex(nextIndex);
@@ -74,12 +74,12 @@ export function ClientFaqAccordion({
               className={cn(
                 'faq-accordion__panel grid overflow-hidden transition-[grid-template-rows,opacity,margin] duration-subtle ease-subtle motion-reduce:transition-none',
                 isOpen
-                  ? 'visible mt-1 grid-rows-[1fr] opacity-100'
+                  ? 'visible mt-2 grid-rows-[1fr] opacity-100'
                   : 'invisible mt-0 grid-rows-[0fr] opacity-0'
               )}
             >
               <div className='min-h-0 overflow-hidden'>
-                <p className='faq-accordion__answer pb-5 pr-10 text-mid leading-7 text-secondary-token'>
+                <p className='faq-accordion__answer max-w-prose pb-7 pr-10 text-base leading-7 text-secondary-token'>
                   {item.answer}
                 </p>
               </div>

--- a/apps/web/components/marketing/ClientFaqAccordion.tsx
+++ b/apps/web/components/marketing/ClientFaqAccordion.tsx
@@ -1,3 +1,4 @@
+// @coverage-via apps/web/tests/unit/home/mounted-home-faq-system-b-style-guard.test.ts
 'use client';
 
 import { Minus, Plus } from 'lucide-react';

--- a/apps/web/components/molecules/AuthActions.stories.tsx
+++ b/apps/web/components/molecules/AuthActions.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { AuthActions } from './AuthActions';
+
+const meta: Meta<typeof AuthActions> = {
+  title: 'Molecules/AuthActions',
+  component: AuthActions,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SignedOut: Story = {};

--- a/apps/web/components/molecules/AuthActions.tsx
+++ b/apps/web/components/molecules/AuthActions.tsx
@@ -9,7 +9,7 @@ export function AuthActions() {
   const isAuthed = useIsAuthenticated();
 
   return (
-    <div className='flex items-center gap-1'>
+    <div className='flex items-center gap-(--linear-gap-buttons)'>
       {isAuthed ? (
         <Link
           href={APP_ROUTES.DASHBOARD}

--- a/apps/web/components/molecules/AuthActions.tsx
+++ b/apps/web/components/molecules/AuthActions.tsx
@@ -1,3 +1,4 @@
+// @coverage-via apps/web/tests/unit/AuthActions.test.tsx
 'use client';
 
 import { getLinearPillClassName } from '@jovie/ui';

--- a/apps/web/components/molecules/AuthActions.tsx
+++ b/apps/web/components/molecules/AuthActions.tsx
@@ -10,7 +10,7 @@ export function AuthActions() {
   const isAuthed = useIsAuthenticated();
 
   return (
-    <div className='flex items-center gap-(--linear-gap-buttons)'>
+    <div className='flex items-center gap-2'>
       {isAuthed ? (
         <Link
           href={APP_ROUTES.DASHBOARD}

--- a/apps/web/components/organisms/HeaderNav.stories.tsx
+++ b/apps/web/components/organisms/HeaderNav.stories.tsx
@@ -23,6 +23,13 @@ type Story = StoryObj<typeof meta>;
 // Default story - shows the header navigation
 export const Default: Story = {};
 
+export const PublicStatic: Story = {
+  args: {
+    authMode: 'public-static',
+    publicCtaLabel: 'Get started',
+  },
+};
+
 // Mobile view story
 export const Mobile: Story = {
   parameters: {

--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -82,7 +82,7 @@ function PublicAuthActions({
     return <MarketingSignInLink variant='ghost' />;
   }
   return (
-    <div className='flex items-center gap-1'>
+    <div className='flex items-center gap-(--linear-gap-buttons)'>
       <Link
         href={APP_ROUTES.SIGNIN}
         className='btn-linear-login focus-ring-themed shrink-0 whitespace-nowrap'

--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -1,3 +1,4 @@
+// @coverage-via apps/web/tests/unit/HeaderNavFlyout.test.tsx
 'use client';
 
 import './HeaderNav.css';

--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -83,7 +83,7 @@ function PublicAuthActions({
     return <MarketingSignInLink variant='ghost' />;
   }
   return (
-    <div className='flex items-center gap-(--linear-gap-buttons)'>
+    <div className='flex items-center gap-2'>
       <Link
         href={APP_ROUTES.SIGNIN}
         className='btn-linear-login focus-ring-themed shrink-0 whitespace-nowrap'

--- a/apps/web/tests/e2e/start-onboarding-chat.spec.ts
+++ b/apps/web/tests/e2e/start-onboarding-chat.spec.ts
@@ -310,18 +310,30 @@ test.describe('canonical /start onboarding chat', () => {
     await waitForHydration(page);
     await expect(page.locator('[data-app-shell-frame="true"]')).toBeVisible();
     await expect(page.locator(CHAT_PANEL)).toBeVisible();
-    // The resolved empty state renders the intro + centered composer (no logo).
+    // The resolved empty state renders only its title and compact composer.
     await expect(
       page.getByTestId('chat-empty-state-centered-composer')
     ).toBeVisible();
     await expect(page.getByTestId('onboarding-empty-intro')).toBeVisible();
     await expect(
       page.getByTestId('onboarding-starter-suggestions')
-    ).toBeVisible();
-    await expect(page.getByTestId('onboarding-sign-in-skip')).toBeVisible();
+    ).toHaveCount(0);
+    await expect(page.getByTestId('onboarding-sign-in-skip')).toHaveCount(0);
     await expect(
       page.getByText(/remember this chat so we can pick up where we left off/i)
-    ).toBeVisible();
+    ).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/signin'
+    );
+    const emptyComposer = page.locator(COMPOSER_TEXTAREA);
+    await expect(emptyComposer).toHaveAttribute(
+      'aria-label',
+      'Chat Message Input'
+    );
+    await emptyComposer.fill('Plan my next release');
+    await expect(emptyComposer).toHaveValue('Plan my next release');
+    await emptyComposer.fill('');
     const mainBox = await page.locator('#main-content').boundingBox();
     const chatBox = await page.locator(CHAT_PANEL).boundingBox();
     expect(mainBox).not.toBeNull();

--- a/apps/web/tests/unit/AuthActions.test.tsx
+++ b/apps/web/tests/unit/AuthActions.test.tsx
@@ -43,6 +43,10 @@ describe('AuthActions', () => {
 
     const logInLink = screen.getByRole('link', { name: /log in/i });
     const container = logInLink.closest('div');
-    expect(container).toHaveClass('flex', 'items-center', 'gap-1');
+    expect(container).toHaveClass(
+      'flex',
+      'items-center',
+      'gap-(--linear-gap-buttons)'
+    );
   });
 });

--- a/apps/web/tests/unit/AuthActions.test.tsx
+++ b/apps/web/tests/unit/AuthActions.test.tsx
@@ -43,10 +43,6 @@ describe('AuthActions', () => {
 
     const logInLink = screen.getByRole('link', { name: /log in/i });
     const container = logInLink.closest('div');
-    expect(container).toHaveClass(
-      'flex',
-      'items-center',
-      'gap-(--linear-gap-buttons)'
-    );
+    expect(container).toHaveClass('flex', 'items-center', 'gap-2');
   });
 });

--- a/apps/web/tests/unit/Header.test.tsx
+++ b/apps/web/tests/unit/Header.test.tsx
@@ -44,7 +44,7 @@ describe('Atomic Design Structure', () => {
       const container = screen.getByRole('link', {
         name: 'Log in',
       }).parentElement;
-      expect(container).toHaveClass('flex', 'items-center', 'gap-1');
+      expect(container).toHaveClass('flex', 'items-center', 'gap-2');
     });
   });
 

--- a/apps/web/tests/unit/HeaderNavFlyout.test.tsx
+++ b/apps/web/tests/unit/HeaderNavFlyout.test.tsx
@@ -36,10 +36,9 @@ describe('HeaderNav flyout interactions', () => {
   it('renders static public auth actions without client auth state', () => {
     render(<HeaderNav authMode='public-static' />);
 
-    expect(screen.getByRole('link', { name: 'Log in' })).toHaveAttribute(
-      'href',
-      '/signin'
-    );
+    const loginLink = screen.getByRole('link', { name: 'Log in' });
+    expect(loginLink).toHaveAttribute('href', '/signin');
+    expect(loginLink.parentElement).toHaveClass('gap-(--linear-gap-buttons)');
     // Default public CTA (no publicCtaLabel override) remains Request Access.
     // Homepage MarketingHeader passes its own "Get started" label separately.
     expect(

--- a/apps/web/tests/unit/HeaderNavFlyout.test.tsx
+++ b/apps/web/tests/unit/HeaderNavFlyout.test.tsx
@@ -38,7 +38,7 @@ describe('HeaderNav flyout interactions', () => {
 
     const loginLink = screen.getByRole('link', { name: 'Log in' });
     expect(loginLink).toHaveAttribute('href', '/signin');
-    expect(loginLink.parentElement).toHaveClass('gap-(--linear-gap-buttons)');
+    expect(loginLink.parentElement).toHaveClass('gap-2');
     // Default public CTA (no publicCtaLabel override) remains Request Access.
     // Homepage MarketingHeader passes its own "Get started" label separately.
     expect(

--- a/apps/web/tests/unit/home/mounted-home-faq-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-faq-system-b-style-guard.test.ts
@@ -82,6 +82,9 @@ describe('mounted homepage FAQ System B source contract', () => {
     ]) {
       expect(source).toContain(className);
     }
+
+    expect(source).toContain('text-lg font-semibold leading-snug');
+    expect(source).toContain('text-base leading-7 text-secondary-token');
   });
 
   it('keeps mounted FAQ shell CSS tokenized and grid-aligned', () => {

--- a/apps/web/tests/unit/marketing/shared-marketing-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/shared-marketing-system-b-style-guard.test.ts
@@ -47,7 +47,7 @@ describe('shared marketing System B style guard', () => {
     expect(faqSource).not.toContain('marketing-h2-linear');
     expect(faqSource).toContain('system-b-marketing-section-heading');
     expect(accordionSource).not.toContain('style={{ visibility');
-    expect(accordionSource).toContain("'visible mt-1");
+    expect(accordionSource).toContain("'visible mt-2");
     expect(accordionSource).toContain("'invisible mt-0");
   });
 });

--- a/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
@@ -116,10 +116,7 @@ describe('OnboardingChat empty intro', () => {
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
     expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
-    // The absolute header affordance must not consume this in-flow rail space.
-    expect(
-      screen.getByTestId('onboarding-starter-suggestions').parentElement
-    ).toHaveClass('min-h-[7.5rem]');
+    expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
   });
 
   it('shows a compact processing state for a validated starter handoff', () => {
@@ -151,6 +148,6 @@ describe('OnboardingChat empty intro', () => {
     await waitFor(() => {
       expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
     });
-    expect(screen.getByTestId('onboarding-starter-suggestions')).toBeTruthy();
+    expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
   });
 });

--- a/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
@@ -1,91 +1,29 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 import { OnboardingChatEmptyIntro } from '@/components/features/onboarding/OnboardingChatEmptyIntro';
-import {
-  ONBOARDING_ENTRY_SUPPORT,
-  ONBOARDING_ENTRY_TITLE,
-  ONBOARDING_STARTER_SUGGESTIONS,
-} from '@/lib/onboarding/empty-state';
+import { ONBOARDING_ENTRY_TITLE } from '@/lib/onboarding/empty-state';
 
 describe('OnboardingChatEmptyIntro', () => {
-  it('renders concise entry copy, composer, and stable starters', () => {
-    const onSelectSuggestion = vi.fn();
-
-    render(
-      <OnboardingChatEmptyIntro
-        composer={<div data-testid='test-composer' />}
-        mode='blank'
-        onSelectSuggestion={onSelectSuggestion}
-      />
-    );
+  it('renders the compact blank entry with its canonical composer', () => {
+    render(<OnboardingChatEmptyIntro mode='blank' />);
 
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
     expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
-    expect(screen.getByText(ONBOARDING_ENTRY_SUPPORT)).toBeTruthy();
-    expect(screen.getByTestId('test-composer')).toBeTruthy();
-    expect(screen.getByTestId('onboarding-starter-suggestions')).toBeTruthy();
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
-    expect(
-      screen.getByTestId('onboarding-starter-suggestions').parentElement
-    ).toHaveClass('min-h-[7.5rem]');
-
-    for (const suggestion of ONBOARDING_STARTER_SUGGESTIONS) {
-      expect(
-        screen.getByRole('button', { name: suggestion.label })
-      ).toBeTruthy();
-    }
-  });
-
-  it('submits the selected starter prompt', () => {
-    const onSelectSuggestion = vi.fn();
-    const [firstSuggestion] = ONBOARDING_STARTER_SUGGESTIONS;
-
-    render(
-      <OnboardingChatEmptyIntro
-        composer={<div />}
-        mode='blank'
-        onSelectSuggestion={onSelectSuggestion}
-      />
-    );
-
-    fireEvent.click(
-      screen.getByRole('button', { name: firstSuggestion.label })
-    );
-
-    expect(onSelectSuggestion).toHaveBeenCalledWith(firstSuggestion.prompt);
-  });
-
-  it('dims suggestions while the slash picker is open', () => {
-    const { container } = render(
-      <OnboardingChatEmptyIntro
-        composer={<div />}
-        mode='blank'
-        onSelectSuggestion={vi.fn()}
-        dimmed
-      />
-    );
-
-    const suggestions = container.querySelector(
-      '[data-testid="onboarding-starter-suggestions"]'
-    );
-    expect(suggestions?.className).toContain('opacity-0');
-    expect(suggestions?.getAttribute('inert')).not.toBeNull();
+    expect(screen.queryByText('Find My Spotify Artist')).toBeNull();
+    expect(screen.queryByText('Plan a Release')).toBeNull();
+    expect(screen.queryByText('Build Artist Profile')).toBeNull();
+    expect(screen.queryByText('Set Up My Link Page')).toBeNull();
+    expect(screen.queryByText('Jovie')).toBeNull();
   });
 
   it('replaces blank controls with one stable handoff status', () => {
-    render(
-      <OnboardingChatEmptyIntro
-        composer={<div data-testid='test-composer' />}
-        mode='spotify_handoff'
-        onSelectSuggestion={vi.fn()}
-      />
-    );
+    render(<OnboardingChatEmptyIntro mode='spotify_handoff' />);
 
     expect(screen.getByText('Getting Your Artist Ready')).toBeTruthy();
     expect(screen.getByRole('status')).toHaveTextContent(
       'Preparing your first message'
     );
-    expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
   });
 });

--- a/apps/web/tests/unit/onboarding/OnboardingShell.sign-in-placement.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingShell.sign-in-placement.test.tsx
@@ -42,19 +42,11 @@ describe('onboarding sign-in placement', () => {
     );
   });
 
-  it('removes the centered duplicate without changing the starter rail reservation', () => {
-    render(
-      <OnboardingChatEmptyIntro
-        composer={<div>Composer</div>}
-        mode='blank'
-        onSelectSuggestion={vi.fn()}
-      />
-    );
+  it('removes the centered duplicate and starter rail from the blank entry', () => {
+    render(<OnboardingChatEmptyIntro mode='blank' />);
 
     expect(screen.queryByText('Already have an account?')).toBeNull();
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
-    expect(
-      screen.getByTestId('onboarding-starter-suggestions').parentElement
-    ).toHaveClass('min-h-[7.5rem]');
+    expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
   });
 });


### PR DESCRIPTION
## Scope
- align the Start empty state with the canonical app chat composition
- use the shared public action gap and quiet sign-in treatment
- improve the shared marketing FAQ question and answer hierarchy
- add focused unit, source-contract, E2E, and Storybook evidence

## Verification
- independent layer pre-push gate passed
- component ship gate, lint, typecheck, and 87 affected tests passed
- managed Playwright Start checks passed at desktop and true narrow viewport

## Stack
- depends on PR #15627
- homepage visual layer follows this PR

<!-- linear-issue-id: 485c079c-ece9-44ed-8bad-f20cb5f192e4 -->