### PR TITLE
feat: test: Gem pipeline verification - add agent-reference.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+Compound documentation index for the Jovie monorepo.
+
+## Agent Fleet
+
+- [Agent Reference](./agent-reference.md) — Discover the agent fleet topology,
+  coordination surfaces, and who to delegate to.
+
+## Indexes
+
+- [API Route Map](./API_ROUTE_MAP.md)
+- [Cron Registry](./CRON_REGISTRY.md)

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -1,0 +1,22 @@
+# Agent Reference
+
+Quick reference for discovering Jovie's agent fleet topology. New agents should
+read this before starting work so they can locate the right coordination
+surface and the right people to delegate to.
+
+## Coordination
+
+- **gbrain agent job ledger** — `coordination/agent-job-ledger`. The
+  system-of-record for which agent owns which area and what work is in flight.
+  Read it before starting any task, and update it when you claim or hand off
+  work. See `scripts/agent/PREFLIGHT.md` for the preflight contract.
+
+## Fleet
+
+- **Gem** — Gem's operating manual lives in `AGENTS.md` on the gem box. Read it
+  for Gem's role, boundaries, and shipping pipeline.
+- **Zoe** (OpenClaw) — Communications & intelligence, outer-loop orchestration.
+  Zoe's operating manual is in `AGENTS.md` (OpenClaw).
+- **Eve** (HyperAgent) — Planner / PM. Specs issues and routes work to build
+  models. Contact Eve through the HyperAgent control plane for planning and
+  routing help.


### PR DESCRIPTION
## Summary
Autonomous ship by Gem through the Vercel AI Gateway-backed deepseek route for pre-scoped issue #13828.

Closes #13828

## Implementation
- Add docs/agent-reference.md with the requested fleet references.
- Add the documentation index entry in docs/README.md.
- Scope limited to the issue request.

## Verification
- [ ] CI passes
- [ ] Changes match issue scope