### PR TITLE
fix(ci): select dashboard route matrix tests

### DIFF
--- a/scripts/lib/__tests__/automation-verify.test.mjs
+++ b/scripts/lib/__tests__/automation-verify.test.mjs
@@ -1323,6 +1323,27 @@ describe('automation-verify affected scope', () => {
     ).toBe('full');
   });
 
+  it('keeps a dashboard route-matrix contract repair on its targeted lane', () => {
+    const plan = buildAffectedTestPlan([
+      'apps/web/app/app/(shell)/contacts/ContactsPageClient.tsx',
+      'apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx',
+      'apps/web/tests/e2e/canonical-customer-shell-navigation.spec.ts',
+      'apps/web/tests/e2e/utils/dashboard-route-matrix.ts',
+      'apps/web/tests/unit/app/contacts-page-client.test.tsx',
+      'apps/web/tests/unit/dashboard/ContactsTable.test.tsx',
+      'apps/web/tests/unit/routes/route-coverage.test.ts',
+    ]);
+
+    expect(plan.mode).toBe('selected');
+    expect(plan.selectedTests).toEqual(
+      expect.arrayContaining([
+        'apps/web/tests/unit/app/contacts-page-client.test.tsx',
+        'apps/web/tests/unit/dashboard/ContactsTable.test.tsx',
+        'apps/web/tests/unit/routes/route-coverage.test.ts',
+      ])
+    );
+  });
+
   it('classifies a deleted unknown source as full-suite work', () => {
     expect(buildAffectedTestPlan(['apps/web/lib/deleted.ts']).mode).toBe(
       'full'

--- a/scripts/run-affected-tests.mjs
+++ b/scripts/run-affected-tests.mjs
@@ -786,6 +786,13 @@ export function buildAffectedTestPlan(
     if (file.startsWith('apps/web/components/')) return true;
     if (file.startsWith('apps/web/app/')) return true;
     if (file.startsWith('packages/ui/')) return true;
+    // The route matrix is test infrastructure: it is imported by the
+    // targeted route-coverage tests and is not product source that warrants
+    // escalating every ordinary route-contract change to a full web suite.
+    // Keep this deliberately narrow; arbitrary Playwright utilities remain
+    // fail-closed until they have an explicit deterministic lane.
+    if (file === 'apps/web/tests/e2e/utils/dashboard-route-matrix.ts')
+      return true;
     if (file.startsWith('apps/web/tests/eval/promptfoo/')) return true;
     if (isInvestorNoteIngestionInput(file)) return true;
     if (isCiCancellationHealerInput(file)) return true;


### PR DESCRIPTION
## Why

The affected-test selector classified `apps/web/tests/e2e/utils/dashboard-route-matrix.ts` as uncovered source, which forced otherwise bounded Contacts changes through the full eight-shard web suite.

## Scope

- Classify only the canonical dashboard route matrix as covered test infrastructure.
- Preserve fail-closed handling for every other Playwright utility.
- Add an exact Contacts-diff regression proving targeted test selection.

## Verification

- `automation-verify` tests: 178/178
- Biome
- direct affected-test plan: selected targeted Contacts tests

No product behavior or CI bypass.