### PR TITLE
fix(marketing): focus Capture Every Fan proof

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.css
@@ -13,25 +13,45 @@
   min-width: 0;
 }
 
-.ap-capture-loop__callout {
-  width: 100%;
+.ap-capture-loop__proof {
+  position: relative;
+  width: calc(100% + max(0px, 50vw - 50%));
   min-height: 34rem;
+  padding-block: clamp(var(--space-10), 7vw, var(--space-20));
+  padding-left: clamp(var(--space-5), 4vw, var(--space-16));
+  background:
+    radial-gradient(
+      circle at 28% 50%,
+      color-mix(in oklab, var(--color-accent-teal) 12%, transparent),
+      transparent 46%
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-text-primary-token) 2.5%, transparent),
+      transparent 72%
+    );
 }
 
-.ap-capture-loop__callout-content {
-  display: flex;
-  min-height: 30rem;
-  align-items: center;
-  padding-block: clamp(var(--space-8), 6vw, var(--space-16));
+.ap-capture-loop__proof > * {
+  width: min(100%, 48rem);
 }
 
-.ap-capture-loop__callout-content > * {
-  width: 100%;
+.ap-capture-loop__proof::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--color-bg-base) 20%, transparent),
+    transparent 45%
+  );
 }
 
 @media (max-width: 47.99rem) {
-  .ap-capture-loop__callout,
-  .ap-capture-loop__callout-content {
+  .ap-capture-loop__proof {
+    width: 100%;
     min-height: 0;
+    padding-inline: 0;
   }
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileCaptureSection.tsx
@@ -3,7 +3,6 @@ import type {
   ArtistProfileLandingCopy,
 } from '@/data/artistProfileCopy';
 import { ArtistProfileCaptureVisual } from '../MarketingStoryPrimitives';
-import { MarketingSurfaceCard } from '../MarketingSurfaceCard';
 import { ArtistProfileSectionHeader } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 import './ArtistProfileCaptureSection.css';
@@ -18,7 +17,7 @@ interface ArtistProfileCaptureSectionProps {
 function isEditorialCapture(
   capture: ArtistProfileCaptureSectionProps['capture']
 ): capture is ArtistProfileLandingCopy['capture'] {
-  return 'journey' in capture && 'benefits' in capture;
+  return 'journey' in capture;
 }
 
 export function ArtistProfileCaptureSection({
@@ -45,35 +44,15 @@ export function ArtistProfileCaptureSection({
 
   return (
     <ArtistProfileSectionShell className='ap-capture-loop bg-surface-0' id={id}>
-      <div className='ap-capture-loop__layout mx-auto grid max-w-public-content items-center gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(30rem,1.2fr)] lg:gap-20'>
-        <div>
+      <div className='ap-capture-loop__layout mx-auto grid max-w-public-content items-center gap-12 lg:grid-cols-[minmax(0,0.58fr)_minmax(34rem,1.42fr)] lg:gap-16'>
+        <div className='ap-capture-loop__copy'>
           <ArtistProfileSectionHeader
             align='left'
             headline={capture.headline}
             body={capture.body}
-            className='max-w-3xl'
-            bodyClassName='max-w-xl'
+            className='max-w-xl'
+            bodyClassName='max-w-lg'
           />
-          <ol className='mt-9 border-t border-subtle'>
-            {capture.benefits.map((benefit, index) => (
-              <li
-                key={benefit.id}
-                className='grid grid-cols-[2rem_minmax(0,1fr)] gap-3 border-b border-subtle py-4'
-              >
-                <span className='font-mono text-3xs text-tertiary-token'>
-                  0{index + 1}
-                </span>
-                <div>
-                  <p className='text-sm font-semibold text-primary-token'>
-                    {benefit.label}
-                  </p>
-                  <p className='mt-1.5 text-app leading-relaxed text-secondary-token'>
-                    {benefit.detail}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ol>
         </div>
 
         <figure
@@ -84,17 +63,10 @@ export function ArtistProfileCaptureSection({
             A focused Jovie fan opt-in accepts an email, confirms the fan, and
             turns that moment into an audience the artist can reach again.
           </figcaption>
-          <MarketingSurfaceCard
-            variant='product-callout'
-            glowTone='teal'
-            chrome='framed'
-            label='Fan Opt-in'
-            stateLabel='Illustrative fan activity'
-            className='ap-capture-loop__callout'
-            contentClassName='ap-capture-loop__callout-content'
-          >
-            <ArtistProfileCaptureVisual capture={capture} />
-          </MarketingSurfaceCard>
+          <ArtistProfileCaptureVisual
+            capture={capture}
+            className='ap-capture-loop__proof'
+          />
         </figure>
       </div>
     </ArtistProfileSectionShell>

--- a/apps/web/data/artistProfileCopy.ts
+++ b/apps/web/data/artistProfileCopy.ts
@@ -311,11 +311,6 @@ export interface ArtistProfileLandingCopy {
       readonly notificationBody: string;
     };
     readonly audienceRails: readonly (readonly ArtistProfileAudiencePill[])[];
-    readonly benefits: readonly {
-      readonly id: 'opt-in' | 'alerts' | 'ownership';
-      readonly label: string;
-      readonly detail: string;
-    }[];
   };
   readonly reactivation: {
     readonly headline: string;
@@ -422,7 +417,7 @@ export interface ArtistProfileLandingCopy {
  */
 export type ArtistProfileCaptureVisualCopy = Omit<
   ArtistProfileLandingCopy['capture'],
-  'action' | 'benefits' | 'journey'
+  'action' | 'journey'
 > & {
   readonly action: Omit<
     ArtistProfileLandingCopy['capture']['action'],
@@ -956,9 +951,9 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     playLabel: 'Play pay flow',
   },
   capture: {
-    headline: 'One fan moment. A relationship you keep.',
+    headline: 'Capture every fan.',
     subhead: 'One opt-in can become the next release listen.',
-    body: 'When a fan opts in, the next release or nearby show has a direct path back to them. Their permission turns one moment into an audience you can reach again.',
+    body: 'Jovie turns each opt-in into a fan you can reach for the next release or nearby show.',
     action: {
       title: 'Get updates',
       detail: 'Release and nearby-show alerts.',
@@ -1048,23 +1043,6 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
           sentence: 'Diego F. paid from the sidewalk QR.',
         },
       ],
-    ],
-    benefits: [
-      {
-        id: 'opt-in',
-        label: 'Opt in once',
-        detail: 'A simple fan action starts the relationship.',
-      },
-      {
-        id: 'alerts',
-        label: 'Reach the moment',
-        detail: 'Release and nearby-show alerts arrive when they matter.',
-      },
-      {
-        id: 'ownership',
-        label: 'Keep the audience',
-        detail: 'The relationship belongs to the artist, not the click.',
-      },
     ],
   },
   reactivation: {

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -170,10 +170,9 @@ describe('artist profile landing family System B source contract', () => {
       ),
       'utf8'
     );
-    expect(capture).toContain('<MarketingSurfaceCard');
-    expect(capture).toContain("variant='product-callout'");
-    expect(capture).toContain("glowTone='teal'");
     expect(capture).toContain('<ArtistProfileCaptureVisual');
+    expect(capture).toContain("className='ap-capture-loop__proof'");
+    expect(capture).not.toContain('MarketingSurfaceCard');
     expect(capture).not.toContain('ArtistProfilePhoneFrame');
 
     const captureShared = readFileSync(


### PR DESCRIPTION
Closes #15658

## Summary

- Replaces the carded Capture Every Fan product callout with a full-bleed cinematic proof treatment.
- Reduces the narrative to `Capture every fan.` and one outcome sentence.
- Removes the redundant three-item benefit list and its source contract.

## Verification

- `biome check --write` on all 4 changed files
- `vitest run tests/unit/app/artist-profiles-page.test.tsx tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts` — 6 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

## Scope

Does not touch the adaptive profile slider owned by #15655.

<!-- linear-issue-id: JOV-15658 -->