### PR TITLE
test(web): keep release filter mock compatible with icon buttons

### DIFF
--- a/apps/web/tests/components/release-provider-matrix/ReleaseFilterDropdown.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseFilterDropdown.test.tsx
@@ -54,6 +54,15 @@ vi.mock('@jovie/ui', () => {
       children: React.ReactNode;
       [key: string]: unknown;
     }) => <button {...props}>{children}</button>,
+    IconButton: ({
+      children,
+      asChild: _,
+      ...props
+    }: {
+      children: React.ReactNode;
+      asChild?: boolean;
+      [key: string]: unknown;
+    }) => <button {...props}>{children}</button>,
     DropdownMenu: ({
       children,
       open,
@@ -129,6 +138,12 @@ vi.mock('@jovie/ui', () => {
       children: React.ReactNode;
       [key: string]: unknown;
     }) => <>{children}</>,
+    // Keep the narrow UI mock compatible with the icon-button contract. The
+    // release matrix reaches this module transitively through inline actions.
+    ICON_BUTTON_VISIBLE_CLASSNAME:
+      'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100',
+    ICON_BUTTON_FADE_CLASSNAME:
+      'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
     MENU_ITEM_BASE: 'menu-item-base',
     Slot,
   };


### PR DESCRIPTION
## Summary
- add canonical icon-button contract exports to the narrow `@jovie/ui` mock used by `ReleaseFilterDropdown`
- preserves compatibility before and after #15615; avoids a merge-group-only Vitest failure

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/components/release-provider-matrix/ReleaseFilterDropdown.test.tsx --config=vitest.config.mts` — 14/14 on current main
- same focused command — 14/14 on #15615 exact head `d1195f9aebb09f4bb2d138a44046efb9c06facf5` with this mock update applied
- `pnpm exec biome check apps/web/tests/components/release-provider-matrix/ReleaseFilterDropdown.test.tsx`
- `git diff --check`