### PR TITLE
feat(web): ship founder-approved homepage pass (JOV-4882)

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -2088,10 +2088,9 @@ body:has(.home-viewport)::-webkit-scrollbar {
   inset: 0;
 }
 
-/* The named view timeline feeds the proof-strip scroll animations
-   (homepage-proof-logos-parallax on the logo grid, homepage-proof-stack-rise
-   on the story stack) consumed by tests/e2e/homepage.spec.ts. Everything
-   else visual for this shell lives in the System B trust strip block. */
+/* The trust strip view timeline fades the logo grid while the Meet Jovie
+   panel uses its own view timeline to glide across it. Both are verified in
+   tests/e2e/homepage.spec.ts. */
 .homepage-trust-section {
   view-timeline-axis: block;
   view-timeline-name: --homepage-proof-strip;
@@ -2165,14 +2164,14 @@ body:has(.home-viewport)::-webkit-scrollbar {
 @supports (animation-timeline: view()) {
   .homepage-trust-logo-grid {
     animation: homepage-proof-logos-parallax linear both;
-    animation-range: cover 18% exit 96%;
+    animation-range: cover 60% exit 96%;
     animation-timeline: --homepage-proof-strip;
   }
 
-  .homepage-story-stack--proof-transition {
-    animation: homepage-proof-stack-rise linear both;
-    animation-range: cover 44% exit 100%;
-    animation-timeline: --homepage-proof-strip;
+  .homepage-meet-jovie {
+    animation: homepage-meet-jovie-panel-glide linear both;
+    animation-range: entry 0% cover 100%;
+    animation-timeline: view();
   }
 }
 
@@ -2183,25 +2182,27 @@ body:has(.home-viewport)::-webkit-scrollbar {
   }
 
   to {
-    opacity: 0.82;
-    transform: translate3d(0, -0.82rem, 0) scale(0.996);
+    opacity: 0.18;
+    transform: translate3d(0, calc(var(--space-4) * -1), 0) scale(0.99);
   }
 }
 
-@keyframes homepage-proof-stack-rise {
+@keyframes homepage-meet-jovie-panel-glide {
   from {
-    transform: translate3d(0, 6.4rem, 0);
+    transform: translate3d(0, 0, 0);
   }
 
   to {
-    transform: translate3d(0, -0.45rem, 0);
+    transform: translate3d(0, calc(var(--space-16) * -1), 0);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .homepage-trust-logo-grid,
-  .homepage-story-stack--proof-transition {
+  .homepage-story-stack--proof-transition,
+  .homepage-meet-jovie {
     animation: none;
+    opacity: 1;
     transform: none;
   }
 }
@@ -3831,7 +3832,20 @@ body:has(.home-viewport)::-webkit-scrollbar {
   font-family: var(--font-sans);
 }
 
+.homepage-closed-loop-section::before {
+  position: absolute;
+  inset: 12% -8% 18% 24%;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklab, var(--system-b-accent-cyan) 12%, transparent);
+  content: "";
+  filter: blur(110px);
+  opacity: 0.42;
+  pointer-events: none;
+}
+
 .homepage-closed-loop-inner {
+  position: relative;
+  z-index: 1;
   display: grid;
   width: min(
     var(--ds-public-content-max),
@@ -4067,9 +4081,16 @@ body:has(.home-viewport)::-webkit-scrollbar {
 /* HOMEPAGE MEET JOVIE SYSTEM B START */
 .homepage-meet-jovie {
   position: relative;
+  z-index: 1;
   overflow: clip;
   padding-block: clamp(var(--space-16), 6vw, var(--space-24));
-  background: var(--system-b-bg-page);
+  border-top: var(--space-px) solid var(--homepage-chapter-rule);
+  border-radius: var(--radius-2xl) var(--radius-2xl) 0 0;
+  background: linear-gradient(
+    180deg,
+    var(--system-b-bg-surface-0) 0%,
+    var(--system-b-bg-page) 100%
+  );
   color: var(--system-b-text-primary);
   font-family: var(--font-sans);
 }
@@ -4080,15 +4101,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
     calc(100% - var(--homepage-page-gutter) * 2)
   );
   margin-inline: auto;
-}
-
-.homepage-meet-jovie__eyebrow {
-  margin: 0 0 var(--space-4);
-  color: var(--system-b-accent-cyan);
-  font-size: var(--ds-marketing-eyebrow-size);
-  font-weight: var(--ds-marketing-eyebrow-weight);
-  line-height: var(--ds-marketing-eyebrow-leading);
-  letter-spacing: var(--ds-marketing-eyebrow-tracking);
 }
 
 .homepage-meet-jovie__heading {
@@ -4105,16 +4117,12 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-meet-jovie__heading-primary,
-.homepage-meet-jovie__intro {
-  display: inline;
+.homepage-meet-jovie__heading-secondary {
+  display: block;
 }
 
-.homepage-meet-jovie__intro {
+.homepage-meet-jovie__heading-secondary {
   color: var(--color-text-tertiary-token);
-  font-size: var(--homepage-section-copy-size);
-  font-weight: var(--font-weight-normal);
-  line-height: var(--leading-relaxed);
-  text-wrap: pretty;
 }
 
 /* HOMEPAGE MEET JOVIE SYSTEM B END */
@@ -4130,19 +4138,24 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-artist-profiles__header {
-  display: grid;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-6);
   width: min(
     var(--ds-public-content-max),
     calc(100% - var(--homepage-page-gutter) * 2)
   );
   margin-inline: auto;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  align-items: end;
-  column-gap: clamp(var(--space-4), 2vw, var(--space-6));
+}
+
+.homepage-artist-profiles__lockup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .homepage-artist-profiles__heading {
-  grid-column: 1 / span 5;
   margin: 0;
   color: var(--color-text-primary-token);
   font-family:
@@ -4155,17 +4168,22 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-artist-profiles__intro {
-  grid-column: 7 / -1;
-  max-width: 42ch;
-  margin: 0;
+  margin: var(--space-1) 0 0;
   color: var(--color-text-tertiary-token);
-  font-size: var(--homepage-section-copy-size);
-  font-weight: var(--font-weight-normal);
-  line-height: var(--leading-relaxed);
-  text-wrap: pretty;
+  font-family:
+    var(--font-satoshi), "Satoshi", -apple-system, "system-ui", sans-serif;
+  font-size: var(--homepage-section-title-size);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--ds-marketing-title-leading);
+  letter-spacing: var(--ds-marketing-title-tracking);
+  text-wrap: balance;
 }
 
-.homepage-artist-profiles__row {
+.homepage-artist-profiles__action {
+  flex: none;
+}
+
+.homepage-artist-profiles__carousel {
   width: min(
     var(--ds-public-content-max),
     calc(100% - var(--homepage-page-gutter) * 2)
@@ -4173,50 +4191,107 @@ body:has(.home-viewport)::-webkit-scrollbar {
   margin: var(--space-16) auto 0;
 }
 
-.homepage-artist-profiles__track {
+.homepage-artist-profiles__carousel-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.homepage-artist-profiles__carousel-controls button {
   display: grid;
+  width: calc(var(--space-10) + var(--space-1));
+  height: calc(var(--space-10) + var(--space-1));
+  place-items: center;
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-primary-token);
+  transition:
+    background-color var(--ds-motion-subtle-duration)
+    var(--ds-motion-subtle-easing),
+    color var(--ds-motion-subtle-duration) var(--ds-motion-subtle-easing);
+}
+
+@media (hover: hover) {
+  .homepage-artist-profiles__carousel-controls button:not(:disabled):hover {
+    background: var(--system-b-bg-surface-1);
+    color: var(--system-b-text-primary);
+  }
+}
+
+.homepage-artist-profiles__carousel-controls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.homepage-artist-profiles__carousel-controls button:focus-visible {
+  outline: var(--space-px) solid var(--system-b-text-primary);
+  outline-offset: var(--space-1);
+}
+
+.homepage-artist-profiles__row {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+
+.homepage-artist-profiles__row::-webkit-scrollbar {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .homepage-artist-profiles__row {
+    scroll-behavior: auto;
+  }
+}
+
+.homepage-artist-profiles__track {
+  --homepage-artist-profiles-card-gap: clamp(
+    var(--space-4),
+    2vw,
+    var(--space-6)
+  );
+
+  display: flex;
   margin: 0;
   padding: 0;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(var(--space-4), 2vw, var(--space-6));
+  gap: var(--homepage-artist-profiles-card-gap);
   list-style: none;
 }
 
 .homepage-artist-profiles__card {
-  width: 100%;
+  flex: 0 0 calc((100% - var(--homepage-artist-profiles-card-gap) * 2) / 3);
+  scroll-snap-align: start;
 }
 
 @media (max-width: 900px) {
   .homepage-artist-profiles__header {
-    grid-template-columns: minmax(0, 1fr);
-    gap: var(--space-6);
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  .homepage-artist-profiles__heading,
-  .homepage-artist-profiles__intro {
-    grid-column: 1;
-  }
-
-  .homepage-artist-profiles__track {
-    grid-template-columns: minmax(0, 1fr);
-    gap: var(--space-5);
-  }
-
-  .homepage-artist-profiles__row {
+  .homepage-artist-profiles__carousel {
     margin-top: var(--space-10);
+  }
+
+  .homepage-artist-profiles__card {
+    flex-basis: 100%;
   }
 }
 /* HOMEPAGE ARTIST PROFILES SYSTEM B END */
 
 /* HOMEPAGE ARTIST OUTCOMES SYSTEM B START */
 .homepage-artist-outcome {
-  --homepage-artist-outcome-copy-track: 30fr;
-  --homepage-artist-outcome-media-track: 70fr;
+  --homepage-artist-outcome-copy-track: 1fr;
+  --homepage-artist-outcome-media-track: 2fr;
 
   position: relative;
   display: grid;
   min-width: 0;
-  aspect-ratio: 0.76;
+  aspect-ratio: 9 / 16;
   overflow: hidden;
   border-radius: var(--radius-2xl);
   background: var(--system-b-primary-bg);
@@ -4273,13 +4348,34 @@ body:has(.home-viewport)::-webkit-scrollbar {
   padding: var(--space-2);
 }
 
+/* The shared Artist Profiles frame includes an editorial surface treatment.
+   Homepage outcome cards are product proof, so keep this instance neutral. */
+.homepage-artist-outcome .homepage-artist-outcome__device.ap-phone-frame {
+  border-color: var(--system-b-app-frame-seam);
+  background: var(--system-b-bg-surface-0);
+  box-shadow: none;
+}
+
+.homepage-artist-outcome
+  .homepage-artist-outcome__device
+  .ap-phone-frame__overlay {
+  background: none;
+}
+
+.homepage-artist-outcome
+  .homepage-artist-outcome__device
+  .ap-phone-frame__notch {
+  background: var(--system-b-cinematic-black);
+  box-shadow: none;
+}
+
 .homepage-artist-outcome__screen {
   display: block;
   width: 100%;
   max-width: none;
   height: 100%;
   border-radius: 0;
-  object-fit: cover;
+  object-fit: contain;
   object-position: center top;
 }
 
@@ -4619,10 +4715,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 @media (max-width: 767px) {
-  .homepage-artist-outcome__media {
-    aspect-ratio: 0.86;
-  }
-
   .homepage-artist-outcome__caption {
     padding: var(--space-5);
   }
@@ -4708,12 +4800,26 @@ body:has(.home-viewport)::-webkit-scrollbar {
   box-shadow: none;
 }
 
+.homepage-story-stack--proof-transition {
+  margin-top: calc(var(--space-8) * -1);
+  overflow: visible;
+  background: transparent;
+}
+
 .homepage-story-stack--proof-transition::before {
   display: none;
 }
 
 .homepage-story-stack > * + * {
   border-top: var(--space-px) solid var(--homepage-chapter-rule);
+}
+
+.homepage-story-stack > .homepage-artist-profiles {
+  border-top: 0;
+}
+
+.homepage-story-stack > .homepage-closed-loop-section {
+  border-top: 0;
 }
 
 .homepage-opportunity-section,
@@ -5108,11 +5214,13 @@ body:has(.home-viewport)::-webkit-scrollbar {
 /* HOMEPAGE FAQ SYSTEM B END */
 
 .system-b-mounted-home-footer-cta {
-  min-height: calc(var(--space-24) * 3.5);
+  min-height: calc(var(--space-24) * 4);
+  margin-top: var(--space-12);
 }
 
 .system-b-mounted-home-footer-cta-copy {
-  padding-block: var(--homepage-chapter-space);
+  padding-top: calc(var(--homepage-chapter-space) + var(--space-16));
+  padding-bottom: calc(var(--homepage-chapter-space) + var(--space-12));
 }
 
 @media (min-width: 768px) and (max-width: 1199px) {
@@ -5209,7 +5317,12 @@ body:has(.home-viewport)::-webkit-scrollbar {
   }
 
   .system-b-mounted-home-footer-cta {
-    min-height: calc(var(--space-24) * 2.75);
+    min-height: calc(var(--space-24) * 3.25);
+    margin-top: var(--space-8);
+  }
+
+  .homepage-story-stack--proof-transition {
+    margin-top: calc(var(--space-6) * -1);
   }
 }
 

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -6,13 +6,15 @@ import {
   HomepageArtistProfiles,
 } from '@/components/homepage/HomepageArtistProfiles';
 import { HomepageClosedLoop } from '@/components/homepage/HomepageClosedLoop';
-import { HomepageElectricSeam } from '@/components/homepage/HomepageElectricSeam';
 import { HomepageHeroCommandCenter } from '@/components/homepage/HomepageHeroCommandCenter';
 import { HomepageMeetJovie } from '@/components/homepage/HomepageMeetJovie';
-import { HomepagePosterHero } from '@/components/homepage/HomepagePosterHero';
 import { HomepageTrackedLink } from '@/components/homepage/HomepageTrackedLink';
 import { HERO_COPY } from '@/components/homepage/intent';
-import { FaqSection } from '@/components/marketing';
+import {
+  FaqSection,
+  MarketingElectricSeam,
+  MarketingPosterHero,
+} from '@/components/marketing';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import { HOMEPAGE_LAUNCH_COPY } from '@/data/homepageLaunchCopy';
 import {
@@ -49,10 +51,10 @@ const HERO_PRODUCT_IMAGES = {
 };
 const ARTIST_OUTCOME_CARDS = [
   {
-    id: 'drive-streams',
-    title: 'Drive Streams',
-    body: 'Put the latest release, pre-save, or countdown at the front of the profile.',
-    image: getMarketingExportImage('tim-white-profile-listen-mobile'),
+    id: 'sell-out',
+    title: 'Sell Out',
+    body: 'Put your next show or tour date where fans can get tickets.',
+    image: getMarketingExportImage('tim-white-profile-tour-mobile'),
   },
   {
     id: 'capture-fans',
@@ -65,6 +67,12 @@ const ARTIST_OUTCOME_CARDS = [
     title: 'Get Paid',
     body: 'Make direct support feel native to the artist profile.',
     image: getMarketingExportImage('tim-white-profile-pay-mobile'),
+  },
+  {
+    id: 'drop-music',
+    title: 'Drop Music',
+    body: 'Give fans one link for the release before it lands.',
+    image: getMarketingExportImage('tim-white-profile-presave-mobile'),
   },
 ] as const satisfies HomepageArtistProfileCards;
 
@@ -195,7 +203,7 @@ const FAQ_SCHEMA = buildFaqSchema([...HOMEPAGE_LAUNCH_COPY.faq]);
 function HomepageHero() {
   return (
     <>
-      <HomepagePosterHero
+      <MarketingPosterHero
         headingId='home-hero-heading'
         headline={HERO_COPY.headline}
         subtitle={HERO_COPY.subhead}
@@ -220,7 +228,7 @@ function HomepageHero() {
           },
         }}
         seam={
-          <HomepageElectricSeam
+          <MarketingElectricSeam
             idSeed='homepage-hero-electric-seam'
             className='homepage-poster-hero__electric-seam'
           />

--- a/apps/web/components/homepage/HomepageArtistProfiles.tsx
+++ b/apps/web/components/homepage/HomepageArtistProfiles.tsx
@@ -1,3 +1,6 @@
+import { Button } from '@jovie/ui';
+import Link from 'next/link';
+import { APP_ROUTES } from '@/constants/routes';
 import { ArtistProfileCardRow } from './MeetJovieCarousel';
 
 export type HomepageArtistProfileCardImage = {
@@ -9,8 +12,8 @@ export type HomepageArtistProfileCardImage = {
 
 export type HomepageArtistProfileCard =
   | {
-      readonly id: 'drive-streams';
-      readonly title: 'Drive Streams';
+      readonly id: 'sell-out';
+      readonly title: 'Sell Out';
       readonly body: string;
       readonly image: HomepageArtistProfileCardImage;
     }
@@ -25,13 +28,15 @@ export type HomepageArtistProfileCard =
       readonly title: 'Get Paid';
       readonly body: string;
       readonly image: HomepageArtistProfileCardImage;
+    }
+  | {
+      readonly id: 'drop-music';
+      readonly title: 'Drop Music';
+      readonly body: string;
+      readonly image: HomepageArtistProfileCardImage;
     };
 
-export type HomepageArtistProfileCards = readonly [
-  Extract<HomepageArtistProfileCard, { readonly id: 'drive-streams' }>,
-  Extract<HomepageArtistProfileCard, { readonly id: 'capture-fans' }>,
-  Extract<HomepageArtistProfileCard, { readonly id: 'get-paid' }>,
-];
+export type HomepageArtistProfileCards = readonly HomepageArtistProfileCard[];
 
 export function HomepageArtistProfiles({
   cards,
@@ -43,17 +48,24 @@ export function HomepageArtistProfiles({
       data-testid='homepage-artist-profiles'
     >
       <div className='homepage-artist-profiles__header'>
-        <h2
-          className='homepage-artist-profiles__heading'
-          data-homepage-section-heading
-          id='homepage-artist-profiles-heading'
+        <div className='homepage-artist-profiles__lockup'>
+          <h2
+            className='homepage-artist-profiles__heading'
+            data-homepage-section-heading
+            id='homepage-artist-profiles-heading'
+          >
+            Artist Profiles
+          </h2>
+          <p className='homepage-artist-profiles__intro'>Built to convert</p>
+        </div>
+        <Button
+          asChild
+          className='homepage-artist-profiles__action'
+          static
+          variant='ghost'
         >
-          Artist Profiles
-        </h2>
-        <p className='homepage-artist-profiles__intro'>
-          One artist presence for the next release, fan capture, and direct
-          support.
-        </p>
+          <Link href={APP_ROUTES.ARTIST_PROFILES}>Explore Artist Profiles</Link>
+        </Button>
       </div>
       <ArtistProfileCardRow cards={cards} />
     </section>

--- a/apps/web/components/homepage/HomepageMeetJovie.tsx
+++ b/apps/web/components/homepage/HomepageMeetJovie.tsx
@@ -6,7 +6,6 @@ export function HomepageMeetJovie() {
       data-testid='homepage-meet-jovie'
     >
       <div className='homepage-meet-jovie__inner'>
-        <p className='homepage-meet-jovie__eyebrow'>Meet Jovie</p>
         <h2
           className='homepage-meet-jovie__heading'
           data-homepage-section-heading
@@ -15,9 +14,9 @@ export function HomepageMeetJovie() {
           {/* ui-casing-allow: marketing display headline (DESIGN.md Text Casing exception) */}
           <span className='homepage-meet-jovie__heading-primary'>
             Jovie is the AI workspace for artists.
-          </span>{' '}
-          <span className='homepage-meet-jovie__intro'>
-            Built around your catalog, audience, and artist presence.
+          </span>
+          <span className='homepage-meet-jovie__heading-secondary'>
+            Built around your artist presence.
           </span>
         </h2>
       </div>

--- a/apps/web/components/homepage/MeetJovieCarousel.tsx
+++ b/apps/web/components/homepage/MeetJovieCarousel.tsx
@@ -1,42 +1,120 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArtistProfilePhoneFrame } from '@/components/marketing/artist-profile/ArtistProfilePhoneFrame';
 import type { HomepageArtistProfileCards } from './HomepageArtistProfiles';
 
 export function ArtistProfileCardRow({
   cards,
 }: Readonly<{ cards: HomepageArtistProfileCards }>) {
+  const railRef = useRef<HTMLDivElement | null>(null);
+  const [scrollState, setScrollState] = useState({
+    canGoPrevious: false,
+    canGoNext: cards.length > 3,
+  });
+
+  const updateScrollState = useCallback(() => {
+    const rail = railRef.current;
+    if (!rail) return;
+    if (rail.clientWidth === 0) return;
+
+    const epsilon = 1;
+    const canGoPrevious = rail.scrollLeft > epsilon;
+    const canGoNext =
+      rail.scrollLeft + rail.clientWidth < rail.scrollWidth - epsilon;
+
+    setScrollState(previous =>
+      previous.canGoPrevious === canGoPrevious &&
+      previous.canGoNext === canGoNext
+        ? previous
+        : { canGoPrevious, canGoNext }
+    );
+  }, []);
+
+  useEffect(() => {
+    updateScrollState();
+    const rail = railRef.current;
+    if (!rail) return;
+
+    const observer = new ResizeObserver(updateScrollState);
+    observer.observe(rail);
+    return () => observer.disconnect();
+  }, [updateScrollState]);
+
+  const scrollRail = useCallback((direction: 'previous' | 'next') => {
+    const rail = railRef.current;
+    if (!rail) return;
+
+    const reducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    rail.scrollBy({
+      left: direction === 'next' ? rail.clientWidth : -rail.clientWidth,
+      behavior: reducedMotion ? 'auto' : 'smooth',
+    });
+  }, []);
+
   return (
-    <div className='homepage-artist-profiles__row'>
-      <ul
-        aria-label='Jovie Artist Profile Outcomes'
-        className='homepage-artist-profiles__track'
+    <div className='homepage-artist-profiles__carousel'>
+      <nav
+        aria-label='Artist Profile Preview Navigation'
+        className='homepage-artist-profiles__carousel-controls'
       >
-        {cards.map(card => (
-          <li
-            className='homepage-artist-outcome homepage-artist-profiles__card'
-            key={card.id}
-          >
-            <div className='homepage-artist-outcome__copy'>
-              <h3>{card.title}</h3>
-              <p>{card.body}</p>
-            </div>
-            <figure className='homepage-artist-outcome__media'>
-              <ArtistProfilePhoneFrame className='homepage-artist-outcome__device'>
-                <Image
-                  alt={card.image.alt}
-                  className='homepage-artist-outcome__screen'
-                  height={card.image.height}
-                  loading='lazy'
-                  quality={100}
-                  sizes='(min-width: 1280px) 13rem, (min-width: 768px) 16vw, 44vw'
-                  src={card.image.publicUrl}
-                  width={card.image.width}
-                />
-              </ArtistProfilePhoneFrame>
-            </figure>
-          </li>
-        ))}
-      </ul>
+        <button
+          aria-label='Previous Artist Profile Preview'
+          disabled={!scrollState.canGoPrevious}
+          onClick={() => scrollRail('previous')}
+          type='button'
+        >
+          <ChevronLeft aria-hidden='true' size={18} strokeWidth={1.9} />
+        </button>
+        <button
+          aria-label='Next Artist Profile Preview'
+          disabled={!scrollState.canGoNext}
+          onClick={() => scrollRail('next')}
+          type='button'
+        >
+          <ChevronRight aria-hidden='true' size={18} strokeWidth={1.9} />
+        </button>
+      </nav>
+      <div
+        className='homepage-artist-profiles__row'
+        onScroll={updateScrollState}
+        ref={railRef}
+      >
+        <ul
+          aria-label='Jovie Artist Profile Outcomes'
+          className='homepage-artist-profiles__track'
+        >
+          {cards.map(card => (
+            <li
+              className='homepage-artist-outcome homepage-artist-profiles__card'
+              key={card.id}
+            >
+              <div className='homepage-artist-outcome__copy'>
+                <h3>{card.title}</h3>
+                <p>{card.body}</p>
+              </div>
+              <figure className='homepage-artist-outcome__media'>
+                <ArtistProfilePhoneFrame className='homepage-artist-outcome__device'>
+                  <Image
+                    alt={card.image.alt}
+                    className='homepage-artist-outcome__screen'
+                    height={card.image.height}
+                    loading='lazy'
+                    quality={100}
+                    sizes='(min-width: 1280px) 13rem, (min-width: 768px) 16vw, 44vw'
+                    src={card.image.publicUrl}
+                    width={card.image.width}
+                  />
+                </ArtistProfilePhoneFrame>
+              </figure>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/homepage/MeetJovieCarousel.tsx
+++ b/apps/web/components/homepage/MeetJovieCarousel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -62,22 +63,26 @@ export function ArtistProfileCardRow({
         aria-label='Artist Profile Preview Navigation'
         className='homepage-artist-profiles__carousel-controls'
       >
-        <button
+        <Button
           aria-label='Previous Artist Profile Preview'
           disabled={!scrollState.canGoPrevious}
           onClick={() => scrollRail('previous')}
+          size='icon'
           type='button'
+          variant='ghost'
         >
           <ChevronLeft aria-hidden='true' size={18} strokeWidth={1.9} />
-        </button>
-        <button
+        </Button>
+        <Button
           aria-label='Next Artist Profile Preview'
           disabled={!scrollState.canGoNext}
           onClick={() => scrollRail('next')}
+          size='icon'
           type='button'
+          variant='ghost'
         >
           <ChevronRight aria-hidden='true' size={18} strokeWidth={1.9} />
-        </button>
+        </Button>
       </nav>
       <div
         className='homepage-artist-profiles__row'

--- a/apps/web/tests/e2e/homepage.spec.ts
+++ b/apps/web/tests/e2e/homepage.spec.ts
@@ -552,6 +552,17 @@ test.describe('Homepage', () => {
     await expect.poll(() => previous.isDisabled()).toBe(true);
     await expect.poll(() => next.isEnabled()).toBe(true);
     await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await expect
+      .poll(async () => {
+        const state = await proofState();
+        return Boolean(
+          state &&
+            state.opacity < 1 &&
+            !identityTransforms.includes(state.logoTransform) &&
+            !identityTransforms.includes(state.panelTransform)
+        );
+      })
+      .toBe(true);
     const duringTransition = await proofState();
     expect(duringTransition?.opacity ?? 1).toBeLessThan(1);
     expect(duringTransition?.opacity ?? 0).toBeGreaterThanOrEqual(0.18);

--- a/apps/web/tests/e2e/homepage.spec.ts
+++ b/apps/web/tests/e2e/homepage.spec.ts
@@ -288,12 +288,14 @@ test.describe('Homepage', () => {
     );
     const opportunity = page.getByTestId('homepage-opportunity-section');
     const workspace = page.getByTestId('homepage-workspace-section');
-    const outcomes = page.getByTestId('homepage-meet-jovie');
+    const meetJovie = page.getByTestId('homepage-meet-jovie');
+    const artistProfiles = page.getByTestId('homepage-artist-profiles');
     const closedLoop = page.getByTestId('homepage-closed-loop');
 
     await expect(opportunity).toBeVisible();
     await expect(workspace).toBeVisible();
-    await expect(outcomes).toBeVisible();
+    await expect(meetJovie).toBeVisible();
+    await expect(artistProfiles).toBeVisible();
     await expect(closedLoop).toBeVisible();
     const proofParallaxAnimation = await page.evaluate(() => {
       const supportsScrollTimeline = CSS.supports('animation-timeline: view()');
@@ -355,24 +357,31 @@ test.describe('Homepage', () => {
       0
     );
     await expect(
-      outcomes.getByRole('heading', { name: 'Meet Jovie' })
+      meetJovie.getByRole('heading', {
+        name: 'Jovie is the AI workspace for artists. Built around your artist presence.',
+      })
     ).toBeVisible();
-    for (const outcome of ['Drive Streams', 'Capture Fans', 'Get Paid']) {
+    for (const outcome of [
+      'Sell Out',
+      'Capture Fans',
+      'Get Paid',
+      'Drop Music',
+    ]) {
       await expect(
-        outcomes.getByRole('heading', { name: outcome })
+        artistProfiles.getByRole('heading', { name: outcome })
       ).toBeVisible();
     }
-    await outcomes.scrollIntoViewIfNeeded();
+    await artistProfiles.scrollIntoViewIfNeeded();
     await page.waitForFunction(() => {
       const section = document.querySelector(
-        '[data-testid="homepage-meet-jovie"]'
+        '[data-testid="homepage-artist-profiles"]'
       );
       if (!section) return false;
       return Array.from(
         section.querySelectorAll<HTMLImageElement>('img')
       ).every(img => img.complete && img.naturalWidth > 0);
     });
-    const profileImageQuality = await outcomes
+    const profileImageQuality = await artistProfiles
       .locator('img')
       .evaluateAll(images =>
         images.map(img => {
@@ -437,6 +446,26 @@ test.describe('Homepage', () => {
     page,
     browserName,
   }) => {
+    const proofState = () =>
+      page.evaluate(() => {
+        const logos = document.querySelector('.homepage-trust-logo-grid');
+        const panel = document.querySelector(
+          '[data-testid="homepage-meet-jovie"]'
+        );
+        if (!(logos instanceof HTMLElement) || !(panel instanceof HTMLElement))
+          return null;
+        const logoStyle = getComputedStyle(logos);
+        return {
+          opacity: Number.parseFloat(logoStyle.opacity),
+          logoTransform: logoStyle.transform,
+          panelTransform: getComputedStyle(panel).transform,
+        };
+      });
+    const identityTransforms = ['none', 'matrix(1, 0, 0, 1, 0, 0)'];
+    const atRest = await proofState();
+    expect(atRest?.opacity).toBe(1);
+    expect(identityTransforms).toContain(atRest?.logoTransform);
+
     if (browserName === 'chromium') {
       await page.evaluate(() => {
         const target = window as Window & { __homepageCls?: number };
@@ -476,8 +505,58 @@ test.describe('Homepage', () => {
     await profiles.scrollIntoViewIfNeeded();
     await expect(
       profiles.locator('.homepage-artist-outcome__device')
-    ).toHaveCount(3);
-    await expect(profiles.locator('img')).toHaveCount(3);
+    ).toHaveCount(4);
+    await expect(profiles.locator('img')).toHaveCount(4);
+    const profileRailGeometry = await profiles.evaluate(section => {
+      const rail = section.querySelector('.homepage-artist-profiles__row');
+      const cards = [
+        ...section.querySelectorAll<HTMLElement>(
+          '.homepage-artist-profiles__card'
+        ),
+      ];
+      if (!(rail instanceof HTMLElement) || cards.length !== 4) return null;
+
+      const railRect = rail.getBoundingClientRect();
+      const cardRects = cards.map(card => card.getBoundingClientRect());
+      return {
+        fullyVisible: cardRects.filter(
+          rect =>
+            rect.left >= railRect.left - 1 && rect.right <= railRect.right + 1
+        ).length,
+        fourthStartsPastRail: cardRects[3].left >= railRect.right,
+      };
+    });
+    expect(profileRailGeometry).toEqual({
+      fullyVisible: 3,
+      fourthStartsPastRail: true,
+    });
+    const previous = profiles.getByRole('button', {
+      name: 'Previous Artist Profile Preview',
+    });
+    const next = profiles.getByRole('button', {
+      name: 'Next Artist Profile Preview',
+    });
+    await expect(previous).toBeDisabled();
+    await expect(next).toBeEnabled();
+    await next.click();
+    await expect.poll(() => previous.isEnabled()).toBe(true);
+    await expect.poll(() => next.isDisabled()).toBe(true);
+    await previous.click();
+    await expect.poll(() => previous.isDisabled()).toBe(true);
+    await expect.poll(() => next.isEnabled()).toBe(true);
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await next.click();
+    await expect.poll(() => previous.isEnabled()).toBe(true);
+    await expect.poll(() => next.isDisabled()).toBe(true);
+    await previous.click();
+    await expect.poll(() => previous.isDisabled()).toBe(true);
+    await expect.poll(() => next.isEnabled()).toBe(true);
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    const duringTransition = await proofState();
+    expect(duringTransition?.opacity ?? 1).toBeLessThan(1);
+    expect(duringTransition?.opacity ?? 0).toBeGreaterThanOrEqual(0.18);
+    expect(identityTransforms).not.toContain(duringTransition?.logoTransform);
+    expect(identityTransforms).not.toContain(duringTransition?.panelTransform);
     await expect(
       page.getByTestId('homepage-closed-loop').getByRole('heading', {
         name: 'All your music working while you sleep',
@@ -497,22 +576,43 @@ test.describe('Homepage', () => {
     ] as const) {
       await page.setViewportSize({ width, height });
       await page.evaluate(() => document.fonts.ready);
-      const lines = await page
+      const headingLines = await page
         .locator(
           '.homepage-poster-hero__headline, [data-homepage-section-heading]'
         )
         .evaluateAll(headings =>
           headings.map(heading => {
             const style = getComputedStyle(heading);
-            return Math.ceil(
-              heading.getBoundingClientRect().height /
-                Number.parseFloat(style.lineHeight) -
-                0.05
-            );
+            return {
+              isMeetJovie: heading.classList.contains(
+                'homepage-meet-jovie__heading'
+              ),
+              lines: Math.ceil(
+                heading.getBoundingClientRect().height /
+                  Number.parseFloat(style.lineHeight) -
+                  0.05
+              ),
+            };
           })
         );
-      expect(Math.max(...lines)).toBeLessThanOrEqual(2);
+      expect(
+        Math.max(
+          ...headingLines
+            .filter(heading => !heading.isMeetJovie)
+            .map(heading => heading.lines)
+        )
+      ).toBeLessThanOrEqual(2);
+      expect(
+        headingLines.find(heading => heading.isMeetJovie)?.lines
+      ).toBeLessThanOrEqual(width >= 768 ? 2 : 4);
     }
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await gotoHomepage(page);
+    await profiles.scrollIntoViewIfNeeded();
+    const reduced = await proofState();
+    expect(reduced?.opacity).toBe(1);
+    expect(reduced?.logoTransform).toBe('none');
+    expect(reduced?.panelTransform).toBe('none');
   });
 
   test('mobile keeps hero and product proof inside the viewport with direct auth CTAs', async ({

--- a/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
+++ b/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
@@ -8,9 +8,9 @@ import { HomepageMeetJovie } from '@/components/homepage/HomepageMeetJovie';
 
 const CARDS: HomepageArtistProfileCards = [
   {
-    id: 'drive-streams',
-    title: 'Drive Streams',
-    body: 'Put the latest release first.',
+    id: 'sell-out',
+    title: 'Sell Out',
+    body: 'Put your next show where fans can get tickets.',
     image: {
       publicUrl: '/artist-streams.png',
       width: 660,
@@ -40,6 +40,17 @@ const CARDS: HomepageArtistProfileCards = [
       alt: 'Jovie artist profile focused on artist payments',
     },
   },
+  {
+    id: 'drop-music',
+    title: 'Drop Music',
+    body: 'Give fans one link for the release before it lands.',
+    image: {
+      publicUrl: '/artist-presave.png',
+      width: 660,
+      height: 1368,
+      alt: 'Jovie artist profile focused on an upcoming release',
+    },
+  },
 ];
 
 describe('HomepageMeetJovie', () => {
@@ -49,17 +60,16 @@ describe('HomepageMeetJovie', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: 'Jovie is the AI workspace for artists. Built around your catalog, audience, and artist presence.',
+        name: 'Jovie is the AI workspace for artists. Built around your artist presence.',
       })
     ).toBeInTheDocument();
-    expect(screen.getByText('Meet Jovie')).toHaveClass(
-      'homepage-meet-jovie__eyebrow'
-    );
     expect(
-      screen.getByText(
-        'Built around your catalog, audience, and artist presence.'
-      )
-    ).toBeInTheDocument();
+      screen.getByText('Jovie is the AI workspace for artists.')
+    ).toHaveClass('homepage-meet-jovie__heading-primary');
+    expect(screen.getByText('Built around your artist presence.')).toHaveClass(
+      'homepage-meet-jovie__heading-secondary'
+    );
+    expect(screen.queryByText('Meet Jovie')).not.toBeInTheDocument();
     expect(container.querySelectorAll('img, ul, button')).toHaveLength(0);
   });
 });
@@ -71,12 +81,20 @@ describe('HomepageArtistProfiles', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: 'Artist Profiles' })
     ).toBeInTheDocument();
+    expect(screen.getByText('Built to convert')).toHaveClass(
+      'homepage-artist-profiles__intro'
+    );
     expect(
       screen.getByRole('list', { name: 'Jovie Artist Profile Outcomes' })
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getAllByRole('listitem')).toHaveLength(4);
 
-    for (const title of ['Drive Streams', 'Capture Fans', 'Get Paid']) {
+    for (const title of [
+      'Sell Out',
+      'Capture Fans',
+      'Get Paid',
+      'Drop Music',
+    ]) {
       expect(
         screen.getByRole('heading', { level: 3, name: title })
       ).toBeInTheDocument();
@@ -87,13 +105,24 @@ describe('HomepageArtistProfiles', () => {
     }
   });
 
-  it('preserves registry-backed image geometry without carousel controls', () => {
+  it('preserves registry-backed image geometry with accessible carousel controls', () => {
     render(<HomepageArtistProfiles cards={CARDS} />);
 
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Explore Artist Profiles' })
+    ).toHaveAttribute('href', '/artist-profiles');
+    expect(
+      screen.getByRole('link', { name: 'Explore Artist Profiles' })
+    ).not.toHaveClass('bg-white');
 
     const images = screen.getAllByRole('img');
-    expect(images).toHaveLength(3);
+    expect(images).toHaveLength(4);
+    expect(
+      screen.getByRole('button', { name: 'Previous Artist Profile Preview' })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Next Artist Profile Preview' })
+    ).toBeEnabled();
 
     for (const [index, card] of CARDS.entries()) {
       expect(images[index].getAttribute('src')).toContain(

--- a/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
+++ b/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
@@ -117,12 +117,19 @@ describe('HomepageArtistProfiles', () => {
 
     const images = screen.getAllByRole('img');
     expect(images).toHaveLength(4);
-    expect(
-      screen.getByRole('button', { name: 'Previous Artist Profile Preview' })
-    ).toBeDisabled();
-    expect(
-      screen.getByRole('button', { name: 'Next Artist Profile Preview' })
-    ).toBeEnabled();
+    const previous = screen.getByRole('button', {
+      name: 'Previous Artist Profile Preview',
+    });
+    const next = screen.getByRole('button', {
+      name: 'Next Artist Profile Preview',
+    });
+
+    expect(previous).toBeDisabled();
+    expect(next).toBeEnabled();
+    expect(previous).toHaveAttribute('data-variant', 'ghost');
+    expect(previous).toHaveAttribute('data-size', 'icon');
+    expect(next).toHaveAttribute('data-variant', 'ghost');
+    expect(next).toHaveAttribute('data-size', 'icon');
 
     for (const [index, card] of CARDS.entries()) {
       expect(images[index].getAttribute('src')).toContain(

--- a/apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts
@@ -50,9 +50,9 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
     for (const className of [
       'homepage-meet-jovie',
       'homepage-meet-jovie__inner',
-      'homepage-meet-jovie__eyebrow',
       'homepage-meet-jovie__heading',
-      'homepage-meet-jovie__intro',
+      'homepage-meet-jovie__heading-primary',
+      'homepage-meet-jovie__heading-secondary',
     ]) {
       expect(source).toContain(className);
     }
@@ -117,10 +117,14 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
       'HOMEPAGE MEET JOVIE SYSTEM B'
     );
 
-    for (const pattern of forbiddenCssPatterns) {
+    for (const pattern of forbiddenCssPatterns.filter(
+      pattern => pattern.source !== 'linear-gradient|radial-gradient'
+    )) {
       expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
     }
 
+    expect(css).toContain('background: linear-gradient(');
+    expect(css).toContain('var(--system-b-bg-surface-0)');
     expect(css).toContain('var(--system-b-bg-page)');
     expect(css).toContain('var(--color-text-primary-token)');
     expect(css).toContain('var(--color-text-tertiary-token)');
@@ -129,8 +133,71 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
     expect(css).toContain('var(--homepage-section-title-size)');
     expect(css).toContain('var(--space-');
     expect(css).toContain('var(--font-sans)');
-    expect(css).toContain('font-size: var(--homepage-section-copy-size)');
-    expect(css).toContain('text-wrap: pretty');
+    expect(css).toContain(
+      'border-top: var(--space-px) solid var(--homepage-chapter-rule)'
+    );
+    expect(css).toContain(
+      'border-radius: var(--radius-2xl) var(--radius-2xl) 0 0'
+    );
+    expect(css).toContain('var(--system-b-bg-surface-0)');
+    expect(css).toContain('homepage-meet-jovie__heading-primary');
+    expect(css).toContain('homepage-meet-jovie__heading-secondary');
+    expect(css).toContain('display: block');
+    expect(css).not.toContain('homepage-meet-jovie__eyebrow');
+    expect(css).not.toContain('font-size: var(--homepage-section-copy-size)');
+  });
+
+  it('keeps the proof transition layered, layout-stable, and motion-safe', () => {
+    const source = readFileSync(path.join(webRoot, cssPath), 'utf8');
+
+    expect(source).toContain('homepage-proof-logos-parallax');
+    expect(source).toContain('animation-range: cover 60% exit 96%');
+    expect(source).toContain('opacity: 1');
+    expect(source).toContain('opacity: 0.18');
+    expect(source).toContain(
+      'transform: translate3d(0, calc(var(--space-4) * -1), 0) scale(0.99)'
+    );
+    expect(source).toContain('homepage-meet-jovie-panel-glide');
+    expect(source).toContain('animation-timeline: view()');
+    expect(source).toContain('transform: translate3d(0, 0, 0)');
+    expect(source).toContain(
+      'transform: translate3d(0, calc(var(--space-16) * -1), 0)'
+    );
+    expect(source).toContain(
+      '.homepage-story-stack > .homepage-artist-profiles'
+    );
+    expect(source).toContain('border-top: 0');
+    expect(source).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.homepage-meet-jovie/
+    );
+    expect(source).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?opacity: 1;[\s\S]*?transform: none;/
+    );
+    expect(source).toContain('.homepage-closed-loop-section::before');
+    expect(source).toContain('filter: blur(110px)');
+  });
+
+  it('keeps the Artist Profiles header as a same-scale two-line lockup', () => {
+    const css = extractCssBlock(
+      readFileSync(path.join(webRoot, cssPath), 'utf8'),
+      'HOMEPAGE ARTIST PROFILES SYSTEM B'
+    );
+
+    expect(css).toContain('justify-content: space-between');
+    expect(css).toContain('homepage-artist-profiles__lockup');
+    expect(css).toContain('margin: var(--space-1) 0 0');
+    expect(css).toContain('homepage-artist-profiles__action');
+
+    for (const token of [
+      'var(--homepage-section-title-size)',
+      'var(--font-weight-semibold)',
+      'var(--ds-marketing-title-leading)',
+      'var(--ds-marketing-title-tracking)',
+    ]) {
+      expect(
+        css.match(new RegExp(token.replace(/[()]/g, '\\$&'), 'g'))
+      ).toHaveLength(2);
+    }
   });
 
   it('keeps outcome card CSS tokenized', () => {
@@ -140,7 +207,10 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
     );
 
     for (const pattern of forbiddenCssPatterns) {
-      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+      expect(
+        css.replaceAll('box-shadow: none;', ''),
+        `${cssPath} leaked ${pattern}`
+      ).not.toMatch(pattern);
     }
 
     expect(css).toContain('var(--system-b-app-frame-seam)');
@@ -148,6 +218,17 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
     expect(css).toContain('var(--system-b-primary-bg)');
     expect(css).toContain('var(--space-');
     expect(css).toContain('var(--radius-2xl)');
+    expect(css).toContain('aspect-ratio: 9 / 16');
+    expect(css).toContain('--homepage-artist-outcome-copy-track: 1fr');
+    expect(css).toContain('--homepage-artist-outcome-media-track: 2fr');
+    expect(css).toContain('height: calc(100% - var(--space-4))');
+    expect(css).not.toContain('transform: translateY(33%)');
+    expect(css).toContain('object-fit: contain');
+    expect(css).toContain('background: var(--system-b-bg-surface-0)');
+    expect(css).toContain('box-shadow: none');
+    expect(css).not.toContain('!important');
+    expect(css).toContain('ap-phone-frame__overlay');
+    expect(css).toContain('ap-phone-frame__notch');
     expect(css).toContain('@media (max-width: 767px)');
   });
 });

--- a/apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts
@@ -47,6 +47,16 @@ describe('mounted homepage footer CTA System B source contract', () => {
     expect(homeCss).not.toMatch(
       /--homepage-footer-cta-(top|bottom)|\\.home-viewport \\.marketing-footer-premium > div|homepage-final-cta-rays/
     );
+    expect(homeCss).toContain('min-height: calc(var(--space-24) * 4)');
+    expect(homeCss).toContain('margin-top: var(--space-12)');
+    expect(homeCss).toContain(
+      'padding-top: calc(var(--homepage-chapter-space) + var(--space-16))'
+    );
+    expect(homeCss).toContain(
+      'padding-bottom: calc(var(--homepage-chapter-space) + var(--space-12))'
+    );
+    expect(homeCss).toContain('min-height: calc(var(--space-24) * 3.25)');
+    expect(homeCss).toContain('margin-top: var(--space-8)');
     expect(css).toMatch(
       /(?=.*var\(--system-b-bg-page\))(?=.*var\(--color-text-primary-token\))(?=.*var\(--color-text-tertiary-token\))(?=.*var\(--system-b-app-frame-seam\))(?=.*var\(--homepage-page-gutter\))(?=.*var\(--ds-public-content-max\))(?=.*var\(--text-4xl\))(?=.*var\(--text-xs\))(?=.*var\(--space-)(?=.*\.home-viewport \.system-b-mounted-home-footer)(?=.*@media \(max-width: 767px\))(?=.*letter-spacing: 0;)/s
     );

--- a/apps/web/tests/unit/home/mounted-home-grid-spine-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-grid-spine-system-b-style-guard.test.ts
@@ -68,7 +68,7 @@ describe('mounted homepage grid spine System B source contract', () => {
     const pageSource = readFileSync(path.join(webRoot, pagePath), 'utf8');
 
     for (const mount of [
-      '<HomepagePosterHero',
+      '<MarketingPosterHero',
       '<HomeTrustSection',
       '<HomepageMeetJovie',
       '<HomepageArtistProfiles',

--- a/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
@@ -66,10 +66,10 @@ describe('mounted homepage hero System B source contract', () => {
       ).not.toMatch(pattern);
     }
 
-    // The homepage compatibility wrapper preserves the route API while the
-    // shared marketing primitive owns the stable poster composition.
-    expect(pageSource).toContain('<HomepagePosterHero');
-    expect(pageSource).toContain('<HomepageElectricSeam');
+    // The shared marketing primitive owns the stable composition while each
+    // route retains its own copy, media, analytics, and visual treatment.
+    expect(pageSource).toContain('<MarketingPosterHero');
+    expect(pageSource).toContain('<MarketingElectricSeam');
     expect(pageSource).toContain('homepage-trust-section');
     expect(pageSource).not.toMatch(/statsRow|stats=\{/);
 


### PR DESCRIPTION
## Scope
- ship the approved Home header actions, Meet Jovie panel, restrained midpoint parallax, and integrated trust-wall fade
- show three desktop Artist Profile cards with accessible previous and next controls and real product captures
- tighten the approved final CTA field while increasing its closing-section breathing room
- add the restrained How It Works light leak behind the truthful product surface
- preserve transform and opacity-only motion, zero layout shift, and static reduced-motion composition

## Verification
- exact stacked tree matches the independently reviewed release candidate
- component ship gate, lint, typecheck, Storybook quality, and 92 affected tests passed
- managed Playwright homepage: 12 passed, 2 intentional skips
- managed Playwright Start desktop and true narrow: 3 passed
- independent design and performance review: no findings

## Stack
- depends on PR #15629 and PR #15627
- excludes the active Artist Profiles landing-page hero work

<!-- linear-issue-id: 485c079c-ece9-44ed-8bad-f20cb5f192e4 -->