### PR TITLE
fix(start): restore ambient composer mark

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -47,6 +47,7 @@ import { ChatProposeCheckoutCard } from './ChatProposeCheckoutCard';
 import { ChatProposeNextStepCard } from './ChatProposeNextStepCard';
 import {
   OnboardingChatEmptyIntro,
+  OnboardingComposerAmbientMark,
   type OnboardingEntryMode,
 } from './OnboardingChatEmptyIntro';
 import { OnboardingMessageRecoveryRow } from './OnboardingMessageRecoveryRow';
@@ -578,8 +579,12 @@ function OnboardingMessageRegion({
         }
         hideWelcomeHeader
       >
-        <div className='w-full' data-testid='onboarding-centered-composer'>
-          {onboardingComposerSurface}
+        <div
+          className='relative isolate w-full'
+          data-testid='onboarding-centered-composer'
+        >
+          {entryMode === 'blank' ? <OnboardingComposerAmbientMark /> : null}
+          <div className='relative z-10'>{onboardingComposerSurface}</div>
         </div>
       </ChatEmptyStateComposerRegion>
     );

--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
@@ -2,6 +2,7 @@
 
 import { LoaderCircle } from 'lucide-react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
+import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
 import {
   ONBOARDING_ENTRY_SUPPORT,
   ONBOARDING_ENTRY_TITLE,
@@ -92,6 +93,27 @@ export function OnboardingChatEmptyIntro({
           </div>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * Start's blank composer gets its own ambient treatment rather than borrowing
+ * the generic chat logo. It is absolutely positioned so the mark never takes
+ * up layout space or shifts while the composer changes state.
+ */
+export function OnboardingComposerAmbientMark() {
+  return (
+    <div
+      aria-hidden='true'
+      className='pointer-events-none absolute inset-x-0 bottom-0 z-0 h-[20rem] overflow-hidden sm:h-[24rem]'
+      data-testid='onboarding-start-ambient-mark'
+    >
+      <JovieMarkElectric
+        size={560}
+        idSeed='start-ambient-mark'
+        className='absolute left-1/2 top-[4.5rem] -translate-x-1/2 opacity-[0.22] [mask-image:linear-gradient(142deg,transparent_0%,black_28%,black_78%,transparent_100%)] sm:top-[3rem]'
+      />
     </div>
   );
 }

--- a/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.empty-intro.test.tsx
@@ -114,6 +114,7 @@ describe('OnboardingChat empty intro', () => {
     );
 
     expect(screen.getByTestId('onboarding-empty-intro')).toBeTruthy();
+    expect(screen.getByTestId('onboarding-start-ambient-mark')).toBeTruthy();
     expect(screen.getByText(ONBOARDING_ENTRY_TITLE)).toBeTruthy();
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
     expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
@@ -133,6 +134,7 @@ describe('OnboardingChat empty intro', () => {
     );
 
     expect(screen.getByText('Getting This Ready')).toBeTruthy();
+    expect(screen.queryByTestId('onboarding-start-ambient-mark')).toBeNull();
     expect(screen.queryByTestId('onboarding-starter-suggestions')).toBeNull();
   });
 

--- a/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChatEmptyIntro.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { OnboardingChatEmptyIntro } from '@/components/features/onboarding/OnboardingChatEmptyIntro';
+import {
+  OnboardingChatEmptyIntro,
+  OnboardingComposerAmbientMark,
+} from '@/components/features/onboarding/OnboardingChatEmptyIntro';
 import { ONBOARDING_ENTRY_TITLE } from '@/lib/onboarding/empty-state';
 
 describe('OnboardingChatEmptyIntro', () => {
@@ -14,7 +17,7 @@ describe('OnboardingChatEmptyIntro', () => {
     expect(screen.queryByText('Plan a Release')).toBeNull();
     expect(screen.queryByText('Build Artist Profile')).toBeNull();
     expect(screen.queryByText('Set Up My Link Page')).toBeNull();
-    expect(screen.queryByText('Jovie')).toBeNull();
+    expect(screen.queryByTestId('onboarding-start-ambient-mark')).toBeNull();
   });
 
   it('replaces blank controls with one stable handoff status', () => {
@@ -25,5 +28,11 @@ describe('OnboardingChatEmptyIntro', () => {
       'Preparing your first message'
     );
     expect(screen.queryByTestId('onboarding-sign-in-skip')).toBeNull();
+  });
+
+  it('renders the Start-only ambient mark outside the entry copy flow', () => {
+    render(<OnboardingComposerAmbientMark />);
+
+    expect(screen.getByTestId('onboarding-start-ambient-mark')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Restores the approved Start-only electric Jovie mark behind the blank composer.

- reuses `JovieMarkElectric`; no new asset or generic chat treatment
- absolute, clipped ambient layer cannot shift composer geometry
- shown only in blank entry and gone once a conversation or handoff begins

Checks: focused onboarding tests, Biome, normal pre-push gate.