### PR TITLE
fix(settings): keep navigation in shell

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsPolished.tsx
@@ -1,19 +1,9 @@
 'use client';
 
 import { PanelRight } from 'lucide-react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import {
-  memo,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { type ReactNode, useCallback, useMemo } from 'react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
-import { getSidebarNavRowClassName } from '@/components/shell/SidebarNavItem';
-import { APP_ROUTES } from '@/constants/routes';
 import { SettingsErrorState } from '@/features/dashboard/molecules/SettingsErrorState';
 import { AccountSettingsSection } from '@/features/dashboard/organisms/account-settings';
 import { DataPrivacySection } from '@/features/dashboard/organisms/DataPrivacySection';
@@ -52,116 +42,6 @@ interface SettingsSectionGroup {
   readonly sections: ReadonlyArray<SettingsSectionConfig>;
 }
 
-interface SettingsSidebarProps {
-  readonly groups: ReadonlyArray<SettingsSectionGroup>;
-  readonly activeSectionId?: string;
-  readonly useRouteLinks?: boolean;
-}
-
-function getFocusedSettingsHref(sectionId: string): string {
-  switch (sectionId) {
-    case 'account':
-      return APP_ROUTES.SETTINGS_APPEARANCE;
-    case 'billing':
-      return APP_ROUTES.SETTINGS_BILLING;
-    case 'usage':
-      return APP_ROUTES.SETTINGS_USAGE;
-    case 'data-privacy':
-      return APP_ROUTES.SETTINGS_DATA_PRIVACY;
-    case 'artist-profile':
-      return APP_ROUTES.SETTINGS_ARTIST_PROFILE;
-    case 'contacts':
-      return APP_ROUTES.SETTINGS_CONTACTS;
-    case 'touring':
-      return APP_ROUTES.SETTINGS_TOURING;
-    case 'audience-tracking':
-      return APP_ROUTES.SETTINGS_AUDIENCE;
-    case 'analytics':
-      return `${APP_ROUTES.SETTINGS}#analytics`;
-    case 'payments':
-      return `${APP_ROUTES.SETTINGS}#payments`;
-    default:
-      return APP_ROUTES.SETTINGS;
-  }
-}
-
-/**
- * Settings sidebar rows share the canonical shell nav-row chrome
- * (`getSidebarNavRowClassName`) so padding/density/active/hover stay
- * byte-identical to the main app sidebar. The only divergence is
- * structural: settings rows have no icon column, so the grid collapses
- * to a single column and the icon guide lines are hidden.
- *
- * Exported for the settings-vs-shell parity test
- * (tests/unit/sidebar-row-alignment.test.tsx).
- */
-export function getSettingsSidebarRowClassName(isActive: boolean): string {
-  return getSidebarNavRowClassName({
-    active: isActive,
-    className: 'grid-cols-[minmax(0,1fr)] text-left',
-  });
-}
-
-const SettingsSidebar = memo(
-  ({
-    groups,
-    activeSectionId,
-    useRouteLinks = false,
-  }: SettingsSidebarProps) => (
-    <aside className='h-fit'>
-      <div className='max-h-[calc(100vh-4.5rem)] overflow-y-auto rounded-xl border border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_97%,var(--linear-bg-surface-0))] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur-sm'>
-        {groups.map(group => (
-          <div key={group.id} className='mb-2 last:mb-0'>
-            <p className='mb-1 px-2.5 text-2xs font-medium tracking-tight text-tertiary-token'>
-              {group.label}
-            </p>
-            <nav aria-label={`${group.label} settings`}>
-              <ul className='space-y-1'>
-                {group.sections.map(section => {
-                  const isActive = section.id === activeSectionId;
-                  const href = useRouteLinks
-                    ? getFocusedSettingsHref(section.id)
-                    : `#${section.id}`;
-                  const rowClassName = getSettingsSidebarRowClassName(isActive);
-                  const rowContent = (
-                    <span className='min-w-0 truncate text-left justify-self-start'>
-                      {section.title}
-                    </span>
-                  );
-
-                  return (
-                    <li key={section.id}>
-                      {useRouteLinks ? (
-                        <Link
-                          href={href}
-                          aria-current={isActive ? 'page' : undefined}
-                          className={rowClassName}
-                        >
-                          {rowContent}
-                        </Link>
-                      ) : (
-                        <a
-                          href={href}
-                          aria-current={isActive ? 'page' : undefined}
-                          className={rowClassName}
-                        >
-                          {rowContent}
-                        </a>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            </nav>
-          </div>
-        ))}
-      </div>
-    </aside>
-  )
-);
-
-SettingsSidebar.displayName = 'SettingsSidebar';
-
 /**
  * Mobile-only trigger to open the profile panel (tabs, links, analytics, share).
  * On desktop the panel is visible as an inline sidebar; on mobile the header
@@ -199,9 +79,6 @@ export function SettingsPolished({
   focusSection,
 }: SettingsPolishedProps) {
   const router = useRouter();
-  const [activeHashSectionId, setActiveHashSectionId] = useState<
-    string | undefined
-  >(undefined);
   const { data: billingData } = useBillingStatusQuery();
   const isPro = billingData?.isPro ?? false;
   const isGrowth = billingData?.plan === 'growth';
@@ -395,22 +272,6 @@ export function SettingsPolished({
     [sectionGroups]
   );
 
-  useEffect(() => {
-    if (focusSection) return;
-
-    const syncActiveSection = () => {
-      const nextHash = globalThis.location.hash.replace(/^#/, '');
-      setActiveHashSectionId(nextHash || undefined);
-    };
-
-    syncActiveSection();
-    globalThis.addEventListener('hashchange', syncActiveSection);
-
-    return () => {
-      globalThis.removeEventListener('hashchange', syncActiveSection);
-    };
-  }, [focusSection]);
-
   if (
     focusSection &&
     !allSections.some(section => section.id === focusSection)
@@ -427,17 +288,9 @@ export function SettingsPolished({
 
     return (
       <div
-        className='mx-auto grid w-full max-w-230 gap-5 pb-6 lg:grid-cols-[172px_minmax(0,1fr)] lg:justify-center lg:gap-6'
+        className='mx-auto w-full max-w-230 pb-6'
         data-testid='settings-polished'
       >
-        <div className='lg:sticky lg:top-4 lg:self-start'>
-          <SettingsSidebar
-            groups={sectionGroups}
-            activeSectionId={focusSection}
-            useRouteLinks
-          />
-        </div>
-
         <div className='space-y-5 pb-5 sm:pb-6'>
           <SettingsSection
             id={section.id}
@@ -457,16 +310,9 @@ export function SettingsPolished({
   // Full settings view with Linear-style grouped navigation
   return (
     <div
-      className='mx-auto grid w-full max-w-230 gap-5 pb-6 lg:grid-cols-[172px_minmax(0,1fr)] lg:justify-center lg:gap-6'
+      className='mx-auto w-full max-w-230 pb-6'
       data-testid='settings-polished'
     >
-      <div className='lg:sticky lg:top-4 lg:self-start'>
-        <SettingsSidebar
-          groups={sectionGroups}
-          activeSectionId={activeHashSectionId}
-        />
-      </div>
-
       <div className='space-y-4'>
         {sectionGroups.map(group => (
           <section

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -16,6 +16,17 @@ const UNIFIED_SIDEBAR = findSourceFile(
   resolve(process.cwd(), 'apps/web/components/organisms/UnifiedSidebar.tsx')
 );
 
+const SETTINGS_POLISHED = findSourceFile(
+  resolve(
+    process.cwd(),
+    'components/features/dashboard/organisms/SettingsPolished.tsx'
+  ),
+  resolve(
+    process.cwd(),
+    'apps/web/components/features/dashboard/organisms/SettingsPolished.tsx'
+  )
+);
+
 const RETARGETING_ROUTE_FILES = [
   findSourceFile(
     resolve(process.cwd(), 'app/app/(shell)/settings/retargeting-ads/page.tsx'),
@@ -188,6 +199,19 @@ describe('settings shell normalization', () => {
     expect(layoutSource).not.toContain('@/features/settings/SettingsSidebar');
     expect(layoutSource).not.toContain('<SettingsSidebar');
     expect(layoutSource).toContain('{children}');
+  });
+
+  it('keeps SettingsPolished content-only so it cannot restore duplicate navigation', () => {
+    expect(SETTINGS_POLISHED).toBeDefined();
+
+    if (!SETTINGS_POLISHED) {
+      throw new Error('Could not find SettingsPolished source');
+    }
+
+    const source = readFileSync(SETTINGS_POLISHED, 'utf8');
+    expect(source).not.toContain('const SettingsSidebar');
+    expect(source).not.toContain('<SettingsSidebar');
+    expect(source).not.toContain('getSettingsSidebarRowClassName');
   });
 
   it('keeps global settings navigation and deep links independent of the content layout on every viewport', () => {

--- a/apps/web/tests/unit/dashboard/SettingsPolished.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsPolished.test.tsx
@@ -78,7 +78,7 @@ describe('SettingsPolished', () => {
     Element.prototype.scrollIntoView = vi.fn();
   });
 
-  it('renders settings sections and sidebar navigation', () => {
+  it('renders settings sections without a second in-content navigation', () => {
     const { container } = render(
       <SettingsPolished
         artist={{ id: 'artist_1' } as Artist}
@@ -86,9 +86,9 @@ describe('SettingsPolished', () => {
       />
     );
 
-    // Sidebar navigation should be rendered
-    const sidebar = screen.getByRole('complementary');
-    expect(sidebar).toBeInTheDocument();
+    // AuthShell owns Settings navigation. This content component must never
+    // recreate a second sidebar beside the global shell rail.
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
 
     // Account section should be rendered
     const firstSection = document.getElementById('account');
@@ -97,15 +97,12 @@ describe('SettingsPolished', () => {
       container.querySelectorAll('section[aria-label$="settings group"] > h3')
     ).toHaveLength(0);
     expect(screen.queryByText('ACCOUNT')).not.toBeInTheDocument();
-    expect(screen.getByText('Account', { selector: 'p' })).toBeVisible();
-
-    const accountNavLink = screen.getByRole('link', { name: 'Account' });
-    expect(accountNavLink.className).toContain('h-7');
-    expect(accountNavLink.className).toContain('px-2.5');
-    expect(accountNavLink.className).not.toContain('py-1');
+    expect(
+      screen.getByRole('heading', { name: 'Account', level: 2 })
+    ).toBeVisible();
   });
 
-  it('keeps the full settings navigation visible when a section is focused', () => {
+  it('renders only the focused section without recreating settings navigation', () => {
     render(
       <SettingsPolished
         artist={{ id: 'artist_1' } as Artist}
@@ -114,16 +111,8 @@ describe('SettingsPolished', () => {
       />
     );
 
-    expect(screen.getByRole('complementary')).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'Billing & Subscription' })
-    ).toBeVisible();
-    expect(screen.getByRole('link', { name: 'Usage Stats' })).toBeVisible();
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
     expect(document.getElementById('contacts')).toBeTruthy();
     expect(document.getElementById('touring')).toBeNull();
-    expect(screen.getByRole('link', { name: 'Touring' })).toHaveAttribute(
-      'href',
-      '/app/settings/touring'
-    );
   });
 });

--- a/apps/web/tests/unit/design-system/linear-namespace.baseline.json
+++ b/apps/web/tests/unit/design-system/linear-namespace.baseline.json
@@ -1,4 +1,4 @@
 {
   "$comment": "Shrink-only floor for --linear-* namespace usage (JOV #12009). Lower this when you migrate consumers; never raise it.",
-  "count": 1694
+  "count": 1692
 }

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps, PropsWithChildren } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getSettingsSidebarRowClassName } from '@/components/features/dashboard/organisms/SettingsPolished';
 import { SidebarCollapsibleGroup } from '@/components/organisms/SidebarCollapsibleGroup';
 import { SidebarGroupLabel } from '@/components/organisms/sidebar/group';
 import {
@@ -139,46 +138,6 @@ describe('Sidebar row alignment', () => {
     expect(header?.getAttribute('class')).toContain('px-2.5');
     expect(content?.getAttribute('class')).toContain('px-0');
     expect(separator?.getAttribute('class')).toContain('mx-2.5');
-  });
-
-  it('keeps settings sidebar rows byte-identical to shell nav-row chrome', () => {
-    // Settings-vs-shell parity (#12025): the settings sidebar must derive its
-    // rows from the canonical shell helper. Its only allowed divergence is
-    // structural — no icon column (single-column grid) — never
-    // padding/density/active/hover treatment.
-    const settingsRow = getSettingsSidebarRowClassName(false);
-    const settingsActiveRow = getSettingsSidebarRowClassName(true);
-    const shellRow = getSidebarNavRowClassName({});
-
-    // Same density, radius, and hover chrome as the shell sidebar.
-    for (const token of [
-      'h-7',
-      'px-2.5',
-      'rounded-full',
-      'text-xs',
-      'font-normal',
-      'hover:bg-sidebar-accent',
-      'text-sidebar-item-foreground',
-    ]) {
-      expect(
-        settingsRow,
-        `settings row missing shell token ${token}`
-      ).toContain(token);
-      expect(shellRow, `shell row missing token ${token}`).toContain(token);
-    }
-
-    // Same active treatment as the shell sidebar.
-    expect(settingsActiveRow).toContain('bg-sidebar-accent-active');
-    expect(settingsActiveRow).toContain('text-white');
-    expect(settingsActiveRow).toContain('font-medium');
-
-    // Allowed structural divergence: icon-less single-column grid. `cn()` runs
-    // tailwind-merge, so the settings override must fully replace the shell's
-    // icon-column grid template.
-    expect(settingsRow).toContain('grid-cols-[minmax(0,1fr)]');
-    expect(settingsRow).not.toContain(
-      'grid-cols-[18px_minmax(0,1fr)_minmax(34px,auto)]'
-    );
   });
 
   it('keeps nav-row chrome borderless in resting, hover, and active states', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-4573 -->

## Summary
- remove the SettingsPolished in-content navigation that reintroduced a second Settings rail
- retain UnifiedSidebar as the sole settings-navigation owner
- lock the single-navigation contract with focused render and static-source coverage

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/SettingsPolished.test.tsx tests/unit/app/settings-shell-normalization.test.ts tests/unit/sidebar-row-alignment.test.tsx` (19/19)
- `pnpm biome check apps/web/components/features/dashboard/organisms/SettingsPolished.tsx apps/web/tests/unit/dashboard/SettingsPolished.test.tsx apps/web/tests/unit/app/settings-shell-normalization.test.ts apps/web/tests/unit/sidebar-row-alignment.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- normal pre-commit and pre-push gates

## Risk
Layout-only subtraction. Routes, shell navigation, and mobile profile access are unchanged.