### PR TITLE
fix(a11y): harden public catalog semantics

### DIFF
--- a/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
+++ b/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
@@ -22,7 +22,7 @@ export function PlaylistGrid({
   if (playlists.length === 0) {
     return (
       <div className='mt-16 text-center'>
-        <p className='text-mid text-white/40'>{emptyMessage}</p>
+        <p className='text-mid text-tertiary-token'>{emptyMessage}</p>
       </div>
     );
   }

--- a/apps/web/app/artists/page.tsx
+++ b/apps/web/app/artists/page.tsx
@@ -57,6 +57,7 @@ export default async function ArtistsPage() {
         <ContentSurfaceCard surface='details'>
           <ContentSectionHeader
             density='compact'
+            headingLevel='h1'
             title='All artists'
             subtitle='Discover public creator profiles across Jovie.'
           />
@@ -161,6 +162,7 @@ function renderFallback() {
       <ContentSurfaceCard surface='details' className='overflow-hidden'>
         <ContentSectionHeader
           density='compact'
+          headingLevel='h1'
           title='Profiles are loading'
           subtitle='Please check back shortly once the connection is available.'
         />

--- a/apps/web/components/molecules/ContentSectionHeader.stories.tsx
+++ b/apps/web/components/molecules/ContentSectionHeader.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ContentSectionHeader } from './ContentSectionHeader';
+
+const meta = {
+  title: 'Molecules/ContentSectionHeader',
+  component: ContentSectionHeader,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [Story => <div className='w-[36rem]'>{Story()}</div>],
+} satisfies Meta<typeof ContentSectionHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SectionHeading: Story = {
+  args: {
+    title: 'Catalog section',
+    subtitle: 'The default section-level heading remains an h2.',
+  },
+};
+
+export const RouteHeading: Story = {
+  args: {
+    headingLevel: 'h1',
+    title: 'All artists',
+    subtitle: 'Use the registered primitive as the route-level heading.',
+  },
+};

--- a/apps/web/components/molecules/ContentSectionHeader.tsx
+++ b/apps/web/components/molecules/ContentSectionHeader.tsx
@@ -5,6 +5,7 @@ export interface ContentSectionHeaderProps {
   readonly title: ReactNode;
   readonly subtitle?: ReactNode;
   readonly actions?: ReactNode;
+  readonly headingLevel?: 'h1' | 'h2';
   readonly density?: 'default' | 'compact';
   readonly variant?: 'default' | 'plain';
   readonly className?: string;
@@ -18,6 +19,7 @@ export function ContentSectionHeader({
   title,
   subtitle,
   actions,
+  headingLevel = 'h2',
   density = 'default',
   variant = 'default',
   className,
@@ -26,6 +28,8 @@ export function ContentSectionHeader({
   subtitleClassName,
   actionsClassName,
 }: Readonly<ContentSectionHeaderProps>) {
+  const Heading = headingLevel;
+
   return (
     <div
       className={cn(
@@ -38,14 +42,14 @@ export function ContentSectionHeader({
       )}
     >
       <div className={cn('min-w-0 flex-1 space-y-0', bodyClassName)}>
-        <h2
+        <Heading
           className={cn(
             'truncate text-xs font-semibold tracking-[-0.012em] text-primary-token',
             titleClassName
           )}
         >
           {title}
-        </h2>
+        </Heading>
         {subtitle ? (
           <p
             className={cn(

--- a/apps/web/tests/unit/app/public-catalog-a11y-contract.test.ts
+++ b/apps/web/tests/unit/app/public-catalog-a11y-contract.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_ROOT = process.cwd();
+
+function read(relativePath: string) {
+  return readFileSync(join(WEB_ROOT, relativePath), 'utf8');
+}
+
+describe('public catalog accessibility contract', () => {
+  it('uses the registered header primitive as the Artists route h1', () => {
+    const source = read('app/artists/page.tsx');
+    const story = read('components/molecules/ContentSectionHeader.stories.tsx');
+
+    expect(source.match(/headingLevel='h1'/g)).toHaveLength(2);
+    expect(source).not.toContain('<h1');
+    expect(story).toContain('export const RouteHeading');
+    expect(story).toContain("headingLevel: 'h1'");
+  });
+
+  it('uses a contrast-gated semantic token for the playlist empty state', () => {
+    const source = read('app/(dynamic)/playlists/_components/PlaylistGrid.tsx');
+
+    expect(source).toContain("className='text-mid text-tertiary-token'");
+    expect(source).not.toContain("className='text-mid text-white/40'");
+  });
+});

--- a/apps/web/tests/unit/components/molecules/ContentSectionHeader.test.tsx
+++ b/apps/web/tests/unit/components/molecules/ContentSectionHeader.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
+
+describe('ContentSectionHeader', () => {
+  it('keeps h2 as the default section heading', () => {
+    render(<ContentSectionHeader title='Section title' />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Section title' })
+    ).toBeInTheDocument();
+  });
+
+  it('can provide the route h1 without introducing page-local title markup', () => {
+    render(<ContentSectionHeader headingLevel='h1' title='Route title' />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Route title' })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- let the registered `ContentSectionHeader` primitive render a route-level `h1` while preserving `h2` as its default
- use that registered heading contract for both `/artists` data and fallback states
- replace the `/playlists` empty-state opacity color with the canonical, contrast-gated tertiary text token
- register the new heading mode in Storybook and add focused source/render contracts

## Production evidence

Exact deployed SHA `2d1e05045aad448638d5bc1e837e2fe1afdabb5b` exposed these issues after JOV-4900 restored the routes:

- `/artists`: HTTP 200 but zero H1 elements at 1440×900 and 390×844
- `/playlists`: Axe serious `color-contrast` at both widths; `.text-white/40` measured 3.73:1 for 15px text on `#06070a`

The existing `/artists` database avatar `https://images.unsplash.com/placeholder` also produces an image-optimizer 404. This PR intentionally does not invent or mutate artist data.

## Verification

- focused Vitest: 4/4 passed
- Biome: passed for all six changed files
- web typecheck: passed
- Storybook production build: passed; `ContentSectionHeader` story emitted
- pre-commit ESLint, staged a11y, proxy guard, typecheck, gitleaks, and TruffleHog: passed
- local structured autoreview failed closed because its standalone helper could not locate TruffleHog; repository pre-commit TruffleHog passed, and PR CI remains authoritative

Linear: [JOV-4901](https://linear.app/jovie/issue/JOV-4901/harden-deployed-public-catalog-accessibility)
