### PR TITLE
fix(library): gate playback affordances on verified media

### DIFF
--- a/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryMediaThumbnail.tsx
@@ -13,7 +13,10 @@ import { LibraryArtworkHoverZoom } from './LibraryArtworkHoverZoom';
 import { LibraryAudioWaveformThumbnail } from './LibraryAudioWaveformThumbnail';
 import { LibraryVideoScrubThumbnail } from './LibraryVideoScrubThumbnail';
 import type { LibraryReleaseAsset } from './library-data';
-import { getLibraryItemKind } from './library-data';
+import {
+  getLibraryItemKind,
+  hasVerifiedLibraryAudioPreview,
+} from './library-data';
 import { scrubRatioFromPointer } from './library-thumbnail-utils';
 
 export type LibraryThumbnailSize = 'card' | 'row' | 'drawer';
@@ -72,7 +75,11 @@ export function LibraryMediaThumbnail({
   const compact = size === 'row';
   const itemKind = getLibraryItemKind(asset);
   const showVideoScrub = Boolean(asset.videoUrl);
-  const showAudioScrub = Boolean(asset.previewUrl) && !showVideoScrub;
+  // Compact rows already expose the row's playback affordance. Keep their
+  // artwork quiet; a waveform overlay belongs to larger cards only and only
+  // after the media QA pipeline verifies the preview.
+  const showAudioScrub =
+    !compact && hasVerifiedLibraryAudioPreview(asset) && !showVideoScrub;
   const hasScrubPreview = showVideoScrub || showAudioScrub;
   const showArtworkHoverZoom =
     !hasScrubPreview &&

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -142,6 +142,7 @@ import {
   getLibraryAspectRatioClass,
   getLibraryAssetAspectRatio,
   getLibraryItemKind,
+  hasVerifiedLibraryAudioPreview,
   LIBRARY_GRID_DENSITY_LAYOUT,
   type LibraryAssetKind,
   type LibraryGridDensity,
@@ -462,7 +463,7 @@ const ReleaseCell = memo(function ReleaseCell({
   const { playingPreviewId, onTogglePreview } = useContext(
     LibraryPreviewContext
   );
-  const hasPreview = Boolean(asset.previewUrl);
+  const hasPreview = hasVerifiedLibraryAudioPreview(asset);
   const isPreviewPlaying = playingPreviewId === asset.id;
 
   return (
@@ -1390,7 +1391,7 @@ const AssetCard = memo(function AssetCard({
   readonly onSelect: () => void;
   readonly onTogglePreview: LibraryPreviewToggle;
 }) {
-  const hasPreview = Boolean(asset.previewUrl);
+  const hasPreview = hasVerifiedLibraryAudioPreview(asset);
   const aspectRatio = getLibraryAssetAspectRatio(asset);
 
   return (
@@ -1761,7 +1762,7 @@ function PreviewActionButton({
   readonly disabledTabIndex?: number;
   readonly reserveSpace?: boolean;
 }) {
-  if (!asset.previewUrl) {
+  if (!hasVerifiedLibraryAudioPreview(asset)) {
     return reserveSpace ? (
       <span
         aria-hidden='true'
@@ -1827,7 +1828,7 @@ function LibraryAudioPanel({
               Audio
             </h3>
           </div>
-          {asset.previewUrl ? (
+          {hasVerifiedLibraryAudioPreview(asset) ? (
             <PreviewActionButton
               asset={asset}
               isPreviewPlaying={isPreviewPlaying}
@@ -2116,7 +2117,7 @@ function AssetDrawer({
                     title='Audio'
                     defaultOpen={false}
                     actions={
-                      current.previewUrl ? (
+                      hasVerifiedLibraryAudioPreview(current) ? (
                         <PreviewActionButton
                           asset={current}
                           isPreviewPlaying={isPreviewPlaying}
@@ -2390,6 +2391,7 @@ export function LibrarySurface({
     () =>
       stackLibraryReleaseVersions(assets).map((asset): LibraryReleaseAsset => {
         const previewUrl = audioOverrides[asset.id];
+        const hasPreviewOverride = Boolean(previewUrl);
         const approvalStatus =
           approvalStatusOverrides[asset.id] ?? asset.approvalStatus;
         const profileVisibility =
@@ -2400,12 +2402,12 @@ export function LibrarySurface({
           'active';
         const share = shareOverrides[asset.id] ?? asset.share ?? null;
         const assetKinds: readonly LibraryAssetKind[] =
-          previewUrl && !asset.assetKinds.includes('preview')
+          hasPreviewOverride && !asset.assetKinds.includes('preview')
             ? [...asset.assetKinds, 'preview']
             : asset.assetKinds;
 
         if (
-          !previewUrl &&
+          !hasPreviewOverride &&
           approvalStatus === asset.approvalStatus &&
           profileVisibility === asset.profileVisibility &&
           lifecycleStatus === (asset.lifecycleStatus ?? 'active') &&
@@ -2416,7 +2418,9 @@ export function LibrarySurface({
 
         return {
           ...asset,
-          ...(previewUrl ? { previewUrl } : {}),
+          ...(hasPreviewOverride
+            ? { previewUrl, previewVerification: 'verified' as const }
+            : {}),
           approvalStatus,
           profileVisibility,
           lifecycleStatus,
@@ -2503,12 +2507,12 @@ export function LibrarySurface({
         return;
       }
 
-      if (!asset.previewUrl) return;
+      if (!hasVerifiedLibraryAudioPreview(asset)) return;
 
       toggleTrack({
         id: asset.id,
         title: asset.title,
-        audioUrl: asset.previewUrl,
+        audioUrl: asset.previewUrl ?? undefined,
         releaseTitle: asset.title,
         artistName: asset.artist,
         artworkUrl: asset.artworkUrl,

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -1,4 +1,7 @@
-import type { ReleaseViewModel } from '@/lib/discography/types';
+import type {
+  PreviewVerification,
+  ReleaseViewModel,
+} from '@/lib/discography/types';
 import {
   DEFAULT_LIBRARY_APPROVAL_STATUS,
   type LibraryApprovalStatus,
@@ -51,6 +54,11 @@ export interface LibraryReleaseAsset {
   readonly artist: string;
   readonly artworkUrl: string | null;
   readonly previewUrl: string | null;
+  /**
+   * Preview playability is an explicit media-QA result. Consumers must not
+   * infer that a provider URL is playable from `previewUrl` alone.
+   */
+  readonly previewVerification?: PreviewVerification;
   readonly videoUrl: string | null;
   readonly waveformSeed: number;
   readonly smartLinkPath: string;
@@ -184,13 +192,16 @@ export function buildLibraryReleaseAssets(
     });
     const artworkUrl = normalizeHttpUrl(release.artworkUrl);
     const previewUrl = normalizeHttpUrl(release.previewUrl);
+    const previewVerification = release.previewVerification;
     const videoUrl = normalizeHttpUrl(release.canvasVideoUrl);
     const hasArtwork = Boolean(artworkUrl);
     const hasLyrics = Boolean(release.lyrics?.trim());
     const hasVideoLinks = Boolean(release.hasVideoLinks);
     const assetKinds: LibraryAssetKind[] = [];
     if (hasArtwork) assetKinds.push('artwork');
-    if (previewUrl) assetKinds.push('preview');
+    if (previewUrl && previewVerification === 'verified') {
+      assetKinds.push('preview');
+    }
     if (hasLyrics) assetKinds.push('lyrics');
     if (providers.length > 0) assetKinds.push('providers');
     if (hasVideoLinks) assetKinds.push('video');
@@ -201,6 +212,7 @@ export function buildLibraryReleaseAssets(
       artist: release.artistNames?.[0]?.trim() || 'Unknown Artist',
       artworkUrl,
       previewUrl,
+      ...(previewVerification ? { previewVerification } : {}),
       videoUrl,
       waveformSeed: hashLibraryWaveformSeed(release.id),
       smartLinkPath: release.smartLinkPath,
@@ -331,6 +343,17 @@ export function getLibraryItemKind(
   return asset.itemKind ?? 'release';
 }
 
+/**
+ * A preview URL is only a candidate until the audio QA pipeline verifies it.
+ * Keep this predicate shared so rows, cards, filters, and playback controls
+ * cannot drift into implying that stale/fallback URLs are playable.
+ */
+export function hasVerifiedLibraryAudioPreview(
+  asset: Pick<LibraryReleaseAsset, 'previewUrl' | 'previewVerification'>
+): boolean {
+  return Boolean(asset.previewUrl && asset.previewVerification === 'verified');
+}
+
 export function libraryAssetMatchesView(
   asset: LibraryReleaseAsset,
   view: LibraryView
@@ -345,7 +368,7 @@ export function libraryAssetMatchesView(
   if (view === 'merch') return itemKind === 'merch';
   if (view === 'images') return asset.assetKinds.includes('artwork');
   if (view === 'videos') return asset.assetKinds.includes('video');
-  return Boolean(asset.previewUrl);
+  return hasVerifiedLibraryAudioPreview(asset);
 }
 
 export function formatLibraryReleaseDate(value: string | null): string {

--- a/apps/web/components/features/library/library-catalog-columns.tsx
+++ b/apps/web/components/features/library/library-catalog-columns.tsx
@@ -5,6 +5,7 @@ import { memo, useMemo } from 'react';
 import { LibraryMediaThumbnail } from '@/app/app/(shell)/library/LibraryMediaThumbnail';
 import {
   formatLibraryDuration,
+  hasVerifiedLibraryAudioPreview,
   type LibraryReleaseAsset,
 } from '@/app/app/(shell)/library/library-data';
 import { libraryWaveformPeaks } from '@/app/app/(shell)/library/library-waveform-peaks';
@@ -203,7 +204,9 @@ const CATALOG_WAVEFORM_HEIGHT = 24;
  * empty/loading/populated states and view-mode switches never shift layout.
  * Peaks derive deterministically from the asset's waveform seed — the same
  * production source as the card scrub waveform. Decorative: row click already
- * opens the asset, so no seek interaction here.
+ * opens the asset, so no seek interaction here. If media QA has not verified a
+ * playable preview, keep the reserved cell and show an honest unavailable
+ * marker instead of a synthetic waveform.
  */
 export const LibraryCatalogWaveformCell = memo(
   function LibraryCatalogWaveformCell({
@@ -211,6 +214,7 @@ export const LibraryCatalogWaveformCell = memo(
   }: {
     readonly asset: LibraryReleaseAsset;
   }) {
+    const hasVerifiedPreview = hasVerifiedLibraryAudioPreview(asset);
     const peaks = useMemo(() => {
       const all = libraryWaveformPeaks(asset.waveformSeed);
       const stride = all.length / CATALOG_WAVEFORM_BAR_COUNT;
@@ -226,32 +230,45 @@ export const LibraryCatalogWaveformCell = memo(
     return (
       <div
         data-testid={`library-catalog-waveform-${asset.id}`}
-        aria-hidden='true'
+        data-audio-state={hasVerifiedPreview ? 'verified' : 'unavailable'}
+        {...(hasVerifiedPreview
+          ? { 'aria-hidden': true }
+          : {
+              role: 'img',
+              'aria-label': 'Audio preview unavailable',
+              title: 'Audio preview unavailable',
+            })}
         className='flex h-6 w-40 items-center text-quaternary-token'
       >
-        <svg
-          viewBox={`0 0 ${CATALOG_WAVEFORM_WIDTH} ${CATALOG_WAVEFORM_HEIGHT}`}
-          preserveAspectRatio='none'
-          aria-hidden='true'
-          className='block h-6 w-40'
-        >
-          {peaks.map((height, index) => {
-            const x = index * barStride + barStride / 2;
-            const half = Math.max(0.5, height * maxAmp);
-            return (
-              <line
-                key={x}
-                x1={x}
-                x2={x}
-                y1={CATALOG_WAVEFORM_HEIGHT / 2 - half}
-                y2={CATALOG_WAVEFORM_HEIGHT / 2 + half}
-                stroke='currentColor'
-                strokeWidth={Math.max(1, barStride * 0.4)}
-                strokeLinecap='round'
-              />
-            );
-          })}
-        </svg>
+        {hasVerifiedPreview ? (
+          <svg
+            viewBox={`0 0 ${CATALOG_WAVEFORM_WIDTH} ${CATALOG_WAVEFORM_HEIGHT}`}
+            preserveAspectRatio='none'
+            aria-hidden='true'
+            className='block h-6 w-40'
+          >
+            {peaks.map((height, index) => {
+              const x = index * barStride + barStride / 2;
+              const half = Math.max(0.5, height * maxAmp);
+              return (
+                <line
+                  key={x}
+                  x1={x}
+                  x2={x}
+                  y1={CATALOG_WAVEFORM_HEIGHT / 2 - half}
+                  y2={CATALOG_WAVEFORM_HEIGHT / 2 + half}
+                  stroke='currentColor'
+                  strokeWidth={Math.max(1, barStride * 0.4)}
+                  strokeLinecap='round'
+                />
+              );
+            })}
+          </svg>
+        ) : (
+          <span aria-hidden='true' className='text-tertiary-token'>
+            &mdash;
+          </span>
+        )}
       </div>
     );
   }

--- a/apps/web/lib/discography/queries.ts
+++ b/apps/web/lib/discography/queries.ts
@@ -32,6 +32,7 @@ import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { publicReleaseEligibilitySqlPredicate } from '@/lib/profile/public-release-eligibility';
 import { uuidSchema } from '@/lib/validation/schemas/base';
 import { resolveTrackProviderLinks } from './track-provider-links';
+import type { PreviewVerification } from './types';
 
 /**
  * Release data source types
@@ -43,6 +44,8 @@ export interface TrackSummary {
   totalDurationMs: number | null;
   primaryIsrc: string | null;
   primaryPreviewUrl: string | null;
+  /** Explicit media-QA state; older callers may omit it while migrating. */
+  primaryPreviewVerification?: PreviewVerification | null;
 }
 
 // Types for release data with provider links
@@ -148,6 +151,24 @@ function trackSummarySelectColumns() {
       drizzleSql<string>`(array_agg(NULLIF(BTRIM(${discogRecordings.previewUrl}), '') ORDER BY ${discogReleaseTracks.discNumber}, ${discogReleaseTracks.trackNumber}) FILTER (WHERE NULLIF(BTRIM(${discogRecordings.previewUrl}), '') IS NOT NULL))[1]`.as(
         'primary_preview_url'
       ),
+    primaryPreviewVerification: drizzleSql<string>`(
+        array_agg(
+          CASE
+            WHEN NULLIF(BTRIM(${discogRecordings.audioUrl}), '') IS NOT NULL
+              THEN 'verified'
+            WHEN NULLIF(BTRIM(${discogRecordings.previewUrl}), '') IS NOT NULL
+              AND COALESCE(${discogRecordings.metadata}->'previewResolution'->>'status', '') = 'fallback'
+              THEN 'fallback'
+            WHEN NULLIF(BTRIM(${discogRecordings.previewUrl}), '') IS NOT NULL
+              THEN 'verified'
+            ELSE 'missing'
+          END
+          ORDER BY ${discogReleaseTracks.discNumber}, ${discogReleaseTracks.trackNumber}
+        ) FILTER (
+          WHERE NULLIF(BTRIM(${discogRecordings.audioUrl}), '') IS NOT NULL
+             OR NULLIF(BTRIM(${discogRecordings.previewUrl}), '') IS NOT NULL
+        )
+      )[1]`.as('primary_preview_verification'),
   };
 }
 
@@ -155,12 +176,31 @@ function rowToTrackSummary(row: {
   totalDurationMs: number | null;
   primaryIsrc: string | null;
   primaryPreviewUrl: string | null;
+  primaryPreviewVerification: string | null;
 }): TrackSummary {
+  const previewVerification = isPreviewVerification(
+    row.primaryPreviewVerification
+  )
+    ? row.primaryPreviewVerification
+    : null;
+
   return {
     totalDurationMs: row.totalDurationMs ?? null,
     primaryIsrc: row.primaryIsrc ?? null,
     primaryPreviewUrl: row.primaryPreviewUrl ?? null,
+    primaryPreviewVerification: previewVerification,
   };
+}
+
+function isPreviewVerification(
+  value: string | null | undefined
+): value is PreviewVerification {
+  return (
+    value === 'verified' ||
+    value === 'fallback' ||
+    value === 'unknown' ||
+    value === 'missing'
+  );
 }
 
 /**

--- a/apps/web/lib/discography/types.ts
+++ b/apps/web/lib/discography/types.ts
@@ -175,6 +175,12 @@ export interface ReleaseViewModel {
   lyrics?: string;
   /** Preview audio URL (typically from the primary track) */
   previewUrl?: string | null;
+  /**
+   * Verification state for the primary preview. Consumers must not infer
+   * playability from `previewUrl` alone: a provider URL can be stale or only
+   * a fallback until the audio QA pipeline confirms it.
+   */
+  previewVerification?: PreviewVerification;
   previewCounts?: PreviewCounts;
   /**
    * Weekly engagement metric for the releases list: non-bot smart-link

--- a/apps/web/lib/releases/release-view-models.ts
+++ b/apps/web/lib/releases/release-view-models.ts
@@ -91,5 +91,7 @@ export function mapReleaseToViewModel(
         release.metadata as Record<string, unknown> | null
       )?.lyrics?.toString() || undefined,
     previewUrl: release.trackSummary?.primaryPreviewUrl || null,
+    previewVerification:
+      release.trackSummary?.primaryPreviewVerification ?? undefined,
   };
 }

--- a/apps/web/tests/unit/library/LibraryCatalogWaveformCell.test.tsx
+++ b/apps/web/tests/unit/library/LibraryCatalogWaveformCell.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { buildLibraryReleaseAssets } from '@/app/app/(shell)/library/library-data';
+import { LibraryCatalogWaveformCell } from '@/components/features/library/library-catalog-columns';
+import type { ReleaseViewModel } from '@/lib/discography/types';
+
+function buildRelease(
+  previewVerification: ReleaseViewModel['previewVerification']
+): ReleaseViewModel {
+  return {
+    profileId: 'profile-1',
+    id: 'release-1',
+    title: 'Test Release',
+    artistNames: ['Test Artist'],
+    status: 'released',
+    artworkUrl: 'https://example.com/art.jpg',
+    slug: 'test-release',
+    smartLinkPath: '/artist/test-release',
+    providers: [],
+    releaseType: 'single',
+    isExplicit: false,
+    totalTracks: 1,
+    previewUrl: 'https://example.com/preview.mp3',
+    previewVerification,
+  };
+}
+
+describe('LibraryCatalogWaveformCell', () => {
+  it('renders the waveform only for a verified preview', () => {
+    const [asset] = buildLibraryReleaseAssets([buildRelease('verified')]);
+
+    render(<LibraryCatalogWaveformCell asset={asset!} />);
+
+    const cell = screen.getByTestId('library-catalog-waveform-release-1');
+    expect(cell).toHaveAttribute('data-audio-state', 'verified');
+    expect(cell.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('keeps unavailable preview slots honest and layout-stable', () => {
+    const [asset] = buildLibraryReleaseAssets([buildRelease('fallback')]);
+
+    render(<LibraryCatalogWaveformCell asset={asset!} />);
+
+    const cell = screen.getByTestId('library-catalog-waveform-release-1');
+    expect(cell).toHaveAttribute('data-audio-state', 'unavailable');
+    expect(cell).toHaveAttribute('aria-label', 'Audio preview unavailable');
+    expect(cell).toHaveAttribute('title', 'Audio preview unavailable');
+    expect(cell.querySelector('svg')).not.toBeInTheDocument();
+    expect(cell).toHaveTextContent('—');
+    expect(cell).toHaveClass('h-6', 'w-40');
+  });
+});

--- a/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
+++ b/apps/web/tests/unit/library/LibraryMediaThumbnail.test.tsx
@@ -22,6 +22,7 @@ function buildAsset(
     artist: 'Tim White',
     artworkUrl: 'https://cdn.example.com/artwork.jpg',
     previewUrl: 'https://cdn.example.com/preview.mp3',
+    previewVerification: 'verified',
     videoUrl: null,
     waveformSeed: 17,
     smartLinkPath: '/tim/take-me-over',
@@ -64,6 +65,33 @@ describe('LibraryMediaThumbnail', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId('library-video-scrub-thumbnail')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not imply playback for an unverified preview URL', () => {
+    render(
+      <LibraryMediaThumbnail
+        asset={buildAsset({ previewVerification: 'fallback' })}
+        size='card'
+      />
+    );
+
+    expect(
+      screen.getByTestId('library-media-thumbnail-release-1')
+    ).toHaveAttribute('data-preview-mode', 'static');
+    expect(
+      screen.queryByTestId('library-audio-waveform-thumbnail')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps compact verified artwork free of waveform chrome', () => {
+    render(<LibraryMediaThumbnail asset={buildAsset()} size='row' />);
+
+    expect(
+      screen.getByTestId('library-media-thumbnail-release-1')
+    ).toHaveAttribute('data-preview-mode', 'static');
+    expect(
+      screen.queryByTestId('library-audio-waveform-thumbnail')
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -150,6 +150,7 @@ function buildAsset(
     artist: 'Tim White',
     artworkUrl: 'https://cdn.example.com/artwork.jpg',
     previewUrl: 'https://cdn.example.com/preview.mp3',
+    previewVerification: 'verified',
     videoUrl: null,
     waveformSeed: 17,
     smartLinkPath: '/tim/take-me-over',

--- a/apps/web/tests/unit/library/library-data.test.ts
+++ b/apps/web/tests/unit/library/library-data.test.ts
@@ -9,6 +9,7 @@ import {
   getLibraryAspectRatioClass,
   getLibraryAssetAspectRatio,
   getLibraryDrawerHeroClass,
+  hasVerifiedLibraryAudioPreview,
   LIBRARY_GRID_DENSITY_LAYOUT,
   libraryAssetMatchesView,
   normalizeLibraryVersionTitle,
@@ -43,6 +44,7 @@ describe('library data', () => {
       buildRelease({
         lyrics: 'Stored lyrics',
         previewUrl: 'https://example.com/preview.mp3',
+        previewVerification: 'verified',
         providers: [
           {
             key: 'spotify',
@@ -64,6 +66,7 @@ describe('library data', () => {
         artist: 'Test Artist',
         artworkUrl: 'https://example.com/art.jpg',
         previewUrl: 'https://example.com/preview.mp3',
+        previewVerification: 'verified',
         primaryIsrc: null,
         videoUrl: null,
         waveformSeed: expect.any(Number),
@@ -97,6 +100,28 @@ describe('library data', () => {
         totalDurationMs: null,
       },
     ]);
+  });
+
+  it('requires verified preview state before exposing audio playback', () => {
+    const [fallback] = buildLibraryReleaseAssets([
+      buildRelease({
+        previewUrl: 'https://example.com/preview.mp3',
+        previewVerification: 'fallback',
+      }),
+    ]);
+    const [verified] = buildLibraryReleaseAssets([
+      buildRelease({
+        previewUrl: 'https://example.com/preview.mp3',
+        previewVerification: 'verified',
+      }),
+    ]);
+
+    expect(hasVerifiedLibraryAudioPreview(fallback!)).toBe(false);
+    expect(fallback?.assetKinds).not.toContain('preview');
+    expect(libraryAssetMatchesView(fallback!, 'audio')).toBe(false);
+    expect(hasVerifiedLibraryAudioPreview(verified!)).toBe(true);
+    expect(verified?.assetKinds).toContain('preview');
+    expect(libraryAssetMatchesView(verified!, 'audio')).toBe(true);
   });
 
   it('maps canvas video URLs and deterministic waveform seeds for scrub previews', () => {


### PR DESCRIPTION
## Summary
- gate Library waveform and playback affordances on canonical `previewVerification` truth instead of URL presence alone
- keep compact artwork rows quiet and show an honest unavailable marker when media is not verified
- propagate verification from track summaries through release view models and add regression coverage

## Verification
- focused Library suites: 4 files, 72 tests passed
- @jovie/web typecheck passed
- Biome and `git diff --check` passed
- normal hooked push passed

## Evidence boundary
This PR has local component/render regression coverage. Hosted, deployed, and production visual proof are not claimed yet.