### PR TITLE
fix(marketing): focus adaptive profile moment

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileModeSwitcher.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileModeSwitcher.css
@@ -10,7 +10,7 @@
  */
 
 .ap-mode-switcher__headline {
-  max-width: 13ch;
+  max-width: 12ch;
 }
 
 .ap-mode-switcher__copy--compact {

--- a/apps/web/components/marketing/artist-profile/ArtistProfileModeSwitcher.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileModeSwitcher.tsx
@@ -27,6 +27,7 @@ export function ArtistProfileModeSwitcher({
   const reducedMotion = useReducedMotion();
   const [activeIndex, setActiveIndex] = useState(0);
   const activeMode = adaptive.modes[activeIndex] ?? adaptive.modes[0];
+  const headlineLines = adaptive.headline.split('\n');
   const compactAccessibleContext = [phoneCaption, phoneSubcaption]
     .filter(Boolean)
     .join(' ');
@@ -65,11 +66,18 @@ export function ArtistProfileModeSwitcher({
           <>
             {/* ui-casing-allow: marketing display headline */}
             <h2 className={cn(SHELL_H2_CLASS, 'ap-mode-switcher__headline')}>
-              {adaptive.headline}
+              {headlineLines.map((line, index) => (
+                <span key={line} className='block'>
+                  {line}
+                  {index < headlineLines.length - 1 ? <br /> : null}
+                </span>
+              ))}
             </h2>
-            <p className={cn(SHELL_LEAD_CLASS, 'mt-6 max-w-xl')}>
-              {adaptive.body}
-            </p>
+            {adaptive.body ? (
+              <p className={cn(SHELL_LEAD_CLASS, 'mt-6 max-w-xl')}>
+                {adaptive.body}
+              </p>
+            ) : null}
           </>
         ) : null}
 
@@ -95,7 +103,7 @@ export function ArtistProfileModeSwitcher({
                   key={mode.id}
                   value={mode.id}
                   className={cn(
-                    'relative flex min-w-0 items-center justify-center px-2 text-center text-3xs font-semibold leading-tight text-tertiary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus data-[state=active]:text-primary-token sm:text-xs',
+                    'relative flex min-w-0 items-center justify-center whitespace-nowrap px-2 text-center text-2xs font-semibold leading-none text-tertiary-token transition-colors duration-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus data-[state=active]:text-primary-token sm:text-xs',
                     showIntroHeading
                       ? 'min-h-12 rounded-lg'
                       : 'min-h-11 rounded-full'
@@ -126,9 +134,7 @@ export function ArtistProfileModeSwitcher({
           </Tabs.List>
           <div
             className={cn(
-              showIntroHeading
-                ? 'mt-6 min-h-28 border-l border-subtle pl-5'
-                : 'mt-2.5 min-h-10 px-2'
+              showIntroHeading ? 'mt-6 min-h-20' : 'mt-2.5 min-h-10 px-2'
             )}
           >
             {adaptive.modes.map(mode => (
@@ -156,7 +162,7 @@ export function ArtistProfileModeSwitcher({
                     {mode.headline}
                   </p>
                   {showIntroHeading ? (
-                    <p className='mt-3 font-mono text-xs tracking-tight text-tertiary-token'>
+                    <p className='mt-2 font-mono text-xs tracking-tight text-tertiary-token'>
                       {mode.pathLabel}
                     </p>
                   ) : null}
@@ -165,52 +171,16 @@ export function ArtistProfileModeSwitcher({
             ))}
           </div>
         </Tabs.Root>
-
-        {showIntroHeading ? (
-          <ul
-            className='mt-7 flex flex-wrap gap-x-5 gap-y-2'
-            aria-label='Profile Context Signals'
-          >
-            {adaptive.contextCues.map(cue => (
-              <li
-                key={cue}
-                className='flex items-center gap-2 text-xs font-medium text-tertiary-token'
-              >
-                <span
-                  aria-hidden='true'
-                  className='h-1 w-1 rounded-full bg-secondary-token'
-                />
-                {cue}
-              </li>
-            ))}
-          </ul>
-        ) : null}
       </div>
 
       <div
         className={cn(
           'relative mx-auto w-full',
           showIntroHeading
-            ? 'max-w-lg rounded-3xl border border-subtle bg-surface-0 p-6 sm:p-8'
+            ? 'max-w-sm lg:max-w-md'
             : 'ap-mode-switcher__phone--compact order-1 mb-4'
         )}
       >
-        {showIntroHeading ? (
-          <div className='mb-5 flex min-h-13 items-center justify-between gap-4 lg:min-h-0'>
-            <div>
-              <p className='text-xs font-semibold text-primary-token'>
-                {adaptive.productLabel}
-              </p>
-              <p className='mt-1 text-xs text-tertiary-token'>
-                {adaptive.productDetail}
-              </p>
-            </div>
-            <span className='inline-flex min-h-11 items-center rounded-full border border-subtle bg-surface-1 px-3 py-1.5 font-mono text-3xs text-secondary-token lg:min-h-0'>
-              {activeMode.label}
-            </span>
-          </div>
-        ) : null}
-
         <div
           className={cn(
             'relative mx-auto w-full',
@@ -219,10 +189,19 @@ export function ArtistProfileModeSwitcher({
         >
           <ArtistProfilePhoneFrame className='relative z-10 max-w-none'>
             <div className='relative h-full w-full'>
+              {showIntroHeading ? (
+                <div
+                  aria-hidden='true'
+                  className='absolute inset-x-0 top-0 z-10 h-10 bg-surface-0'
+                />
+              ) : null}
               <AnimatePresence initial={false} mode='sync'>
                 <motion.div
                   key={activeMode.id}
-                  className='absolute inset-0'
+                  className={cn(
+                    'absolute inset-0',
+                    showIntroHeading ? 'top-10' : null
+                  )}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}

--- a/apps/web/data/artistProfileCopy.ts
+++ b/apps/web/data/artistProfileCopy.ts
@@ -458,21 +458,21 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
   },
   adaptive: {
     eyebrow: '',
-    headline: 'One adaptive profile. Four moments.',
+    headline: 'One profile.\nRight action.',
     alternateHeadlines: [
       'One profile for every release moment.',
       'One link, tuned to what matters right now.',
       'The same link, different job.',
     ],
-    body: 'Keep the same link everywhere. Jovie changes the leading action as the moment changes.',
+    body: '',
     contextCues: [
       'Release-aware',
       'Location-aware',
       'Service-aware',
       'Moment-aware',
     ],
-    productLabel: 'Same profile',
-    productDetail: 'Different job, exactly when it matters.',
+    productLabel: 'Choose the moment',
+    productDetail: 'The profile already knows the next action.',
     restingScreenshotAlt:
       "Jovie artist profile showing Tim White's live profile view.",
     restingScreenshotSrc: getMarketingExportImage(
@@ -481,9 +481,9 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     modes: [
       {
         id: 'upcoming-release',
-        label: 'Upcoming Release',
-        headline: 'Before a drop, your profile collects release alerts.',
-        description: 'Fans opt in once and hear from you when the song lands.',
+        label: 'Pre-save',
+        headline: 'Collect release alerts before it lands.',
+        description: 'Collect release alerts before it lands.',
         pathLabel: 'jov.ie/you',
         drawer: {
           title: 'The Deep End',
@@ -520,7 +520,7 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
       },
       {
         id: 'release-day',
-        label: 'Release Day',
+        label: 'Out now',
         headline:
           'When the song is live, fans go straight to the right service.',
         description:
@@ -561,7 +561,7 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
       },
       {
         id: 'touring',
-        label: 'Touring',
+        label: 'On tour',
         headline: "When you're on the road, nearby dates come first.",
         description: "When you're on the road, nearby dates come first.",
         pathLabel: 'jov.ie/you/tour',
@@ -599,7 +599,7 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
       },
       {
         id: 'live-support',
-        label: 'Live Support',
+        label: 'Support',
         headline: 'At the merch table, one scan becomes support and capture.',
         description:
           'At the merch table, one scan becomes support and capture.',

--- a/apps/web/tests/e2e/artist-profiles.spec.ts
+++ b/apps/web/tests/e2e/artist-profiles.spec.ts
@@ -49,10 +49,10 @@ async function expectFullyInViewport(
 const MODE_TRANSITION_SETTLE_MS = 400;
 const GEOMETRY_TOLERANCE_PX = 1;
 const ARTIST_PROFILE_MODE_LABELS = [
-  'Upcoming Release',
-  'Release Day',
-  'Touring',
-  'Live Support',
+  'Pre-save',
+  'Out now',
+  'On tour',
+  'Support',
 ] as const;
 
 interface GeometrySnapshot {
@@ -176,7 +176,7 @@ test.describe('Artist Profiles Landing', () => {
 
     await expect(
       adaptiveSection.getByRole('heading', {
-        name: 'One adaptive profile. Four moments.',
+        name: 'One profile. Right action.',
       })
     ).toBeVisible();
     await expect(adaptiveSection.getByRole('tab')).toHaveCount(4);
@@ -186,26 +186,26 @@ test.describe('Artist Profiles Landing', () => {
     );
     const modes = [
       {
-        label: 'Upcoming Release',
-        headline: 'Before a drop, your profile collects release alerts.',
+        label: 'Pre-save',
+        headline: 'Collect release alerts before it lands.',
         screenshotAlt:
           'Jovie artist profile inviting fans to get release updates.',
       },
       {
-        label: 'Release Day',
+        label: 'Out now',
         headline:
           'When the song is live, fans go straight to the right service.',
         screenshotAlt:
           'Jovie artist profile showing a release-day listen view.',
       },
       {
-        label: 'Touring',
+        label: 'On tour',
         headline: "When you're on the road, nearby dates come first.",
         screenshotAlt:
           'Jovie artist profile showing nearby shows and ticket paths.',
       },
       {
-        label: 'Live Support',
+        label: 'Support',
         headline: 'At the merch table, one scan becomes support and capture.',
         screenshotAlt: 'Jovie artist profile showing direct support options.',
       },
@@ -253,7 +253,7 @@ test.describe('Artist Profiles Landing', () => {
       });
       const panelSlot = tabList.locator('xpath=following-sibling::*[1]');
       const upcomingRelease = adaptiveSection.getByRole('tab', {
-        name: 'Upcoming Release',
+        name: 'Pre-save',
       });
 
       await tabList.scrollIntoViewIfNeeded();
@@ -302,7 +302,7 @@ test.describe('Artist Profiles Landing', () => {
 
       await page.waitForTimeout(2500);
       await expect(
-        adaptiveSection.getByRole('tab', { name: 'Live Support' })
+        adaptiveSection.getByRole('tab', { name: 'Support' })
       ).toHaveAttribute('aria-selected', 'true');
     }
   });

--- a/apps/web/tests/unit/marketing/artist-profile/ArtistProfileModeSwitcher.test.tsx
+++ b/apps/web/tests/unit/marketing/artist-profile/ArtistProfileModeSwitcher.test.tsx
@@ -20,14 +20,14 @@ describe('ArtistProfileModeSwitcher', () => {
       <ArtistProfileModeSwitcher adaptive={ARTIST_PROFILE_COPY.adaptive} />
     );
 
-    expectSelectedTab('Upcoming Release');
+    expectSelectedTab('Pre-save');
 
-    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Touring' }), {
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'On tour' }), {
       button: 0,
       ctrlKey: false,
     });
 
-    expectSelectedTab('Touring');
+    expectSelectedTab('On tour');
   });
 
   it('keeps all four accessible modes in one reserved panel slot', () => {
@@ -36,7 +36,7 @@ describe('ArtistProfileModeSwitcher', () => {
     );
 
     const panelSlot = screen.getByRole('tabpanel').parentElement;
-    expect(panelSlot).toHaveClass('min-h-28');
+    expect(panelSlot).toHaveClass('min-h-20');
 
     for (const mode of ARTIST_PROFILE_COPY.adaptive.modes) {
       fireEvent.mouseDown(screen.getByRole('tab', { name: mode.label }), {
@@ -45,6 +45,25 @@ describe('ArtistProfileModeSwitcher', () => {
       });
       expectSelectedTab(mode.label);
       expect(screen.getByRole('tabpanel').parentElement).toBe(panelSlot);
+    }
+  });
+
+  it('uses compact one-line labels for every profile moment', () => {
+    render(
+      <ArtistProfileModeSwitcher adaptive={ARTIST_PROFILE_COPY.adaptive} />
+    );
+
+    expect(ARTIST_PROFILE_COPY.adaptive.modes.map(mode => mode.label)).toEqual([
+      'Pre-save',
+      'Out now',
+      'On tour',
+      'Support',
+    ]);
+
+    for (const mode of ARTIST_PROFILE_COPY.adaptive.modes) {
+      expect(screen.getByRole('tab', { name: mode.label })).toHaveClass(
+        'whitespace-nowrap'
+      );
     }
   });
 
@@ -72,11 +91,11 @@ describe('ArtistProfileModeSwitcher', () => {
       })
     ).toBeInTheDocument();
 
-    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Release Day' }), {
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Out now' }), {
       button: 0,
       ctrlKey: false,
     });
-    expectSelectedTab('Release Day');
+    expectSelectedTab('Out now');
     expect(
       screen.getByRole('img', {
         name: ARTIST_PROFILE_COPY.adaptive.modes[1].screenshotAlt,


### PR DESCRIPTION
## What changed
- rewrites Profile Modes labels so every option stays on one line
- gives the adaptive section one visual focus: the live profile phone, without the nested product card or signal list
- makes the heading an intentional two-line thesis and reserves a notch-safe screen area

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/artist-profile/ArtistProfileModeSwitcher.test.tsx tests/unit/app/artist-profiles-page.test.tsx --reporter=dot` (8 passed)
- `pnpm exec biome check` on the five changed files
- `pnpm --filter @jovie/web typecheck`

Visual review is advisory under the current shipping policy; source CI remains required.