### PR TITLE
fix(quality): clear main Sonar reliability findings

### DIFF
--- a/apps/web/components/organisms/table/NoirIonWorkspaceStatesSpecimen.tsx
+++ b/apps/web/components/organisms/table/NoirIonWorkspaceStatesSpecimen.tsx
@@ -49,6 +49,11 @@ export function NoirIonWorkspaceStatesSpecimen() {
         className='w-full overflow-hidden rounded-lg border border-subtle'
         aria-label='Workspace State Specimen'
       >
+        <thead className='sr-only'>
+          <tr>
+            <th scope='col'>Workspace state</th>
+          </tr>
+        </thead>
         <tbody>
           <tr
             className={cn(

--- a/apps/web/lib/chat/chat-tool-inventory.test.ts
+++ b/apps/web/lib/chat/chat-tool-inventory.test.ts
@@ -76,13 +76,18 @@ describe('CHAT_ROUTE_TOOL_IDS inventory', () => {
     expect(() => assertChatToolsRegistered(tools)).not.toThrow();
   });
 
-  it('assertChatToolsRegistered fails closed on unregistered tools', () => {
+  it('assertChatToolsRegistered fails closed with sorted unregistered tools', () => {
     expect(() =>
-      assertChatToolsRegistered({
-        proposeAvatarUpload: {},
-        totallyFakeTool: {},
-      })
-    ).toThrow(/totallyFakeTool/);
+      assertChatToolsRegistered(
+        {
+          zetaTool: {},
+          alphaTool: {},
+        },
+        new Set()
+      )
+    ).toThrow(
+      'Chat tools missing from CHAT_ROUTE_TOOL_IDS: alphaTool, zetaTool.'
+    );
   });
 });
 

--- a/apps/web/lib/chat/chat-tool-inventory.ts
+++ b/apps/web/lib/chat/chat-tool-inventory.ts
@@ -90,7 +90,9 @@ export function assertChatToolsRegistered(
   }
 
   throw new Error(
-    `Chat tools missing from CHAT_ROUTE_TOOL_IDS: ${unregistered.sort().join(', ')}. ` +
+    `Chat tools missing from CHAT_ROUTE_TOOL_IDS: ${unregistered
+      .sort((a, b) => a.localeCompare(b))
+      .join(', ')}. ` +
       'Add them to apps/web/lib/chat/chat-tool-inventory.ts. ' +
       'Do not use PUBLIC_SKILL_REGISTRY/SKILL_REGISTRY as the chat tool inventory ' +
       '(that catalog is productized skills only).'

--- a/apps/web/tests/unit/design-system/noir-ion-workspace-states.test.tsx
+++ b/apps/web/tests/unit/design-system/noir-ion-workspace-states.test.tsx
@@ -142,6 +142,9 @@ describe('Noir Ion D — workspace state surfaces (JOV-4648)', () => {
       'true'
     );
     expect(
+      screen.getByRole('columnheader', { name: 'Workspace state' })
+    ).toBeInTheDocument();
+    expect(
       screen.getByText('Selected row').closest('[data-state]')
     ).toHaveAttribute('data-state', 'selected');
     expect(


### PR DESCRIPTION
## Summary

- use localeCompare for deterministic alphabetical chat-tool diagnostics
- add a visually hidden semantic header row to the Noir Ion workspace specimen table

## Verification

- 13 focused Vitest tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed
- Biome passed on all edited files
- component ship gate and coverage ratchet passed

## Risk

Mechanical quality-gate fixes only. The table header is visually hidden and does not change layout.