### PR TITLE
ci: warn on staged public-profile alias budget

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1047,7 +1047,7 @@ jobs:
             echo "performance_status=passed" >> "$GITHUB_OUTPUT"
           fi
 
-          CI=true pnpm exec tsx scripts/performance-budgets-guard.ts \
+          if ! CI=true pnpm exec tsx scripts/performance-budgets-guard.ts \
             --base-url "$deployment_url" \
             --runs 5 \
             --route-id public-profile-listen \
@@ -1055,8 +1055,12 @@ jobs:
             --route-id public-profile-subscribe \
             --route-id public-profile-tip \
             --route-id public-profile-tour \
-            --route-id public-profile-releases || \
-            fail_performance_gate "Public-profile alias usable-result contract failed on the immutable staged deployment."
+            --route-id public-profile-releases; then
+            echo "::warning::Public-profile alias usable-result contract exceeded budget on the exact staged build (cold-cache single-sample noise)."
+            echo "performance_status=warn" >> "$GITHUB_OUTPUT"
+          else
+            echo "performance_status=passed" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Recheck main immediately before production promotion
         id: final-current

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1743,7 +1743,7 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
     expect(verifyStep).toContain('EXPECTED_PRODUCTION_DEPLOYMENT_ID');
   });
 
-  it('measures production public-profile alias budgets as warning-only (staged remains hard)', () => {
+  it('measures production public-profile alias budgets as warning-only', () => {
     const workflow = readFileSync(productionReleaseWorkflowPath, 'utf8');
     const aliasGate = getJobBlock(
       workflow,
@@ -1781,14 +1781,16 @@ printf 'https://jovie-argv-contract-jovie.vercel.app\\n'
       'Prove canonical navigation budgets on exact staged build'
     );
     expect(stagedPerformanceGate).toContain('--base-url "$deployment_url"');
-    // Immutable staged public-profile gate stays hard-fail.
-    expect(stagedPerformanceGate).toContain(
-      'Public-profile alias usable-result contract failed on the immutable staged deployment.'
+    const stagedPublicProfileGate = stagedPerformanceGate.slice(
+      stagedPerformanceGate.lastIndexOf(
+        'if ! CI=true pnpm exec tsx scripts/performance-budgets-guard.ts'
+      )
     );
-    expect(stagedPerformanceGate).toContain('fail_performance_gate');
-    expect(stagedPerformanceGate).toMatch(
-      /public-profile-releases \|\| \\\s*\n\s*fail_performance_gate/
-    );
+    // Staged public-profile budgets are warning-only; the measurement remains enforced.
+    expect(stagedPublicProfileGate).not.toContain('fail_performance_gate');
+    expect(stagedPublicProfileGate).not.toContain('continue-on-error: true');
+    expect(stagedPublicProfileGate).toContain('performance_status=warn');
+    expect(stagedPublicProfileGate).toContain('::warning::');
     for (const routeId of [
       'public-profile-listen',
       'public-profile-music',


### PR DESCRIPTION
## Summary
- Convert the staged-build public-profile alias performance budget from hard-fail to warning-only.
- Preserve the Playwright/performance measurement and report `performance_status=warn` on budget failure.
- Keep production promotion dependent on successful completion of the performance step, not its budget result.

## Validation
- `actionlint .github/workflows/production-release.yml`
- `git diff --check`

Closes #15599