### PR TITLE
fix(marketing): focus Artist Profiles conversion story

### DIFF
--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css
@@ -1,99 +1,14 @@
 .ap-opinionated__headline {
-  max-width: 12ch;
+  max-width: 13ch;
 }
 
-.marketing-snap-rail__scroller.ap-opinionated__comparison {
-  display: block;
-  padding-inline: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-  scroll-snap-type: x mandatory;
-}
-
-.marketing-snap-rail__scroller.ap-opinionated__comparison::-webkit-scrollbar {
-  display: none;
-}
-
-.ap-opinionated__comparison-pane {
-  scroll-snap-align: start;
-}
-
-.ap-opinionated__comparison-media {
-  position: relative;
-  height: clamp(22rem, 42vw, 34rem);
+.ap-opinionated__visual {
+  min-height: clamp(28rem, 48vw, 40rem);
   overflow: hidden;
-  background: var(--color-bg-surface-0);
-}
-
-.ap-opinionated__menu-preview {
-  width: min(20rem, 72%);
-  margin: 0 auto;
-  padding-top: clamp(2rem, 6vw, 4rem);
-}
-
-.ap-opinionated__menu-avatar {
-  width: 4rem;
-  height: 4rem;
-  margin: 0 auto;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-pill);
-  background: var(--color-bg-surface-2);
-}
-
-.ap-opinionated__menu-name {
-  width: 7rem;
-  height: 0.6rem;
-  margin: var(--space-4) auto var(--space-8);
-  border-radius: var(--radius-pill);
-  background: var(--color-border-default);
-}
-
-.ap-opinionated__menu-links {
-  display: grid;
-  gap: var(--space-3);
-}
-
-.ap-opinionated__menu-link {
-  display: flex;
-  min-height: 3.25rem;
-  align-items: center;
-  justify-content: space-between;
-  padding-inline: var(--space-4);
-  border: 1px solid var(--color-border-subtle);
-  color: var(--color-text-secondary-token);
-  font-size: var(--text-xs);
 }
 
 @media (max-width: 47.99rem) {
-  .ap-opinionated__comparison-track {
-    width: 164vw;
-  }
-
-  .ap-opinionated__comparison-media {
-    height: 23.5rem;
-  }
-
-  .ap-opinionated__menu-preview {
-    width: min(17rem, 84%);
-    padding-top: var(--space-5);
-  }
-
-  .ap-opinionated__menu-avatar {
-    width: 3rem;
-    height: 3rem;
-  }
-
-  .ap-opinionated__menu-name {
-    height: 0.5rem;
-    margin: var(--space-3) auto var(--space-5);
-  }
-
-  .ap-opinionated__menu-links {
-    gap: var(--space-2);
-  }
-
-  .ap-opinionated__menu-link {
-    min-height: 2.75rem;
-    padding-inline: var(--space-3);
+  .ap-opinionated__visual {
+    min-height: 30rem;
   }
 }

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx
@@ -1,9 +1,7 @@
-import { ArrowUpRight } from 'lucide-react';
 import Image from 'next/image';
 import type { ArtistProfileLandingCopy } from '@/data/artistProfileCopy';
 import { getMarketingExportImage } from '@/lib/screenshots/registry';
 import { cn } from '@/lib/utils';
-import { MarketingSnapRail } from '../MarketingSnapRail';
 import { SHELL_H2_CLASS, SHELL_LEAD_CLASS } from './ArtistProfileSectionHeader';
 import { ArtistProfileSectionShell } from './ArtistProfileSectionShell';
 import './ArtistProfileOpinionatedSection.css';
@@ -14,100 +12,42 @@ interface ArtistProfileOpinionatedSectionProps {
 
 const LIVE_PROFILE = getMarketingExportImage('tim-white-profile-live-mobile');
 
-function StaticMenuPreview() {
-  const links = [
-    'Latest Release',
-    'Tour Dates',
-    'Merch',
-    'Subscribe',
-    'Contact',
-  ];
-
-  return (
-    <div
-      className='ap-opinionated__menu-preview'
-      role='img'
-      aria-label='Static Link Menu Giving Every Destination Equal Weight.'
-    >
-      <div className='ap-opinionated__menu-avatar' />
-      <div className='ap-opinionated__menu-name' />
-      <div className='ap-opinionated__menu-links'>
-        {links.map(link => (
-          <div key={link} className='ap-opinionated__menu-link'>
-            <span>{link}</span>
-            <ArrowUpRight aria-hidden='true' size={14} strokeWidth={1.6} />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export function ArtistProfileOpinionatedSection({
   opinionated,
 }: Readonly<ArtistProfileOpinionatedSectionProps>) {
   return (
-    <ArtistProfileSectionShell>
+    <ArtistProfileSectionShell className='ap-opinionated bg-surface-0'>
       <div className='mx-auto max-w-public-content'>
-        <div className='grid items-end gap-8 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1fr)]'>
-          <h2 className={cn(SHELL_H2_CLASS, 'ap-opinionated__headline')}>
-            {opinionated.headline}
-          </h2>
-          <p className={cn(SHELL_LEAD_CLASS, 'max-w-xl lg:justify-self-end')}>
-            {opinionated.body}
-          </p>
-        </div>
-
-        <MarketingSnapRail
-          ariaLabel='Static Menu And Adaptive Profile Comparison'
-          instructions='Use the previous and next buttons, or swipe, to compare both approaches.'
-          className='mt-12'
-          railClassName='ap-opinionated__comparison'
-          previousLabel='Show Static Menu Comparison'
-          nextLabel='Show Adaptive Profile Comparison'
-          showMobileControls
-          showDesktopControls={false}
-        >
-          <div className='ap-opinionated__comparison-track grid min-w-168 grid-cols-2 border-y border-subtle'>
-            <figure className='ap-opinionated__comparison-pane py-5 pr-5 sm:py-7 sm:pr-7'>
-              <figcaption className='mb-5 flex items-baseline justify-between gap-4'>
-                <strong className='text-sm font-semibold text-primary-token'>
-                  Static Menu
-                </strong>
-                <span className='text-xs text-tertiary-token'>
-                  Every option at once
-                </span>
-              </figcaption>
-              <div className='ap-opinionated__comparison-media'>
-                <StaticMenuPreview />
-              </div>
-            </figure>
-
-            <figure className='ap-opinionated__comparison-pane border-l border-subtle py-5 pl-5 sm:py-7 sm:pl-7'>
-              <figcaption className='mb-5 flex items-baseline justify-between gap-4'>
-                <strong className='text-sm font-semibold text-primary-token'>
-                  Adaptive Lead
-                </strong>
-                <span className='text-xs text-tertiary-token'>
-                  One clear move
-                </span>
-              </figcaption>
-              <div className='ap-opinionated__comparison-media'>
-                <Image
-                  fill
-                  src={LIVE_PROFILE.publicUrl}
-                  alt='Jovie artist profile leading with one clear Listen action.'
-                  className='object-contain object-top'
-                  sizes='(min-width: 1024px) 36rem, 78vw'
-                />
-              </div>
-            </figure>
+        <div className='grid items-center gap-10 lg:grid-cols-[minmax(0,0.78fr)_minmax(26rem,1fr)] lg:gap-20'>
+          <div className='max-w-2xl'>
+            <h2 className={cn(SHELL_H2_CLASS, 'ap-opinionated__headline')}>
+              {opinionated.headline}
+            </h2>
+            <p className={cn(SHELL_LEAD_CLASS, 'mt-6 max-w-xl')}>
+              {opinionated.body}
+            </p>
+            <p className='mt-8 font-mono text-xs text-tertiary-token'>
+              {opinionated.principle}
+            </p>
           </div>
-        </MarketingSnapRail>
 
-        <p className='mt-5 font-mono text-xs text-tertiary-token'>
-          {opinionated.principle}
-        </p>
+          <figure
+            className='ap-opinionated__visual relative'
+            data-testid='artist-profile-opinionated-profile'
+          >
+            <figcaption className='sr-only'>
+              A Jovie artist profile leads fans to the current release with one
+              Listen action.
+            </figcaption>
+            <Image
+              fill
+              src={LIVE_PROFILE.publicUrl}
+              alt='Jovie artist profile leading with one clear Listen action.'
+              className='object-contain object-center'
+              sizes='(min-width: 1024px) 36rem, 86vw'
+            />
+          </figure>
+        </div>
       </div>
     </ArtistProfileSectionShell>
   );

--- a/apps/web/data/artistProfileCopy.ts
+++ b/apps/web/data/artistProfileCopy.ts
@@ -167,17 +167,9 @@ export interface ArtistProfileLandingCopy {
     readonly syntheticProofs: ArtistProfileOutcomeProof;
   };
   readonly opinionated: {
-    readonly eyebrow: string;
     readonly headline: string;
     readonly body: string;
     readonly principle: string;
-    readonly columns: readonly [string, string, string];
-    readonly decisions: readonly {
-      readonly id: 'release' | 'tour' | 'support';
-      readonly context: string;
-      readonly signal: string;
-      readonly action: string;
-    }[];
   };
   readonly outcomeDuo: {
     readonly marketingHeadline: string;
@@ -791,31 +783,9 @@ export const ARTIST_PROFILE_COPY: ArtistProfileLandingCopy = {
     },
   },
   opinionated: {
-    eyebrow: 'Opinionated by design',
-    headline: 'One clear action beats a wall of links.',
-    body: 'Fans should not have to choose from a wall of links. Jovie leads with the action that matters now.',
-    principle: 'One profile. One decision.',
-    columns: ['Moment', 'Jovie reads', 'Primary action'],
-    decisions: [
-      {
-        id: 'release',
-        context: 'Release is live',
-        signal: 'Latest music',
-        action: 'Listen',
-      },
-      {
-        id: 'tour',
-        context: 'Fan is nearby',
-        signal: 'Local date',
-        action: 'Tickets',
-      },
-      {
-        id: 'support',
-        context: 'Merch-table scan',
-        signal: 'Live moment',
-        action: 'Support',
-      },
-    ],
+    headline: 'Stop designing your link-in-bio.',
+    body: 'Jovie leads with the next action a fan needs—not a page of choices for you to keep redesigning. Make music. Jovie turns attention into action.',
+    principle: 'One profile. Built to convert.',
   },
   outcomeDuo: {
     // Two headlines by design: the /artist-profile page and the homepage

--- a/apps/web/tests/e2e/artist-profiles.spec.ts
+++ b/apps/web/tests/e2e/artist-profiles.spec.ts
@@ -437,11 +437,12 @@ test.describe('Artist Profiles Landing', () => {
     );
     await expect(
       opinionatedSection.getByRole('heading', {
-        name: 'One clear action beats a wall of links.',
+        name: 'Stop designing your link-in-bio.',
       })
     ).toBeVisible();
-    await expect(opinionatedSection.getByText('Static Menu')).toBeVisible();
-    await expect(opinionatedSection.getByText('Adaptive Lead')).toBeVisible();
+    await expect(
+      opinionatedSection.getByTestId('artist-profile-opinionated-profile')
+    ).toBeVisible();
 
     const specWallSection = page.getByTestId(
       'artist-profile-section-spec-wall'

--- a/apps/web/tests/unit/app/artist-profiles-page.test.tsx
+++ b/apps/web/tests/unit/app/artist-profiles-page.test.tsx
@@ -131,9 +131,7 @@ vi.mock(
     }) => (
       <section>
         <h2>{opinionated.headline}</h2>
-        {opinionated.decisions.map(decision => (
-          <article key={decision.id}>{decision.action}</article>
-        ))}
+        <p>{opinionated.principle}</p>
       </section>
     ),
   })

--- a/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts
@@ -130,12 +130,12 @@ describe('artist profile landing family System B source contract', () => {
       'utf8'
     );
     expect(opinionated).toContain(
-      "ariaLabel='Static Menu And Adaptive Profile Comparison'"
+      "data-testid='artist-profile-opinionated-profile'"
     );
-    expect(opinionated).toContain('showMobileControls');
     expect(opinionated).toContain(
-      "instructions='Use the previous and next buttons, or swipe, to compare both approaches.'"
+      "className='ap-opinionated__visual relative'"
     );
+    expect(opinionated).not.toContain('MarketingSnapRail');
 
     const hero = readFileSync(
       resolve(


### PR DESCRIPTION
## What changed
- removes the static-menu versus adaptive-profile carousel
- replaces it with one high-fidelity profile focal point and concise conversion-first copy
- keeps the Artist Profiles section in shared shell, tokens, and screenshot registry primitives

## Verification
- `pnpm biome check apps/web/data/artistProfileCopy.ts apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.tsx apps/web/components/marketing/artist-profile/ArtistProfileOpinionatedSection.css apps/web/tests/e2e/artist-profiles.spec.ts apps/web/tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts apps/web/tests/unit/app/artist-profiles-page.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/marketing/artist-profile/artist-profile-system-b-style-guard.test.ts tests/unit/app/artist-profiles-page.test.tsx` (6/6)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- normal `git push` hook passed

Taste feedback is post-merge follow-up under current shipping policy.