### PR TITLE
Enlarge Artist Profiles phone proof

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4348,6 +4348,24 @@ body:has(.home-viewport)::-webkit-scrollbar {
   padding: var(--space-2);
 }
 
+/* The product proof is deliberately larger than its outcome card. The media
+   frame owns the crop so the phone feels like a real continuation below it,
+   rather than a thumbnail floating inside a card. */
+.homepage-artist-profiles__card .homepage-artist-outcome__device {
+  width: min(22rem, 118%);
+  max-width: none;
+  height: auto;
+  margin: var(--space-4) 0 calc(var(--space-24) * -1);
+  padding: var(--space-1);
+}
+
+@media (max-width: 900px) {
+  .homepage-artist-profiles__card .homepage-artist-outcome__device {
+    width: min(24rem, 96%);
+    margin-bottom: calc(var(--space-32) * -1);
+  }
+}
+
 /* The shared Artist Profiles frame includes an editorial surface treatment.
    Homepage outcome cards are product proof, so keep this instance neutral. */
 .homepage-artist-outcome .homepage-artist-outcome__device.ap-phone-frame {

--- a/apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-artist-outcomes-system-b-style-guard.test.ts
@@ -222,6 +222,10 @@ describe('mounted homepage Meet Jovie System B source contract', () => {
     expect(css).toContain('--homepage-artist-outcome-copy-track: 1fr');
     expect(css).toContain('--homepage-artist-outcome-media-track: 2fr');
     expect(css).toContain('height: calc(100% - var(--space-4))');
+    expect(css).toContain('width: min(22rem, 118%)');
+    expect(css).toContain(
+      'margin: var(--space-4) 0 calc(var(--space-24) * -1)'
+    );
     expect(css).not.toContain('transform: translateY(33%)');
     expect(css).toContain('object-fit: contain');
     expect(css).toContain('background: var(--system-b-bg-surface-0)');


### PR DESCRIPTION
## What changed
- preserve the approved three-card Artist Profiles outcome rail
- enlarge each phone within its card and intentionally crop the lower edge

## Verification
- focused Home unit/style tests: 10 passed
- Biome check passed
- normal pre-commit completed including lint and typecheck
- `git diff --check` passed
- local desktop render: no console errors or horizontal overflow
- narrow render source check: 390px has no horizontal overflow

This is deliberately CSS-only. It corrects the requested phone presentation without changing the approved rail or interaction model.