### PR TITLE
fix(ci): run required checks when draft becomes ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    # Draft synchronizes are intentionally cheap/skipped by the source gate.
-    # Re-run the required contexts when the same head becomes reviewable so it
-    # can enter the native queue without a synthetic close/reopen.
+    # An unchanged head can be synchronized while its PR is still a draft.
+    # Re-run the required contexts when that PR becomes reviewable so it can
+    # enter the native queue without a synthetic close/reopen.
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, 'integration/**']
   # GitHub native merge queue validates the exact synthetic combined head.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   pull_request:
+    # Draft synchronizes are intentionally cheap/skipped by the source gate.
+    # Re-run the required contexts when the same head becomes reviewable so it
+    # can enter the native queue without a synthetic close/reopen.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, 'integration/**']
   # GitHub native merge queue validates the exact synthetic combined head.
   merge_group:

--- a/.github/workflows/fork-pr-gate.yml
+++ b/.github/workflows/fork-pr-gate.yml
@@ -11,7 +11,7 @@
 # reviews if CI passes. This workflow closes that gap with a required status
 # check that only blocks fork PRs.
 #
-# TRIGGER: PR opened/synchronized/reopened + review submitted (to re-evaluate)
+# TRIGGER: PR opened/synchronized/reopened/marked ready + review submitted (to re-evaluate)
 #
 # HOW IT WORKS:
 # 1. Detects if PR is from a fork
@@ -29,14 +29,14 @@ name: Fork PR Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
   # pull_request_target gives the dependabot-gate job access to the Jovie Bot
   # App secrets (regular Actions secrets are hidden from dependabot's
   # pull_request context). The dependabot-gate only sets a status — it does
   # not check out fork code — so this trigger is safe.
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
   # Approval is a review event, not a pull_request synchronize event. This
   # workflow never checks out PR code, so re-evaluating metadata is safe.

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -14,8 +14,9 @@ name: PR Size Guard
 # coverage, and the fixed 2500-line / 60-file cap are fail-closed in
 # pr-size-guard-policy.mjs.
 
-# PR size can only change on a push (opened/synchronize/reopened), never on a
-# label event. This guard is a REQUIRED check, so re-running it on
+# PR size can only change on a source update (opened/synchronize/reopened) or
+# when a draft becomes ready for review, never on a label event. This guard is
+# a REQUIRED check, so re-running it on
 # labeled/unlabeled is not just wasteful: rapid label churn (the autonomous
 # merge loop does this constantly) cancels the in-flight run via
 # cancel-in-progress, leaving a CANCELLED/QUEUED run as the latest for a
@@ -32,7 +33,7 @@ name: PR Size Guard
 # pr-size-guard-label-override.yml posts a passing check-run override.
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Active native-queue required-context producer. Labels and policy inputs can
   # change after a source status turns green, so revalidate every member of the
   # exact synthetic group before reproducing the required context on the head.

--- a/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
+++ b/scripts/lib/__tests__/merge-group-workflow-contract.test.mjs
@@ -115,6 +115,23 @@ describe('merge_group workflow contract', () => {
     expect(CI_WORKFLOW).not.toContain('steps.graphite');
   });
 
+  it('re-emits every required source context when a draft becomes reviewable', () => {
+    const readyForReviewTrigger =
+      'types: [opened, synchronize, reopened, ready_for_review]';
+
+    // A synchronize that occurs while a PR is still a draft cannot be reused
+    // for branch protection. Every source producer must therefore subscribe
+    // to the ready_for_review event on the exact unchanged head.
+    expect(CI_WORKFLOW).toContain(readyForReviewTrigger);
+    expect(SIZE_GUARD_WORKFLOW).toContain(readyForReviewTrigger);
+    expect(FORK_GATE_WORKFLOW).toContain(
+      `pull_request:\n    ${readyForReviewTrigger}`
+    );
+    expect(FORK_GATE_WORKFLOW).toContain(
+      `pull_request_target:\n    ${readyForReviewTrigger}`
+    );
+  });
+
   it('quarantines fixed unit capacity until all named warm receipts exist', () => {
     const route = getJobBlock(CI_WORKFLOW, 'ci-unit-runner-route');
     const units = getJobBlock(CI_WORKFLOW, 'ci-unit-tests');

--- a/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
+++ b/scripts/lib/__tests__/pr-size-guard-label-override.test.mjs
@@ -100,7 +100,9 @@ describe('pr-size-guard workflow invariants (JOV-3580 + label override)', () => 
   it('keeps the primary size guard off labeled events', () => {
     const workflow = readFileSync(SIZE_GUARD_WORKFLOW, 'utf8');
 
-    expect(workflow).toContain('types: [opened, synchronize, reopened]');
+    expect(workflow).toContain(
+      'types: [opened, synchronize, reopened, ready_for_review]'
+    );
     expect(workflow).not.toMatch(/types:\s*\[[^\]]*labeled/);
     expect(workflow).toContain(
       "group: pr-size-${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.number }}"


### PR DESCRIPTION
Closes #15633

## Why
A head synchronized while a PR is a draft did not receive the required source contexts after it moved to ready-for-review, leaving clean work blocked until a close/reopen.

## Change
- subscribe CI, Fork PR Gate, and PR Size Guard to `ready_for_review`
- retain the existing event and concurrency behavior; labels still do not fan out the size guard
- add contract coverage for every required source-context producer

## Verification
- `pnpm exec vitest run --config scripts/vitest.config.mts scripts/lib/__tests__/merge-group-workflow-contract.test.mjs scripts/lib/__tests__/pr-size-guard-label-override.test.mjs` (28 passed)
- `actionlint .github/workflows/ci.yml .github/workflows/fork-pr-gate.yml .github/workflows/pr-size-guard.yml` (existing shellcheck advisories only; exit 0)
- YAML parse and explicit ready-for-review producer assertion passed
- `git diff --check` passed

No browser/server work: this is workflow configuration only.