### PR TITLE
fix(profiles): expose connector filter

### DIFF
--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.test.tsx
@@ -135,6 +135,24 @@ const data: ProfilesWorkspaceData = {
   providerAvailable: true,
 };
 
+const dataWithConnector: ProfilesWorkspaceData = {
+  ...data,
+  rows: [
+    ...data.rows,
+    {
+      id: 'gmail',
+      rowType: 'connector',
+      kind: 'connector',
+      platform: 'gmail',
+      label: 'Gmail',
+      handle: 'artist@example.com',
+      url: '/app/settings/connectors',
+      status: 'connected',
+      monitoringState: 'active',
+    },
+  ],
+};
+
 function renderWorkspace(workspaceData: ProfilesWorkspaceData | null) {
   return render(
     <HeaderActionsProvider>
@@ -255,8 +273,24 @@ describe('ProfilesWorkspace', () => {
     expect(screen.queryByText('Jovie Profile')).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole('button', { name: 'Connectors' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('button', { name: 'Connectors' })
+    ).toBeInTheDocument();
+  });
+
+  it('exposes connector rows through a dedicated filter', async () => {
+    const user = userEvent.setup();
+    renderWorkspace(dataWithConnector);
+
+    await user.click(screen.getByRole('button', { name: 'Connectors' }));
+
+    expect(screen.getByText('Gmail')).toBeInTheDocument();
+    expect(screen.queryByText('Spotify')).not.toBeInTheDocument();
+    expect(screen.queryByText('Instagram')).not.toBeInTheDocument();
+    expect(screen.queryByText('Jovie Profile')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Connectors' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('uses the row action registry to open connection-specific details', async () => {

--- a/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
+++ b/apps/web/app/app/(shell)/profiles/ProfilesWorkspace.tsx
@@ -83,6 +83,7 @@ const FILTERS: ReadonlyArray<{
   { id: 'all', label: 'All Pages' },
   { id: 'dsp', label: DSP_FILTER_LABEL },
   { id: 'social', label: 'Social' },
+  { id: 'connector', label: 'Connectors' },
   { id: 'source', label: 'Sources' },
   { id: 'website', label: 'Websites' },
   { id: 'jovie', label: 'Jovie' },


### PR DESCRIPTION
## What changed
- expose the existing Connectors filter in the Profiles/Connections toolbar
- add a regression fixture and interaction test proving connector rows are isolated from DSP, social, and Jovie rows

## Verification
- ProfilesWorkspace tests: 17 passed
- Biome: passed
- git diff --check: passed

Closes JOV-4897