### PR TITLE
Focus Artist Profiles phone preview

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4191,22 +4191,32 @@ body:has(.home-viewport)::-webkit-scrollbar {
   margin: var(--space-16) auto 0;
 }
 
-.homepage-artist-profiles__carousel-controls {
+.homepage-artist-profiles__outcome-tabs {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: flex-start;
+  overflow-x: auto;
   gap: var(--space-2);
-  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-4);
+  scrollbar-width: none;
 }
 
-.homepage-artist-profiles__carousel-controls button {
-  display: grid;
-  width: calc(var(--space-10) + var(--space-1));
-  height: calc(var(--space-10) + var(--space-1));
-  place-items: center;
-  border: var(--space-px) solid var(--system-b-app-frame-seam);
+.homepage-artist-profiles__outcome-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.homepage-artist-profiles__outcome-tab {
+  flex: none;
   border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--color-text-primary-token);
+}
+
+.homepage-artist-profiles__outcome-tab[aria-selected="true"] {
+  background: var(--system-b-bg-surface-1);
+  color: var(--system-b-text-primary);
+}
+
+.homepage-artist-profiles__outcome-tab:not([aria-selected="true"]) {
+  color: var(--color-text-tertiary-token);
   transition:
     background-color var(--ds-motion-subtle-duration)
     var(--ds-motion-subtle-easing),
@@ -4214,82 +4224,34 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 @media (hover: hover) {
-  .homepage-artist-profiles__carousel-controls button:not(:disabled):hover {
+  .homepage-artist-profiles__outcome-tab:not([aria-selected="true"]):hover {
     background: var(--system-b-bg-surface-1);
     color: var(--system-b-text-primary);
   }
 }
 
-.homepage-artist-profiles__carousel-controls button:disabled {
-  cursor: not-allowed;
-  opacity: 0.4;
-}
-
-.homepage-artist-profiles__carousel-controls button:focus-visible {
+.homepage-artist-profiles__outcome-tab:focus-visible {
   outline: var(--space-px) solid var(--system-b-text-primary);
   outline-offset: var(--space-1);
 }
 
-.homepage-artist-profiles__row {
-  overflow-x: auto;
-  overscroll-behavior-x: contain;
-  scroll-behavior: smooth;
-  scroll-snap-type: x mandatory;
-  scrollbar-width: none;
+.homepage-artist-profiles__stage {
+  min-height: clamp(42rem, 64vw, 56rem);
+  aspect-ratio: auto;
+  grid-template-columns: minmax(14rem, 0.8fr) minmax(20rem, 1.2fr);
+  grid-template-rows: 1fr;
 }
 
-.homepage-artist-profiles__row::-webkit-scrollbar {
-  display: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .homepage-artist-profiles__row {
-    scroll-behavior: auto;
-  }
-}
-
-.homepage-artist-profiles__track {
-  --homepage-artist-profiles-card-gap: clamp(
-    var(--space-4),
-    2vw,
-    var(--space-6)
-  );
-
-  display: flex;
-  margin: 0;
-  padding: 0;
-  gap: var(--homepage-artist-profiles-card-gap);
-  list-style: none;
-}
-
-.homepage-artist-profiles__card {
-  flex: 0 0 100%;
-  scroll-snap-align: start;
-}
-
-.homepage-artist-profiles__card {
-  min-height: min(46rem, 72vw);
-}
-
-.homepage-artist-profiles__select {
-  position: absolute;
-  inset: 0;
-  z-index: 3;
-  cursor: pointer;
-  border: 0;
-  background: transparent;
-}
-
-.homepage-artist-profiles__card .homepage-artist-outcome__media {
+.homepage-artist-profiles__stage .homepage-artist-outcome__media {
   align-items: end;
 }
 
-.homepage-artist-profiles__card .homepage-artist-outcome__device {
-  width: min(31rem, 52%);
+.homepage-artist-profiles__stage .homepage-artist-outcome__device {
+  width: min(31rem, 88%);
   max-width: none;
-  height: auto;
+  height: min(47rem, 112%);
   min-height: 35rem;
-  margin-bottom: -18%;
+  margin-bottom: -20%;
 }
 
 @media (max-width: 900px) {
@@ -4302,8 +4264,17 @@ body:has(.home-viewport)::-webkit-scrollbar {
     margin-top: var(--space-10);
   }
 
-  .homepage-artist-profiles__card {
-    flex-basis: 100%;
+  .homepage-artist-profiles__stage {
+    min-height: clamp(39rem, 132vw, 48rem);
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(12rem, auto) 1fr;
+  }
+
+  .homepage-artist-profiles__stage .homepage-artist-outcome__device {
+    width: min(25rem, 78%);
+    height: min(42rem, 118%);
+    min-height: 32rem;
+    margin-bottom: -24%;
   }
 }
 /* HOMEPAGE ARTIST PROFILES SYSTEM B END */

--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4263,8 +4263,33 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-artist-profiles__card {
-  flex: 0 0 calc((100% - var(--homepage-artist-profiles-card-gap) * 2) / 3);
+  flex: 0 0 100%;
   scroll-snap-align: start;
+}
+
+.homepage-artist-profiles__card {
+  min-height: min(46rem, 72vw);
+}
+
+.homepage-artist-profiles__select {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+}
+
+.homepage-artist-profiles__card .homepage-artist-outcome__media {
+  align-items: end;
+}
+
+.homepage-artist-profiles__card .homepage-artist-outcome__device {
+  width: min(31rem, 52%);
+  max-width: none;
+  height: auto;
+  min-height: 35rem;
+  margin-bottom: -18%;
 }
 
 @media (max-width: 900px) {

--- a/apps/web/components/homepage/MeetJovieCarousel.tsx
+++ b/apps/web/components/homepage/MeetJovieCarousel.tsx
@@ -1,137 +1,67 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useId, useState } from 'react';
 import { ArtistProfilePhoneFrame } from '@/components/marketing/artist-profile/ArtistProfilePhoneFrame';
 import type { HomepageArtistProfileCards } from './HomepageArtistProfiles';
 
 export function ArtistProfileCardRow({
   cards,
 }: Readonly<{ cards: HomepageArtistProfileCards }>) {
-  const railRef = useRef<HTMLDivElement | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollState, setScrollState] = useState({
-    canGoPrevious: false,
-    canGoNext: cards.length > 3,
-  });
-
-  const updateScrollState = useCallback(() => {
-    const rail = railRef.current;
-    if (!rail) return;
-    if (rail.clientWidth === 0) return;
-
-    const epsilon = 1;
-    const canGoPrevious = rail.scrollLeft > epsilon;
-    const canGoNext =
-      rail.scrollLeft + rail.clientWidth < rail.scrollWidth - epsilon;
-
-    setScrollState(previous =>
-      previous.canGoPrevious === canGoPrevious &&
-      previous.canGoNext === canGoNext
-        ? previous
-        : { canGoPrevious, canGoNext }
-    );
-  }, []);
-
-  useEffect(() => {
-    updateScrollState();
-    const rail = railRef.current;
-    if (!rail) return;
-
-    const observer = new ResizeObserver(updateScrollState);
-    observer.observe(rail);
-    return () => observer.disconnect();
-  }, [updateScrollState]);
-
-  const scrollRail = useCallback((direction: 'previous' | 'next') => {
-    const rail = railRef.current;
-    if (!rail) return;
-
-    const reducedMotion = window.matchMedia(
-      '(prefers-reduced-motion: reduce)'
-    ).matches;
-    const nextIndex = Math.max(
-      0,
-      Math.min(cards.length - 1, selectedIndex + (direction === 'next' ? 1 : -1))
-    );
-    setSelectedIndex(nextIndex);
-    rail.scrollTo({
-      left: nextIndex * rail.clientWidth,
-      behavior: reducedMotion ? 'auto' : 'smooth',
-    });
-  }, [cards.length, selectedIndex]);
+  const id = useId();
+  const selectedCard = cards[selectedIndex];
 
   return (
     <div className='homepage-artist-profiles__carousel'>
-      <nav
-        aria-label='Artist Profile Preview Navigation'
-        className='homepage-artist-profiles__carousel-controls'
-      >
-        <Button
-          aria-label='Previous Artist Profile Preview'
-          disabled={!scrollState.canGoPrevious}
-          onClick={() => scrollRail('previous')}
-          size='icon'
-          type='button'
-          variant='ghost'
-        >
-          <ChevronLeft aria-hidden='true' size={18} strokeWidth={1.9} />
-        </Button>
-        <Button
-          aria-label='Next Artist Profile Preview'
-          disabled={!scrollState.canGoNext}
-          onClick={() => scrollRail('next')}
-          size='icon'
-          type='button'
-          variant='ghost'
-        >
-          <ChevronRight aria-hidden='true' size={18} strokeWidth={1.9} />
-        </Button>
-      </nav>
       <div
-        className='homepage-artist-profiles__row'
-        onScroll={updateScrollState}
-        ref={railRef}
+        aria-label='Artist Profile outcomes'
+        className='homepage-artist-profiles__outcome-tabs'
+        role='tablist'
       >
-        <ul
-          aria-label='Jovie Artist Profile Outcomes'
-          className='homepage-artist-profiles__track'
-        >
-          {cards.map((card, index) => (
-            <li
-              className={`homepage-artist-outcome homepage-artist-profiles__card${index === selectedIndex ? ' homepage-artist-profiles__card--selected' : ''}`}
-              key={card.id}
-            >
-              <button
-                aria-label={`Show ${card.title}`}
-                className='homepage-artist-profiles__select'
-                onClick={() => setSelectedIndex(index)}
-                type='button'
-              />
-              <div className='homepage-artist-outcome__copy'>
-                <h3>{card.title}</h3>
-                <p>{card.body}</p>
-              </div>
-              <figure className='homepage-artist-outcome__media'>
-                <ArtistProfilePhoneFrame className='homepage-artist-outcome__device'>
-                  <Image
-                    alt={card.image.alt}
-                    className='homepage-artist-outcome__screen'
-                    height={card.image.height}
-                    loading='lazy'
-                    quality={100}
-                    sizes='(min-width: 1280px) 13rem, (min-width: 768px) 16vw, 44vw'
-                    src={card.image.publicUrl}
-                    width={card.image.width}
-                  />
-                </ArtistProfilePhoneFrame>
-              </figure>
-            </li>
-          ))}
-        </ul>
+        {cards.map((card, index) => (
+          <Button
+            aria-controls={`${id}-${card.id}`}
+            aria-selected={index === selectedIndex}
+            className='homepage-artist-profiles__outcome-tab'
+            id={`${id}-${card.id}-tab`}
+            key={card.id}
+            onClick={() => setSelectedIndex(index)}
+            role='tab'
+            size='sm'
+            type='button'
+            variant='ghost'
+          >
+            {card.title}
+          </Button>
+        ))}
       </div>
+      <section
+        aria-labelledby={`${id}-${selectedCard.id}-tab`}
+        className='homepage-artist-outcome homepage-artist-profiles__stage'
+        id={`${id}-${selectedCard.id}`}
+        role='tabpanel'
+      >
+        <div className='homepage-artist-outcome__copy'>
+          <h3>{selectedCard.title}</h3>
+          <p>{selectedCard.body}</p>
+        </div>
+        <figure className='homepage-artist-outcome__media'>
+          <ArtistProfilePhoneFrame className='homepage-artist-outcome__device'>
+            <Image
+              alt={selectedCard.image.alt}
+              className='homepage-artist-outcome__screen'
+              height={selectedCard.image.height}
+              loading='lazy'
+              quality={100}
+              sizes='(min-width: 1280px) 30rem, (min-width: 768px) 46vw, 88vw'
+              src={selectedCard.image.publicUrl}
+              width={selectedCard.image.width}
+            />
+          </ArtistProfilePhoneFrame>
+        </figure>
+      </section>
     </div>
   );
 }

--- a/apps/web/components/homepage/MeetJovieCarousel.tsx
+++ b/apps/web/components/homepage/MeetJovieCarousel.tsx
@@ -11,6 +11,7 @@ export function ArtistProfileCardRow({
   cards,
 }: Readonly<{ cards: HomepageArtistProfileCards }>) {
   const railRef = useRef<HTMLDivElement | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [scrollState, setScrollState] = useState({
     canGoPrevious: false,
     canGoNext: cards.length > 3,
@@ -51,11 +52,16 @@ export function ArtistProfileCardRow({
     const reducedMotion = window.matchMedia(
       '(prefers-reduced-motion: reduce)'
     ).matches;
-    rail.scrollBy({
-      left: direction === 'next' ? rail.clientWidth : -rail.clientWidth,
+    const nextIndex = Math.max(
+      0,
+      Math.min(cards.length - 1, selectedIndex + (direction === 'next' ? 1 : -1))
+    );
+    setSelectedIndex(nextIndex);
+    rail.scrollTo({
+      left: nextIndex * rail.clientWidth,
       behavior: reducedMotion ? 'auto' : 'smooth',
     });
-  }, []);
+  }, [cards.length, selectedIndex]);
 
   return (
     <div className='homepage-artist-profiles__carousel'>
@@ -93,11 +99,17 @@ export function ArtistProfileCardRow({
           aria-label='Jovie Artist Profile Outcomes'
           className='homepage-artist-profiles__track'
         >
-          {cards.map(card => (
+          {cards.map((card, index) => (
             <li
-              className='homepage-artist-outcome homepage-artist-profiles__card'
+              className={`homepage-artist-outcome homepage-artist-profiles__card${index === selectedIndex ? ' homepage-artist-profiles__card--selected' : ''}`}
               key={card.id}
             >
+              <button
+                aria-label={`Show ${card.title}`}
+                className='homepage-artist-profiles__select'
+                onClick={() => setSelectedIndex(index)}
+                type='button'
+              />
               <div className='homepage-artist-outcome__copy'>
                 <h3>{card.title}</h3>
                 <p>{card.body}</p>

--- a/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
+++ b/apps/web/tests/unit/home/HomepageMeetJovie.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   type HomepageArtistProfileCards,
@@ -85,24 +85,10 @@ describe('HomepageArtistProfiles', () => {
       'homepage-artist-profiles__intro'
     );
     expect(
-      screen.getByRole('list', { name: 'Jovie Artist Profile Outcomes' })
+      screen.getByRole('tablist', { name: 'Artist Profile outcomes' })
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('listitem')).toHaveLength(4);
-
-    for (const title of [
-      'Sell Out',
-      'Capture Fans',
-      'Get Paid',
-      'Drop Music',
-    ]) {
-      expect(
-        screen.getByRole('heading', { level: 3, name: title })
-      ).toBeInTheDocument();
-    }
-
-    for (const body of CARDS.map(card => card.body)) {
-      expect(screen.getByText(body)).toBeInTheDocument();
-    }
+    expect(screen.getAllByRole('tab')).toHaveLength(4);
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Sell Out');
   });
 
   it('preserves registry-backed image geometry with accessible carousel controls', () => {
@@ -115,32 +101,30 @@ describe('HomepageArtistProfiles', () => {
       screen.getByRole('link', { name: 'Explore Artist Profiles' })
     ).not.toHaveClass('bg-white');
 
-    const images = screen.getAllByRole('img');
-    expect(images).toHaveLength(4);
-    const previous = screen.getByRole('button', {
-      name: 'Previous Artist Profile Preview',
-    });
-    const next = screen.getByRole('button', {
-      name: 'Next Artist Profile Preview',
-    });
+    const selected = screen.getByRole('tab', { name: 'Sell Out' });
+    expect(selected).toHaveAttribute('aria-selected', 'true');
+    expect(selected).toHaveAttribute('data-variant', 'ghost');
+    expect(selected).toHaveAttribute('data-size', 'sm');
 
-    expect(previous).toBeDisabled();
-    expect(next).toBeEnabled();
-    expect(previous).toHaveAttribute('data-variant', 'ghost');
-    expect(previous).toHaveAttribute('data-size', 'icon');
-    expect(next).toHaveAttribute('data-variant', 'ghost');
-    expect(next).toHaveAttribute('data-size', 'icon');
+    const image = screen.getByRole('img');
+    expect(image.getAttribute('src')).toContain(
+      encodeURIComponent(CARDS[0].image.publicUrl)
+    );
+    expect(image).toHaveAttribute('alt', CARDS[0].image.alt);
+    expect(image).toHaveAttribute('width', String(CARDS[0].image.width));
+    expect(image).toHaveAttribute('height', String(CARDS[0].image.height));
+  });
 
-    for (const [index, card] of CARDS.entries()) {
-      expect(images[index].getAttribute('src')).toContain(
-        encodeURIComponent(card.image.publicUrl)
-      );
-      expect(images[index]).toHaveAttribute('alt', card.image.alt);
-      expect(images[index]).toHaveAttribute('width', String(card.image.width));
-      expect(images[index]).toHaveAttribute(
-        'height',
-        String(card.image.height)
-      );
-    }
+  it('makes each outcome an explicit selectable preview', () => {
+    render(<HomepageArtistProfiles cards={CARDS} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Get Paid' }));
+
+    expect(screen.getByRole('tab', { name: 'Get Paid' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Get Paid');
+    expect(screen.getByRole('img')).toHaveAttribute('alt', CARDS[2].image.alt);
   });
 });

--- a/apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts
@@ -66,9 +66,9 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
     }
 
     for (const className of [
-      'homepage-artist-profiles__row',
-      'homepage-artist-profiles__track',
-      'homepage-artist-profiles__card',
+      'homepage-artist-profiles__outcome-tabs',
+      'homepage-artist-profiles__outcome-tab',
+      'homepage-artist-profiles__stage',
       'homepage-artist-outcome',
       'homepage-artist-outcome__copy',
       'homepage-artist-outcome__media',


### PR DESCRIPTION
## What changed
- replace the equal-card outcome rail with explicit compact outcome tabs and one selected phone stage
- make the selected phone dominant and intentionally bottom-cropped
- add selection behavior and source-contract regression coverage

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/home/HomepageMeetJovie.test.tsx tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts --reporter=dot` (11 passed)
- `pnpm --filter @jovie/web exec biome check components/homepage/MeetJovieCarousel.tsx app/(home)/home.css tests/unit/home/HomepageMeetJovie.test.tsx tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts`
- `git diff --check`

Visual capture is a follow-up in the local self-review loop; this PR is intentionally source/CI-first under the current shipping policy.