### PR TITLE
test(web): keep existing icon-button mocks contract compatible

### DIFF
--- a/apps/web/tests/unit/DrawerHeaderActions.test.tsx
+++ b/apps/web/tests/unit/DrawerHeaderActions.test.tsx
@@ -15,6 +15,15 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
+  IconButton: ({
+    children,
+    asChild: _,
+    ...props
+  }: ComponentProps<'button'> & { asChild?: boolean }) => (
+    <button type='button' {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 vi.mock('next/link', () => ({

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -32,6 +32,17 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
+  IconButton: ({
+    children,
+    asChild: _,
+    ...props
+  }: ComponentProps<'button'> & { asChild?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+  ICON_BUTTON_VISIBLE_CLASSNAME:
+    'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100',
+  ICON_BUTTON_FADE_CLASSNAME:
+    'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
   SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 

--- a/apps/web/tests/unit/chat/ChatMessage.memo.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.memo.test.tsx
@@ -34,6 +34,17 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
+  IconButton: ({
+    children,
+    asChild: _,
+    ...props
+  }: ComponentProps<'button'> & { asChild?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+  ICON_BUTTON_VISIBLE_CLASSNAME:
+    'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100',
+  ICON_BUTTON_FADE_CLASSNAME:
+    'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
   SimpleTooltip: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -34,6 +34,17 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
+  IconButton: ({
+    children,
+    asChild: _,
+    ...props
+  }: ComponentProps<'button'> & { asChild?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+  ICON_BUTTON_VISIBLE_CLASSNAME:
+    'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100',
+  ICON_BUTTON_FADE_CLASSNAME:
+    'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
   Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
   PopoverContent: ({
     children,

--- a/apps/web/tests/unit/components/molecules/DrawerCardActionBar.test.tsx
+++ b/apps/web/tests/unit/components/molecules/DrawerCardActionBar.test.tsx
@@ -12,6 +12,15 @@ vi.mock('@jovie/ui', () => ({
       {children}
     </button>
   ),
+  IconButton: ({
+    children,
+    asChild: _,
+    ...props
+  }: ComponentProps<'button'> & { asChild?: boolean }) => (
+    <button type='button' {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 vi.mock('@/components/atoms/table-action-menu', () => ({

--- a/apps/web/tests/unit/dashboard/audience-table/AudienceSourceCell.test.tsx
+++ b/apps/web/tests/unit/dashboard/audience-table/AudienceSourceCell.test.tsx
@@ -4,6 +4,17 @@ import { AudienceSourceCell } from '@/components/organisms/table';
 
 // SimpleTooltip requires TooltipProvider — mock it to render children directly
 vi.mock('@jovie/ui', () => ({
+  IconButton: ({
+    children,
+    asChild: _,
+    ...props
+  }: React.ComponentProps<'button'> & { asChild?: boolean }) => (
+    <button {...props}>{children}</button>
+  ),
+  ICON_BUTTON_VISIBLE_CLASSNAME:
+    'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100',
+  ICON_BUTTON_FADE_CLASSNAME:
+    'p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
   SimpleTooltip: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),


### PR DESCRIPTION
## Summary
- update existing narrow `@jovie/ui` mocks affected by the canonical icon-button contract
- cover Audience source, Chat message, drawer card action, and drawer header action suites
- no product-source or homepage changes

## Verification
- focused affected suite: 31/31 on current main
- same focused suite: 31/31 on #15615 exact head `d1195f9aebb09f4bb2d138a44046efb9c06facf5` with these mock updates
- Biome and `git diff --check` pass