### PR TITLE
chore(hermes): route Gem deepseek through Vercel Gateway

### DIFF
--- a/scripts/hermes/config/model-registry.json
+++ b/scripts/hermes/config/model-registry.json
@@ -17,13 +17,13 @@
     },
     {
       "id": "deepseek-v4-flash",
-      "provider": "openrouter",
+      "provider": "vercel-ai-gateway",
       "model": "deepseek/deepseek-v4-flash",
       "capabilities": ["mechanical", "code", "review", "semantic"],
-      "cost_tier": "cheap-paid",
+      "cost_tier": "gateway-budgeted-paid",
       "executable_env": "GEM_DEEPSEEK_EXECUTABLE",
-      "executable_default": "hermes",
-      "probe_argv": ["{executable}", "--help"],
+      "executable_default": "/home/timwhite/.local/bin/hermes",
+      "probe_argv": ["{executable}", "--profile", "gem-shipper", "--provider", "custom:vercel-ai-gateway", "--model", "{model}", "--help"],
       "cooldown_seconds": 1800
     },
     {

--- a/scripts/hermes/config/model-registry.json
+++ b/scripts/hermes/config/model-registry.json
@@ -23,7 +23,16 @@
       "cost_tier": "gateway-budgeted-paid",
       "executable_env": "GEM_DEEPSEEK_EXECUTABLE",
       "executable_default": "/home/timwhite/.local/bin/hermes",
-      "probe_argv": ["{executable}", "--profile", "gem-shipper", "--provider", "custom:vercel-ai-gateway", "--model", "{model}", "--help"],
+      "probe_argv": [
+        "{executable}",
+        "--profile",
+        "gem-shipper",
+        "--provider",
+        "custom:vercel-ai-gateway",
+        "--model",
+        "{model}",
+        "--help"
+      ],
       "cooldown_seconds": 1800
     },
     {


### PR DESCRIPTION
## Summary
- route Gem's deepseek registry entry through the configured Vercel AI Gateway provider
- keep the registry probe on the dedicated `gem-shipper` Hermes profile
- preserve the existing model capabilities and cooldown

## Verification
- JSON validation passed
- diff check passed
- runtime route canary was verified separately without exposing key material

This is a narrow source-persistence change for the Gem shipping lane.