### PR TITLE
fix(sidebar): preserve primary nav label track

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx
@@ -70,4 +70,19 @@ describe('CustomerNavMoreMenu', () => {
       expect.stringMatching(/pointer|keyboard/)
     );
   });
+
+  it('keeps its label in the full grid track with a right-edge fade', () => {
+    render(
+      <ul>
+        <CustomerNavMoreMenu items={moreItems} isItemActive={() => false} />
+      </ul>
+    );
+
+    const label = screen.getByText('More');
+    expect(label.className).toContain('w-full');
+    expect(label.className).toContain('justify-self-stretch');
+    expect(label.className).toContain('overflow-hidden');
+    expect(label.className).toContain('mask-image:linear-gradient');
+    expect(label.className).not.toContain('justify-self-start');
+  });
 });

--- a/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx
@@ -76,7 +76,14 @@ export function CustomerNavMoreMenu({
                 strokeWidth={2.25}
                 aria-hidden='true'
               />
-              <span className='min-w-0 truncate text-left justify-self-start group-data-[collapsible=icon]:hidden'>
+              <span
+                className={cn(
+                  'min-w-0 w-full justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left',
+                  '[-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
+                  '[mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
+                  'group-data-[collapsible=icon]:hidden'
+                )}
+              >
                 More
               </span>
               {hasActiveOverflow ? (

--- a/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx
@@ -78,7 +78,7 @@ export function CustomerNavMoreMenu({
               />
               <span
                 className={cn(
-                  'min-w-0 w-full justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left',
+                  'min-w-0 w-full justify-self-stretch truncate overflow-hidden whitespace-nowrap text-left',
                   '[-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
                   '[mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
                   'group-data-[collapsible=icon]:hidden'

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.test.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { Music } from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+import { NavMenuItem } from './NavMenuItem';
+
+vi.mock('@/lib/desktop/electron-bridge', () => ({
+  useIsElectronRuntime: () => false,
+}));
+
+describe('NavMenuItem', () => {
+  it('keeps a long primary label in its assigned grid track with a right-edge fade', () => {
+    const name =
+      'A deliberately long primary destination that must fade instead of overflowing';
+
+    render(
+      <NavMenuItem
+        item={{
+          id: 'library',
+          name,
+          href: '/app/library',
+          icon: Music,
+        }}
+        isActive={false}
+      />
+    );
+
+    const label = screen.getByText(name);
+    expect(label.className).toContain('w-full');
+    expect(label.className).toContain('justify-self-stretch');
+    expect(label.className).toContain('overflow-hidden');
+    expect(label.className).toContain('mask-image:linear-gradient');
+    expect(label.className).not.toContain('justify-self-start');
+  });
+});

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -303,7 +303,7 @@ export function NavMenuItem({
       )}
       <span
         className={cn(
-          'min-w-0 w-full justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left',
+          'min-w-0 w-full justify-self-stretch truncate overflow-hidden whitespace-nowrap text-left',
           '[-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
           '[mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
           'group-data-[collapsible=icon]:hidden'

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -29,6 +29,7 @@ import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import type { KeyboardShortcut } from '@/lib/keyboard-shortcuts';
 import { navigationInputMethodFromClick } from '@/lib/tracking/navigation-telemetry';
 import type { NavigationInputMethod } from '@/lib/tracking/navigation-telemetry-contract';
+import { cn } from '@/lib/utils';
 import type { NavItem } from './types';
 
 interface NavMenuItemProps {
@@ -300,7 +301,14 @@ export function NavMenuItem({
           aria-hidden='true'
         />
       )}
-      <span className='min-w-0 truncate text-left justify-self-start group-data-[collapsible=icon]:hidden'>
+      <span
+        className={cn(
+          'min-w-0 w-full justify-self-stretch overflow-hidden whitespace-nowrap text-clip text-left',
+          '[-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
+          '[mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]',
+          'group-data-[collapsible=icon]:hidden'
+        )}
+      >
         {item.name}
       </span>
       {item.badge != null ? (


### PR DESCRIPTION
## Summary
- Keep primary navigation labels inside their assigned grid track.
- Add the same right-edge fade used by the canonical sidebar label and thread rows.
- Cover the primary and overflow `More` labels with focused unit tests.

## Verification
- `pnpm --filter @jovie/web exec vitest run components/features/dashboard/dashboard-nav/NavMenuItem.test.tsx components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx components/shell/SidebarNavItem.test.tsx --reporter=dot`
- `pnpm biome check apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.tsx apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.test.tsx apps/web/components/features/dashboard/dashboard-nav/CustomerNavMoreMenu.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Normal pre-commit and pre-push hooks passed.