### PR TITLE
fix(a11y): make mobile More navigation modal

### DIFF
--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -8,9 +8,11 @@ import {
   type SVGProps,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from 'react';
+import { useModalFocusBoundary } from '@/lib/a11y/modal-focus-boundary';
 import { navigationInputMethodFromClick } from '@/lib/tracking/navigation-telemetry';
 import type { NavigationInputMethod } from '@/lib/tracking/navigation-telemetry-contract';
 import { cn } from '@/lib/utils';
@@ -258,7 +260,9 @@ export function LiquidGlassMenu({
   const [isExpanded, setIsExpanded] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const expandedMenuRef = useRef<HTMLElement>(null);
+  const expandedDialogRef = useRef<HTMLDivElement>(null);
   const moreButtonRef = useRef<HTMLButtonElement>(null);
+  const expandedDialogId = useId();
   const previousPathnameRef = useRef(pathname);
 
   const closeMenu = useCallback(() => {
@@ -277,6 +281,7 @@ export function LiquidGlassMenu({
   }, [closeMenuAndRestoreFocus, isExpanded]);
 
   useCloseOnEscapeOrOutside(menuRef, isExpanded, closeMenuAndRestoreFocus);
+  useModalFocusBoundary(expandedDialogRef, isExpanded);
 
   // Move keyboard focus into the menu as soon as it opens.
   useEffect(() => {
@@ -327,6 +332,12 @@ export function LiquidGlassMenu({
 
           {/* Expanded menu */}
           <div
+            ref={expandedDialogRef}
+            id={expandedDialogId}
+            role='dialog'
+            aria-modal='true'
+            aria-label={expandedNavigationLabel}
+            tabIndex={-1}
             className='relative z-50 mx-3 mb-2 overflow-hidden rounded-xl'
             style={{
               background: 'var(--liquid-glass-bg-solid)',
@@ -493,6 +504,7 @@ export function LiquidGlassMenu({
             onClick={toggleMenu}
             aria-label={isExpanded ? 'Close menu' : 'More options'}
             aria-expanded={isExpanded}
+            aria-controls={expandedDialogId}
             className={cn(
               'relative flex min-h-11 min-w-11 flex-1 flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
               isExpanded

--- a/apps/web/components/molecules/drawer/RightDrawer.tsx
+++ b/apps/web/components/molecules/drawer/RightDrawer.tsx
@@ -7,48 +7,16 @@ import { CommonDropdown } from '@jovie/ui';
 import React, { useEffect, useId, useRef, useState } from 'react';
 
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
+import {
+  getFocusableElements,
+  useModalFocusBoundary,
+} from '@/lib/a11y/modal-focus-boundary';
 import { cn } from '@/lib/utils';
 
 /**
  * Lock body scroll when a mobile drawer is open to prevent
  * background page from scrolling behind the overlay.
  */
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'area[href]',
-  'button:not([disabled])',
-  'input:not([disabled]):not([type="hidden"])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  'iframe',
-  'object',
-  'embed',
-  '[contenteditable="true"]',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',');
-
-function getFocusableElements(container: HTMLElement) {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
-  ).filter(element => !element.hasAttribute('inert'));
-}
-
-function getDrawerBackgroundElements(drawer: HTMLElement) {
-  const background: HTMLElement[] = [];
-  let current: HTMLElement | null = drawer;
-
-  while (current?.parentElement) {
-    for (const sibling of Array.from(current.parentElement.children)) {
-      if (sibling !== current && sibling instanceof HTMLElement) {
-        background.push(sibling);
-      }
-    }
-    current = current.parentElement;
-  }
-
-  return background;
-}
-
 function useBodyScrollLock(isOpen: boolean, isMobile: boolean) {
   useEffect(() => {
     if (!isMobile || !isOpen) return;
@@ -149,56 +117,7 @@ function useMobileDrawerFocus(
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    const drawer = drawerRef.current;
-    if (!drawer || !isMobile || !isOpen || !isActive) return;
-
-    const background = getDrawerBackgroundElements(drawer);
-    const priorInertStates = background.map(element => ({
-      element,
-      wasInert: element.inert,
-    }));
-    for (const { element } of priorInertStates) {
-      element.inert = true;
-    }
-
-    return () => {
-      for (const { element, wasInert } of priorInertStates) {
-        element.inert = wasInert;
-      }
-    };
-  }, [drawerRef, isActive, isMobile, isOpen]);
-
-  useEffect(() => {
-    const drawer = drawerRef.current;
-    if (!drawer || !isMobile || !isOpen || !isActive) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Tab') return;
-
-      const focusable = getFocusableElements(drawer);
-      if (focusable.length === 0) {
-        event.preventDefault();
-        drawer.focus();
-        return;
-      }
-
-      const first = focusable[0];
-      const last = focusable.at(-1);
-      if (!last) return;
-
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [drawerRef, isActive, isMobile, isOpen]);
+  useModalFocusBoundary(drawerRef, isMobile && isOpen && isActive);
 }
 
 function hasOpenModalDialog() {

--- a/apps/web/lib/a11y/modal-focus-boundary.ts
+++ b/apps/web/lib/a11y/modal-focus-boundary.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { type RefObject, useEffect } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  ).filter(element => !element.hasAttribute('inert'));
+}
+
+function getModalBackgroundElements(modal: HTMLElement): HTMLElement[] {
+  const background: HTMLElement[] = [];
+  let current: HTMLElement | null = modal;
+
+  while (current?.parentElement) {
+    for (const sibling of Array.from(current.parentElement.children)) {
+      if (sibling !== current && sibling instanceof HTMLElement) {
+        background.push(sibling);
+      }
+    }
+    current = current.parentElement;
+  }
+
+  return background;
+}
+
+/**
+ * Applies the shared mobile-modal boundary used by drawer and menu surfaces:
+ * sibling content is inert and keyboard focus cannot leave the active modal.
+ */
+export function useModalFocusBoundary(
+  modalRef: RefObject<HTMLElement | null>,
+  isOpen: boolean
+): void {
+  useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal || !isOpen) return;
+
+    const priorInertStates = getModalBackgroundElements(modal).map(element => ({
+      element,
+      wasInert: element.inert,
+    }));
+
+    for (const { element } of priorInertStates) {
+      element.inert = true;
+    }
+
+    return () => {
+      for (const { element, wasInert } of priorInertStates) {
+        element.inert = wasInert;
+      }
+    };
+  }, [isOpen, modalRef]);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal || !isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+
+      const focusable = getFocusableElements(modal);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        modal.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (!last) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, modalRef]);
+}

--- a/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/RightDrawer.interaction.test.tsx
@@ -317,7 +317,7 @@ describe('RightDrawer', () => {
       <>
         <button type='button'>Background action</button>
         <RightDrawer isOpen width={360} ariaLabel='Focus trap drawer'>
-          <button type='button'>First action</button>
+          <a href='/app'>First action</a>
           <button type='button'>Last action</button>
         </RightDrawer>
       </>
@@ -326,7 +326,7 @@ describe('RightDrawer', () => {
     const background = screen.getByRole('button', {
       name: 'Background action',
     });
-    const first = screen.getByRole('button', { name: 'First action' });
+    const first = screen.getByRole('link', { name: 'First action' });
     const last = screen.getByRole('button', { name: 'Last action' });
 
     await waitFor(() => expect(background.inert).toBe(true));

--- a/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardMobileTabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DashboardMobileTabs } from '@/components/features/dashboard/organisms/DashboardMobileTabs';
@@ -156,6 +156,51 @@ describe('DashboardMobileTabs', () => {
         .getAllByRole('link')
         .map(link => link.getAttribute('href'))
     ).toEqual(before);
+  });
+
+  it('treats More as a modal mobile surface with contained focus and inert background', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type='button'>Background action</button>
+        <DashboardMobileTabs />
+      </>
+    );
+
+    const more = screen.getByRole('button', { name: 'More options' });
+    await user.click(more);
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Expanded Navigation Menu',
+    });
+    const menu = within(dialog).getByRole('navigation', {
+      name: 'Expanded Navigation Menu',
+    });
+    const first = within(menu).getByRole('link', { name: 'Inbox' });
+    const last = within(dialog).getByRole('button', { name: 'Sign out' });
+    const background = screen.getByRole('button', {
+      name: 'Background action',
+    });
+
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(more).toHaveAttribute('aria-controls', dialog.id);
+    expect(first).toHaveFocus();
+    expect(background.inert).toBe(true);
+
+    last.focus();
+    await user.tab();
+    expect(first).toHaveFocus();
+
+    first.focus();
+    await user.tab({ shift: true });
+    expect(last).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+    expect(
+      screen.queryByRole('dialog', { name: 'Expanded Navigation Menu' })
+    ).not.toBeInTheDocument();
+    expect(background.inert).toBeFalsy();
+    await waitFor(() => expect(more).toHaveFocus());
   });
 
   it('marks Inbox active only at the shell root', () => {


### PR DESCRIPTION
## Summary
- expose expanded mobile More navigation as an accessible modal dialog
- trap Tab and Shift+Tab, move initial focus into the navigation, restore trigger focus on close, and make background inert
- retain existing Liquid Glass tokens and layout

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/DashboardMobileTabs.test.tsx tests/unit/components/organisms/OperatorMobileNavigation.test.tsx` (14 passed)
- `pnpm --filter @jovie/web exec biome check components/features/dashboard/organisms/LiquidGlassMenu.tsx tests/unit/dashboard/DashboardMobileTabs.test.tsx`
- `git diff --check`