### PR TITLE
test(design): ratchet linear namespace baseline [JOV-4871]

### DIFF
--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1698
+  "count": 1694
 }


### PR DESCRIPTION
## Summary
- aligns the shrink-only `--linear-*` namespace baseline with JOV-4871’s four removed usages
- targets #15615 so source reduction and floor land atomically

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/design-system/linear-namespace-ratchet.test.ts`
- `pnpm biome check apps/web/tests/unit/design-system/linear-namespace.baseline.json`
- `git diff --check`

Refs JOV-4871
<!-- linear-issue-id:JOV-4871 -->