### PR TITLE
feat: establish canonical marketing registry gates

### DIFF
--- a/apps/web/data/marketing/componentRegistry.ts
+++ b/apps/web/data/marketing/componentRegistry.ts
@@ -1,0 +1,120 @@
+/** Server-safe canonical projection of marketing shells, sections, and variants. */
+
+import {
+  MARKETING_SECTIONS,
+  type MarketingSectionId,
+  type MarketingVariant,
+} from './sections';
+
+export type MarketingRegistryKind = 'shell' | 'section';
+
+export interface MarketingShellRegistryEntry {
+  readonly id: `shell.${string}`;
+  readonly kind: 'shell';
+  readonly source: string;
+  readonly storybookTitle: `Marketing/Shells/${string}`;
+}
+
+export interface MarketingSectionRegistryEntry {
+  readonly id: `section.${MarketingSectionId}`;
+  readonly kind: 'section';
+  readonly sectionId: MarketingSectionId;
+  readonly source: string;
+  readonly storybookTitle: `Marketing/Sections/${MarketingSectionId}`;
+  readonly variants: readonly MarketingVariant['id'][];
+  readonly defaultVariant: string;
+  readonly maxPerComposition?: number;
+}
+
+export type MarketingRegistryEntry =
+  | MarketingShellRegistryEntry
+  | MarketingSectionRegistryEntry;
+
+const shell = (
+  id: MarketingShellRegistryEntry['id'],
+  source: string,
+  storybookTitle: MarketingShellRegistryEntry['storybookTitle']
+): MarketingShellRegistryEntry => ({
+  id,
+  kind: 'shell',
+  source,
+  storybookTitle,
+});
+
+export const MARKETING_SHELL_REGISTRY = [
+  shell(
+    'shell.public-page',
+    'apps/web/components/site/PublicPageShell',
+    'Marketing/Shells/PublicPageShell'
+  ),
+  shell(
+    'shell.header',
+    'apps/web/components/site/MarketingHeader',
+    'Marketing/Shells/MarketingHeader'
+  ),
+  shell(
+    'shell.footer',
+    'apps/web/components/site/MarketingFooter',
+    'Marketing/Shells/MarketingFooter'
+  ),
+  shell(
+    'shell.page',
+    'apps/web/components/marketing/MarketingPageShell',
+    'Marketing/Shells/MarketingPageShell'
+  ),
+  shell(
+    'shell.container',
+    'apps/web/components/marketing/MarketingContainer',
+    'Marketing/Shells/MarketingContainer/page'
+  ),
+  shell(
+    'shell.prose',
+    'apps/web/components/marketing/MarketingContentShell',
+    'Marketing/Shells/MarketingContainer/prose'
+  ),
+] as const satisfies readonly MarketingShellRegistryEntry[];
+
+/** Section taxonomy and legal variants remain sourced from `sections.ts`. */
+export const MARKETING_SECTION_REGISTRY: readonly MarketingSectionRegistryEntry[] =
+  MARKETING_SECTIONS.map(section => ({
+    id: `section.${section.id}` as const,
+    kind: 'section' as const,
+    sectionId: section.id,
+    source: section.component,
+    storybookTitle: `Marketing/Sections/${section.id}` as const,
+    variants: section.variants.map(variant => variant.id),
+    defaultVariant: section.defaultVariant,
+    ...(section.id === 'hero' ? { maxPerComposition: 1 } : {}),
+  }));
+
+export const MARKETING_COMPONENT_REGISTRY: readonly MarketingRegistryEntry[] = [
+  ...MARKETING_SHELL_REGISTRY,
+  ...MARKETING_SECTION_REGISTRY,
+];
+
+export const MARKETING_COMPOSITION_CONTRACT = {
+  shell: 'shell.public-page',
+  hero: { sectionId: 'hero', exactly: 1, first: true },
+  sections: {
+    source: 'MARKETING_SECTION_REGISTRY',
+    unregisteredAllowed: false,
+  },
+} as const;
+
+const REGISTRY_BY_ID: Readonly<Record<string, MarketingRegistryEntry>> =
+  Object.fromEntries(
+    MARKETING_COMPONENT_REGISTRY.map(entry => [entry.id, entry])
+  );
+
+export function getMarketingRegistryEntry(
+  id: string
+): MarketingRegistryEntry | null {
+  return REGISTRY_BY_ID[id] ?? null;
+}
+
+export function getMarketingSectionRegistryEntry(
+  sectionId: string
+): MarketingSectionRegistryEntry | null {
+  const entry = getMarketingRegistryEntry(`section.${sectionId}`);
+  return entry?.kind === 'section' ? entry : null;
+}

--- a/apps/web/data/marketing/composition.ts
+++ b/apps/web/data/marketing/composition.ts
@@ -20,6 +20,7 @@
  */
 
 import { z } from 'zod';
+import { assertMarketingComposition } from './compositionValidation';
 import { getMarketingRecipe, type RecipeId } from './recipes';
 import {
   getMarketingSection,
@@ -29,6 +30,7 @@ import {
   MARKETING_SECTION_IDS,
   type MarketingSectionId,
 } from './sections';
+import { MARKETING_SPEC_VERSION } from './spec';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Brief — the inputs a future agent receives (charter success criterion)
@@ -952,7 +954,7 @@ export function resolveComposition(input: unknown): MarketingComposition {
   );
 
   // 8. CTA label + cadence from recipe
-  return {
+  return assertMarketingComposition({
     specVersion: MARKETING_SPEC_VERSION,
     recipeId,
     sections: compositionSections,
@@ -960,7 +962,7 @@ export function resolveComposition(input: unknown): MarketingComposition {
     secondaryCtaLabel: recipe.ctaCadence.secondaryLabel,
     ctaCadence: recipe.ctaCadence.cadence,
     trace,
-  };
+  });
 }
 
 /**
@@ -1005,6 +1007,4 @@ function pickDegradationRung(
   return 1; // non-asset sections default to rung 1
 }
 
-// Import the spec version from the barrel (avoids a circular import via index.ts)
-// We re-declare it here as the source of truth; index.ts re-exports.
-export const MARKETING_SPEC_VERSION = '1.1.0';
+export { MARKETING_SPEC_VERSION } from './spec';

--- a/apps/web/data/marketing/compositionValidation.ts
+++ b/apps/web/data/marketing/compositionValidation.ts
@@ -1,0 +1,122 @@
+/** Runtime closed-world composition gate shared by routes, Storybook, and Pencil. */
+
+import {
+  getMarketingSectionRegistryEntry,
+  MARKETING_COMPOSITION_CONTRACT,
+} from './componentRegistry';
+import type { MarketingComposition } from './composition';
+import { MARKETING_SPEC_VERSION } from './spec';
+
+export type MarketingCompositionValidationCode =
+  | 'spec-version-mismatch'
+  | 'empty-composition'
+  | 'hero-cardinality'
+  | 'hero-order'
+  | 'unregistered-section'
+  | 'unregistered-variant'
+  | 'duplicate-cardinality';
+
+export interface MarketingCompositionValidationIssue {
+  readonly code: MarketingCompositionValidationCode;
+  readonly message: string;
+  readonly sectionId?: string;
+  readonly variantId?: string;
+}
+
+export interface MarketingCompositionValidationResult {
+  readonly valid: boolean;
+  readonly issues: readonly MarketingCompositionValidationIssue[];
+}
+
+export function validateMarketingComposition(
+  composition: MarketingComposition
+): MarketingCompositionValidationResult {
+  const issues: MarketingCompositionValidationIssue[] = [];
+  const add = (
+    code: MarketingCompositionValidationCode,
+    message: string,
+    sectionId?: string,
+    variantId?: string
+  ) => issues.push({ code, message, sectionId, variantId });
+  const hero = MARKETING_COMPOSITION_CONTRACT.hero;
+
+  if (composition.specVersion !== MARKETING_SPEC_VERSION) {
+    add(
+      'spec-version-mismatch',
+      `composition specVersion ${composition.specVersion} does not match ${MARKETING_SPEC_VERSION}`
+    );
+  }
+  if (composition.sections.length === 0) {
+    add('empty-composition', 'a marketing composition must contain a section');
+  }
+
+  const heroIndexes = composition.sections.flatMap((section, index) =>
+    section.sectionId === hero.sectionId ? [index] : []
+  );
+  if (heroIndexes.length !== hero.exactly) {
+    add(
+      'hero-cardinality',
+      `a marketing composition must contain exactly ${hero.exactly} hero`,
+      hero.sectionId
+    );
+  }
+  if (hero.first && heroIndexes[0] !== undefined && heroIndexes[0] !== 0) {
+    add(
+      'hero-order',
+      'the hero must be the first section in a marketing composition',
+      hero.sectionId
+    );
+  }
+
+  const counts = new Map<string, number>();
+  for (const section of composition.sections) {
+    const entry = getMarketingSectionRegistryEntry(section.sectionId);
+    if (!entry) {
+      add(
+        'unregistered-section',
+        `section ${section.sectionId} is not registered in ${MARKETING_COMPOSITION_CONTRACT.sections.source}`,
+        section.sectionId,
+        section.variantId
+      );
+      continue;
+    }
+
+    const count = (counts.get(section.sectionId) ?? 0) + 1;
+    counts.set(section.sectionId, count);
+    if (!entry.variants.includes(section.variantId)) {
+      add(
+        'unregistered-variant',
+        `variant ${section.sectionId}/${section.variantId} is not registered`,
+        section.sectionId,
+        section.variantId
+      );
+    }
+    if (
+      entry.maxPerComposition !== undefined &&
+      count > entry.maxPerComposition
+    ) {
+      add(
+        'duplicate-cardinality',
+        `${section.sectionId} may appear at most ${entry.maxPerComposition} time in a composition`,
+        section.sectionId,
+        section.variantId
+      );
+    }
+  }
+  return { valid: issues.length === 0, issues };
+}
+
+export function assertMarketingComposition(
+  composition: MarketingComposition
+): MarketingComposition {
+  const result = validateMarketingComposition(composition);
+  if (!result.valid) {
+    throw new Error(
+      [
+        'Marketing composition registry gate failed:',
+        ...result.issues.map(issue => `- [${issue.code}] ${issue.message}`),
+      ].join('\n')
+    );
+  }
+  return composition;
+}

--- a/apps/web/data/marketing/index.ts
+++ b/apps/web/data/marketing/index.ts
@@ -23,6 +23,20 @@
  */
 
 export type {
+  MarketingRegistryEntry,
+  MarketingRegistryKind,
+  MarketingSectionRegistryEntry,
+  MarketingShellRegistryEntry,
+} from './componentRegistry';
+export {
+  getMarketingRegistryEntry,
+  getMarketingSectionRegistryEntry,
+  MARKETING_COMPONENT_REGISTRY,
+  MARKETING_COMPOSITION_CONTRACT,
+  MARKETING_SECTION_REGISTRY,
+  MARKETING_SHELL_REGISTRY,
+} from './componentRegistry';
+export type {
   MarketingBrief,
   MarketingComposition,
   MarketingCompositionSection,
@@ -34,6 +48,15 @@ export {
   MarketingCompositionSectionSchema,
   resolveComposition,
 } from './composition';
+export type {
+  MarketingCompositionValidationCode,
+  MarketingCompositionValidationIssue,
+  MarketingCompositionValidationResult,
+} from './compositionValidation';
+export {
+  assertMarketingComposition,
+  validateMarketingComposition,
+} from './compositionValidation';
 export type {
   MarketingCopyAction,
   MarketingCopyAuditIssue,
@@ -121,16 +144,19 @@ export {
   MARKETING_RECIPES,
 } from './recipes';
 export type {
+  MarketingRouteHealthTarget,
   RouteManifestEntry,
   RouteRecipeParityReport,
 } from './routeManifest';
 export {
   DEPRECATION_RATCHET_BASELINE,
   EXEMPTION_RATCHET_BASELINE,
+  getMarketingRouteHealthTarget,
   getRouteManifestEntry,
   getRouteRecipeParity,
   isExempt,
   isRecipeRoute,
+  MARKETING_ROUTE_HEALTH_TARGETS,
   MARKETING_ROUTE_MANIFEST,
 } from './routeManifest';
 export type {

--- a/apps/web/data/marketing/routeManifest.ts
+++ b/apps/web/data/marketing/routeManifest.ts
@@ -81,6 +81,16 @@ export interface RouteManifestEntry {
   readonly specVersion: string; // MARKETING_SPEC_VERSION at binding time
   /** Canonical URL the route serves (for cross-reference). */
   readonly url: string;
+  /**
+   * Concrete public path used by the pre-migration render gate. Exact routes
+   * default to `url`; wildcard routes and intentional legacy redirects must
+   * declare a fixture explicitly so CI never tests an unresolved glob.
+   */
+  readonly healthCheck?: {
+    readonly path: string;
+    readonly expected: 'page' | 'redirect';
+    readonly allowedFinalPaths?: readonly string[];
+  };
   /** noindex flag — true if the route is noindex today (e.g. /ai, /investors, /demo/video). */
   readonly noindex?: boolean;
   /** Alias-of — when this route is an alias of another (e.g. /artist-profile → /artist-profiles). */
@@ -100,7 +110,7 @@ export interface RouteManifestEntry {
 /**
  * The route manifest. Per JOV-4508 — 25 page.tsx under (marketing)/ after
  * retiring the legacy launch pricing visual fork, plus (home)/page.tsx and
- * app/waitlist/page.tsx = 27 entries.
+ * app/waitlist/page.tsx = 28 entries.
  *
  * Exemptions are sanctioned (carry linearId + approvedBy + prUrl) per DX2.
  * The baseline exemption count for the ratchet = current sanctioned count.
@@ -394,6 +404,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/compare/*',
+    healthCheck: {
+      path: '/compare/linktree',
+      expected: 'page',
+    },
   },
   {
     glob: '(marketing)/alternatives/[slug]/page.tsx',
@@ -413,6 +427,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/alternatives/*',
+    healthCheck: {
+      path: '/alternatives/linktree',
+      expected: 'page',
+    },
   },
   {
     glob: '(marketing)/blog/page.tsx',
@@ -445,6 +463,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/blog/category/*',
+    healthCheck: {
+      path: '/blog/category/artist-management',
+      expected: 'page',
+    },
   },
   // waitlist — stub recipe; route lives outside (marketing)/ but manifest binds it
   {
@@ -460,6 +482,11 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/waitlist',
+    healthCheck: {
+      path: '/waitlist',
+      expected: 'redirect',
+      allowedFinalPaths: ['/start'],
+    },
   },
 
   // ── Exemptions (sanctioned per DX2 — linearId + approvedBy + prUrl required) ──
@@ -499,6 +526,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/blog/*',
+    healthCheck: {
+      path: '/blog/the-contact-problem',
+      expected: 'page',
+    },
   },
   {
     glob: '(marketing)/blog/authors/[username]/page.tsx',
@@ -517,6 +548,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/blog/authors/*',
+    healthCheck: {
+      path: '/blog/authors/tim',
+      expected: 'page',
+    },
   },
   {
     glob: '(marketing)/changelog/page.tsx',
@@ -627,6 +662,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/renders/*',
+    healthCheck: {
+      path: '/renders/catalog',
+      expected: 'page',
+    },
   },
   {
     glob: '(marketing)/renders/surfaces/[surface]/page.tsx',
@@ -645,6 +684,10 @@ export const MARKETING_ROUTE_MANIFEST: readonly RouteManifestEntry[] = [
     status: 'active',
     specVersion: '1.0.0',
     url: '/renders/surfaces/*',
+    healthCheck: {
+      path: '/renders/surfaces/profile',
+      expected: 'page',
+    },
   },
 ] as const;
 
@@ -668,6 +711,68 @@ export function isExempt(glob: string): boolean {
 export function isRecipeRoute(glob: string): boolean {
   return MANIFEST_BY_GLOB[glob]?.recipeId !== undefined;
 }
+
+export interface MarketingRouteHealthTarget {
+  readonly glob: string;
+  readonly path: string;
+  readonly expected: 'page' | 'redirect';
+  readonly allowedFinalPaths: readonly string[];
+  readonly requiresSharedChrome: boolean;
+}
+
+/**
+ * Resolve the concrete route target used by the hard pre-migration gate.
+ * Wildcards cannot be handed to a browser, so they fail closed unless the
+ * manifest declares an explicit fixture path.
+ */
+export function getMarketingRouteHealthTarget(
+  entry: RouteManifestEntry
+): MarketingRouteHealthTarget {
+  const healthCheck = entry.healthCheck;
+  const path = healthCheck?.path ?? entry.url;
+
+  if (path.includes('*')) {
+    throw new Error(
+      `Marketing route ${entry.glob} has no concrete healthCheck.path; wildcard targets are not valid render evidence`
+    );
+  }
+  if (!path.startsWith('/')) {
+    throw new Error(
+      `Marketing route ${entry.glob} has an invalid healthCheck.path; use a concrete absolute path`
+    );
+  }
+
+  const expected = healthCheck?.expected ?? 'page';
+  const allowedFinalPaths = healthCheck?.allowedFinalPaths ?? [];
+  if (expected === 'redirect' && allowedFinalPaths.length === 0) {
+    throw new Error(
+      `Marketing route ${entry.glob} declares a redirect health check without an allowed final path`
+    );
+  }
+
+  if (
+    allowedFinalPaths.some(
+      finalPath => !finalPath.startsWith('/') || finalPath.includes('*')
+    )
+  ) {
+    throw new Error(
+      `Marketing route ${entry.glob} declares an invalid redirect target; use concrete absolute paths`
+    );
+  }
+
+  return {
+    glob: entry.glob,
+    path,
+    expected,
+    allowedFinalPaths,
+    // Exemptions remain render-gated, but their eventual shell migration is a
+    // separate workstream. Recipe routes must prove the shared shell now.
+    requiresSharedChrome: entry.recipeId !== undefined,
+  };
+}
+
+export const MARKETING_ROUTE_HEALTH_TARGETS: readonly MarketingRouteHealthTarget[] =
+  MARKETING_ROUTE_MANIFEST.map(getMarketingRouteHealthTarget);
 
 export interface RouteRecipeParityReport {
   readonly url: string;

--- a/apps/web/data/marketing/spec.ts
+++ b/apps/web/data/marketing/spec.ts
@@ -1,0 +1,2 @@
+/** Normative version for the marketing registry and composition contract. */
+export const MARKETING_SPEC_VERSION = '1.1.0';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -190,6 +190,7 @@
     "perf:interactions": "tsx scripts/performance-interaction-audit.ts",
     "perf:queue": "doppler run --project jovie-web --config dev -- tsx scripts/performance-batch-queue.ts",
     "qa:routes": "tsx scripts/route-qa.ts",
+    "qa:marketing:route-health": "E2E_USE_TEST_AUTH_BYPASS=1 PUBLIC_NOAUTH_SMOKE=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_E2E_MODE=1 playwright test tests/e2e/marketing-route-health.spec.ts --project=marketing-route-health --reporter=line",
     "public:route-qa": "tsx scripts/public-route-qa.ts",
     "qa:public:exhaustive": "tsx scripts/public-surface-qa.ts",
     "qa:public:exhaustive:staging": "BASE_URL=https://staging.jov.ie E2E_SKIP_WEB_SERVER=1 tsx scripts/public-surface-qa.ts",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -127,6 +127,13 @@ export default defineConfig({
 
   projects: [
     {
+      name: 'marketing-route-health',
+      testMatch: /marketing-route-health\.spec\.ts/,
+      // This gate must exercise the anonymous public surface directly. It
+      // intentionally does not depend on the authenticated app setup project.
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
       name: 'auth-setup',
       testMatch: /auth\.setup\.ts/,
       // Ensure setup project never attempts to read persisted auth from disk.
@@ -181,6 +188,7 @@ export default defineConfig({
             E2E_FAST_ONBOARDING: '1',
             E2E_ALLOW_DEV_CSP: '1',
             E2E_WEB_SERVER_WARMUP: webServerWarmupProfile,
+            PUBLIC_NOAUTH_SMOKE: process.env.PUBLIC_NOAUTH_SMOKE || '0',
             ...(useTestAuthBypass
               ? {
                   NEXT_PUBLIC_CLERK_MOCK: '1',

--- a/apps/web/tests/e2e/marketing-route-health.spec.ts
+++ b/apps/web/tests/e2e/marketing-route-health.spec.ts
@@ -1,0 +1,154 @@
+/** Blocking anonymous render gate required before marketing migration/import. */
+
+import type { Page } from '@playwright/test';
+import {
+  MARKETING_ROUTE_HEALTH_TARGETS,
+  type MarketingRouteHealthTarget,
+} from '@/data/marketing';
+import { expect, test } from './setup';
+import { installPublicRouteMocks } from './utils/public-surface-helpers';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const NAVIGATION_TIMEOUT = 300_000;
+const BOUNDARY_SELECTORS = [
+  '[data-testid="not-found"]',
+  '[data-testid="error-boundary"]',
+  '[data-testid="error-page"]',
+  'next-error-h1',
+].join(', ');
+const ERROR_TEXT = [
+  /application error/i,
+  /internal server error/i,
+  /unhandled runtime error/i,
+  /something went wrong/i,
+  /a server-side exception has occurred/i,
+  /this page could not be found/i,
+  /page not found/i,
+];
+const AUTH_PATH = /\/(?:auth|login|signin|sign-in|signup|sign-up)(?:\/|$)/i;
+const AUTH_SELECTORS =
+  '[data-auth-shell], [data-clerk-component], [data-testid="auth-clerk-unavailable"]';
+
+const pathname = (value: string) => new URL(value, 'http://localhost').pathname;
+
+async function assertNoDevChrome(page: Page) {
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-dev-chrome-disabled',
+    '1'
+  );
+  for (const selector of [
+    '[data-testid="dev-toolbar"]',
+    '[data-testid="dev-toolbar-flag-drawer"]',
+    '[data-vercel-toolbar]',
+    '[data-nextjs-dev-tools-button]',
+  ]) {
+    await expect(page.locator(selector)).toHaveCount(0);
+  }
+}
+
+async function assertPageHealth(
+  page: Page,
+  target: MarketingRouteHealthTarget,
+  consoleErrors: readonly string[],
+  pageErrors: readonly string[],
+  failedResponses: readonly string[],
+  failedRequests: readonly string[]
+) {
+  const finalPath = pathname(page.url());
+  expect(
+    target.expected === 'page'
+      ? finalPath
+      : target.allowedFinalPaths.map(pathname),
+    `${target.glob} did not settle on the declared path`
+  ).toEqual(
+    target.expected === 'page'
+      ? pathname(target.path)
+      : expect.arrayContaining([finalPath])
+  );
+  expect(failedResponses, `${target.glob} has same-origin 4xx/5xx`).toEqual([]);
+  expect(failedRequests, `${target.glob} has failed requests`).toEqual([]);
+  expect(consoleErrors, `${target.glob} emitted console errors`).toEqual([]);
+  expect(pageErrors, `${target.glob} threw runtime exceptions`).toEqual([]);
+  if (target.expected === 'redirect') return;
+
+  await assertNoDevChrome(page);
+  await expect(page.locator('main').first()).toBeVisible();
+  const body = (await page.locator('body').innerText())
+    .replace(/\s+/g, ' ')
+    .trim();
+  expect(
+    body.length,
+    `${target.glob} rendered no meaningful body`
+  ).toBeGreaterThan(20);
+  for (const pattern of ERROR_TEXT) {
+    expect(body, `${target.glob} rendered an error signal`).not.toMatch(
+      pattern
+    );
+  }
+  await expect(page.locator(BOUNDARY_SELECTORS)).toHaveCount(0);
+  await expect(page.locator(AUTH_SELECTORS)).toHaveCount(0);
+  expect(AUTH_PATH.test(finalPath), `${target.glob} ended on auth path`).toBe(
+    false
+  );
+  if (target.requiresSharedChrome) {
+    await expect(page.locator('[data-testid="header-nav"]')).toHaveCount(1);
+    await expect(page.locator('[data-testid="marketing-footer"]')).toHaveCount(
+      1
+    );
+  }
+}
+
+async function checkTarget(page: Page, target: MarketingRouteHealthTarget) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  const failedResponses: string[] = [];
+  const failedRequests: string[] = [];
+  const origin = new URL(
+    process.env.BASE_URL?.trim() || 'http://localhost:3100'
+  ).origin;
+  page.on('console', message => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('pageerror', error => pageErrors.push(error.message));
+  page.on('response', response => {
+    if (response.status() >= 400 && response.url().startsWith(origin)) {
+      failedResponses.push(`${response.status()} ${response.url()}`);
+    }
+  });
+  page.on('requestfailed', request => {
+    if (request.url().startsWith(origin)) {
+      failedRequests.push(
+        `${request.url()} ${request.failure()?.errorText ?? 'unknown failure'}`
+      );
+    }
+  });
+
+  await installPublicRouteMocks(page);
+  const response = await page.goto(target.path, {
+    waitUntil: 'domcontentloaded',
+    timeout: NAVIGATION_TIMEOUT,
+  });
+  expect(
+    response?.status() ?? 0,
+    `${target.glob} has no document response`
+  ).toBeLessThan(400);
+  await page.waitForTimeout(750);
+  await assertPageHealth(
+    page,
+    target,
+    consoleErrors,
+    pageErrors,
+    failedResponses,
+    failedRequests
+  );
+}
+
+test.describe('canonical marketing route health gate', () => {
+  test.setTimeout(NAVIGATION_TIMEOUT + 60_000);
+  for (const target of MARKETING_ROUTE_HEALTH_TARGETS) {
+    test(`${target.glob} → ${target.path}`, async ({ page }) => {
+      await checkTarget(page, target);
+    });
+  }
+});

--- a/apps/web/tests/unit/marketing/component-registry.test.ts
+++ b/apps/web/tests/unit/marketing/component-registry.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MARKETING_COMPONENT_REGISTRY,
+  MARKETING_SECTION_IDS,
+  MARKETING_SECTION_REGISTRY,
+  MARKETING_SECTIONS,
+  MARKETING_SHELL_REGISTRY,
+} from '@/data/marketing';
+
+describe('canonical marketing component registry', () => {
+  it('projects normative sections, variants, defaults, and stories once', () => {
+    expect(MARKETING_SECTION_REGISTRY).toHaveLength(
+      MARKETING_SECTION_IDS.length
+    );
+    expect(MARKETING_SECTION_REGISTRY.map(entry => entry.sectionId)).toEqual(
+      MARKETING_SECTION_IDS
+    );
+    expect(
+      new Set(MARKETING_SECTION_REGISTRY.map(entry => entry.id)).size
+    ).toBe(MARKETING_SECTION_REGISTRY.length);
+    for (const section of MARKETING_SECTIONS) {
+      const entry = MARKETING_SECTION_REGISTRY.find(
+        candidate => candidate.sectionId === section.id
+      );
+      expect(entry, section.id).toMatchObject({
+        variants: section.variants.map(variant => variant.id),
+        defaultVariant: section.defaultVariant,
+        storybookTitle: `Marketing/Sections/${section.id}`,
+      });
+    }
+  });
+
+  it('has one id per registered component and one shared shell set', () => {
+    const ids = MARKETING_COMPONENT_REGISTRY.map(entry => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(MARKETING_SHELL_REGISTRY.map(entry => entry.id)).toEqual([
+      'shell.public-page',
+      'shell.header',
+      'shell.footer',
+      'shell.page',
+      'shell.container',
+      'shell.prose',
+    ]);
+  });
+
+  it('limits compositions to one registered hero', () => {
+    expect(
+      MARKETING_SECTION_REGISTRY.find(entry => entry.sectionId === 'hero')
+        ?.maxPerComposition
+    ).toBe(1);
+  });
+});

--- a/apps/web/tests/unit/marketing/composition-validation.test.ts
+++ b/apps/web/tests/unit/marketing/composition-validation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertMarketingComposition,
+  MARKETING_SPEC_VERSION,
+  type MarketingComposition,
+  validateMarketingComposition,
+} from '@/data/marketing';
+
+const section = (
+  sectionId: MarketingComposition['sections'][number]['sectionId'],
+  variantId: string,
+  index = 0
+): MarketingComposition['sections'][number] => ({
+  sectionId,
+  variantId,
+  ctaPosition: index === 0 ? 'primary' : 'none',
+  proofVerified: false,
+  degradationRung: 1,
+});
+
+const composition = (
+  sections: MarketingComposition['sections']
+): MarketingComposition => ({
+  specVersion: MARKETING_SPEC_VERSION,
+  recipeId: 'feature',
+  sections,
+  primaryCtaLabel: 'Get started',
+  ctaCadence: 'hero-and-close',
+  trace: [],
+});
+
+const codes = (value: MarketingComposition) =>
+  validateMarketingComposition(value).issues.map(issue => issue.code);
+
+describe('marketing composition registry gate', () => {
+  it('accepts a registered hero followed by registered sections', () => {
+    expect(
+      validateMarketingComposition(
+        composition([
+          section('hero', 'centered-none'),
+          section('faq', 'objection-handler', 1),
+        ])
+      )
+    ).toEqual({ valid: true, issues: [] });
+    expect(
+      assertMarketingComposition(
+        composition([section('hero', 'centered-none')])
+      )
+    ).toBeDefined();
+  });
+
+  it('rejects missing, repeated, or misplaced heroes', () => {
+    expect(codes(composition([section('faq', 'objection-handler')]))).toContain(
+      'hero-cardinality'
+    );
+    expect(
+      codes(
+        composition([
+          section('hero', 'centered-none'),
+          section('hero', 'centered-phone', 1),
+        ])
+      )
+    ).toEqual(
+      expect.arrayContaining(['hero-cardinality', 'duplicate-cardinality'])
+    );
+    expect(
+      codes(
+        composition([
+          section('faq', 'objection-handler'),
+          section('hero', 'centered-none', 1),
+        ])
+      )
+    ).toContain('hero-order');
+  });
+
+  it('rejects variants absent from the registry', () => {
+    expect(
+      codes(
+        composition([
+          section('hero', 'not-a-real-variant'),
+          section('faq', 'objection-handler', 1),
+        ])
+      )
+    ).toContain('unregistered-variant');
+  });
+});

--- a/apps/web/tests/unit/marketing/route-health-contract.test.ts
+++ b/apps/web/tests/unit/marketing/route-health-contract.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMarketingRouteHealthTarget,
+  MARKETING_ROUTE_HEALTH_TARGETS,
+  MARKETING_ROUTE_MANIFEST,
+} from '@/data/marketing';
+
+describe('marketing route health contract', () => {
+  it('has one concrete target per manifest entry', () => {
+    expect(MARKETING_ROUTE_HEALTH_TARGETS).toHaveLength(
+      MARKETING_ROUTE_MANIFEST.length
+    );
+    const globs = MARKETING_ROUTE_HEALTH_TARGETS.map(target => target.glob);
+    expect(new Set(globs).size).toBe(MARKETING_ROUTE_MANIFEST.length);
+    for (const target of MARKETING_ROUTE_HEALTH_TARGETS) {
+      expect(target.path, `${target.glob} has a wildcard path`).not.toContain(
+        '*'
+      );
+      expect(target.path, `${target.glob} needs an absolute path`).toMatch(
+        /^\//
+      );
+    }
+  });
+
+  it('fails closed for wildcard routes and undeclared redirects', () => {
+    expect(() =>
+      getMarketingRouteHealthTarget({
+        ...MARKETING_ROUTE_MANIFEST[0],
+        glob: '(marketing)/future/[slug]/page.tsx',
+        url: '/future/*',
+      })
+    ).toThrow(/concrete healthCheck\.path/);
+    expect(() =>
+      getMarketingRouteHealthTarget({
+        ...MARKETING_ROUTE_MANIFEST[0],
+        glob: 'waitlist/page.tsx',
+        url: '/waitlist',
+        healthCheck: { path: '/waitlist', expected: 'redirect' },
+      })
+    ).toThrow(/without an allowed final path/);
+    expect(() =>
+      getMarketingRouteHealthTarget({
+        ...MARKETING_ROUTE_MANIFEST[0],
+        glob: '(marketing)/future/page.tsx',
+        url: 'future',
+      })
+    ).toThrow(/concrete absolute path/);
+  });
+
+  it('only permits the explicit waitlist redirect', () => {
+    const redirects = MARKETING_ROUTE_HEALTH_TARGETS.filter(
+      target => target.expected === 'redirect'
+    );
+    expect(redirects.map(target => target.glob)).toEqual(['waitlist/page.tsx']);
+    expect(redirects[0]?.allowedFinalPaths).toEqual(['/start']);
+  });
+});

--- a/apps/web/tests/unit/marketing/storybook-catalog-coverage.test.ts
+++ b/apps/web/tests/unit/marketing/storybook-catalog-coverage.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from 'vitest';
 import {
   MARKETING_RECIPES,
   MARKETING_SECTION_IDS,
+  MARKETING_SECTION_REGISTRY,
   type MarketingSectionId,
   type RecipeId,
 } from '@/data/marketing';
@@ -95,6 +96,12 @@ async function collectCatalogTitles(): Promise<{
   return { recipes, sections, shells, rawTitles };
 }
 
+function storyExportName(sectionId: string): string {
+  return sectionId.replace(/-([a-z])/g, (_, character: string) =>
+    character.toUpperCase()
+  );
+}
+
 describe('marketing Storybook catalog coverage (JOV-4420)', () => {
   it('covers every proven recipe under Marketing/Recipes/<recipeId>', async () => {
     const { recipes } = await collectCatalogTitles();
@@ -115,6 +122,22 @@ describe('marketing Storybook catalog coverage (JOV-4420)', () => {
     expect(
       missing,
       `Missing Storybook titles for sections: ${missing.join(', ')}. Add stories under MarketingSections.stories.tsx with name: '<sectionId>'.`
+    ).toEqual([]);
+  });
+
+  it('requires a real CSF story export for every registry entry', async () => {
+    const storyFile = join(STORYBOOK_DIR, 'MarketingSections.stories.tsx');
+    const storySource = await readFile(storyFile, 'utf8');
+    const missing = MARKETING_SECTION_REGISTRY.filter(
+      entry =>
+        !new RegExp(
+          `export\\s+const\\s+${storyExportName(entry.sectionId)}\\b`
+        ).test(storySource)
+    ).map(entry => entry.sectionId);
+
+    expect(
+      missing,
+      `Registry entries without real Storybook exports: ${missing.join(', ')}. A title/comment alone is not catalog coverage.`
     ).toEqual([]);
   });
 

--- a/docs/marketing/AGENT_GUIDE.md
+++ b/docs/marketing/AGENT_GUIDE.md
@@ -79,6 +79,31 @@ component paths are tagged `wip` and listed in
 
 Local: `pnpm --filter web storybook` → browse the `Marketing/` tree.
 
+### 2.6. Registry, route-health, and Pencil gates
+
+Before composing, query `MARKETING_COMPONENT_REGISTRY` in
+`apps/web/data/marketing/`. New components must be registered and storied in
+the same change; route-local copies are not available to agents. Before Pencil
+import or visual migration, run:
+
+```bash
+pnpm --filter @jovie/web run qa:marketing:route-health
+```
+
+It follows `MARKETING_ROUTE_MANIFEST` and checks every concrete target for a
+successful response, no 404/boundary/auth wall/failed request/runtime or
+console error; recipe routes also prove shared header/footer. Wildcards need a
+fixture and `/waitlist → /start` is the only allowed redirect.
+
+It uses supported capture flags (`NEXT_DISABLE_TOOLBAR=1`,
+`NEXT_PUBLIC_E2E_MODE=1`, `PUBLIC_NOAUTH_SMOKE=1`) and asserts dev chrome is
+absent without weakening production/preview/local diagnostics.
+
+**Earliest safe Pencil handoff:** route-health and registry/Storybook gates pass;
+Pencil may use registered ids, but this is not page parity. **Full canonical
+migration:** all pages use the registry, exemptions are retired/approved, and
+token/motion/accessibility/responsive/visual parity is green.
+
 ### 3. Lock meaning before writing
 
 For every rendered section, create a `MarketingCopySectionBrief` before
@@ -368,8 +393,9 @@ registry sections.
 
 ## When the spec version bumps
 
-`MARKETING_SPEC_VERSION` lives in `composition.ts`, echoed into docs via the
-`spec-version:` freshness marker. When it bumps:
+`MARKETING_SPEC_VERSION` lives in `apps/web/data/marketing/spec.ts` (and is
+re-exported by `composition.ts`), echoed into docs via the `spec-version:`
+freshness marker. When it bumps:
 1. Read `ARCHITECTURE.md` §Lifecycle + §Extension Rules.
 2. If minor (addition): add the new section/recipe/variant + a golden-fixture
    brief that exercises it + the docs anchor.

--- a/docs/marketing/ARCHITECTURE.md
+++ b/docs/marketing/ARCHITECTURE.md
@@ -199,8 +199,7 @@ is a committed vitest test that runs on every PR forever — not one-shot.
 
 ## 10. Lifecycle + versioning
 
-`MARKETING_SPEC_VERSION` lives in `composition.ts`, re-exported from `index.ts`,
-echoed into docs via the `spec-version:` freshness marker (this file's header).
+`MARKETING_SPEC_VERSION` lives in `apps/web/data/marketing/spec.ts`, is re-exported from `composition.ts` and `index.ts`, and is echoed via the `spec-version:` freshness marker.
 Spec-doc version drift fails Structural Contract doc-freshness (E13).
 
 | Bump type | When |


### PR DESCRIPTION
## Summary

- add the server-safe canonical marketing component registry and composition validator
- fail closed on unknown sections/variants, duplicate heroes, misplaced heroes, and unresolved route fixtures
- add an anonymous 28-target browser health gate before Pencil import/migration
- require real Storybook CSF exports for registered marketing sections
- document the earliest safe Pencil handoff separately from full page migration

## Verification

- `qa:marketing:route-health`: 28 passed
- focused marketing Vitest: 55 passed
- web production typecheck: passed
- Storybook build: passed
- Biome and git diff check: passed
- repository `typecheck:tests` remains red on unrelated baseline failures; no new-file errors were found

The browser gate asserted no same-origin 4xx/5xx, failed requests, page errors, console errors, error boundaries, auth walls, or dev chrome. It uses the existing supported capture/no-auth flags without changing production diagnostics. The only observed browser output was an existing `whitePill` deprecation warning.

This is a draft foundation PR only. It must be reviewed before merge and does not deploy anything.