### PR TITLE
perf(cmdk): warm active routes before navigation

### DIFF
--- a/apps/web/components/organisms/CmdKPalette.test.tsx
+++ b/apps/web/components/organisms/CmdKPalette.test.tsx
@@ -1,12 +1,18 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { type ReactNode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { CmdKPalette } from './CmdKPalette';
 
 const pushMock = vi.fn();
+const prefetchMock = vi.fn();
+const onOpenChangeMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useRouter: () => ({
+    push: pushMock,
+    prefetch: prefetchMock,
+    replace: vi.fn(),
+  }),
 }));
 
 vi.mock('next/image', () => ({
@@ -44,7 +50,11 @@ vi.mock('@/lib/queries/useChatCapabilitiesQuery', () => ({
   }),
 }));
 
-function MainPlaneHarness() {
+function MainPlaneHarness({
+  onOpenChange = vi.fn(),
+}: {
+  onOpenChange?: (open: boolean) => void;
+}) {
   const [header, setHeader] = useState<ReactNode>(null);
 
   return (
@@ -53,7 +63,7 @@ function MainPlaneHarness() {
       <CmdKPalette
         profileId='profile-1'
         open
-        onOpenChange={vi.fn()}
+        onOpenChange={onOpenChange}
         presentation='main'
         onHeaderChange={setHeader}
       />
@@ -85,6 +95,31 @@ describe('CmdKPalette', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(pushMock).toHaveBeenCalledWith('/app/calendar');
+  });
+
+  it('prefetches the active route and closes before pushing it', async () => {
+    pushMock.mockClear();
+    prefetchMock.mockClear();
+    onOpenChangeMock.mockClear();
+
+    render(<MainPlaneHarness onOpenChange={onOpenChangeMock} />);
+
+    const input = screen.getByRole('combobox', {
+      name: 'Command Palette Search',
+    });
+    fireEvent.change(input, { target: { value: 'Calendar' } });
+
+    await waitFor(() => {
+      expect(prefetchMock).toHaveBeenCalledWith('/app/calendar');
+    });
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false);
+    expect(pushMock).toHaveBeenCalledWith('/app/calendar');
+    expect(onOpenChangeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      pushMock.mock.invocationCallOrder[0]
+    );
   });
 
   it('keeps dense table results keyboard-selectable before committing', () => {

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -249,6 +249,31 @@ export function CmdKPalette({
     return ids;
   }, [filteredAdditional]);
 
+  // Warm only the route the user is currently about to choose. This keeps the
+  // palette responsive without eagerly loading every destination, and makes
+  // keyboard search (for example, `Presence` + Enter) benefit from the same
+  // warm route cache as pointer navigation.
+  const activeHref = useMemo(() => {
+    if (activeIndex === null) return null;
+    const item = flatItems[activeIndex];
+    if (!item || additionalIds.has(pickerItemKey(item))) return null;
+    if (item.kind === 'nav') return item.nav.href;
+    if (item.kind === 'skill') {
+      return `${APP_ROUTES.CHAT}?skill=${encodeURIComponent(item.skill.id)}`;
+    }
+    if (item.kind === 'prompt') return null;
+    return resolveEntityHref(item.entity);
+  }, [activeIndex, additionalIds, flatItems]);
+
+  const prefetchedHrefsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!open || !activeHref || prefetchedHrefsRef.current.has(activeHref)) {
+      return;
+    }
+    prefetchedHrefsRef.current.add(activeHref);
+    router.prefetch(activeHref);
+  }, [activeHref, open, router]);
+
   // Clamp selected index whenever the visible list changes.
   useEffect(() => {
     if (selectedIndex >= flatItems.length) {
@@ -276,14 +301,14 @@ export function CmdKPalette({
       }
 
       if (item.kind === 'nav') {
-        router.push(item.nav.href);
         handleClose();
+        router.push(item.nav.href);
         return;
       }
       if (item.kind === 'skill') {
         const url = `${APP_ROUTES.CHAT}?skill=${encodeURIComponent(item.skill.id)}`;
-        router.push(url);
         handleClose();
+        router.push(url);
         return;
       }
       if (item.kind === 'prompt') {
@@ -292,8 +317,8 @@ export function CmdKPalette({
       }
       const href = resolveEntityHref(item.entity);
       if (href) {
-        router.push(href);
         handleClose();
+        router.push(href);
       }
     },
     [flatItems, additionalIds, onAdditionalSelect, handleClose, router]

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -17,10 +17,15 @@ import {
 } from '@/lib/commands/registry';
 
 const pushMock = vi.fn();
+const prefetchMock = vi.fn();
 const CMD_LABEL = String.fromCodePoint(0x2318);
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useRouter: () => ({
+    push: pushMock,
+    prefetch: prefetchMock,
+    replace: vi.fn(),
+  }),
 }));
 
 vi.mock('next/image', () => ({

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -22,10 +22,15 @@ import {
 } from '@/contexts/HeaderActionsContext';
 
 const pushMock = vi.fn();
+const prefetchMock = vi.fn();
 const pathnameMock = vi.hoisted(() => vi.fn(() => '/app'));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useRouter: () => ({
+    push: pushMock,
+    prefetch: prefetchMock,
+    replace: vi.fn(),
+  }),
   usePathname: () => pathnameMock(),
 }));
 


### PR DESCRIPTION
## What changed
- prefetch only the currently active Cmd-K destination, including nav/entity/skill routes
- close the palette before pushing so the route transition is not blocked by an open overlay
- cover active-route prefetch and close-before-push ordering in palette tests

## Verification
- `CmdKPalette.test.tsx` + `SharedCommandPalette.test.tsx`: 25/25 passed
- Biome check: passed
- `git diff --check`: passed
- full web typecheck: baseline failure in unrelated shared UI typings/files; no diagnostics for changed files

Runtime latency measurement and deployment proof remain separate from this source/CI change.