### PR TITLE
fix(start): retain ambient electric trace

### DIFF
--- a/apps/web/components/atoms/JovieMarkElectric.stories.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { JovieMarkElectric } from './JovieMarkElectric';
+
+const meta = {
+  title: 'Atoms/JovieMarkElectric',
+  component: JovieMarkElectric,
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    size: 128,
+    idSeed: 'storybook-jovie-mark',
+  },
+} satisfies Meta<typeof JovieMarkElectric>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SettledTrace: Story = {
+  args: {
+    settledSpark: true,
+  },
+};
+
+export const Static: Story = {
+  args: {
+    spark: false,
+    settledSpark: true,
+  },
+};

--- a/apps/web/components/atoms/JovieMarkElectric.test.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.test.tsx
@@ -39,6 +39,15 @@ describe('JovieMarkElectric', () => {
     expect(paths.length).toBe(0);
   });
 
+  it('can retain a static electric trace after the entrance animation', () => {
+    const { container } = render(<JovieMarkElectric settledSpark />);
+    expect(
+      container.querySelector(
+        '[data-testid="jovie-mark-electric-settled-trace"]'
+      )
+    ).not.toBeNull();
+  });
+
   it('omits the spark paths under prefers-reduced-motion', () => {
     vi.mocked(useReducedMotion).mockReturnValue(true);
     const { container } = render(<JovieMarkElectric />);

--- a/apps/web/components/atoms/JovieMarkElectric.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.tsx
@@ -24,6 +24,12 @@ interface JovieMarkElectricProps {
    * fallbacks that still need the same visual idiom).
    */
   readonly spark?: boolean;
+  /**
+   * Keep a dim electric trace visible after the one-shot entrance spark.
+   * Used by the Start composer, where the mark remains ambient until the
+   * first message instead of resolving to an entirely monochrome outline.
+   */
+  readonly settledSpark?: boolean;
 }
 
 const ASPECT_RATIO = 1;
@@ -34,6 +40,7 @@ export function JovieMarkElectric({
   style,
   idSeed,
   spark = true,
+  settledSpark = false,
 }: JovieMarkElectricProps) {
   const reactId = useId();
   const safeId = (idSeed ?? reactId).replace(/[^a-zA-Z0-9_-]/g, '');
@@ -82,6 +89,19 @@ export function JovieMarkElectric({
           stroke='rgba(255,255,255,0.065)'
           strokeWidth='1.15'
         />
+        {settledSpark && (
+          <path
+            data-testid='jovie-mark-electric-settled-trace'
+            pathLength='1000'
+            d={JOVIE_ICON_PATH}
+            fill='none'
+            stroke='rgba(78,190,255,0.46)'
+            strokeWidth='2.2'
+            strokeDasharray='62 938'
+            strokeDashoffset='-580'
+            strokeLinecap='round'
+          />
+        )}
         {showSpark && (
           <>
             <path

--- a/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChatEmptyIntro.tsx
@@ -112,6 +112,7 @@ export function OnboardingComposerAmbientMark() {
       <JovieMarkElectric
         size={560}
         idSeed='start-ambient-mark'
+        settledSpark
         className='absolute left-1/2 top-[4.5rem] -translate-x-1/2 opacity-[0.22] [mask-image:linear-gradient(142deg,transparent_0%,black_28%,black_78%,transparent_100%)] sm:top-[3rem]'
       />
     </div>


### PR DESCRIPTION
Restores the approved Start visual: a dim electric-blue trace settles after its one-shot arrival while blank, remains out of layout flow, and vanishes when conversation starts.

Deterministic evidence:
- prior focused Start regression suite: 3 files / 14 tests passed before the mechanical rebase
- post-rebase Biome + diff-check pass
- normal push completed

No marketing shell changes; Start remains its dedicated onboarding surface.