### PR TITLE
test(ui): register authenticated app screens

### DIFF
--- a/apps/web/data/appScreens/index.ts
+++ b/apps/web/data/appScreens/index.ts
@@ -1,0 +1,2 @@
+export * from './registry';
+export * from './validation';

--- a/apps/web/data/appScreens/registry.ts
+++ b/apps/web/data/appScreens/registry.ts
@@ -1,0 +1,377 @@
+/**
+ * Server-safe, closed-world registry for authenticated app screens.
+ *
+ * This module deliberately contains metadata only. Route implementations keep
+ * their existing ownership while CI can reject unregistered screens and
+ * recipes before they become new design references.
+ */
+
+export type AppScreenKind = 'canonical' | 'alias' | 'legacy' | 'operator';
+
+export type AppScreenComponentId =
+  | 'component.app-shell-frame'
+  | 'component.page-shell'
+  | 'component.settings-panel'
+  | 'component.unified-table'
+  | 'component.entity-sidebar'
+  | 'component.empty-state'
+  | 'component.error-fallback';
+
+export type AppScreenRecipeId =
+  | 'recipe.app-standard'
+  | 'recipe.app-settings'
+  | 'recipe.app-operator'
+  | 'recipe.app-compatibility';
+
+export interface AppScreenComponentRegistryEntry {
+  readonly id: AppScreenComponentId;
+  readonly source: string;
+  readonly storySource: string;
+  readonly storybookTitle: string;
+}
+
+export interface AppScreenRecipeRegistryEntry {
+  readonly id: AppScreenRecipeId;
+  readonly componentIds: readonly AppScreenComponentId[];
+  readonly errorBoundarySource: string;
+  readonly allowedKinds: readonly AppScreenKind[];
+}
+
+export interface AppScreenRegistryEntry {
+  readonly id: `screen.${string}`;
+  readonly route: `/app${string}`;
+  readonly source: string;
+  readonly kind: AppScreenKind;
+  readonly conceptId: string;
+  readonly recipeId: AppScreenRecipeId;
+  readonly designReference: boolean;
+}
+
+export const APP_SCREEN_COMPONENT_REGISTRY = [
+  {
+    id: 'component.app-shell-frame',
+    source: 'apps/web/components/organisms/AppShellFrame.tsx',
+    storySource: 'apps/web/components/organisms/AppShellFrame.stories.tsx',
+    storybookTitle: 'Organisms/AppShellFrame',
+  },
+  {
+    id: 'component.page-shell',
+    source: 'apps/web/components/organisms/PageShell.tsx',
+    storySource: 'apps/web/components/organisms/PageShell.stories.tsx',
+    storybookTitle: 'Organisms/PageShell',
+  },
+  {
+    id: 'component.settings-panel',
+    source: 'apps/web/components/molecules/settings/SettingsPanel.tsx',
+    storySource:
+      'apps/web/components/molecules/settings/SettingsPanel.stories.tsx',
+    storybookTitle: 'Molecules/Settings/SettingsPanel',
+  },
+  {
+    id: 'component.unified-table',
+    source: 'apps/web/components/organisms/table/organisms/UnifiedTable.tsx',
+    storySource:
+      'apps/web/components/organisms/table/organisms/UnifiedTable.stories.tsx',
+    storybookTitle: 'Organisms/Table/UnifiedTable',
+  },
+  {
+    id: 'component.entity-sidebar',
+    source: 'apps/web/components/molecules/drawer/EntitySidebarShell.tsx',
+    storySource:
+      'apps/web/components/molecules/drawer/EntitySidebarShell.stories.tsx',
+    storybookTitle: 'Molecules/Drawer/EntitySidebarShell',
+  },
+  {
+    id: 'component.empty-state',
+    source: 'apps/web/components/organisms/EmptyState.tsx',
+    storySource: 'apps/web/components/organisms/EmptyState.stories.tsx',
+    storybookTitle: 'UI/EmptyState',
+  },
+  {
+    id: 'component.error-fallback',
+    source: 'apps/web/components/organisms/DashboardErrorFallback.tsx',
+    storySource:
+      'apps/web/components/organisms/DashboardErrorFallback.stories.tsx',
+    storybookTitle: 'Organisms/DashboardErrorFallback',
+  },
+] as const satisfies readonly AppScreenComponentRegistryEntry[];
+
+const ROOT_ERROR_BOUNDARY = 'apps/web/app/app/(shell)/error.tsx';
+
+export const APP_SCREEN_RECIPE_REGISTRY = [
+  {
+    id: 'recipe.app-standard',
+    componentIds: [
+      'component.app-shell-frame',
+      'component.page-shell',
+      'component.empty-state',
+      'component.entity-sidebar',
+      'component.error-fallback',
+    ],
+    errorBoundarySource: ROOT_ERROR_BOUNDARY,
+    allowedKinds: ['canonical'],
+  },
+  {
+    id: 'recipe.app-settings',
+    componentIds: [
+      'component.app-shell-frame',
+      'component.page-shell',
+      'component.settings-panel',
+      'component.error-fallback',
+    ],
+    errorBoundarySource: ROOT_ERROR_BOUNDARY,
+    allowedKinds: ['canonical'],
+  },
+  {
+    id: 'recipe.app-operator',
+    componentIds: [
+      'component.app-shell-frame',
+      'component.page-shell',
+      'component.unified-table',
+      'component.empty-state',
+      'component.error-fallback',
+    ],
+    errorBoundarySource: ROOT_ERROR_BOUNDARY,
+    allowedKinds: ['operator'],
+  },
+  {
+    id: 'recipe.app-compatibility',
+    componentIds: ['component.app-shell-frame', 'component.error-fallback'],
+    errorBoundarySource: ROOT_ERROR_BOUNDARY,
+    allowedKinds: ['alias', 'legacy'],
+  },
+] as const satisfies readonly AppScreenRecipeRegistryEntry[];
+
+/** Explicit closed-world inventory. The coverage test fails when this drifts. */
+export const APP_SCREEN_SOURCES = [
+  'apps/web/app/app/(shell)/admin/activity/page.tsx',
+  'apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx',
+  'apps/web/app/app/(shell)/admin/algorithm-health/page.tsx',
+  'apps/web/app/app/(shell)/admin/campaigns/page.tsx',
+  'apps/web/app/app/(shell)/admin/chat/page.tsx',
+  'apps/web/app/app/(shell)/admin/costs/page.tsx',
+  'apps/web/app/app/(shell)/admin/creators/page.tsx',
+  'apps/web/app/app/(shell)/admin/features/page.tsx',
+  'apps/web/app/app/(shell)/admin/feedback/page.tsx',
+  'apps/web/app/app/(shell)/admin/growth/page.tsx',
+  'apps/web/app/app/(shell)/admin/growth/yc-metrics/page.tsx',
+  'apps/web/app/app/(shell)/admin/ingest/page.tsx',
+  'apps/web/app/app/(shell)/admin/interviews/page.tsx',
+  'apps/web/app/app/(shell)/admin/investors/links/page.tsx',
+  'apps/web/app/app/(shell)/admin/investors/page.tsx',
+  'apps/web/app/app/(shell)/admin/investors/settings/page.tsx',
+  'apps/web/app/app/(shell)/admin/leads/page.tsx',
+  'apps/web/app/app/(shell)/admin/ops/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/dm/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/email/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/review/page.tsx',
+  'apps/web/app/app/(shell)/admin/page.tsx',
+  'apps/web/app/app/(shell)/admin/people/page.tsx',
+  'apps/web/app/app/(shell)/admin/platform-connections/page.tsx',
+  'apps/web/app/app/(shell)/admin/playlists/page.tsx',
+  'apps/web/app/app/(shell)/admin/releases/page.tsx',
+  'apps/web/app/app/(shell)/admin/revenue-lift/page.tsx',
+  'apps/web/app/app/(shell)/admin/screenshots/page.tsx',
+  'apps/web/app/app/(shell)/admin/share-studio/page.tsx',
+  'apps/web/app/app/(shell)/admin/system/page.tsx',
+  'apps/web/app/app/(shell)/admin/users/page.tsx',
+  'apps/web/app/app/(shell)/admin/waitlist/page.tsx',
+  'apps/web/app/app/(shell)/audience/page.tsx',
+  'apps/web/app/app/(shell)/calendar/page.tsx',
+  'apps/web/app/app/(shell)/chat/[id]/page.tsx',
+  'apps/web/app/app/(shell)/chat/page.tsx',
+  'apps/web/app/app/(shell)/chats/page.tsx',
+  'apps/web/app/app/(shell)/contact/page.tsx',
+  'apps/web/app/app/(shell)/contacts/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/audience/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/catalog-scan/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/chat/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/contacts/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/earnings/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/insights/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/library/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/links/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/presence/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/profile/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/release-plan/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/releases/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/tasks/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/tipping/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/tour-dates/page.tsx',
+  'apps/web/app/app/(shell)/earnings/page.tsx',
+  'apps/web/app/app/(shell)/feature-flags/page.tsx',
+  'apps/web/app/app/(shell)/insights/page.tsx',
+  'apps/web/app/app/(shell)/jovie-work/page.tsx',
+  'apps/web/app/app/(shell)/library/page.tsx',
+  'apps/web/app/app/(shell)/lyrics/[trackId]/page.tsx',
+  'apps/web/app/app/(shell)/page.tsx',
+  'apps/web/app/app/(shell)/presence/page.tsx',
+  'apps/web/app/app/(shell)/profile/page.tsx',
+  'apps/web/app/app/(shell)/profiles/page.tsx',
+  'apps/web/app/app/(shell)/releases/[releaseId]/tasks/page.tsx',
+  'apps/web/app/app/(shell)/releases/page.tsx',
+  'apps/web/app/app/(shell)/settings/account/page.tsx',
+  'apps/web/app/app/(shell)/settings/admin/page.tsx',
+  'apps/web/app/app/(shell)/settings/analytics/page.tsx',
+  'apps/web/app/app/(shell)/settings/appearance/page.tsx',
+  'apps/web/app/app/(shell)/settings/artist-profile/page.tsx',
+  'apps/web/app/app/(shell)/settings/audience/page.tsx',
+  'apps/web/app/app/(shell)/settings/billing/page.tsx',
+  'apps/web/app/app/(shell)/settings/connectors/page.tsx',
+  'apps/web/app/app/(shell)/settings/contacts/page.tsx',
+  'apps/web/app/app/(shell)/settings/data-privacy/page.tsx',
+  'apps/web/app/app/(shell)/settings/delete-account/page.tsx',
+  'apps/web/app/app/(shell)/settings/page.tsx',
+  'apps/web/app/app/(shell)/settings/payments/page.tsx',
+  'apps/web/app/app/(shell)/settings/profile/page.tsx',
+  'apps/web/app/app/(shell)/settings/referral/page.tsx',
+  'apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx',
+  'apps/web/app/app/(shell)/settings/touring/page.tsx',
+  'apps/web/app/app/(shell)/settings/usage/page.tsx',
+  'apps/web/app/app/(shell)/tasks/page.tsx',
+  'apps/web/app/app/(shell)/threads/page.tsx',
+  'apps/web/app/app/(shell)/tipping/page.tsx',
+  'apps/web/app/app/(shell)/tour-dates/page.tsx',
+  'apps/web/app/app/(shell)/tracks/page.tsx',
+  'apps/web/app/app/(shell)/youtube/page.tsx',
+] as const;
+
+const LEGACY_PREFIXES = ['apps/web/app/app/(shell)/dashboard/'] as const;
+
+const LEGACY_SOURCES = new Set<string>([
+  'apps/web/app/app/(shell)/audience/page.tsx',
+  'apps/web/app/app/(shell)/contact/page.tsx',
+  'apps/web/app/app/(shell)/feature-flags/page.tsx',
+  'apps/web/app/app/(shell)/presence/page.tsx',
+  'apps/web/app/app/(shell)/profile/page.tsx',
+  'apps/web/app/app/(shell)/releases/page.tsx',
+  'apps/web/app/app/(shell)/threads/page.tsx',
+  'apps/web/app/app/(shell)/tipping/page.tsx',
+  'apps/web/app/app/(shell)/tracks/page.tsx',
+]);
+
+const ALIAS_SOURCES = new Set<string>([
+  'apps/web/app/app/(shell)/settings/admin/page.tsx',
+  'apps/web/app/app/(shell)/settings/appearance/page.tsx',
+  'apps/web/app/app/(shell)/settings/delete-account/page.tsx',
+  'apps/web/app/app/(shell)/settings/page.tsx',
+  'apps/web/app/app/(shell)/settings/profile/page.tsx',
+]);
+
+/** Conservative: a redirecting source is never eligible as a visual reference. */
+const NON_REFERENCE_SOURCES = new Set<string>([
+  'apps/web/app/app/(shell)/admin/algorithm-health/page.tsx',
+  'apps/web/app/app/(shell)/admin/campaigns/page.tsx',
+  'apps/web/app/app/(shell)/admin/creators/page.tsx',
+  'apps/web/app/app/(shell)/admin/feedback/page.tsx',
+  'apps/web/app/app/(shell)/admin/growth/yc-metrics/page.tsx',
+  'apps/web/app/app/(shell)/admin/ingest/page.tsx',
+  'apps/web/app/app/(shell)/admin/leads/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/dm/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/email/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/page.tsx',
+  'apps/web/app/app/(shell)/admin/outreach/review/page.tsx',
+  'apps/web/app/app/(shell)/admin/releases/page.tsx',
+  'apps/web/app/app/(shell)/admin/users/page.tsx',
+  'apps/web/app/app/(shell)/admin/waitlist/page.tsx',
+  'apps/web/app/app/(shell)/audience/page.tsx',
+  'apps/web/app/app/(shell)/contact/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/audience/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/catalog-scan/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/chat/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/contacts/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/insights/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/library/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/links/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/presence/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/profile/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/tasks/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/tipping/page.tsx',
+  'apps/web/app/app/(shell)/dashboard/tour-dates/page.tsx',
+  'apps/web/app/app/(shell)/feature-flags/page.tsx',
+  'apps/web/app/app/(shell)/presence/page.tsx',
+  'apps/web/app/app/(shell)/profile/page.tsx',
+  'apps/web/app/app/(shell)/releases/page.tsx',
+  'apps/web/app/app/(shell)/settings/admin/page.tsx',
+  'apps/web/app/app/(shell)/settings/appearance/page.tsx',
+  'apps/web/app/app/(shell)/settings/delete-account/page.tsx',
+  'apps/web/app/app/(shell)/settings/page.tsx',
+  'apps/web/app/app/(shell)/settings/payments/page.tsx',
+  'apps/web/app/app/(shell)/settings/profile/page.tsx',
+  'apps/web/app/app/(shell)/threads/page.tsx',
+  'apps/web/app/app/(shell)/tipping/page.tsx',
+  'apps/web/app/app/(shell)/tracks/page.tsx',
+]);
+
+const SOURCE_PREFIX = 'apps/web/app/app/(shell)';
+
+export function appScreenSourceToRoute(source: string): `/app${string}` {
+  const relative = source
+    .slice(SOURCE_PREFIX.length)
+    .replace(/\/page\.tsx$/, '');
+  return (
+    relative.length === 0 ? '/app' : `/app${relative}`
+  ) as `/app${string}`;
+}
+
+function classifyScreen(source: string): AppScreenKind {
+  if (source.startsWith(`${SOURCE_PREFIX}/admin/`)) return 'operator';
+  if (
+    LEGACY_SOURCES.has(source) ||
+    LEGACY_PREFIXES.some(prefix => source.startsWith(prefix))
+  ) {
+    return 'legacy';
+  }
+  if (ALIAS_SOURCES.has(source)) return 'alias';
+  return 'canonical';
+}
+
+function recipeFor(source: string, kind: AppScreenKind): AppScreenRecipeId {
+  if (kind === 'operator') return 'recipe.app-operator';
+  if (kind === 'alias' || kind === 'legacy') {
+    return 'recipe.app-compatibility';
+  }
+  if (source.includes('/settings/')) return 'recipe.app-settings';
+  return 'recipe.app-standard';
+}
+
+function routeToId(route: string): `screen.${string}` {
+  const suffix = route
+    .replace(/^\/app\/?/, '')
+    .replace(/\[([^\]]+)\]/g, 'by-$1')
+    .replace(/[^a-zA-Z0-9]+/g, '.')
+    .replace(/^\.|\.$/g, '');
+  return `screen.${suffix || 'root'}`;
+}
+
+export const APP_SCREEN_REGISTRY: readonly AppScreenRegistryEntry[] =
+  APP_SCREEN_SOURCES.map(source => {
+    const route = appScreenSourceToRoute(source);
+    const kind = classifyScreen(source);
+    return {
+      id: routeToId(route),
+      route,
+      source,
+      kind,
+      conceptId: route,
+      recipeId: recipeFor(source, kind),
+      designReference:
+        kind !== 'alias' &&
+        kind !== 'legacy' &&
+        !NON_REFERENCE_SOURCES.has(source),
+    };
+  });
+
+const SCREEN_BY_ROUTE: Readonly<Record<string, AppScreenRegistryEntry>> =
+  Object.fromEntries(APP_SCREEN_REGISTRY.map(entry => [entry.route, entry]));
+
+export function getAppScreenRegistryEntry(
+  route: string
+): AppScreenRegistryEntry | null {
+  return SCREEN_BY_ROUTE[route] ?? null;
+}

--- a/apps/web/data/appScreens/validation.ts
+++ b/apps/web/data/appScreens/validation.ts
@@ -1,0 +1,158 @@
+import {
+  APP_SCREEN_COMPONENT_REGISTRY,
+  APP_SCREEN_RECIPE_REGISTRY,
+  APP_SCREEN_REGISTRY,
+  type AppScreenComponentRegistryEntry,
+  type AppScreenRecipeRegistryEntry,
+  type AppScreenRegistryEntry,
+  appScreenSourceToRoute,
+} from './registry';
+
+export type AppScreenValidationCode =
+  | 'duplicate-component'
+  | 'duplicate-recipe'
+  | 'duplicate-screen'
+  | 'duplicate-source'
+  | 'duplicate-route'
+  | 'duplicate-reference-concept'
+  | 'missing-component'
+  | 'duplicate-recipe-component'
+  | 'missing-recipe'
+  | 'invalid-recipe-kind'
+  | 'invalid-reference-kind'
+  | 'route-source-mismatch'
+  | 'missing-error-boundary';
+
+export interface AppScreenValidationIssue {
+  readonly code: AppScreenValidationCode;
+  readonly message: string;
+}
+
+export interface AppScreenValidationInput {
+  readonly components?: readonly AppScreenComponentRegistryEntry[];
+  readonly recipes?: readonly AppScreenRecipeRegistryEntry[];
+  readonly screens?: readonly AppScreenRegistryEntry[];
+}
+
+const duplicates = (values: readonly string[]): readonly string[] => {
+  const seen = new Set<string>();
+  const repeated = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated];
+};
+
+export function validateAppScreenSystem({
+  components = APP_SCREEN_COMPONENT_REGISTRY,
+  recipes = APP_SCREEN_RECIPE_REGISTRY,
+  screens = APP_SCREEN_REGISTRY,
+}: AppScreenValidationInput = {}): readonly AppScreenValidationIssue[] {
+  const issues: AppScreenValidationIssue[] = [];
+  const add = (code: AppScreenValidationCode, message: string) =>
+    issues.push({ code, message });
+
+  for (const id of duplicates(components.map(entry => entry.id))) {
+    add('duplicate-component', `component ${id} is registered more than once`);
+  }
+  for (const id of duplicates(recipes.map(entry => entry.id))) {
+    add('duplicate-recipe', `recipe ${id} is registered more than once`);
+  }
+  for (const id of duplicates(screens.map(entry => entry.id))) {
+    add('duplicate-screen', `screen ${id} is registered more than once`);
+  }
+  for (const source of duplicates(screens.map(entry => entry.source))) {
+    add('duplicate-source', `source ${source} is registered more than once`);
+  }
+  for (const route of duplicates(screens.map(entry => entry.route))) {
+    add('duplicate-route', `route ${route} is registered more than once`);
+  }
+
+  const componentsById = new Map(
+    components.map(component => [component.id, component])
+  );
+  const recipesById = new Map(recipes.map(recipe => [recipe.id, recipe]));
+
+  for (const recipe of recipes) {
+    for (const componentId of duplicates(recipe.componentIds)) {
+      add(
+        'duplicate-recipe-component',
+        `recipe ${recipe.id} repeats ${componentId}`
+      );
+    }
+    for (const componentId of recipe.componentIds) {
+      if (!componentsById.has(componentId)) {
+        add(
+          'missing-component',
+          `recipe ${recipe.id} uses unregistered ${componentId}`
+        );
+      }
+    }
+    if (!recipe.errorBoundarySource) {
+      add(
+        'missing-error-boundary',
+        `recipe ${recipe.id} has no error boundary`
+      );
+    }
+  }
+
+  const referenceConceptCounts = new Map<string, number>();
+  for (const screen of screens) {
+    const recipe = recipesById.get(screen.recipeId);
+    if (!recipe) {
+      add(
+        'missing-recipe',
+        `screen ${screen.id} uses unregistered ${screen.recipeId}`
+      );
+    } else if (!recipe.allowedKinds.includes(screen.kind)) {
+      add(
+        'invalid-recipe-kind',
+        `recipe ${recipe.id} does not allow ${screen.kind} screens`
+      );
+    }
+    if (
+      screen.designReference &&
+      (screen.kind === 'alias' || screen.kind === 'legacy')
+    ) {
+      add(
+        'invalid-reference-kind',
+        `${screen.kind} screen ${screen.id} cannot be a design reference`
+      );
+    }
+    if (screen.route !== appScreenSourceToRoute(screen.source)) {
+      add(
+        'route-source-mismatch',
+        `${screen.route} does not match ${screen.source}`
+      );
+    }
+    if (screen.designReference) {
+      referenceConceptCounts.set(
+        screen.conceptId,
+        (referenceConceptCounts.get(screen.conceptId) ?? 0) + 1
+      );
+    }
+  }
+  for (const [conceptId, count] of referenceConceptCounts) {
+    if (count > 1) {
+      add(
+        'duplicate-reference-concept',
+        `concept ${conceptId} has ${count} design references`
+      );
+    }
+  }
+
+  return issues;
+}
+
+export function assertAppScreenSystem(): void {
+  const issues = validateAppScreenSystem();
+  if (issues.length > 0) {
+    throw new Error(
+      [
+        'Authenticated screen registry gate failed:',
+        ...issues.map(issue => `- [${issue.code}] ${issue.message}`),
+      ].join('\n')
+    );
+  }
+}

--- a/apps/web/tests/unit/design-system/app-screen-registry.test.ts
+++ b/apps/web/tests/unit/design-system/app-screen-registry.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  APP_SCREEN_COMPONENT_REGISTRY,
+  APP_SCREEN_RECIPE_REGISTRY,
+  APP_SCREEN_REGISTRY,
+  type AppScreenRegistryEntry,
+  validateAppScreenSystem,
+} from '@/data/appScreens';
+
+const repoRoot = path.resolve(__dirname, '../../../../..');
+const shellRoot = path.join(repoRoot, 'apps/web/app/app/(shell)');
+
+function listPageSources(directory: string): string[] {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .flatMap(entry => {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) return listPageSources(absolute);
+      if (entry.name !== 'page.tsx') return [];
+      return [path.relative(repoRoot, absolute)];
+    })
+    .sort();
+}
+
+describe('authenticated app screen registry', () => {
+  it('registers every authenticated shell page exactly once', () => {
+    expect(APP_SCREEN_REGISTRY.map(entry => entry.source).sort()).toEqual(
+      listPageSources(shellRoot)
+    );
+    expect(APP_SCREEN_REGISTRY).toHaveLength(94);
+  });
+
+  it('has a valid registered recipe and component composition', () => {
+    expect(validateAppScreenSystem()).toEqual([]);
+    expect(new Set(APP_SCREEN_REGISTRY.map(entry => entry.kind))).toEqual(
+      new Set(['canonical', 'alias', 'legacy', 'operator'])
+    );
+  });
+
+  it('backs every registered component with its real Storybook title', () => {
+    for (const component of APP_SCREEN_COMPONENT_REGISTRY) {
+      expect(fs.existsSync(path.join(repoRoot, component.source))).toBe(true);
+      const storyPath = path.join(repoRoot, component.storySource);
+      expect(fs.existsSync(storyPath), component.id).toBe(true);
+      expect(fs.readFileSync(storyPath, 'utf8'), component.id).toContain(
+        `title: '${component.storybookTitle}'`
+      );
+    }
+  });
+
+  it('keeps every recipe behind a real error boundary', () => {
+    for (const recipe of APP_SCREEN_RECIPE_REGISTRY) {
+      expect(
+        fs.existsSync(path.join(repoRoot, recipe.errorBoundarySource)),
+        recipe.id
+      ).toBe(true);
+    }
+  });
+
+  it('never treats redirecting routes as design references', () => {
+    for (const screen of APP_SCREEN_REGISTRY) {
+      const source = fs.readFileSync(
+        path.join(repoRoot, screen.source),
+        'utf8'
+      );
+      if (/\b(?:permanentRedirect|redirect)\s*\(/.test(source)) {
+        expect(screen.designReference, screen.route).toBe(false);
+      }
+    }
+  });
+
+  it('fails closed on one-offs, duplicate concepts, and invalid composition', () => {
+    const canonical = APP_SCREEN_REGISTRY.find(
+      entry => entry.designReference
+    ) as AppScreenRegistryEntry;
+    const invalid = [
+      ...APP_SCREEN_REGISTRY,
+      {
+        ...canonical,
+        id: 'screen.invalid-one-off' as const,
+        source: canonical.source,
+        route: canonical.route,
+      },
+    ];
+    expect(
+      validateAppScreenSystem({ screens: invalid }).map(x => x.code)
+    ).toEqual(
+      expect.arrayContaining([
+        'duplicate-source',
+        'duplicate-route',
+        'duplicate-reference-concept',
+      ])
+    );
+    expect(
+      validateAppScreenSystem({
+        screens: [
+          {
+            ...canonical,
+            recipeId: 'recipe.missing' as never,
+          },
+        ],
+      }).map(x => x.code)
+    ).toContain('missing-recipe');
+  });
+
+  it('keeps success, warning, and error on Mint, Gold, and Flare aliases', () => {
+    const tokens = fs.readFileSync(
+      path.join(repoRoot, 'apps/web/styles/design-system.css'),
+      'utf8'
+    );
+    expect(tokens).toMatch(/--color-success:\s*var\(--color-accent-green\);/);
+    expect(tokens).toMatch(/--color-warning:\s*var\(--color-accent-orange\);/);
+    expect(tokens).toMatch(/--color-error:\s*var\(--color-accent-red\);/);
+    expect(tokens).not.toMatch(/--color-(?:success|warning|error):\s*#/);
+  });
+});


### PR DESCRIPTION
## Summary
- register all 94 authenticated app shell pages as canonical, alias, legacy, or operator routes
- require each route to select a closed-world recipe composed only from Storybook-backed components
- fail on unregistered pages, duplicate routes/sources/concepts, invalid composition, missing error boundaries, redirect design references, missing stories, and semantic status-token drift
- keep the lane metadata/test-only; no shell, component, route, or marketing implementation changes

## Verification
- focused Vitest: 7/7 passed
- Biome: passed
- strict standalone TypeScript validation for registry modules: passed
- exact-main full typecheck is delegated to required CI; local cross-worktree dependency linking produced unrelated baseline module-resolution errors

Closes JOV-4899