### PR TITLE
fix(tasks): let table rows own interaction state

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
@@ -12,8 +12,7 @@ export const TASK_DATA_TABLE_CLASSNAME = 'text-app';
 export const TASK_DATA_TABLE_CONTAINER_CLASSNAME =
   'h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5';
 
-export const TASK_DATA_TABLE_ROW_CLASSNAME =
-  'group/row group/task-row !bg-transparent !shadow-none hover:!bg-transparent hover:!shadow-none focus-visible:!bg-transparent focus-visible:!shadow-none focus-within:!bg-transparent focus-within:!shadow-none';
+export const TASK_DATA_TABLE_ROW_CLASSNAME = 'group/row group/task-row';
 
 export type TaskDataTableProps<TData> = UnifiedTableProps<TData>;
 

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -173,7 +173,7 @@ export const TaskListRow = memo(function TaskListRow({
     <ShellListRowFrame
       data-testid={`task-list-row-${task.id}`}
       isSelected={isSelected}
-      interaction='task-row-group'
+      interaction='none'
       className={cn(
         'group/row flex h-full w-full items-center gap-2 px-3 py-1 transition-[opacity] duration-subtle ease-subtle',
         isDone && !isSelected && 'opacity-75',

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -2038,6 +2038,7 @@ export function TasksPageClient() {
         isLoading={isActiveListLoading}
         getRowId={row => row.id}
         onRowClick={row => openTaskDocument(row)}
+        isRowSelected={row => row.id === effectiveSelectedTaskId}
         getContextMenuItems={getTaskContextMenuItems}
         emptyState={
           <TaskEmptyState

--- a/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
@@ -64,14 +64,17 @@ describe('TaskDataTable', () => {
     expect(table).toHaveAttribute('data-row-height', '56');
     expect(table).toHaveAttribute('data-skeleton-rows', '8');
     expect(table).toHaveAttribute('data-virtualized', 'false');
-    expect(TASK_DATA_TABLE_ROW_CLASSNAME).toContain(
-      'focus-within:!shadow-none'
-    );
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).toContain('group/row');
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).toContain('group/task-row');
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).not.toContain('!bg-transparent');
     expect(TASK_DATA_TABLE_ROW_CLASSNAME).not.toContain(
       'focus-visible:!ring-0'
     );
-    expect(TASK_DATA_TABLE_ROW_CLASSNAME).toContain(
-      'focus-visible:!shadow-none'
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).not.toContain(
+      'focus-visible:!bg-transparent'
+    );
+    expect(TASK_DATA_TABLE_ROW_CLASSNAME).not.toContain(
+      'focus-within:!bg-transparent'
     );
   });
 

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -88,7 +88,7 @@ describe('TaskListRow', () => {
       'data-selected',
       'true'
     );
-    expect(getByTestId('task-list-row-task-1').className).toContain(
+    expect(getByTestId('task-list-row-task-1').className).not.toContain(
       'system-b-shell-list-task-row-selected'
     );
     expect(getByText(mockTask.title)).toBeVisible();

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -654,6 +654,7 @@ function getLatestTableProps() {
     | {
         readonly data?: ReadonlyArray<TaskView>;
         readonly onRowClick?: (task: TaskView) => void;
+        readonly isRowSelected?: (task: TaskView, index: number) => boolean;
         readonly getRowClassName?: (task: TaskView, index: number) => string;
         readonly getContextMenuItems?: (task: TaskView) => ReadonlyArray<{
           readonly id?: string;
@@ -856,23 +857,19 @@ describe('TasksPageClient', () => {
     );
   });
 
-  it('leaves table shells unselected so the task row owns selection treatment', () => {
+  it('lets the shared table row own task interaction state', () => {
     renderPage();
 
+    expect(getLatestTableProps()?.isRowSelected?.(mockTaskTwo, 0)).toBe(false);
     expect(
       getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)
-    ).not.toContain('system-b-table-row-selected');
-    expect(getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)).toContain(
-      '!bg-transparent'
-    );
+    ).not.toContain('!bg-transparent');
 
     act(() => {
       getLatestTableProps()?.onRowClick?.(mockTaskTwo);
     });
 
-    expect(
-      getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)
-    ).not.toContain('system-b-table-row-selected');
+    expect(getLatestTableProps()?.isRowSelected?.(mockTaskTwo, 0)).toBe(true);
   });
 
   it('resets the canonical detail selection when subview filters exclude the selected task', () => {


### PR DESCRIPTION
## Summary
- let the shared table row own hover, focus-within, and selected state
- remove nested TaskListRow background interaction to prevent inset highlights
- add regression coverage for the row ownership contract

## Verification
- focused Vitest: 68 tests passed across TaskDataTable, TaskListRow, and TasksPageClient
- @jovie/web typecheck passed
- Biome check passed

This is a bounded UI polish slice; no deployment or merge is claimed.